### PR TITLE
test: add integration tests for InventoryItemRestController

### DIFF
--- a/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
@@ -5,7 +5,8 @@ import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;

--- a/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
@@ -45,8 +45,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
         mockSession.setAttribute(IActionConstants.USER_SESSION_DATA, usd);
     }
 
-    // ==================== READ ====================
-
     @Test
     public void testGetAllActive_ShouldReturnList() throws Exception {
         mockMvc.perform(get("/rest/inventory/items")).andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
@@ -63,7 +61,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .andExpect(jsonPath("$.name").value("Test Reagent A"));
     }
 
-    // service throws → controller returns 500
     @Test
     public void testGetById_NotFound_ShouldReturn500() throws Exception {
         mockMvc.perform(get("/rest/inventory/items/999999")).andExpect(status().isInternalServerError());
@@ -75,7 +72,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .andExpect(jsonPath("$").isArray());
     }
 
-    // enum conversion may fail → 500 possible
     @Test
     public void testGetByType_ShouldReturnList() throws Exception {
         mockMvc.perform(get("/rest/inventory/items/type/REAGENT")).andExpect(result -> {
@@ -96,8 +92,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .andExpect(jsonPath("$").isArray());
     }
 
-    // ==================== BUSINESS ====================
-
     @Test
     public void testGetStock_ShouldReturnCorrectData() throws Exception {
         mockMvc.perform(get("/rest/inventory/items/1000/stock")).andExpect(status().isOk())
@@ -115,8 +109,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
         mockMvc.perform(get("/rest/inventory/items/low-stock")).andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());
     }
-
-    // ==================== CREATE ====================
 
     @Test
     public void testCreate_ShouldCreateItem() throws Exception {
@@ -161,7 +153,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .andExpect(jsonPath("$.fhirUuid").value(uuid.toString()));
     }
 
-    // validation not handled → 500
     @Test
     public void testCreate_Invalid_ShouldReturn500() throws Exception {
         InventoryItem item = new InventoryItem();
@@ -170,8 +161,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .content(objectMapper.writeValueAsString(item)).session(mockSession))
                 .andExpect(status().isInternalServerError());
     }
-
-    // ==================== UPDATE ====================
 
     @Test
     public void testUpdate_ShouldUpdateItem() throws Exception {
@@ -185,7 +174,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .andExpect(jsonPath("$.name").value("Updated Name"));
     }
 
-    // service throws → 500
     @Test
     public void testUpdate_NotFound_ShouldReturn500() throws Exception {
         InventoryItem item = new InventoryItem();
@@ -196,8 +184,6 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
                 .content(objectMapper.writeValueAsString(item)).session(mockSession))
                 .andExpect(status().isInternalServerError());
     }
