### PR TITLE
Fixed overlapping and overflowing section of start and end date input field 

### DIFF
--- a/frontend/src/components/inventory/InventoryReports.jsx
+++ b/frontend/src/components/inventory/InventoryReports.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import {
   Form,
   Stack,
+  Row,
   Dropdown,
   DatePicker,
   DatePickerInput,
@@ -226,29 +227,46 @@ const InventoryReports = () => {
                       <span style={{ color: "#da1e28" }}> *</span>
                     )}
                   </FormLabel>
-                  <DatePicker
-                    datePickerType="range"
-                    value={[formData.startDate, formData.endDate]}
-                    onChange={(dates) => {
-                      handleChange("startDate", dates[0] || null);
-                      handleChange("endDate", dates[1] || null);
-                    }}
-                  >
-                    <DatePickerInput
-                      id="startDate"
-                      placeholder="mm/dd/yyyy"
-                      labelText={intl.formatMessage({
-                        id: "reports.startDate",
-                      })}
-                      size="md"
-                    />
-                    <DatePickerInput
-                      id="endDate"
-                      placeholder="mm/dd/yyyy"
-                      labelText={intl.formatMessage({ id: "reports.endDate" })}
-                      size="md"
-                    />
-                  </DatePicker>
+
+                  <Row>
+                    <Column lg={4} md={4} sm={4}>
+                      <DatePicker
+                        datePickerType="single"
+                        value={formData.startDate}
+                        onChange={(dates) =>
+                          handleChange("startDate", dates[0] || null)
+                        }
+                      >
+                        <DatePickerInput
+                          id="startDate"
+                          placeholder="mm/dd/yyyy"
+                          labelText={intl.formatMessage({
+                            id: "reports.startDate",
+                          })}
+                          size="md"
+                        />
+                      </DatePicker>
+                    </Column>
+
+                    <Column lg={4} md={4} sm={4}>
+                      <DatePicker
+                        datePickerType="single"
+                        value={formData.endDate}
+                        onChange={(dates) =>
+                          handleChange("endDate", dates[0] || null)
+                        }
+                      >
+                        <DatePickerInput
+                          id="endDate"
+                          placeholder="mm/dd/yyyy"
+                          labelText={intl.formatMessage({
+                            id: "reports.endDate",
+                          })}
+                          size="md"
+                        />
+                      </DatePicker>
+                    </Column>
+                  </Row>
                 </div>
 
                 {/* Filter Options */}


### PR DESCRIPTION
# Changes

Replaced datePickerType="range" with two individual datePickerType="single" components.

Wrapped each DatePicker inside Carbon Row and Column components.

Leveraged Carbon’s responsive grid (lg, md, sm) to ensure:

Start Date and End Date appear side-by-side on desktop and tablet.

Start Date and End Date stack vertically in mobile view.

# Pull Requests Requirements

- [X] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [X] The PR includes a video showing the changes for the work done.
- [X] The PR title follows conventional commit label standards.
- [X] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [X] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots


https://github.com/user-attachments/assets/55ccece3-10f9-44c0-a36c-c6f2afe667c1



## Related Issue

[https://github.com/DIGI-UW/OpenELIS-Global-2/issues/2778]

## Other


