### PR TITLE
issue-3743: separate Cold Storage device delete from enable/disable

### DIFF
--- a/src/main/java/org/openelisglobal/coldstorage/dao/impl/FreezerDAOImpl.java
+++ b/src/main/java/org/openelisglobal/coldstorage/dao/impl/FreezerDAOImpl.java
@@ -21,7 +21,7 @@ public class FreezerDAOImpl extends BaseDAOImpl<Freezer, Long> implements Freeze
 
     @Override
     public Optional<Freezer> findByName(String name) {
-        String hql = "FROM Freezer f WHERE lower(f.name) = lower(:name)";
+        String hql = "FROM Freezer f WHERE lower(f.name) = lower(:name) AND f.deleted = false";
         Query<Freezer> query = entityManager.unwrap(Session.class).createQuery(hql, Freezer.class);
         query.setParameter("name", name);
         query.setMaxResults(1);
@@ -30,20 +30,20 @@ public class FreezerDAOImpl extends BaseDAOImpl<Freezer, Long> implements Freeze
 
     @Override
     public List<Freezer> findActiveFreezers() {
-        String hql = "SELECT DISTINCT f FROM Freezer f LEFT JOIN FETCH f.storageDevice WHERE f.active = true ORDER BY f.name";
+        String hql = "SELECT DISTINCT f FROM Freezer f LEFT JOIN FETCH f.storageDevice WHERE f.active = true AND f.deleted = false ORDER BY f.name";
         return entityManager.unwrap(Session.class).createQuery(hql, Freezer.class).list();
     }
 
     @Override
     public List<Freezer> getAllFreezers() {
-        String hql = "SELECT DISTINCT f FROM Freezer f LEFT JOIN FETCH f.storageDevice ORDER BY f.name";
+        String hql = "SELECT DISTINCT f FROM Freezer f LEFT JOIN FETCH f.storageDevice WHERE f.deleted = false ORDER BY f.name";
         return entityManager.unwrap(Session.class).createQuery(hql, Freezer.class).list();
     }
 
     @Override
     public List<Freezer> searchFreezers(String search) {
         String hql = "SELECT DISTINCT f FROM Freezer f LEFT JOIN FETCH f.storageDevice "
-                + "WHERE lower(f.name) LIKE lower(:search) " + "ORDER BY f.name";
+                + "WHERE lower(f.name) LIKE lower(:search) AND f.deleted = false " + "ORDER BY f.name";
         Query<Freezer> query = entityManager.unwrap(Session.class).createQuery(hql, Freezer.class);
         query.setParameter("search", "%" + search + "%");
         return query.list();

--- a/src/main/java/org/openelisglobal/coldstorage/service/impl/FreezerServiceImpl.java
+++ b/src/main/java/org/openelisglobal/coldstorage/service/impl/FreezerServiceImpl.java
@@ -168,6 +168,9 @@ public class FreezerServiceImpl implements FreezerService {
     @Transactional
     public void setDeviceStatus(Long id, Boolean active) {
         Freezer freezer = requireFreezer(id);
+        if (Boolean.TRUE.equals(freezer.getDeleted())) {
+            throw new IllegalArgumentException("Cannot change status of a deleted freezer: " + id);
+        }
         freezer.setActive(active);
         freezerDAO.update(freezer);
     }
@@ -176,8 +179,7 @@ public class FreezerServiceImpl implements FreezerService {
     @Transactional
     public void deleteFreezer(Long id) {
         Freezer freezer = requireFreezer(id);
-        // Soft delete by setting inactive
-        freezer.setActive(false);
+        freezer.setDeleted(true);
         freezerDAO.update(freezer);
     }
 

--- a/src/main/java/org/openelisglobal/coldstorage/valueholder/Freezer.java
+++ b/src/main/java/org/openelisglobal/coldstorage/valueholder/Freezer.java
@@ -116,6 +116,9 @@ public class Freezer extends BaseObject<Long> {
     @Column(name = "active")
     private Boolean active = Boolean.TRUE;
 
+    @Column(name = "deleted", nullable = false)
+    private Boolean deleted = Boolean.FALSE;
+
     @OneToMany(mappedBy = "freezer", cascade = CascadeType.ALL, orphanRemoval = false)
     @JsonIgnore
     private List<FreezerReading> readings = new ArrayList<>();

--- a/src/main/resources/liquibase/3.5.x.x/070-add-freezer-deleted-column.xml
+++ b/src/main/resources/liquibase/3.5.x.x/070-add-freezer-deleted-column.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="3.5.0-070-add-freezer-deleted" author="collins-wagima">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="freezer" columnName="deleted" schemaName="clinlims"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="freezer" schemaName="clinlims">
+      <column name="deleted" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="3.5.0-070-freezer-name-unique-active" author="collins-wagima">
+    <preConditions onFail="MARK_RAN">
+      <indexExists indexName="idx_freezer_name" schemaName="clinlims"/>
+    </preConditions>
+    <dropUniqueConstraint tableName="freezer" constraintName="freezer_name_key" schemaName="clinlims"/>
+    <dropIndex tableName="freezer" indexName="idx_freezer_name" schemaName="clinlims"/>
+    <sql>CREATE UNIQUE INDEX idx_freezer_name_active ON clinlims.freezer (name) WHERE deleted = false;</sql>
+    <rollback>
+      <sql>DROP INDEX IF EXISTS clinlims.idx_freezer_name_active;</sql>
+      <addUniqueConstraint tableName="freezer" columnNames="name" constraintName="freezer_name_key" schemaName="clinlims"/>
+      <createIndex tableName="freezer" indexName="idx_freezer_name" unique="true" schemaName="clinlims">
+        <column name="name"/>
+      </createIndex>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -184,4 +184,7 @@
   <!-- Sample Entry Config: requesterRequired toggle for Search Requester + First/Last Name -->
   <include relativeToChangelogFile="true" file="069-requester-required-config.xml"/>
 
+  <!-- Cold storage freezer soft-delete flag -->
+  <include relativeToChangelogFile="true" file="070-add-freezer-deleted-column.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/coldstorage/FreezerServiceTest.java
+++ b/src/test/java/org/openelisglobal/coldstorage/FreezerServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -188,17 +189,35 @@ public class FreezerServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
-    public void deleteFreezer_shouldSoftDeleteFreezer() {
+    public void deleteFreezer_shouldMarkDeletedAndExcludeFromListings() {
         Long freezerId = 100L;
         Freezer freezer = freezerService.findById(freezerId).orElse(null);
         assertNotNull("Freezer should exist before deletion", freezer);
-        assertTrue("Freezer should be active before deletion", freezer.getActive());
+        assertFalse("Freezer should not be deleted initially", Boolean.TRUE.equals(freezer.getDeleted()));
 
         freezerService.deleteFreezer(freezerId);
 
         Freezer deletedFreezer = freezerService.findById(freezerId).orElse(null);
-        assertNotNull("Freezer should still exist (soft delete)", deletedFreezer);
-        assertFalse("Freezer should be inactive after deletion", deletedFreezer.getActive());
+        assertNotNull("Freezer row should still exist after soft delete", deletedFreezer);
+        assertTrue("Freezer should be flagged deleted", deletedFreezer.getDeleted());
+
+        assertTrue("Deleted freezer should not appear in getAllFreezers",
+                freezerService.getAllFreezers("").stream().noneMatch(f -> freezerId.equals(f.getId())));
+        assertTrue("Deleted freezer should not appear in active list",
+                freezerService.getActiveFreezers().stream().noneMatch(f -> freezerId.equals(f.getId())));
+    }
+
+    @Test
+    public void setDeviceStatus_shouldRejectReactivatingDeletedFreezer() {
+        Long freezerId = 100L;
+        freezerService.deleteFreezer(freezerId);
+
+        try {
+            freezerService.setDeviceStatus(freezerId, true);
+            fail("Toggling status on a deleted freezer should throw");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
     }
 
     @Test


### PR DESCRIPTION
  Addresses item 1 (device delete) of #3743

  ## Problem
  Deleting a device in the Cold Storage Dashboard didn't remove it thus it stayed
  in the device list permanently even after a server restart, and its
  enable/power toggle could bring it back.

  ## Root cause
  Delete was a *soft delete that reused the `active` flag* (`deleteFreezer`
  set `active = false`). But `active` is also the enable/disable toggle, and
  the device-management list query (`FreezerDAOImpl.getAllFreezers` /
  `searchFreezers`) never filtered on it. So "deleted" devices kept showing,
  and `setDeviceStatus` (the toggle) could flip `active` back to true.

  ## Fix
  Introduce a dedicated `deleted` flag, distinct from `active`:
  - **Liquibase `046-add-freezer-deleted-column.xml`** thus adds `freezer.deleted`
    (`BOOLEAN NOT NULL DEFAULT false`), idempotent precondition, backfills existing rows.
  - **`Freezer.deleted`** field.
  - **`FreezerDAOImpl`** — `findByName`, `findActiveFreezers`, `getAllFreezers`,
    `searchFreezers` now exclude `deleted = true` (`get(id)` left unfiltered).
  - **`FreezerServiceImpl`** — `deleteFreezer` sets `deleted = true` (no longer
    touches `active`); `setDeviceStatus` rejects status changes on a deleted device.
  - **`FreezerServiceTest`** — updated the delete test + added a guard test.

  Chose a `deleted` flag over a hard delete because `freezer_reading` rows FK to
  `freezer`; a hard delete would destroy temperature history. **Happy to switch
  to a hard delete if you'd prefer** — flagged this as an open question on the issue.

  ## Testing
  Verified on the dev stack (build 3.2.1.10): add device → delete → it disappears
  from the list; DB shows `deleted = true`; `getAllFreezers` returns it no longer;
  deleted device can't be re-activated.

https://github.com/user-attachments/assets/7a3d11d6-0f5b-4e72-9d6a-b28b48a97ddd



  ## Notes / follow-ups (not in this PR)
  - A soft-deleted device keeps its (unique) `name`, so a device with that exact
    name can't be re-added. Could be addressed with a partial unique index
    (`... WHERE deleted = false`) if desired.
  - Separate pre-existing bug noticed while testing: creating a device whose
    generated `StorageDevice` code exceeds 10 chars fails with 500
    (`generateDeviceCode` truncates to 50, column max is 10). Can file separately.