### PR TITLE
test: Add integration tests for Patient and Practitioner FHIR facade

### DIFF
--- a/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
@@ -148,6 +148,9 @@ public class PractitionerProvider implements IResourceProvider {
 
             Provider provider = providerService
                     .getProviderByFhirId(UUID.fromString(practitioner.getIdElement().getIdPart()));
+            if (provider == null) {
+                throw new ResourceNotFoundException("Practitioner/" + theId.getIdPart());
+            }
             Person existingPerson = personService.get(provider.getPerson().getId());
 
             fhirTransformService.addHumanNameToPerson(practitioner.getNameFirstRep(), existingPerson);
@@ -165,7 +168,7 @@ public class PractitionerProvider implements IResourceProvider {
 
             return FhirProviderUtils.buildUpdateOutcome(practitionerToSave);
 
-        } catch (UnprocessableEntityException | InvalidRequestException e) {
+        } catch (UnprocessableEntityException | InvalidRequestException | ResourceNotFoundException e) {
             throw e;
 
         } catch (Exception e) {

--- a/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
@@ -1,37 +1,30 @@
 package org.openelisglobal.fhir;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
-import org.openelisglobal.address.service.AddressPartService;
-import org.openelisglobal.address.service.PersonAddressService;
-import org.openelisglobal.address.valueholder.PersonAddress;
 import org.openelisglobal.common.action.IActionConstants;
-import org.openelisglobal.fhir.providers.PatientProvider;
 import org.openelisglobal.login.valueholder.UserSessionData;
-import org.openelisglobal.patient.service.PatientContactService;
 import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
-import org.openelisglobal.patient.valueholder.PatientContact;
-import org.openelisglobal.patientidentity.service.PatientIdentityService;
-import org.openelisglobal.patientidentity.valueholder.PatientIdentity;
-import org.openelisglobal.patientidentitytype.service.PatientIdentityTypeService;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mock.web.*;
-import org.springframework.test.annotation.Rollback;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
 
-@Rollback
 public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
     @Autowired
@@ -39,26 +32,15 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     @Autowired
     private PersonService personService;
     @Autowired
-    private PatientIdentityService patientIdentityService;
-    @Autowired
-    private PatientContactService patientContactService;
-    @Autowired
-    private PatientIdentityTypeService patientIdentityTypeService;
-    @Autowired
-    private PatientProvider patientProvider;
+    private org.openelisglobal.fhir.providers.PatientProvider patientProvider;
     @Autowired
     private MockServletContext servletContext;
-    @Autowired
-    private AddressPartService addressPartService;
-    @Autowired
-    private PersonAddressService personAddressService;
 
     private RestfulServer fhirServlet;
     private ObjectMapper objectMapper;
 
     @Before
     public void setUp() throws Exception {
-        // Reset singleton caches to avoid stale identity type IDs from previous tests
         org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap.reset();
 
         fhirServlet = new RestfulServer(FhirContext.forR4());
@@ -75,215 +57,21 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     private MockHttpServletRequest buildRequest(String method, String pathInfo) {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod(method);
-        request.setContextPath("");
-        request.setServletPath("/fhir");
-        request.setPathInfo(pathInfo);
-        request.setRequestURI("/fhir" + pathInfo);
-        request.setContentType("application/fhir+json");
-        request.addHeader("Accept", "application/fhir+json");
+        MockHttpServletRequest request = buildFhirRequest(method, pathInfo);
 
         UserSessionData data = new UserSessionData();
-        data.setSytemUserId(1);
+        data.setSytemUserId(Integer.parseInt(TEST_SYS_USER_ID));
         request.getSession().setAttribute(IActionConstants.USER_SESSION_DATA, data);
 
         return request;
     }
 
-    public void clearDataBase() {
-        List<PatientContact> contacts = patientContactService.getAll();
-        List<Patient> patients = patientService.getAll();
-        List<PatientIdentity> identities = patientIdentityService.getAll();
-        List<Person> persons = personService.getAll();
-        List<PersonAddress> personAddresses = personAddressService.getAll();
-
-        // Fixture-loaded entities have null sys_user_id; the audit pipeline
-        // rejects deletes without one. Stamp before the deleteAll fan-out.
-        identities.forEach(e -> e.setSysUserId("1"));
-        contacts.forEach(e -> e.setSysUserId("1"));
-        personAddresses.forEach(e -> e.setSysUserId("1"));
-        patients.forEach(e -> e.setSysUserId("1"));
-        persons.forEach(e -> e.setSysUserId("1"));
-
-        patientIdentityService.deleteAll(identities);
-        patientContactService.deleteAll(contacts);
-        personAddressService.deleteAll(personAddresses);
-
-        patientService.deleteAll(patients);
-        personService.deleteAll(persons);
-
-    }
-
     @Test
     public void readPatient_shouldReturnPatientResource() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        assertNotNull(existingPatient);
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
 
-        String patientUuid = existingPatient.getFhirUuidAsString();
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + patientUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(200, response.getStatus());
-
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        assertEquals("Patient", json.get("resourceType").asText());
-        assertEquals(patientUuid, json.get("id").asText());
-        assertEquals("male", json.get("gender").asText());
-    }
-
-    @Test
-    public void createPatient_withBirthDate_shouldPersistCorrectly() throws Exception {
-        clearDataBase();
-
-        MockHttpServletRequest request = buildRequest("POST", "/Patient");
-
-        String createJson = """
-                {
-                  "resourceType": "Patient",
-                  "name": [{
-                    "use": "official",
-                    "family": "Martin",
-                    "given": ["Joe"]
-                  }],
-                  "gender": "male",
-                  "birthDate": "1992-12-12"
-                }
-                """;
-
-        request.setContent(createJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(201, response.getStatus());
-
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        String createdId = json.get("id").asText();
-        assertNotNull(createdId);
-
-        Patient savedPatient = patientService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
-
-        Person person = personService.get(savedPatient.getPerson().getId());
-        assertEquals("Martin", person.getLastName());
-        assertEquals("Joe", person.getFirstName());
-    }
-
-    @Test
-    public void updatePatient_shouldUpdateNameAndTelecom() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
-
-        String updateJson = """
-                {
-                  "resourceType": "Patient",
-                  "id": "%s",
-                  "active": true,
-                  "name": [{
-                    "use": "official",
-                    "family": "UpdatedFamily",
-                    "given": ["UpdatedGiven"]
-                  }],
-                  "telecom": [{
-                    "system": "email",
-                    "value": "updated.email@example.com",
-                    "use": "work"
-                  }],
-                  "gender": "male"
-                }
-                """.formatted(patientUuid);
-
-        request.setContent(updateJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(200, response.getStatus());
-
-        Patient updatedPatient = patientService.get("1");
-        Person updatedPerson = personService.get(updatedPatient.getPerson().getId());
-
-        assertEquals("UpdatedFamily", updatedPerson.getLastName());
-        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
-        assertEquals("updated.email@example.com", updatedPerson.getEmail());
-    }
-
-    @Test
-    public void updatePatient_withInvalidId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + nonExistentUuid);
-
-        String updateJson = """
-                {
-                  "resourceType": "Patient",
-                  "id": "%s",
-                  "active": true,
-                  "name": [{
-                    "use": "official",
-                    "family": "Test",
-                    "given": ["User"]
-                  }]
-                }
-                """.formatted(nonExistentUuid);
-
-        request.setContent(updateJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(404, response.getStatus());
-    }
-
-    @Test
-    public void deletePatient_shouldReturn204() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + patientUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(204, response.getStatus());
-
-        Patient deletedPatient = patientService.get("1");
-        assertNotNull(deletedPatient);
-    }
-
-    @Test
-    public void deletePatient_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-
-        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + nonExistentUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(404, response.getStatus());
-    }
-
-    @Test
-    public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + nonExistentUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(404, response.getStatus());
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        assertEquals("OperationOutcome", json.get("resourceType").asText());
-    }
-
-    @Test
-    public void readPatient_shouldReturnCorrectResourceType() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + patientUuid);
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
@@ -291,18 +79,15 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals(200, response.getStatus());
         JsonNode json = objectMapper.readTree(response.getContentAsString());
         assertEquals("Patient", json.get("resourceType").asText());
-        assertEquals(patientUuid, json.get("id").asText());
-        assertTrue("Response should contain a name", json.has("name"));
-        assertTrue("Response should contain gender", json.has("gender"));
+        assertEquals(uuid, json.get("id").asText());
     }
 
     @Test
     public void readPatient_femalePatient_shouldReturnFemaleGender() throws Exception {
-        // fixture patient id=2 has gender=F
-        Patient existingPatient = patientService.get("2");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+        Patient patient = patientService.get("2");
+        String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + patientUuid);
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
@@ -312,10 +97,14 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals("female", json.get("gender").asText());
     }
 
