### PR TITLE
feat: populate patient info on validation screen (#2893)

### DIFF
--- a/src/main/java/org/openelisglobal/resultvalidation/action/util/ResultValidationItem.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/action/util/ResultValidationItem.java
@@ -83,6 +83,7 @@ public class ResultValidationItem implements ResultItem, Serializable {
     private boolean normalResult;
     private String normalRange;
     private String patientName;
+    private String patientInfo;
     private double lowerCritical;
     private double higherCritical;
 
@@ -457,6 +458,14 @@ public class ResultValidationItem implements ResultItem, Serializable {
 
     public void setPatientName(String patientName) {
         this.patientName = patientName;
+    }
+
+    public String getPatientInfo() {
+        return patientInfo;
+    }
+
+    public void setPatientInfo(String patientInfo) {
+        this.patientInfo = patientInfo;
     }
 
     public String getNormalRange() {

--- a/src/main/java/org/openelisglobal/resultvalidation/controller/rest/AccessionValidationRestController.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/controller/rest/AccessionValidationRestController.java
@@ -219,28 +219,6 @@ public class AccessionValidationRestController extends BaseResultValidationContr
 
         addFlashMsgsToRequest(request);
 
-        for (AnalysisItem analysisItem : filteredresultList) {
-            Sample itemSample = sampleService.getSampleByAccessionNumber(analysisItem.getAccessionNumber());
-            if (itemSample == null) {
-                continue;
-            }
-            Patient itemPatient = sampleHumanService.getPatientForSample(itemSample);
-            if (itemPatient == null) {
-                continue;
-            }
-            analysisItem
-                    .setPatientName(
-                            itemPatient
-                                    .getPerson() == null
-                                            ? ""
-                                            : (StringUtils.trimToEmpty(itemPatient.getPerson().getLastName()) + " "
-                                                    + StringUtils.trimToEmpty(itemPatient.getPerson().getFirstName()))
-                                                    .trim());
-            analysisItem.setPatientInfo(StringUtils.trimToEmpty(itemPatient.getNationalId()) + ", "
-                    + StringUtils.trimToEmpty(itemPatient.getGender()) + ", "
-                    + StringUtils.trimToEmpty(itemPatient.getBirthDateForDisplay()));
-        }
-
         return form;
     }
 

--- a/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/util/ResultsValidationUtility.java
@@ -67,6 +67,7 @@ import org.openelisglobal.resultvalidation.action.util.ResultValidationItem;
 import org.openelisglobal.resultvalidation.bean.AnalysisItem;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.statusofsample.util.StatusRules;
 import org.openelisglobal.test.service.TestSectionService;
@@ -108,6 +109,8 @@ public class ResultsValidationUtility {
     protected ResultLimitService resultLimitService;
     @Autowired
     protected org.openelisglobal.testresultcomponent.service.TestResultComponentService testResultComponentService;
+    @Autowired
+    protected SampleHumanService sampleHumanService;
 
     private Patient currentPatient;
     protected String SAMPLE_STATUS_OBSERVATION_HISTORY_TYPE_ID;
@@ -276,6 +279,9 @@ public class ResultsValidationUtility {
         List<ResultValidationItem> selectedTestList = new ArrayList<>();
         Dictionary dictionary;
 
+        // Cache patient info per sample to avoid repeated DB lookups (N+1 prevention)
+        Map<String, String[]> samplePatientInfoCache = new HashMap<>();
+
         for (Analysis analysis : filteredAnalysisList) {
 
             if (ignoreRecordStatus || sampleReadyForValidation(analysis.getSampleItem().getSample())) {
@@ -304,12 +310,51 @@ public class ResultsValidationUtility {
                     validationItem.setAnalysis(analysis);
                     validationItem.setNonconforming(QAService.isAnalysisParentNonConforming(analysis) || StatusService
                             .getInstance().matches(analysis.getStatusId(), AnalysisStatus.TechnicalRejected));
+
+                    populatePatientInfo(validationItem, analysis, samplePatientInfoCache);
+
                     selectedTestList.add(validationItem);
                 }
             }
         }
 
         return selectedTestList;
+    }
+
+    /**
+     * Populates patientName and patientInfo on the given validation item, using a
+     * per-sample cache to avoid N+1 DB lookups. Respects the depersonalize flag.
+     */
+    private void populatePatientInfo(ResultValidationItem validationItem, Analysis analysis,
+            Map<String, String[]> samplePatientInfoCache) {
+        Sample sample = analysis.getSampleItem().getSample();
+        String sampleId = sample.getId();
+
+        String[] cached = samplePatientInfoCache.get(sampleId);
+        if (cached == null) {
+            Patient patient = sampleHumanService.getPatientForSample(sample);
+            String patientName = "";
+            String patientInfo = "";
+            if (patient != null) {
+                String nationalId = patientService.getNationalId(patient);
+                if (depersonalize) {
+                    if (GenericValidator.isBlankOrNull(nationalId)) {
+                        patientInfo = patientService.getExternalId(patient);
+                    } else {
+                        patientInfo = nationalId;
+                    }
+                } else {
+                    patientName = patientService.getLastFirstName(patient);
+                    patientInfo = nationalId + ", " + patientService.getGender(patient) + ", "
+                            + patientService.getBirthdayForDisplay(patient);
+                }
+            }
+            cached = new String[] { patientName, patientInfo };
+            samplePatientInfoCache.put(sampleId, cached);
+        }
+
+        validationItem.setPatientName(cached[0]);
+        validationItem.setPatientInfo(cached[1]);
     }
 
     public final int getCountGroupedTestsForAnalysisList(Collection<Analysis> filteredAnalysisList,
@@ -639,6 +684,7 @@ public class ResultsValidationUtility {
                 condensedItem.setHasQualifiedResult(true);
                 condensedItem.setNormalRange(testResultItem.getNormalRange());
                 condensedItem.setPatientName(testResultItem.getPatientName());
+                condensedItem.setPatientInfo(testResultItem.getPatientInfo());
             }
         }
 
@@ -686,6 +732,7 @@ public class ResultsValidationUtility {
                 : testResultItem.getHigherCritical());
         analysisResultItem.setNormalRange(testResultItem.getNormalRange());
         analysisResultItem.setPatientName(testResultItem.getPatientName());
+        analysisResultItem.setPatientInfo(testResultItem.getPatientInfo());
         analysisResultItem.setTestName(testName);
         analysisResultItem.setUnits(testUnits);
         analysisResultItem.setAnalysisId(testResultItem.getAnalysis().getId());


### PR DESCRIPTION
Move patient info (name, national ID, gender, DOB) population from the controller into ResultsValidationUtility where it belongs per the layered architecture. Use a per-sample cache to prevent N+1 queries, and respect the DepersonalizedResults flag for privacy.

The frontend (Validation.jsx) already renders row.patientName and row.patientInfo — only the backend was missing.

Changes:
- ResultValidationItem: add patientInfo field + getter/setter
- ResultsValidationUtility: add SampleHumanService injection, populatePatientInfo() with per-sample cache, copy patientInfo through testResultItemToAnalysisItem and condensed item handling
- AccessionValidationRestController: remove N+1 patient info loop

Closes #2893

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
