### PR TITLE
fix: resolve Maven build warnings in pom.xml and Java source files (#2934)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -645,7 +645,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
-            <scope>scope</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/src/main/java/org/openelisglobal/common/util/StringUtil.java
+++ b/src/main/java/org/openelisglobal/common/util/StringUtil.java
@@ -3,15 +3,19 @@
  * you may not use this file except in compliance with the License. You may obtain a copy of the
  * License at http://www.mozilla.org/MPL/
  *
- * <p>Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
- * ANY KIND, either express or implied. See the License for the specific language governing rights
- * and limitations under the License.
+ * <p>
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
  *
- * <p>The Original Code is OpenELIS code.
+ * <p>
+ * The Original Code is OpenELIS code.
  *
- * <p>Copyright (C) The Minnesota Department of Health. All Rights Reserved.
+ * <p>
+ * Copyright (C) The Minnesota Department of Health. All Rights Reserved.
  *
- * <p>Contributor(s): CIRG, University of Washington, Seattle WA.
+ * <p>
+ * Contributor(s): CIRG, University of Washington, Seattle WA.
  */
 package org.openelisglobal.common.util;
 
@@ -69,7 +73,6 @@ public class StringUtil {
     }
 
     // private static SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
-
     /**
      * bugzilla 2311 request parameter values coming back as string "null" when
      * checked for isNullorNill in an Action class need to return true
@@ -624,7 +627,7 @@ public class StringUtil {
         }
 
         try {
-            return new Double(significantDigits);
+            return Double.valueOf(significantDigits);
         } catch (NumberFormatException e) {
             LogEvent.logError(e);
             return null;
@@ -690,8 +693,9 @@ public class StringUtil {
     }
 
     public static boolean isNumeric(String str) {
-        if (str == null)
+        if (str == null) {
             return false;
+        }
         try {
             Double.parseDouble(str);
             return true;

--- a/src/main/java/org/openelisglobal/panel/valueholder/PanelSortOrderComparator.java
+++ b/src/main/java/org/openelisglobal/panel/valueholder/PanelSortOrderComparator.java
@@ -13,12 +13,12 @@
  *
  * Copyright (C) ITECH, University of Washington, Seattle WA.  All Rights Reserved.
  */
-
 package org.openelisglobal.panel.valueholder;
 
 import java.util.Comparator;
 
 public class PanelSortOrderComparator implements Comparable<Object> {
+
     String sortOrder;
 
     public int compareTo(Object obj) {
@@ -30,7 +30,7 @@ public class PanelSortOrderComparator implements Comparable<Object> {
         public int compare(Object a, Object b) {
             Panel t_a = (Panel) a;
             Panel t_b = (Panel) b;
-            return (new Integer(t_a.getSortOrderInt())).compareTo(new Integer(t_b.getSortOrderInt()));
+            return Integer.valueOf(t_a.getSortOrderInt()).compareTo(Integer.valueOf(t_b.getSortOrderInt()));
         }
     };
 }

--- a/src/main/java/org/openelisglobal/sitebranding/service/SiteBrandingService.java
+++ b/src/main/java/org/openelisglobal/sitebranding/service/SiteBrandingService.java
@@ -6,7 +6,7 @@ import org.openelisglobal.sitebranding.valueholder.SiteBranding;
 
 /**
  * Service interface for SiteBranding entity
- * 
+ *
  * Task Reference: T014
  */
 public interface SiteBrandingService extends BaseObjectService<SiteBranding, Integer> {
@@ -14,14 +14,14 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
     /**
      * Get the current branding configuration Creates a default record if none
      * exists
-     * 
+     *
      * @return SiteBranding entity with current or default values
      */
     SiteBranding getBranding();
 
     /**
      * Save branding configuration (insert or update)
-     * 
+     *
      * @param branding SiteBranding entity to save
      * @return Saved SiteBranding entity
      */
@@ -38,11 +38,12 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
      * @deprecated Validation is now permissive; this method returns true for any
      *             non-empty string
      */
+    @Deprecated
     boolean validateColor(String color);
 
     /**
      * Validate logo file format and size
-     * 
+     *
      * @param file MultipartFile to validate
      * @return true if valid, false otherwise
      */
@@ -50,7 +51,7 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
 
     /**
      * Upload logo file and update branding configuration
-     * 
+     *
      * @param file MultipartFile to upload
      * @param type LogoType (HEADER, LOGIN, or FAVICON)
      * @return Full filesystem path to uploaded file
@@ -60,7 +61,7 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
 
     /**
      * Get logo URL for serving
-     * 
+     *
      * @param type LogoType
      * @return URL path to logo or null if default should be used
      */
@@ -68,7 +69,7 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
 
     /**
      * Remove logo file and update branding configuration
-     * 
+     *
      * @param type LogoType (HEADER, LOGIN, or FAVICON)
      * @throws IOException if file cannot be deleted
      */
@@ -77,7 +78,7 @@ public interface SiteBrandingService extends BaseObjectService<SiteBranding, Int
     /**
      * Reset all branding to default values Deletes all logo files and resets colors
      * to defaults
-     * 
+     *
      * @throws IOException if files cannot be deleted
      */
     void resetToDefaults() throws IOException;


### PR DESCRIPTION
## Issue
Fixes #2934 — Fix Maven build warnings in pom.xml

## Description
Resolved multiple Maven build warnings that appear during `mvn clean install`:

1. **pom.xml**: Fixed invalid dependency scope `scope` → `runtime` for 
   postgresql dependency (line 648)
2. **StringUtil.java**: Replaced deprecated `new Double(String)` constructor 
   with `Double.valueOf()` (line 627)
3. **PanelSortOrderComparator.java**: Replaced deprecated `new Integer(int)` 
   constructors with `Integer.valueOf()` (line 33)
4. **SiteBrandingService.java**: Added missing `@Deprecated` annotation on 
   `validateColor()` method (line 43)

## How to Test
1. Run `mvn clean install -DskipTests 2>&1 | grep -i "warning"`
2. Verify the following warnings no longer appear:
   - `'dependencies.dependency.scope' for org.postgresql:postgresql must be one of [provided, compile, runtime, test, system]`
   - `Double(java.lang.String) has been deprecated and marked for removal`
   - `Integer(int) has been deprecated and marked for removal`
   - `deprecated item is not annotated with @Deprecated`

## Files Changed
- `pom.xml`
- `src/main/java/org/openelisglobal/common/util/StringUtil.java`
- `src/main/java/org/openelisglobal/panel/valueholder/PanelSortOrderComparator.java`
- `src/main/java/org/openelisglobal/sitebranding/service/SiteBrandingService.java`

## Screenshots
N/A (build warning fixes, no UI changes)