-
-    // ==================== ACTIVATE / DEACTIVATE ====================
 
     @Test
     public void testDeactivate_ShouldWork() throws Exception {

--- a/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
@@ -1,0 +1,215 @@
+package org.openelisglobal.inventory.controller.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.inventory.service.InventoryItemService;
+import org.openelisglobal.inventory.valueholder.InventoryEnums.ItemType;
+import org.openelisglobal.inventory.valueholder.InventoryItem;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.annotation.Rollback;
+
+@Rollback
+public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private InventoryItemService inventoryItemService;
+
+    private ObjectMapper objectMapper;
+    private MockHttpSession mockSession;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/inventory-test-data.xml");
+
+        objectMapper = new ObjectMapper();
+
+        UserSessionData usd = new UserSessionData();
+        usd.setSytemUserId(1);
+
+        mockSession = new MockHttpSession();
+        mockSession.setAttribute(IActionConstants.USER_SESSION_DATA, usd);
+    }
+
+    // ==================== READ ====================
+
+    @Test
+    public void testGetAllActive_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items")).andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    public void testGetAll_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/all")).andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    public void testGetById_ValidId_ShouldReturnItem() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/1000")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Test Reagent A"));
+    }
+
+    // service throws → controller returns 500
+    @Test
+    public void testGetById_NotFound_ShouldReturn500() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/999999")).andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    public void testGetAllItemTypes_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/types")).andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    // enum conversion may fail → 500 possible
+    @Test
+    public void testGetByType_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/type/REAGENT")).andExpect(result -> {
+            int status = result.getResponse().getStatus();
+            assertTrue(status == 200 || status == 500);
+        });
+    }
+
+    @Test
+    public void testGetByCategory_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/category/CHEMISTRY")).andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].category").value("CHEMISTRY"));
+    }
+
+    @Test
+    public void testSearch_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/search").param("query", "Reagent")).andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    // ==================== BUSINESS ====================
+
+    @Test
+    public void testGetStock_ShouldReturnCorrectData() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/1000/stock")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.quantity").value(150.0)).andExpect(jsonPath("$.inStock").value(true));
+    }
+
+    @Test
+    public void testGetStock_NonExistent_ShouldReturnZero() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/99999/stock")).andExpect(status().isOk())
+                .andExpect(jsonPath("$.quantity").value(0.0)).andExpect(jsonPath("$.inStock").value(false));
+    }
+
+    @Test
+    public void testGetLowStock_ShouldReturnList() throws Exception {
+        mockMvc.perform(get("/rest/inventory/items/low-stock")).andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    // ==================== CREATE ====================
+
+    @Test
+    public void testCreate_ShouldCreateItem() throws Exception {
+        InventoryItem item = new InventoryItem();
+        item.setName("PR Test Item");
+        item.setItemType(ItemType.REAGENT);
+        item.setUnits("mL");
+        item.setLowStockThreshold(10);
+        item.setIsActive("Y");
+
+        mockMvc.perform(post("/rest/inventory/items").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("PR Test Item"));
+    }
+
+    @Test
+    public void testCreate_ShouldAutoGenerateUuid() throws Exception {
+        InventoryItem item = new InventoryItem();
+        item.setName("Auto UUID Item");
+        item.setItemType(ItemType.REAGENT);
+        item.setUnits("mL");
+        item.setIsActive("Y");
+
+        mockMvc.perform(post("/rest/inventory/items").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fhirUuid").isNotEmpty());
+    }
+
+    @Test
+    public void testCreate_ShouldPreserveUuid() throws Exception {
+        UUID uuid = UUID.randomUUID();
+
+        InventoryItem item = new InventoryItem();
+        item.setName("UUID Test");
+        item.setItemType(ItemType.REAGENT);
+        item.setUnits("mL");
+        item.setIsActive("Y");
+        item.setFhirUuid(uuid);
+
+        mockMvc.perform(post("/rest/inventory/items").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession)).andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fhirUuid").value(uuid.toString()));
+    }
+
+    // validation not handled → 500
+    @Test
+    public void testCreate_Invalid_ShouldReturn500() throws Exception {
+        InventoryItem item = new InventoryItem();
+
+        mockMvc.perform(post("/rest/inventory/items").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession))
+                .andExpect(status().isInternalServerError());
+    }
+
+    // ==================== UPDATE ====================
+
+    @Test
+    public void testUpdate_ShouldUpdateItem() throws Exception {
+        InventoryItem item = new InventoryItem();
+        item.setName("Updated Name");
+        item.setItemType(ItemType.REAGENT);
+        item.setUnits("mL"); // avoid null issues
+
+        mockMvc.perform(put("/rest/inventory/items/1000").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Updated Name"));
+    }
+
+    // service throws → 500
+    @Test
+    public void testUpdate_NotFound_ShouldReturn500() throws Exception {
+        InventoryItem item = new InventoryItem();
+        item.setName("Ghost");
+        item.setItemType(ItemType.REAGENT);
+
+        mockMvc.perform(put("/rest/inventory/items/999999").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(item)).session(mockSession))
+                .andExpect(status().isInternalServerError());
+    }
+
+    // ==================== ACTIVATE / DEACTIVATE ====================
+
+    @Test
+    public void testDeactivate_ShouldWork() throws Exception {
+        mockMvc.perform(put("/rest/inventory/items/1001/deactivate").session(mockSession)).andExpect(status().isOk());
+
+        assertEquals("N", inventoryItemService.get(1001L).getIsActive());
+    }
+
+    @Test
+    public void testActivate_ShouldWork() throws Exception {
+        mockMvc.perform(put("/rest/inventory/items/1000/activate").session(mockSession)).andExpect(status().isOk());
+
+        assertEquals("Y", inventoryItemService.get(1000L).getIsActive());
+    }
+}

--- a/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestControllerTest.java
@@ -1,7 +1,6 @@
 package org.openelisglobal.inventory.controller.rest;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -75,10 +74,8 @@ public class InventoryItemRestControllerTest extends BaseWebContextSensitiveTest
 
     @Test
     public void testGetByType_ShouldReturnList() throws Exception {
-        mockMvc.perform(get("/rest/inventory/items/type/REAGENT")).andExpect(result -> {
-            int status = result.getResponse().getStatus();
-            assertTrue(status == 200 || status == 500);
-        });
+        mockMvc.perform(get("/rest/inventory/items/type/REAGENT")).andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray()).andExpect(jsonPath("$[0].itemType").value("REAGENT"));
     }
 
     @Test


### PR DESCRIPTION
- Added 19 test cases covering CRUD, stock logic, and UUID generation.
- Implemented session handling using UserSessionData.
- Configured error handling tests to match controller's 500 status responses.

Closes #3397

# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
-Added 19 integration test cases for InventoryItemRestController.
-Covered CRUD operations, stock logic, and FHIR UUID generation.
-Handled session data and verified 500 error responses for service exceptions.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue
Closes #3397

## Other

[Add any additional information or notes here]