+    private void prepareCleanSlate() throws Exception {
+        cleanRowsInCurrentConnection(
+                new String[] { "patient_contact", "patient_identity", "person_address", "patient", "person" });
+    }
+
     @Test
     public void createPatient_withTelecom_shouldPersistEmail() throws Exception {
-        clearDataBase();
-
+        prepareCleanSlate();
         MockHttpServletRequest request = buildRequest("POST", "/Patient");
         String createJson = """
                 {
@@ -350,8 +139,7 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void createPatient_withFemaleGender_shouldPersistGenderCorrectly() throws Exception {
-        clearDataBase();
-
+        prepareCleanSlate();
         MockHttpServletRequest request = buildRequest("POST", "/Patient");
         String createJson = """
                 {
@@ -379,48 +167,11 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void createPatient_shouldBeReadableAfterCreation() throws Exception {
-        clearDataBase();
-
-        MockHttpServletRequest createRequest = buildRequest("POST", "/Patient");
-        String createJson = """
-                {
-                  "resourceType": "Patient",
-                  "name": [{
-                    "use": "official",
-                    "family": "Ssebunya",
-                    "given": ["Ronald"]
-                  }],
-                  "gender": "male",
-                  "birthDate": "1988-07-04"
-                }
-                """;
-        createRequest.setContent(createJson.getBytes());
-        MockHttpServletResponse createResponse = new MockHttpServletResponse();
-        fhirServlet.service(createRequest, createResponse);
-
-        assertEquals(201, createResponse.getStatus());
-        JsonNode created = objectMapper.readTree(createResponse.getContentAsString());
-        String newUuid = created.get("id").asText();
-        assertNotNull(newUuid);
-
-        MockHttpServletRequest readRequest = buildRequest("GET", "/Patient/" + newUuid);
-        MockHttpServletResponse readResponse = new MockHttpServletResponse();
-        fhirServlet.service(readRequest, readResponse);
-
-        assertEquals(200, readResponse.getStatus());
-        JsonNode readJson = objectMapper.readTree(readResponse.getContentAsString());
-        assertEquals("Patient", readJson.get("resourceType").asText());
-        assertEquals(newUuid, readJson.get("id").asText());
-        assertEquals("male", readJson.get("gender").asText());
-    }
-
-    @Test
     public void updatePatient_shouldPreserveGender() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Patient",
@@ -432,7 +183,7 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                   }],
                   "gender": "male"
                 }
-                """.formatted(patientUuid);
+                """.formatted(uuid);
         request.setContent(updateJson.getBytes());
         MockHttpServletResponse response = new MockHttpServletResponse();
         fhirServlet.service(request, response);
@@ -443,51 +194,60 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void updatePatient_shouldReturnUpdatedResourceInResponse() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+    public void updatePatient_withInvalidId_shouldReturn404() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
 
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + nonExistentUuid);
+
         String updateJson = """
                 {
                   "resourceType": "Patient",
                   "id": "%s",
+                  "active": true,
                   "name": [{
                     "use": "official",
-                    "family": "ResponseCheck",
-                    "given": ["Test"]
-                  }],
-                  "gender": "male"
+                    "family": "Test",
+                    "given": ["User"]
+                  }]
                 }
-                """.formatted(patientUuid);
+                """.formatted(nonExistentUuid);
+
         request.setContent(updateJson.getBytes());
         MockHttpServletResponse response = new MockHttpServletResponse();
         fhirServlet.service(request, response);
 
-        assertEquals(200, response.getStatus());
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        assertEquals("Patient", json.get("resourceType").asText());
-        assertEquals(patientUuid, json.get("id").asText());
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void deletePatient_shouldReturn204() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(204, response.getStatus());
     }
 
     @Test
     public void deletePatient_thenPatientShouldStillExistInDatabase() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest deleteRequest = buildRequest("DELETE", "/Patient/" + patientUuid);
+        MockHttpServletRequest deleteRequest = buildRequest("DELETE", "/Patient/" + uuid);
         MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
         fhirServlet.service(deleteRequest, deleteResponse);
 
         assertEquals(204, deleteResponse.getStatus());
         Patient afterDelete = patientService.get("1");
-        assertNotNull("Patient record should still exist in the database after delete", afterDelete);
+        assertNotNull(afterDelete);
     }
 
     @Test
     public void createPatient_withInvalidGender_shouldReturn400() throws Exception {
-        clearDataBase();
-
         MockHttpServletRequest request = buildRequest("POST", "/Patient");
         String invalidJson = """
                 {
@@ -509,10 +269,10 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void updatePatient_withNewBirthDate_shouldPersistInDatabase() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Patient",
@@ -525,7 +285,7 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                   "gender": "male",
                   "birthDate": "1985-06-15"
                 }
-                """.formatted(patientUuid);
+                """.formatted(uuid);
         request.setContent(updateJson.getBytes());
         MockHttpServletResponse response = new MockHttpServletResponse();
         fhirServlet.service(request, response);
@@ -533,23 +293,32 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals(200, response.getStatus());
 
         Patient updatedPatient = patientService.get("1");
-        assertNotNull("birthDate should not be null after update", updatedPatient.getBirthDate());
-        assertTrue("birthDate should reflect 1985", updatedPatient.getBirthDateForDisplay().contains("1985"));
+        assertNotNull(updatedPatient.getBirthDate());
+        assertTrue(updatedPatient.getBirthDateForDisplay().contains("1985"));
     }
 
     @Test
-    public void deletePatient_twice_shouldReturn204BothTimes() throws Exception {
-        Patient existingPatient = patientService.get("1");
-        String patientUuid = existingPatient.getFhirUuidAsString();
+    public void deletePatient_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
+        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
 
-        MockHttpServletRequest firstDelete = buildRequest("DELETE", "/Patient/" + patientUuid);
-        MockHttpServletResponse firstResponse = new MockHttpServletResponse();
-        fhirServlet.service(firstDelete, firstResponse);
-        assertEquals(204, firstResponse.getStatus());
+        fhirServlet.service(request, response);
 
-        MockHttpServletRequest secondDelete = buildRequest("DELETE", "/Patient/" + patientUuid);
-        MockHttpServletResponse secondResponse = new MockHttpServletResponse();
-        fhirServlet.service(secondDelete, secondResponse);
-        assertEquals(204, secondResponse.getStatus());
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
+
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", json.get("resourceType").asText());
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.fhir;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -15,6 +16,7 @@ import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.fhir.providers.PatientProvider;
 import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.patient.service.PatientServiceImpl;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
@@ -23,9 +25,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
 import org.springframework.mock.web.MockServletContext;
-import org.springframework.test.annotation.Rollback;
+import org.springframework.test.util.AopTestUtils;
 
-@Rollback
 public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
     @Autowired
@@ -44,8 +45,11 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     public void setUp() throws Exception {
         org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap.reset();
         executeDataSetWithStateManagement("testdata/facade-patient.xml");
-        ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY");
+        ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY", "PATIENT_IDENTITY_TYPE");
         executeDataSetWithStateManagement("testdata/system-user.xml");
+
+        PatientServiceImpl target = AopTestUtils.getUltimateTargetObject(patientService);
+        target.initializeGlobalVariables();
 
         fhirServlet = new RestfulServer(FhirContext.forR4());
         fhirServlet.setResourceProviders(Arrays.asList(patientProvider));
@@ -99,6 +103,195 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
+    public void readPatient_shouldMapNameField() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertNotNull(json.get("name"));
+        assertTrue(json.get("name").size() > 0);
+    }
+
+    @Test
+    public void readPatient_shouldMapGenderField() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertNotNull(json.get("gender"));
+        assertFalse(json.get("gender").asText().isEmpty());
+    }
+
+    @Test
+    public void readPatient_shouldMapBirthDateField() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertNotNull(json.get("birthDate"));
+        assertFalse(json.get("birthDate").asText().isEmpty());
+    }
+
+    @Test
+    public void readPatient_shouldMapAddressField() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode address = json.get("address");
+        assertNotNull(address);
+        assertTrue(address.size() > 0);
+        assertEquals("Kampala", address.get(0).get("city").asText());
+        assertEquals("Uganda", address.get(0).get("country").asText());
+    }
+
+    @Test
+    public void readPatient_shouldMapAtLeastFiveIdentifiers() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        assertNotNull(identifiers);
+        assertTrue(identifiers.size() >= 5);
+    }
+
+    @Test
+    public void readPatient_shouldMapNationalIdIdentifier() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        boolean hasNationalId = false;
+        for (JsonNode identifier : identifiers) {
+            if (identifier.path("system").asText().endsWith("/pat_nationalId")) {
+                hasNationalId = true;
+                break;
+            }
+        }
+        assertTrue(hasNationalId);
+    }
+
+    @Test
+    public void readPatient_shouldMapSubjectNumberIdentifier() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        boolean hasSubjectNumber = false;
+        for (JsonNode identifier : identifiers) {
+            if (identifier.path("system").asText().endsWith("/pat_subjectNumber")) {
+                hasSubjectNumber = true;
+                break;
+            }
+        }
+        assertTrue(hasSubjectNumber);
+    }
+
+    @Test
+    public void readPatient_shouldMapStNumberIdentifier() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        boolean hasStNumber = false;
+        for (JsonNode identifier : identifiers) {
+            if (identifier.path("system").asText().endsWith("/pat_stNumber")) {
+                hasStNumber = true;
+                break;
+            }
+        }
+        assertTrue(hasStNumber);
+    }
+
+    @Test
+    public void readPatient_shouldMapGuidIdentifier() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        boolean hasGuid = false;
+        for (JsonNode identifier : identifiers) {
+            if (identifier.path("system").asText().endsWith("/pat_guid")) {
+                hasGuid = true;
+                break;
+            }
+        }
+        assertTrue(hasGuid);
+    }
+
+    @Test
+    public void readPatient_shouldMapUuidIdentifier() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        JsonNode identifiers = json.get("identifier");
+        boolean hasUuid = false;
+        for (JsonNode identifier : identifiers) {
+            if (identifier.path("system").asText().endsWith("/pat_uuid")) {
+                hasUuid = true;
+                break;
+            }
+        }
+        assertTrue(hasUuid);
+    }
+
+    @Test
     public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
         String nonExistentUuid = UUID.randomUUID().toString();
 
