### PR TITLE
fix: restore X-Forwarded-For/X-Forwarded-Proto forwarding in nginx location blocks

### DIFF
--- a/volume/nginx/nginx.conf
+++ b/volume/nginx/nginx.conf
@@ -61,7 +61,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -118,7 +118,7 @@ http {
             proxy_set_header   Host $host;
             proxy_set_header   Upgrade $http_upgrade;
             proxy_set_header   Connection $connection_upgrade;
-            proxy_set_header   X-Forwarded-For $proxy_protocol_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
         }
 

--- a/volume/nginx/nginx.conf
+++ b/volume/nginx/nginx.conf
@@ -61,6 +61,8 @@ http {
             proxy_set_header Host $host;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-For $proxy_protocol_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         location /api/ {
@@ -116,6 +118,8 @@ http {
             proxy_set_header   Host $host;
             proxy_set_header   Upgrade $http_upgrade;
             proxy_set_header   Connection $connection_upgrade;
+            proxy_set_header   X-Forwarded-For $proxy_protocol_addr;
+            proxy_set_header   X-Forwarded-Proto $scheme;
         }
 
         location /api/ {


### PR DESCRIPTION
Follow-up to #3932 (issue #3931). @mozzy11 flagged this as a non-blocking observation during review — declaring any `proxy_set_header` inside a `location` block stops inheritance of the server-level ones, so the `Host`/`Upgrade`/`Connection` headers added in #3932 silently dropped `X-Forwarded-For`/`X-Forwarded-Proto` forwarding to the frontend upstream in both `location /` blocks. This re-declares them explicitly in each block so the original forwarding behavior is preserved.

Ref: mozzy11's review comment — https://github.com/DIGI-UW/OpenELIS-Global-2/pull/3932#discussion_r3664934786

**Update:** Copilot's automated review caught that the initial commit used `$proxy_protocol_addr`, which only populates when PROXY protocol is enabled on the `listen` socket (it isn't here) — the header would have forwarded empty. Fixed in c7a8470 to use `$proxy_add_x_forwarded_for`, consistent with the `/api/` and `/rest/` blocks elsewhere in this file.