### PR TITLE
fix: resolve JasperReports/JFreeChart version conflict causing chart report failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,16 +644,6 @@
             <version>0.4</version>
         </dependency>
         <dependency>
-            <groupId>org.jfree</groupId>
-            <artifactId>jcommon</artifactId>
-            <version>1.0.24</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jfree</groupId>
-            <artifactId>jfreechart</artifactId>
-            <version>1.5.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>


### PR DESCRIPTION
Fixes #3967

## Fix

Removed the explicit `org.jfree:jfreechart:1.5.0` and `org.jfree:jcommon:1.0.24` version overrides in `pom.xml`. These overrode JasperReports 6.15.0's own transitive dependency (`jfreechart:1.0.19`/`jcommon:1.0.23`) via Maven's nearest-declaration-wins mediation, causing a `NoSuchMethodError` whenever a report with a bar chart was generated — JasperReports' internal chart engine is compiled against the old API. See #3967 for the full root-cause analysis.

## Verification

Reproduced and fixed locally via `dev.docker-compose.yml`, navigating to `Reports → Study → Indicator → Section Performance`.

**Before (error):**

<img width="1423" height="912" alt="Screenshot 2026-08-02 154324" src="https://github.com/user-attachments/assets/d56ec49a-555e-442f-bad5-212652ddd23a" />


**After (fixed):**

<img width="1595" height="937" alt="Screenshot 2026-08-02 160651" src="https://github.com/user-attachments/assets/d06833dd-2fa0-4ca1-97f8-67894df75f22" />