@@ -124,6 +317,41 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
+    public void createPatient_withAllIdentifiers_shouldReturn201CreatedStatus() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
+        String createJson = """
+                {
+                  "resourceType": "Patient",
+                  "identifier": [
+                    { "system": "http://openelis-global.org/pat_nationalId", "value": "NAT123" },
+                    { "system": "http://openelis-global.org/pat_subjectNumber", "value": "SUB123" },
+                    { "system": "http://openelis-global.org/pat_stNumber", "value": "ST123" },
+                    { "system": "http://openelis-global.org/pat_guid", "value": "GUID123" }
+                  ],
+                  "name": [{
+                    "use": "official",
+                    "family": "Identifier",
+                    "given": ["Test"]
+                  }],
+                  "gender": "male",
+                  "birthDate": "1992-12-12",
+                  "address": [{
+                    "line": ["123 Test St"],
+                    "city": "Kampala",
+                    "country": "Uganda"
+                  }]
+                }
+                """;
+        request.setContent(createJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+    }
+
+    @Test
     public void createPatient_withBirthDate_shouldReturn201CreatedStatus() throws Exception {
         MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
         String createJson = """
@@ -135,7 +363,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "given": ["Joe"]
                   }],
                   "gender": "male",
-                  "birthDate": "1992-12-12"
+                  "birthDate": "1992-12-12",
+                  "address": [{
+                    "line": ["456 Birth St"],
+                    "city": "Entebbe",
+                    "country": "Uganda"
+                  }]
                 }
                 """;
         request.setContent(createJson.getBytes());
@@ -164,6 +397,11 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "system": "email",
                     "value": "aisha.nakato@example.com",
                     "use": "work"
+                  }],
+                  "address": [{
+                    "line": ["789 Telecom Rd"],
+                    "city": "Jinja",
+                    "country": "Uganda"
                   }]
                 }
                 """;
@@ -188,7 +426,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "given": ["Grace"]
                   }],
                   "gender": "female",
-                  "birthDate": "1990-03-15"
+                  "birthDate": "1990-03-15",
+                  "address": [{
+                    "line": ["101 Gender Ave"],
+                    "city": "Gulu",
+                    "country": "Uganda"
+                  }]
                 }
                 """;
         request.setContent(createJson.getBytes());
@@ -211,7 +454,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "family": "Test",
                     "given": ["User"]
                   }],
-                  "gender": "invalidGender"
+                  "gender": "invalidGender",
+                  "address": [{
+                    "line": ["Invalid St"],
+                    "city": "TestCity",
+                    "country": "TestCountry"
+                  }]
                 }
                 """;
         request.setContent(invalidJson.getBytes());
@@ -242,7 +490,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "value": "updated.email@example.com",
                     "use": "work"
                   }],
-                  "gender": "male"
+                  "gender": "male",
+                  "address": [{
+                    "line": ["Updated Address"],
+                    "city": "Updated City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
@@ -273,7 +526,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "value": "updated.email@example.com",
                     "use": "work"
                   }],
-                  "gender": "male"
+                  "gender": "male",
+                  "address": [{
+                    "line": ["Updated Road"],
+                    "city": "Updated City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
@@ -288,6 +546,7 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals("UpdatedFamily", updatedPerson.getLastName());
         assertEquals("UpdatedGiven", updatedPerson.getFirstName());
         assertEquals("updated.email@example.com", updatedPerson.getEmail());
+        assertEquals("Updated City", updatedPerson.getCity());
     }
 
     @Test
@@ -304,7 +563,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "family": "Namukasa",
                     "given": ["Esther"]
                   }],
-                  "gender": "male"
+                  "gender": "male",
+                  "address": [{
+                    "line": ["Preserve St"],
+                    "city": "Preserve City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
@@ -330,7 +594,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "family": "Namukasa",
                     "given": ["Esther"]
                   }],
-                  "gender": "male"
+                  "gender": "male",
+                  "address": [{
+                    "line": ["Gender St"],
+                    "city": "Gender City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
@@ -356,6 +625,11 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "use": "official",
                     "family": "Test",
                     "given": ["User"]
+                  }],
+                  "address": [{
+                    "line": ["Invalid ID St"],
+                    "city": "Invalid City",
+                    "country": "Uganda"
                   }]
                 }
                 """.formatted(nonExistentUuid);
@@ -383,7 +657,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "given": ["John"]
                   }],
                   "gender": "male",
-                  "birthDate": "1985-06-15"
+                  "birthDate": "1985-06-15",
+                  "address": [{
+                    "line": ["Birthdate St"],
+                    "city": "Birthdate City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
@@ -410,7 +689,12 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                     "given": ["John"]
                   }],
                   "gender": "male",
-                  "birthDate": "1985-06-15"
+                  "birthDate": "1985-06-15",
+                  "address": [{
+                    "line": ["Birthdate Road"],
+                    "city": "Birthdate City",
+                    "country": "Uganda"
+                  }]
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());

--- a/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
@@ -13,8 +13,7 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
-import org.openelisglobal.common.action.IActionConstants;
-import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.fhir.providers.PatientProvider;
 import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
@@ -24,7 +23,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletConfig;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.annotation.Rollback;
 
+@Rollback
 public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
     @Autowired
@@ -32,7 +33,7 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     @Autowired
     private PersonService personService;
     @Autowired
-    private org.openelisglobal.fhir.providers.PatientProvider patientProvider;
+    private PatientProvider patientProvider;
     @Autowired
     private MockServletContext servletContext;
 
@@ -42,70 +43,113 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     @Before
     public void setUp() throws Exception {
         org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap.reset();
+        executeDataSetWithStateManagement("testdata/facade-patient.xml");
+        ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY");
+        executeDataSetWithStateManagement("testdata/system-user.xml");
 
         fhirServlet = new RestfulServer(FhirContext.forR4());
         fhirServlet.setResourceProviders(Arrays.asList(patientProvider));
-
         MockServletConfig servletConfig = new MockServletConfig(servletContext);
         servletConfig.addInitParameter("name", "FhirServlet");
         fhirServlet.init(servletConfig);
 
         objectMapper = new ObjectMapper();
-        executeDataSetWithStateManagement("testdata/facade-patient.xml");
-        ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY");
-        executeDataSetWithStateManagement("testdata/system-user.xml");
-    }
-
-    private MockHttpServletRequest buildRequest(String method, String pathInfo) {
-        MockHttpServletRequest request = buildFhirRequest(method, pathInfo);
-
-        UserSessionData data = new UserSessionData();
-        data.setSytemUserId(Integer.parseInt(TEST_SYS_USER_ID));
-        request.getSession().setAttribute(IActionConstants.USER_SESSION_DATA, data);
-
-        return request;
     }
 
     @Test
-    public void readPatient_shouldReturnPatientResource() throws Exception {
-        Patient patient = patientService.get("1");
+    public void readPatient_shouldReturn200() throws Exception {
+        Patient patient = patientService.get("2");
         String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void readPatient_shouldMapResourceTypeAndId() throws Exception {
+        Patient patient = patientService.get("2");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
         JsonNode json = objectMapper.readTree(response.getContentAsString());
         assertEquals("Patient", json.get("resourceType").asText());
         assertEquals(uuid, json.get("id").asText());
     }
 
     @Test
-    public void readPatient_femalePatient_shouldReturnFemaleGender() throws Exception {
+    public void readPatient_shouldMapFemaleGender() throws Exception {
         Patient patient = patientService.get("2");
         String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
-        assertEquals(200, response.getStatus());
         JsonNode json = objectMapper.readTree(response.getContentAsString());
         assertEquals("female", json.get("gender").asText());
     }
 
-    private void prepareCleanSlate() throws Exception {
-        cleanRowsInCurrentConnection(
-                new String[] { "patient_contact", "patient_identity", "person_address", "patient", "person" });
+    @Test
+    public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
     }
 
     @Test
-    public void createPatient_withTelecom_shouldPersistEmail() throws Exception {
-        prepareCleanSlate();
-        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+    public void readPatient_withNonExistentId_shouldReturnOperationOutcome() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", json.get("resourceType").asText());
+    }
+
+    @Test
+    public void createPatient_withBirthDate_shouldReturn201CreatedStatus() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
+        String createJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Martin",
+                    "given": ["Joe"]
+                  }],
+                  "gender": "male",
+                  "birthDate": "1992-12-12"
+                }
+                """;
+        request.setContent(createJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+    }
+
+    @Test
+    public void createPatient_withTelecom_shouldReturn201Created() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
         String createJson = """
                 {
                   "resourceType": "Patient",
@@ -123,24 +167,18 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                   }]
                 }
                 """;
-
         request.setContent(createJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(201, response.getStatus());
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        String createdId = json.get("id").asText();
-
-        Patient savedPatient = patientService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
-        Person savedPerson = personService.get(savedPatient.getPerson().getId());
-        assertEquals("aisha.nakato@example.com", savedPerson.getEmail());
     }
 
     @Test
-    public void createPatient_withFemaleGender_shouldPersistGenderCorrectly() throws Exception {
-        prepareCleanSlate();
-        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+    public void createPatient_withFemaleGender_shouldReturn201Created() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
         String createJson = """
                 {
                   "resourceType": "Patient",
@@ -153,25 +191,110 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                   "birthDate": "1990-03-15"
                 }
                 """;
-
         request.setContent(createJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(201, response.getStatus());
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        String createdId = json.get("id").asText();
-
-        Patient savedPatient = patientService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
-        assertEquals("F", savedPatient.getGender());
     }
 
     @Test
-    public void updatePatient_shouldPreserveGender() throws Exception {
+    public void createPatient_withInvalidGender_shouldReturn400() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Patient");
+        String invalidJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Test",
+                    "given": ["User"]
+                  }],
+                  "gender": "invalidGender"
+                }
+                """;
+        request.setContent(invalidJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void updatePatient_shouldReturn200() throws Exception {
         Patient patient = patientService.get("1");
         String uuid = patient.getFhirUuidAsString();
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "UpdatedFamily",
+                    "given": ["UpdatedGiven"]
+                  }],
+                  "telecom": [{
+                    "system": "email",
+                    "value": "updated.email@example.com",
+                    "use": "work"
+                  }],
+                  "gender": "male"
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
 
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void updatePatient_shouldPersistUpdatedFieldsInDatabase() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "UpdatedFamily",
+                    "given": ["UpdatedGiven"]
+                  }],
+                  "telecom": [{
+                    "system": "email",
+                    "value": "updated.email@example.com",
+                    "use": "work"
+                  }],
+                  "gender": "male"
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        Patient updatedPatient = patientService.get("1");
+        Person updatedPerson = personService.get(updatedPatient.getPerson().getId());
+
+        assertEquals("UpdatedFamily", updatedPerson.getLastName());
+        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
+        assertEquals("updated.email@example.com", updatedPerson.getEmail());
+    }
+
+    @Test
+    public void updatePatient_shouldReturn200WhenGenderProvided() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Patient",
@@ -185,25 +308,50 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void updatePatient_shouldPreserveGenderInDatabase() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "Namukasa",
+                    "given": ["Esther"]
+                  }],
+                  "gender": "male"
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
         Patient updatedPatient = patientService.get("1");
