### PR TITLE
fix: prevent CRLF rewriting of adminPassword.txt via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Preserve line endings as-is; this file is read directly for password bootstrap
+# and must not be rewritten by Git's CRLF normalization (see #3891).
+src/main/resources/adminPassword.txt -text


### PR DESCRIPTION
Follow-up to #3919 (issue #3891). @mozzy11 suggested this as a non-blocking defense-in-depth addition during review — stops Git from rewriting \`src/main/resources/adminPassword.txt\`'s line endings on checkout, complementing the runtime CRLF-normalization fix already merged in #3919.

Ref: mozzy11's review comment — https://github.com/DIGI-UW/OpenELIS-Global-2/pull/3919#pullrequestreview-4796528889