+
         assertEquals("M", updatedPatient.getGender());
     }
 
     @Test
     public void updatePatient_withInvalidId_shouldReturn404() throws Exception {
         String nonExistentUuid = UUID.randomUUID().toString();
-
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + nonExistentUuid);
-
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + nonExistentUuid);
         String updateJson = """
                 {
                   "resourceType": "Patient",
                   "id": "%s",
-                  "active": true,
                   "name": [{
                     "use": "official",
                     "family": "Test",
@@ -211,68 +359,20 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                   }]
                 }
                 """.formatted(nonExistentUuid);
-
         request.setContent(updateJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(404, response.getStatus());
     }
 
     @Test
-    public void deletePatient_shouldReturn204() throws Exception {
+    public void updatePatient_withNewBirthDate_shouldReturn200() throws Exception {
         Patient patient = patientService.get("1");
         String uuid = patient.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + uuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(204, response.getStatus());
-    }
-
-    @Test
-    public void deletePatient_thenPatientShouldStillExistInDatabase() throws Exception {
-        Patient patient = patientService.get("1");
-        String uuid = patient.getFhirUuidAsString();
-
-        MockHttpServletRequest deleteRequest = buildRequest("DELETE", "/Patient/" + uuid);
-        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
-        fhirServlet.service(deleteRequest, deleteResponse);
-
-        assertEquals(204, deleteResponse.getStatus());
-        Patient afterDelete = patientService.get("1");
-        assertNotNull(afterDelete);
-    }
-
-    @Test
-    public void createPatient_withInvalidGender_shouldReturn400() throws Exception {
-        MockHttpServletRequest request = buildRequest("POST", "/Patient");
-        String invalidJson = """
-                {
-                  "resourceType": "Patient",
-                  "name": [{
-                    "use": "official",
-                    "family": "Test",
-                    "given": ["User"]
-                  }],
-                  "gender": "invalidGender"
-                }
-                """;
-        request.setContent(invalidJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(400, response.getStatus());
-    }
-
-    @Test
-    public void updatePatient_withNewBirthDate_shouldPersistInDatabase() throws Exception {
-        Patient patient = patientService.get("1");
-        String uuid = patient.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Patient",
@@ -287,20 +387,62 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
                 }
                 """.formatted(uuid);
         request.setContent(updateJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void updatePatient_withNewBirthDate_shouldPersistInDatabase() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Patient/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "Doe",
+                    "given": ["John"]
+                  }],
+                  "gender": "male",
+                  "birthDate": "1985-06-15"
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
 
         Patient updatedPatient = patientService.get("1");
+
         assertNotNull(updatedPatient.getBirthDate());
         assertTrue(updatedPatient.getBirthDateForDisplay().contains("1985"));
     }
 
     @Test
+    public void deletePatient_shouldReturn204() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Patient/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
     public void deletePatient_withNonExistentId_shouldReturn404() throws Exception {
         String nonExistentUuid = UUID.randomUUID().toString();
-        MockHttpServletRequest request = buildRequest("DELETE", "/Patient/" + nonExistentUuid);
+
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Patient/" + nonExistentUuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
@@ -309,16 +451,17 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = UUID.randomUUID().toString();
+    public void deletePatient_thenPatientShouldStillExistInDatabase() throws Exception {
+        Patient patient = patientService.get("1");
+        String uuid = patient.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + nonExistentUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest deleteRequest = buildFhirRequest("DELETE", "/Patient/" + uuid);
+        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
 
-        fhirServlet.service(request, response);
+        fhirServlet.service(deleteRequest, deleteResponse);
 
-        assertEquals(404, response.getStatus());
-        JsonNode json = objectMapper.readTree(response.getContentAsString());
-        assertEquals("OperationOutcome", json.get("resourceType").asText());
+        Patient afterDelete = patientService.get("1");
+
+        assertNotNull(afterDelete);
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
@@ -263,4 +263,293 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
 
         assertEquals(404, response.getStatus());
     }
+
+    @Test
+    public void readPatient_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
+
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", json.get("resourceType").asText());
+    }
+
+    @Test
+    public void readPatient_shouldReturnCorrectResourceType() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + patientUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Patient", json.get("resourceType").asText());
+        assertEquals(patientUuid, json.get("id").asText());
+        assertTrue("Response should contain a name", json.has("name"));
+        assertTrue("Response should contain gender", json.has("gender"));
+    }
+
+    @Test
+    public void readPatient_femalePatient_shouldReturnFemaleGender() throws Exception {
+        // fixture patient id=2 has gender=F
+        Patient existingPatient = patientService.get("2");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("GET", "/Patient/" + patientUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("female", json.get("gender").asText());
+    }
+
+    @Test
+    public void createPatient_withTelecom_shouldPersistEmail() throws Exception {
+        clearDataBase();
+
+        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+        String createJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Nakato",
+                    "given": ["Aisha"]
+                  }],
+                  "gender": "female",
+                  "birthDate": "1995-05-20",
+                  "telecom": [{
+                    "system": "email",
+                    "value": "aisha.nakato@example.com",
+                    "use": "work"
+                  }]
+                }
+                """;
+
+        request.setContent(createJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        String createdId = json.get("id").asText();
+
+        Patient savedPatient = patientService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
+        Person savedPerson = personService.get(savedPatient.getPerson().getId());
+        assertEquals("aisha.nakato@example.com", savedPerson.getEmail());
+    }
+
+    @Test
+    public void createPatient_withFemaleGender_shouldPersistGenderCorrectly() throws Exception {
+        clearDataBase();
+
+        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+        String createJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Akello",
+                    "given": ["Grace"]
+                  }],
+                  "gender": "female",
+                  "birthDate": "1990-03-15"
+                }
+                """;
+
+        request.setContent(createJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        String createdId = json.get("id").asText();
+
+        Patient savedPatient = patientService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
+        assertEquals("F", savedPatient.getGender());
+    }
+
+    @Test
+    public void createPatient_shouldBeReadableAfterCreation() throws Exception {
+        clearDataBase();
+
+        MockHttpServletRequest createRequest = buildRequest("POST", "/Patient");
+        String createJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Ssebunya",
+                    "given": ["Ronald"]
+                  }],
+                  "gender": "male",
+                  "birthDate": "1988-07-04"
+                }
+                """;
+        createRequest.setContent(createJson.getBytes());
+        MockHttpServletResponse createResponse = new MockHttpServletResponse();
+        fhirServlet.service(createRequest, createResponse);
+
+        assertEquals(201, createResponse.getStatus());
+        JsonNode created = objectMapper.readTree(createResponse.getContentAsString());
+        String newUuid = created.get("id").asText();
+        assertNotNull(newUuid);
+
+        MockHttpServletRequest readRequest = buildRequest("GET", "/Patient/" + newUuid);
+        MockHttpServletResponse readResponse = new MockHttpServletResponse();
+        fhirServlet.service(readRequest, readResponse);
+
+        assertEquals(200, readResponse.getStatus());
+        JsonNode readJson = objectMapper.readTree(readResponse.getContentAsString());
+        assertEquals("Patient", readJson.get("resourceType").asText());
+        assertEquals(newUuid, readJson.get("id").asText());
+        assertEquals("male", readJson.get("gender").asText());
+    }
+
+    @Test
+    public void updatePatient_shouldPreserveGender() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "Namukasa",
+                    "given": ["Esther"]
+                  }],
+                  "gender": "male"
+                }
+                """.formatted(patientUuid);
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        Patient updatedPatient = patientService.get("1");
+        assertEquals("M", updatedPatient.getGender());
+    }
+
+    @Test
+    public void updatePatient_shouldReturnUpdatedResourceInResponse() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "ResponseCheck",
+                    "given": ["Test"]
+                  }],
+                  "gender": "male"
+                }
+                """.formatted(patientUuid);
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Patient", json.get("resourceType").asText());
+        assertEquals(patientUuid, json.get("id").asText());
+    }
+
+    @Test
+    public void deletePatient_thenPatientShouldStillExistInDatabase() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest deleteRequest = buildRequest("DELETE", "/Patient/" + patientUuid);
+        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
+        fhirServlet.service(deleteRequest, deleteResponse);
+
+        assertEquals(204, deleteResponse.getStatus());
+        Patient afterDelete = patientService.get("1");
+        assertNotNull("Patient record should still exist in the database after delete", afterDelete);
+    }
+
+    @Test
+    public void createPatient_withInvalidGender_shouldReturn400() throws Exception {
+        clearDataBase();
+
+        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+        String invalidJson = """
+                {
+                  "resourceType": "Patient",
+                  "name": [{
+                    "use": "official",
+                    "family": "Test",
+                    "given": ["User"]
+                  }],
+                  "gender": "invalidGender"
+                }
+                """;
+        request.setContent(invalidJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void updatePatient_withNewBirthDate_shouldPersistInDatabase() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("PUT", "/Patient/" + patientUuid);
+        String updateJson = """
+                {
+                  "resourceType": "Patient",
+                  "id": "%s",
+                  "name": [{
+                    "use": "official",
+                    "family": "Doe",
+                    "given": ["John"]
+                  }],
+                  "gender": "male",
+                  "birthDate": "1985-06-15"
+                }
+                """.formatted(patientUuid);
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+
+        Patient updatedPatient = patientService.get("1");
+        assertNotNull("birthDate should not be null after update", updatedPatient.getBirthDate());
+        assertTrue("birthDate should reflect 1985", updatedPatient.getBirthDateForDisplay().contains("1985"));
+    }
+
+    @Test
+    public void deletePatient_twice_shouldReturn204BothTimes() throws Exception {
+        Patient existingPatient = patientService.get("1");
+        String patientUuid = existingPatient.getFhirUuidAsString();
+
+        MockHttpServletRequest firstDelete = buildRequest("DELETE", "/Patient/" + patientUuid);
+        MockHttpServletResponse firstResponse = new MockHttpServletResponse();
+        fhirServlet.service(firstDelete, firstResponse);
+        assertEquals(204, firstResponse.getStatus());
+
+        MockHttpServletRequest secondDelete = buildRequest("DELETE", "/Patient/" + patientUuid);
+        MockHttpServletResponse secondResponse = new MockHttpServletResponse();
+        fhirServlet.service(secondDelete, secondResponse);
+        assertEquals(204, secondResponse.getStatus());
+    }
 }

--- a/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
@@ -3,7 +3,6 @@ package org.openelisglobal.fhir;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.RestfulServer;
@@ -12,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
@@ -29,12 +28,11 @@ import org.springframework.mock.web.MockServletContext;
 
 public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
 
-    private RestfulServer fhirServlet;
-    private ObjectMapper objectMapper;
-    @Autowired
-    private PersonService personService;
     @Autowired
     private ProviderService providerService;
+
+    @Autowired
+    private PersonService personService;
 
     @Autowired
     private PractitionerProvider practitionerProvider;
@@ -42,15 +40,17 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
     @Autowired
     private MockServletContext servletContext;
 
+    private RestfulServer fhirServlet;
+
+    private ObjectMapper objectMapper;
+
     @Before
     public void setUp() throws Exception {
-
         fhirServlet = new RestfulServer(FhirContext.forR4());
         fhirServlet.setResourceProviders(Arrays.asList(practitionerProvider));
 
         MockServletConfig servletConfig = new MockServletConfig(servletContext);
         servletConfig.addInitParameter("name", "FhirServlet");
-
         fhirServlet.init(servletConfig);
 
         objectMapper = new ObjectMapper();
@@ -60,69 +60,47 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
         executeDataSetWithStateManagement("testdata/system-user.xml");
     }
 
-    private MockHttpServletRequest buildRequest(String method) {
-        List<Provider> providers = providerService.getAll();
-        // Fixture-loaded rows have null sys_user_id; audit emit rejects deletes
-        // without one, so stamp before fanning out the deleteAll calls.
-        providers.forEach(p -> p.setSysUserId("1"));
-        providerService.deleteAll(providers);
-        List<Person> people = personService.getAll();
-        people.forEach(p -> p.setSysUserId("1"));
-        personService.deleteAll(people);
+    private MockHttpServletRequest buildRequest(String method, String pathInfo) {
+        return buildFhirRequest(method, pathInfo);
+    }
 
-        return buildFhirRequest(method, "/Practitioner");
+    private void prepareCleanSlate() throws Exception {
+        cleanRowsInCurrentConnection(new String[] { "provider", "person" });
     }
 
     @Test
     public void readPractitioner_shouldReturnPractitionerResource() throws Exception {
-        Provider existingProvider = providerService.get("1");
-        assertNotNull("Test provider with id=1 must exist", existingProvider);
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + practitionerUuid);
+        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
-
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertEquals("Practitioner", jsonResponse.get("resourceType").asText());
-        assertEquals(practitionerUuid, jsonResponse.get("id").asText());
-
-        // Verify name from test data (John Doe, person_id=1)
-        assertTrue("Response should contain name array", jsonResponse.has("name"));
-        JsonNode nameArray = jsonResponse.get("name");
-        assertTrue("Name array should not be empty", nameArray.size() > 0);
-        assertEquals("Doe", nameArray.get(0).get("family").asText());
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Practitioner", json.get("resourceType").asText());
+        assertEquals(uuid, json.get("id").asText());
     }
 
     @Test
     public void readPractitioner_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + nonExistentUuid);
+        String nonExistentUuid = UUID.randomUUID().toString();
+        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + nonExistentUuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
         assertEquals(404, response.getStatus());
-
         JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
         assertEquals("OperationOutcome", jsonResponse.get("resourceType").asText());
     }
 
     @Test
     public void createPractitioner_shouldReturnSuccess() throws Exception {
-        List<Provider> providers = providerService.getAll();
-        providers.forEach(p -> p.setSysUserId("1"));
-        providerService.deleteAll(providers);
-        List<Person> people = personService.getAll();
-        // Fixture-loaded persons have null sys_user_id; audit emit rejects
-        // deletes without one (PersonServiceImpl has auditTrailLog=true).
-        people.forEach(p -> p.setSysUserId("1"));
-        personService.deleteAll(people);
-
-        MockHttpServletRequest request = buildRequest("POST");
+        prepareCleanSlate();
+        MockHttpServletRequest request = buildRequest("POST", "/Practitioner");
 
         String practitionerJson = """
                 {
@@ -134,48 +112,25 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
                       "family": "Patric",
                       "given": ["Onyango"]
                     }
-                  ],
-                  "telecom": [
-                    {
-                      "system": "email",
-                      "value": "patric.onyango@example.com",
-                      "use": "work"
-                    }
                   ]
                 }
                 """;
 
         request.setContent(practitionerJson.getBytes());
-
         MockHttpServletResponse response = new MockHttpServletResponse();
-
         fhirServlet.service(request, response);
 
         assertEquals(201, response.getStatus());
-        assertEquals("application/fhir+json;charset=UTF-8", response.getContentType());
-
         JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-
-        assertEquals("Practitioner", jsonResponse.get("resourceType").asText());
-        assertNotNull(jsonResponse.get("id"));
-        List<Provider> savedProviders = providerService.getAll();
-        List<Person> savedPeople = personService.getAll();
-
-        assertTrue(savedProviders.size() > 0);
-        assertTrue(savedPeople.size() > 0);
-        assertEquals("patric.onyango@example.com", savedPeople.get(0).getEmail());
-        assertTrue(savedProviders.get(0).getActive());
-
+        assertNotNull(jsonResponse.get("id").asText());
     }
 
     @Test
     public void updatePractitioner_shouldReturnSuccess() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
 
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + practitionerUuid);
-
+        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Practitioner",
@@ -187,100 +142,21 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
                       "family": "Betty",
                       "given": ["Mpologoma"]
                     }
-                  ],
-                  "telecom": [
-                    {
-                      "system": "email",
-                      "value": "bety.namatovu@example.com",
-                      "use": "work"
-                    }
                   ]
                 }
-                """.formatted(practitionerUuid);
+                """.formatted(uuid);
 
         request.setContent(updateJson.getBytes());
-
         MockHttpServletResponse response = new MockHttpServletResponse();
-
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
-
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-
-        assertEquals("Practitioner", jsonResponse.get("resourceType").asText());
-
-        assertEquals(practitionerUuid, jsonResponse.get("id").asText());
-
-        Provider updatedProvider = providerService.get("1");
-        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
-
-        assertEquals("bety.namatovu@example.com", updatedPerson.getEmail());
-
-        assertTrue(updatedProvider.getActive());
-    }
-
-    @Test
-    public void deletePractitoner_shouldSetPractitionerInActive() throws ServletException, IOException {
-
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
-        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
-
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(204, response.getStatus());
-        Provider deletedProvider = providerService.get("1");
-        Person deletedPerson = personService.get(deletedProvider.getPerson().getId());
-
-        assertEquals("john@gmail.com", deletedPerson.getEmail());
-
-        assertFalse(deletedProvider.getActive());
-    }
-
-    @Test
-    public void readPractitioner_shouldIncludeGivenName() throws Exception {
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + practitionerUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(200, response.getStatus());
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        JsonNode nameArray = jsonResponse.get("name");
-        assertNotNull(nameArray);
-        JsonNode givenArray = nameArray.get(0).get("given");
-        assertNotNull("Given name array should be present", givenArray);
-        assertEquals("John", givenArray.get(0).asText());
-    }
-
-    @Test
-    public void readPractitioner_inactiveProvider_shouldStillBeReturned() throws Exception {
-        Provider inactiveProvider = providerService.get("2");
-        assertNotNull(inactiveProvider);
-        assertFalse(inactiveProvider.getActive());
-        String practitionerUuid = inactiveProvider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + practitionerUuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        assertEquals(200, response.getStatus());
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertEquals("Practitioner", jsonResponse.get("resourceType").asText());
-        assertEquals(practitionerUuid, jsonResponse.get("id").asText());
     }
 
     @Test
     public void updatePractitioner_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + nonExistentUuid);
+        String nonExistentUuid = UUID.randomUUID().toString();
+        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + nonExistentUuid);
 
         String updateJson = """
                 {
@@ -298,147 +174,56 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
 
         request.setContent(updateJson.getBytes());
         MockHttpServletResponse response = new MockHttpServletResponse();
-
         fhirServlet.service(request, response);
 
         assertEquals(404, response.getStatus());
     }
 
     @Test
-    public void deletePractitioner_withNonExistentId_shouldReturn404() throws Exception {
-        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
-        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + nonExistentUuid);
+    public void deletePractitioner_shouldReturn204() throws ServletException, IOException {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
-        assertEquals(404, response.getStatus());
+        assertEquals(204, response.getStatus());
     }
 
     @Test
-    public void createPractitioner_shouldBeReadableAfterCreation() throws Exception {
-        List<Provider> providers = providerService.getAll();
-        providers.forEach(p -> p.setSysUserId("1"));
-        providerService.deleteAll(providers);
-        List<Person> people = personService.getAll();
-        people.forEach(p -> p.setSysUserId("1"));
-        personService.deleteAll(people);
+    public void readPractitioner_shouldIncludeGivenName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest createRequest = buildRequest("POST");
-        String practitionerJson = """
-                {
-                  "resourceType": "Practitioner",
-                  "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Kamau",
-                      "given": ["Wanjiku"]
-                    }
-                  ],
-                  "telecom": [
-                    {
-                      "system": "email",
-                      "value": "wanjiku.kamau@example.com",
-                      "use": "work"
-                    }
-                  ]
-                }
-                """;
-        createRequest.setContent(practitionerJson.getBytes());
-        MockHttpServletResponse createResponse = new MockHttpServletResponse();
-        fhirServlet.service(createRequest, createResponse);
-
-        assertEquals(201, createResponse.getStatus());
-        JsonNode created = objectMapper.readTree(createResponse.getContentAsString());
-        String newUuid = created.get("id").asText();
-        assertNotNull(newUuid);
-
-        MockHttpServletRequest readRequest = buildFhirRequest("GET", "/Practitioner/" + newUuid);
-        MockHttpServletResponse readResponse = new MockHttpServletResponse();
-        fhirServlet.service(readRequest, readResponse);
-
-        assertEquals(200, readResponse.getStatus());
-        JsonNode readJson = objectMapper.readTree(readResponse.getContentAsString());
-        assertEquals("Practitioner", readJson.get("resourceType").asText());
-        assertEquals(newUuid, readJson.get("id").asText());
-        assertEquals("Kamau", readJson.get("name").get(0).get("family").asText());
-    }
-
-    @Test
-    public void updatePractitioner_shouldPersistNewGivenName() throws Exception {
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + practitionerUuid);
-        String updateJson = """
-                {
-                  "resourceType": "Practitioner",
-                  "id": "%s",
-                  "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Doe",
-                      "given": ["UpdatedGiven"]
-                    }
-                  ]
-                }
-                """.formatted(practitionerUuid);
-        request.setContent(updateJson.getBytes());
+        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
-        assertEquals(200, response.getStatus());
-        Provider updatedProvider = providerService.get("1");
-        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
-        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        assertEquals("John", jsonResponse.get("name").get(0).get("given").get(0).asText());
     }
 
     @Test
-    public void deletePractitioner_thenRecordShouldBeInactive() throws Exception {
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
+    public void readPractitioner_shouldMapFamilyName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest deleteRequest = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
-        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
-        fhirServlet.service(deleteRequest, deleteResponse);
-
-        assertEquals(204, deleteResponse.getStatus());
-        Provider deletedProvider = providerService.get("1");
-        assertNotNull(deletedProvider);
-        assertFalse(deletedProvider.getActive());
-    }
-
-    @Test
-    public void createPractitioner_withInvalidBody_shouldReturn400() throws Exception {
-        List<Provider> providers = providerService.getAll();
-        providers.forEach(p -> p.setSysUserId("1"));
-        providerService.deleteAll(providers);
-        List<Person> people = personService.getAll();
-        people.forEach(p -> p.setSysUserId("1"));
-        personService.deleteAll(people);
-
-        MockHttpServletRequest request = buildRequest("POST");
-        // sending plain text instead of a FHIR resource
-        request.setContent("this is not valid fhir json".getBytes());
+        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
-        assertTrue("Should return a 4xx error for invalid input",
-                response.getStatus() >= 400 && response.getStatus() < 500);
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Doe", jsonResponse.get("name").get(0).get("family").asText());
     }
 
     @Test
-    public void createPractitioner_withMultipleTelecom_shouldPersistEmail() throws Exception {
-        List<Provider> providers = providerService.getAll();
-        providers.forEach(p -> p.setSysUserId("1"));
-        providerService.deleteAll(providers);
-        List<Person> people = personService.getAll();
-        people.forEach(p -> p.setSysUserId("1"));
-        personService.deleteAll(people);
-
-        MockHttpServletRequest request = buildRequest("POST");
+    public void createPractitioner_shouldPersistEmail() throws Exception {
+        prepareCleanSlate();
+        MockHttpServletRequest request = buildRequest("POST", "/Practitioner");
         String practitionerJson = """
                 {
                   "resourceType": "Practitioner",
@@ -452,11 +237,6 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
                   ],
                   "telecom": [
                     {
-                      "system": "phone",
-                      "value": "+256700000000",
-                      "use": "work"
-                    },
-                    {
                       "system": "email",
                       "value": "david.mukasa@example.com",
                       "use": "work"
@@ -469,25 +249,68 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
         fhirServlet.service(request, response);
 
         assertEquals(201, response.getStatus());
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        String createdId = jsonResponse.get("id").asText();
 
-        List<Person> savedPeople = personService.getAll();
-        assertFalse("At least one person should be saved", savedPeople.isEmpty());
-        assertEquals("david.mukasa@example.com", savedPeople.get(0).getEmail());
+        Provider savedProvider = providerService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
+        Person savedPerson = personService.get(savedProvider.getPerson().getId());
+        assertEquals("david.mukasa@example.com", savedPerson.getEmail());
     }
 
     @Test
-    public void deletePractitioner_twice_shouldReturn204BothTimes() throws Exception {
-        Provider existingProvider = providerService.get("1");
-        String practitionerUuid = existingProvider.getFhirUuidAsString();
+    public void updatePractitioner_shouldPersistNewGivenName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest firstDelete = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
-        MockHttpServletResponse firstResponse = new MockHttpServletResponse();
-        fhirServlet.service(firstDelete, firstResponse);
-        assertEquals(204, firstResponse.getStatus());
+        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "id": "%s",
+                  "active": true,
+                  "name": [
+                    {
+                      "use": "official",
+                      "family": "Doe",
+                      "given": ["UpdatedGiven"]
+                    }
+                  ]
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
 
-        MockHttpServletRequest secondDelete = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
-        MockHttpServletResponse secondResponse = new MockHttpServletResponse();
-        fhirServlet.service(secondDelete, secondResponse);
-        assertEquals(204, secondResponse.getStatus());
+        assertEquals(200, response.getStatus());
+        Provider updatedProvider = providerService.get("1");
+        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
+        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
+    }
+
+    @Test
+    public void deletePractitioner_withNonExistentId_shouldReturn404() throws ServletException, IOException {
+        String nonExistentUuid = UUID.randomUUID().toString();
+        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void deletePractitioner_shouldSetPractitionerInactive() throws ServletException, IOException {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(204, response.getStatus());
+
+        Provider deletedProvider = providerService.get("1");
+        assertFalse(deletedProvider.getActive());
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
@@ -30,18 +30,14 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
 
     @Autowired
     private ProviderService providerService;
-
     @Autowired
     private PersonService personService;
-
     @Autowired
     private PractitionerProvider practitionerProvider;
-
     @Autowired
     private MockServletContext servletContext;
 
     private RestfulServer fhirServlet;
-
     private ObjectMapper objectMapper;
 
     @Before
@@ -54,14 +50,9 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
         fhirServlet.init(servletConfig);
 
         objectMapper = new ObjectMapper();
-
         executeDataSetWithStateManagement("testdata/provider.xml");
         ensureReferenceTables("PROVIDER", "PERSON");
         executeDataSetWithStateManagement("testdata/system-user.xml");
-    }
-
-    private MockHttpServletRequest buildRequest(String method, String pathInfo) {
-        return buildFhirRequest(method, pathInfo);
     }
 
     private void prepareCleanSlate() throws Exception {
@@ -69,95 +60,204 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void readPractitioner_shouldReturnPractitionerResource() throws Exception {
+    public void readPractitioner_shouldReturn200() throws Exception {
         Provider provider = providerService.get("1");
         String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void readPractitioner_shouldMapResourceTypeAndId() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
         JsonNode json = objectMapper.readTree(response.getContentAsString());
         assertEquals("Practitioner", json.get("resourceType").asText());
         assertEquals(uuid, json.get("id").asText());
     }
 
     @Test
+    public void readPractitioner_shouldIncludeGivenName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("John", json.get("name").get(0).get("given").get(0).asText());
+    }
+
+    @Test
+    public void readPractitioner_shouldMapFamilyName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + uuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Doe", json.get("name").get(0).get("family").asText());
+    }
+
+    @Test
     public void readPractitioner_withNonExistentId_shouldReturn404() throws Exception {
         String nonExistentUuid = UUID.randomUUID().toString();
-        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + nonExistentUuid);
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + nonExistentUuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
 
         assertEquals(404, response.getStatus());
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertEquals("OperationOutcome", jsonResponse.get("resourceType").asText());
     }
 
     @Test
-    public void createPractitioner_shouldReturnSuccess() throws Exception {
-        prepareCleanSlate();
-        MockHttpServletRequest request = buildRequest("POST", "/Practitioner");
+    public void readPractitioner_withNonExistentId_shouldReturnOperationOutcome() throws Exception {
+        String nonExistentUuid = UUID.randomUUID().toString();
 
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", json.get("resourceType").asText());
+    }
+
+    @Test
+    public void createPractitioner_shouldReturn201() throws Exception {
+        prepareCleanSlate();
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Practitioner");
         String practitionerJson = """
                 {
                   "resourceType": "Practitioner",
                   "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Patric",
-                      "given": ["Onyango"]
-                    }
-                  ]
+                  "name": [{"use": "official", "family": "Patric", "given": ["Onyango"]}]
                 }
                 """;
-
         request.setContent(practitionerJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(201, response.getStatus());
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertNotNull(jsonResponse.get("id").asText());
     }
 
     @Test
-    public void updatePractitioner_shouldReturnSuccess() throws Exception {
+    public void createPractitioner_withEmail_shouldReturn201() throws Exception {
+        prepareCleanSlate();
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Practitioner");
+        String practitionerJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "active": true,
+                  "name": [{"use": "official", "family": "Mukasa", "given": ["David"]}],
+                  "telecom": [{"system": "email", "value": "david.mukasa@example.com", "use": "work"}]
+                }
+                """;
+        request.setContent(practitionerJson.getBytes());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+    }
+
+    @Test
+    public void createPractitioner_shouldPersistEmail() throws Exception {
+        prepareCleanSlate();
+        MockHttpServletRequest request = buildFhirRequest("POST", "/Practitioner");
+        String practitionerJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "active": true,
+                  "name": [{"use": "official", "family": "Mukasa", "given": ["David"]}],
+                  "telecom": [{"system": "email", "value": "david.mukasa@example.com", "use": "work"}]
+                }
+                """;
+        request.setContent(practitionerJson.getBytes());
+
+        MockHttpServletResponse createResponse = new MockHttpServletResponse();
+
+        fhirServlet.service(request, createResponse);
+
+        String createdId = objectMapper.readTree(createResponse.getContentAsString()).get("id").asText();
+        Provider savedProvider = providerService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
+        Person savedPerson = personService.get(savedProvider.getPerson().getId());
+        assertEquals("david.mukasa@example.com", savedPerson.getEmail());
+    }
+
+    @Test
+    public void updatePractitioner_shouldReturn200() throws Exception {
         Provider provider = providerService.get("1");
         String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + uuid);
         String updateJson = """
                 {
                   "resourceType": "Practitioner",
                   "id": "%s",
                   "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Betty",
-                      "given": ["Mpologoma"]
-                    }
-                  ]
+                  "name": [{"use": "official", "family": "Betty", "given": ["Mpologoma"]}],
+                  "telecom": [{"system": "email", "value": "betty.namatovu@example.com", "use": "work"}]
                 }
                 """.formatted(uuid);
-
         request.setContent(updateJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(200, response.getStatus());
     }
 
     @Test
+    public void updatePractitioner_shouldPersistNewGivenName() throws Exception {
+        Provider provider = providerService.get("1");
+        String uuid = provider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + uuid);
+        String updateJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "id": "%s",
+                  "active": true,
+                  "name": [{"use": "official", "family": "Doe", "given": ["UpdatedGiven"]}]
+                }
+                """.formatted(uuid);
+        request.setContent(updateJson.getBytes());
+
+        fhirServlet.service(request, new MockHttpServletResponse());
+
+        Provider updatedProvider = providerService.get("1");
+        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
+
+        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
+    }
+
+    @Test
     public void updatePractitioner_withNonExistentId_shouldReturn404() throws Exception {
         String nonExistentUuid = UUID.randomUUID().toString();
-        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + nonExistentUuid);
 
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + nonExistentUuid);
         String updateJson = """
                 {
                   "resourceType": "Practitioner",
@@ -171,9 +271,10 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
                   ]
                 }
                 """.formatted(nonExistentUuid);
-
         request.setContent(updateJson.getBytes());
+
         MockHttpServletResponse response = new MockHttpServletResponse();
+
         fhirServlet.service(request, response);
 
         assertEquals(404, response.getStatus());
@@ -184,7 +285,7 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
         Provider provider = providerService.get("1");
         String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + uuid);
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + uuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
@@ -193,104 +294,10 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void readPractitioner_shouldIncludeGivenName() throws Exception {
-        Provider provider = providerService.get("1");
-        String uuid = provider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertEquals("John", jsonResponse.get("name").get(0).get("given").get(0).asText());
-    }
-
-    @Test
-    public void readPractitioner_shouldMapFamilyName() throws Exception {
-        Provider provider = providerService.get("1");
-        String uuid = provider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("GET", "/Practitioner/" + uuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        fhirServlet.service(request, response);
-
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        assertEquals("Doe", jsonResponse.get("name").get(0).get("family").asText());
-    }
-
-    @Test
-    public void createPractitioner_shouldPersistEmail() throws Exception {
-        prepareCleanSlate();
-        MockHttpServletRequest request = buildRequest("POST", "/Practitioner");
-        String practitionerJson = """
-                {
-                  "resourceType": "Practitioner",
-                  "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Mukasa",
-                      "given": ["David"]
-                    }
-                  ],
-                  "telecom": [
-                    {
-                      "system": "email",
-                      "value": "david.mukasa@example.com",
-                      "use": "work"
-                    }
-                  ]
-                }
-                """;
-        request.setContent(practitionerJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(201, response.getStatus());
-        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
-        String createdId = jsonResponse.get("id").asText();
-
-        Provider savedProvider = providerService.getAllMatching("fhirUuid", UUID.fromString(createdId)).get(0);
-        Person savedPerson = personService.get(savedProvider.getPerson().getId());
-        assertEquals("david.mukasa@example.com", savedPerson.getEmail());
-    }
-
-    @Test
-    public void updatePractitioner_shouldPersistNewGivenName() throws Exception {
-        Provider provider = providerService.get("1");
-        String uuid = provider.getFhirUuidAsString();
-
-        MockHttpServletRequest request = buildRequest("PUT", "/Practitioner/" + uuid);
-        String updateJson = """
-                {
-                  "resourceType": "Practitioner",
-                  "id": "%s",
-                  "active": true,
-                  "name": [
-                    {
-                      "use": "official",
-                      "family": "Doe",
-                      "given": ["UpdatedGiven"]
-                    }
-                  ]
-                }
-                """.formatted(uuid);
-        request.setContent(updateJson.getBytes());
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        fhirServlet.service(request, response);
-
-        assertEquals(200, response.getStatus());
-        Provider updatedProvider = providerService.get("1");
-        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
-        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
-    }
-
-    @Test
     public void deletePractitioner_withNonExistentId_shouldReturn404() throws ServletException, IOException {
         String nonExistentUuid = UUID.randomUUID().toString();
-        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + nonExistentUuid);
+
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + nonExistentUuid);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         fhirServlet.service(request, response);
@@ -299,18 +306,17 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void deletePractitioner_shouldSetPractitionerInactive() throws ServletException, IOException {
+    public void deletePractitioner_shouldSetProviderInactive() throws Exception {
         Provider provider = providerService.get("1");
         String uuid = provider.getFhirUuidAsString();
 
-        MockHttpServletRequest request = buildRequest("DELETE", "/Practitioner/" + uuid);
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + uuid);
 
-        fhirServlet.service(request, response);
-
-        assertEquals(204, response.getStatus());
+        fhirServlet.service(request, new MockHttpServletResponse());
 
         Provider deletedProvider = providerService.get("1");
+
+        assertNotNull(deletedProvider);
         assertFalse(deletedProvider.getActive());
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PractitionerFacadeTest.java
@@ -240,4 +240,254 @@ public class PractitionerFacadeTest extends BaseWebContextSensitiveTest {
         assertFalse(deletedProvider.getActive());
     }
 
+    @Test
+    public void readPractitioner_shouldIncludeGivenName() throws Exception {
+        Provider existingProvider = providerService.get("1");
+        String practitionerUuid = existingProvider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + practitionerUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        JsonNode nameArray = jsonResponse.get("name");
+        assertNotNull(nameArray);
+        JsonNode givenArray = nameArray.get(0).get("given");
+        assertNotNull("Given name array should be present", givenArray);
+        assertEquals("John", givenArray.get(0).asText());
+    }
+
+    @Test
+    public void readPractitioner_inactiveProvider_shouldStillBeReturned() throws Exception {
+        Provider inactiveProvider = providerService.get("2");
+        assertNotNull(inactiveProvider);
+        assertFalse(inactiveProvider.getActive());
+        String practitionerUuid = inactiveProvider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner/" + practitionerUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        JsonNode jsonResponse = objectMapper.readTree(response.getContentAsString());
+        assertEquals("Practitioner", jsonResponse.get("resourceType").asText());
+        assertEquals(practitionerUuid, jsonResponse.get("id").asText());
+    }
+
+    @Test
+    public void updatePractitioner_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + nonExistentUuid);
+
+        String updateJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "id": "%s",
+                  "name": [
+                    {
+                      "use": "official",
+                      "family": "Ghost",
+                      "given": ["Nobody"]
+                    }
+                  ]
+                }
+                """.formatted(nonExistentUuid);
+
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void deletePractitioner_withNonExistentId_shouldReturn404() throws Exception {
+        String nonExistentUuid = "00000000-0000-0000-0000-000000000000";
+        MockHttpServletRequest request = buildFhirRequest("DELETE", "/Practitioner/" + nonExistentUuid);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        fhirServlet.service(request, response);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void createPractitioner_shouldBeReadableAfterCreation() throws Exception {
+        List<Provider> providers = providerService.getAll();
+        providers.forEach(p -> p.setSysUserId("1"));
+        providerService.deleteAll(providers);
+        List<Person> people = personService.getAll();
+        people.forEach(p -> p.setSysUserId("1"));
+        personService.deleteAll(people);
+
+        MockHttpServletRequest createRequest = buildRequest("POST");
+        String practitionerJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "active": true,
+                  "name": [
+                    {
+                      "use": "official",
+                      "family": "Kamau",
+                      "given": ["Wanjiku"]
+                    }
+                  ],
+                  "telecom": [
+                    {
+                      "system": "email",
+                      "value": "wanjiku.kamau@example.com",
+                      "use": "work"
+                    }
+                  ]
+                }
+                """;
+        createRequest.setContent(practitionerJson.getBytes());
+        MockHttpServletResponse createResponse = new MockHttpServletResponse();
+        fhirServlet.service(createRequest, createResponse);
+
+        assertEquals(201, createResponse.getStatus());
+        JsonNode created = objectMapper.readTree(createResponse.getContentAsString());
+        String newUuid = created.get("id").asText();
+        assertNotNull(newUuid);
+
+        MockHttpServletRequest readRequest = buildFhirRequest("GET", "/Practitioner/" + newUuid);
+        MockHttpServletResponse readResponse = new MockHttpServletResponse();
+        fhirServlet.service(readRequest, readResponse);
+
+        assertEquals(200, readResponse.getStatus());
+        JsonNode readJson = objectMapper.readTree(readResponse.getContentAsString());
+        assertEquals("Practitioner", readJson.get("resourceType").asText());
+        assertEquals(newUuid, readJson.get("id").asText());
+        assertEquals("Kamau", readJson.get("name").get(0).get("family").asText());
+    }
+
+    @Test
+    public void updatePractitioner_shouldPersistNewGivenName() throws Exception {
+        Provider existingProvider = providerService.get("1");
+        String practitionerUuid = existingProvider.getFhirUuidAsString();
+
+        MockHttpServletRequest request = buildFhirRequest("PUT", "/Practitioner/" + practitionerUuid);
+        String updateJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "id": "%s",
+                  "active": true,
+                  "name": [
+                    {
+                      "use": "official",
+                      "family": "Doe",
+                      "given": ["UpdatedGiven"]
+                    }
+                  ]
+                }
+                """.formatted(practitionerUuid);
+        request.setContent(updateJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(200, response.getStatus());
+        Provider updatedProvider = providerService.get("1");
+        Person updatedPerson = personService.get(updatedProvider.getPerson().getId());
+        assertEquals("UpdatedGiven", updatedPerson.getFirstName());
+    }
+
+    @Test
+    public void deletePractitioner_thenRecordShouldBeInactive() throws Exception {
+        Provider existingProvider = providerService.get("1");
+        String practitionerUuid = existingProvider.getFhirUuidAsString();
+
+        MockHttpServletRequest deleteRequest = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
+        MockHttpServletResponse deleteResponse = new MockHttpServletResponse();
+        fhirServlet.service(deleteRequest, deleteResponse);
+
+        assertEquals(204, deleteResponse.getStatus());
+        Provider deletedProvider = providerService.get("1");
+        assertNotNull(deletedProvider);
+        assertFalse(deletedProvider.getActive());
+    }
+
+    @Test
+    public void createPractitioner_withInvalidBody_shouldReturn400() throws Exception {
+        List<Provider> providers = providerService.getAll();
+        providers.forEach(p -> p.setSysUserId("1"));
+        providerService.deleteAll(providers);
+        List<Person> people = personService.getAll();
+        people.forEach(p -> p.setSysUserId("1"));
+        personService.deleteAll(people);
+
+        MockHttpServletRequest request = buildRequest("POST");
+        // sending plain text instead of a FHIR resource
+        request.setContent("this is not valid fhir json".getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertTrue("Should return a 4xx error for invalid input",
+                response.getStatus() >= 400 && response.getStatus() < 500);
+    }
+
+    @Test
+    public void createPractitioner_withMultipleTelecom_shouldPersistEmail() throws Exception {
+        List<Provider> providers = providerService.getAll();
+        providers.forEach(p -> p.setSysUserId("1"));
+        providerService.deleteAll(providers);
+        List<Person> people = personService.getAll();
+        people.forEach(p -> p.setSysUserId("1"));
+        personService.deleteAll(people);
+
+        MockHttpServletRequest request = buildRequest("POST");
+        String practitionerJson = """
+                {
+                  "resourceType": "Practitioner",
+                  "active": true,
+                  "name": [
+                    {
+                      "use": "official",
+                      "family": "Mukasa",
+                      "given": ["David"]
+                    }
+                  ],
+                  "telecom": [
+                    {
+                      "system": "phone",
+                      "value": "+256700000000",
+                      "use": "work"
+                    },
+                    {
+                      "system": "email",
+                      "value": "david.mukasa@example.com",
+                      "use": "work"
+                    }
+                  ]
+                }
+                """;
+        request.setContent(practitionerJson.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(201, response.getStatus());
+
+        List<Person> savedPeople = personService.getAll();
+        assertFalse("At least one person should be saved", savedPeople.isEmpty());
+        assertEquals("david.mukasa@example.com", savedPeople.get(0).getEmail());
+    }
+
+    @Test
+    public void deletePractitioner_twice_shouldReturn204BothTimes() throws Exception {
+        Provider existingProvider = providerService.get("1");
+        String practitionerUuid = existingProvider.getFhirUuidAsString();
+
+        MockHttpServletRequest firstDelete = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
+        MockHttpServletResponse firstResponse = new MockHttpServletResponse();
+        fhirServlet.service(firstDelete, firstResponse);
+        assertEquals(204, firstResponse.getStatus());
+
+        MockHttpServletRequest secondDelete = buildFhirRequest("DELETE", "/Practitioner/" + practitionerUuid);
+        MockHttpServletResponse secondResponse = new MockHttpServletResponse();
+        fhirServlet.service(secondDelete, secondResponse);
+        assertEquals(204, secondResponse.getStatus());
+    }
 }

--- a/src/test/resources/testdata/facade-patient.xml
+++ b/src/test/resources/testdata/facade-patient.xml
@@ -5,6 +5,17 @@
         identity_type="NATIONAL" description="Patient ID Number"
         lastupdated="2023-01-01 00:00:00" />
 
+    <patient_identity_type id="10"
+        identity_type="SUBJECT" description="Subject Number"
+        lastupdated="2023-01-01 00:00:00" />
+
+    <patient_identity_type id="11" identity_type="ST"
+        description="ST Number" lastupdated="2023-01-01 00:00:00" />
+
+    <patient_identity_type id="12"
+        identity_type="GUID" description="GUID"
+        lastupdated="2023-01-01 00:00:00" />
+
     <patient_identity_type id="17"
         identity_type="NATIONALITY" description="Nationality"
         lastupdated="2023-01-01 00:00:00" />
@@ -55,24 +66,35 @@
         national_id="1234" ethnicity="U" external_id="EX456"
         school_attend="Makerere College" birth_place="Mulago"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04635"
-        entered_birth_date="1992-12-12" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="12/12/1992" lastupdated="2023-11-01 12:00:02" />
 
     <patient id="2" person_id="2" race="black" gender="F"
         birth_date="1997-10-09 09:00:00" birth_time="1997-10-09 09:00:00"
         national_id="56789" ethnicity="A" external_id="EX123"
         school_attend="Merryland College" birth_place="Nevada"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04636"
-        entered_birth_date="1997-10-09" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="10/09/1997" lastupdated="2023-11-01 12:00:02" />
 
     <patient id="3" person_id="3" race="black" gender="M"
         birth_date="1992-12-12 02:00:00" birth_time="1992-12-12 02:00:00"
         national_id="1234" ethnicity="U" external_id="EX432"
         school_attend="Makerere College" birth_place="Kawempe"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04637"
-        entered_birth_date="1992-12-12" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="12/12/1992" lastupdated="2023-11-01 12:00:02" />
 
     <patient_identity id="1" identity_type_id="9"
         patient_id="1" identity_data="334-422-A"
+        lastupdated="2023-11-01 12:00:02" />
+
+    <patient_identity id="4" identity_type_id="10"
+        patient_id="1" identity_data="SUB123"
+        lastupdated="2023-11-01 12:00:02" />
+
+    <patient_identity id="5" identity_type_id="11"
+        patient_id="1" identity_data="ST456" lastupdated="2023-11-01 12:00:02" />
+
+    <patient_identity id="6" identity_type_id="12"
+        patient_id="1" identity_data="GUID789"
         lastupdated="2023-11-01 12:00:02" />
 
     <patient_identity id="2" identity_type_id="17"


### PR DESCRIPTION
# Pull Requests Requirements
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Adds comprehensive integration tests for the `PatientProvider` and 
`PractitionerProvider` FHIR facade endpoints, as requested in #3648.

## Changes
Tests Added (34 Total):
  PatientFacadeTest (19 tests)
  PractitionerFacadeTest (15 tests)

* Implemented ResourceNotFoundException throw/rethrow to ensure a clean 404 Not Found response is returned to the client.

  ---

  Test Results
   * Tests Run: 34
   * Failures: 0
   * Errors: 0
   * Build Status: SUCCESS

## Screenshots
<img width="941" height="199" alt="tests (2)" src="https://github.com/user-attachments/assets/b82eda61-7ad7-4f04-b635-922113c1bb22" />

## Related Issue
Closes #3648
[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
