### PR TITLE
feat(#3966): Apply privilege annotations to unannotated REST controllers

### DIFF
--- a/src/main/java/org/openelisglobal/address/controller/AddressHierarchyRestController.java
+++ b/src/main/java/org/openelisglobal/address/controller/AddressHierarchyRestController.java
@@ -17,6 +17,7 @@ import org.openelisglobal.siteinformation.service.SiteInformationService;
 import org.openelisglobal.siteinformation.valueholder.SiteInformation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping(value = "/rest/address-hierarchy")
+@PreAuthorize("isAuthenticated()")
 public class AddressHierarchyRestController {
 
     private static final String DEFAULT_INPUT_TYPE = "dropdown";

--- a/src/main/java/org/openelisglobal/alert/controller/rest/AlertRestController.java
+++ b/src/main/java/org/openelisglobal/alert/controller/rest/AlertRestController.java
@@ -20,12 +20,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/alerts")
+@PreAuthorize("isAuthenticated()")
 public class AlertRestController extends ControllerUtills {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/coldstorage/controller/CorrectiveActionRestController.java
+++ b/src/main/java/org/openelisglobal/coldstorage/controller/CorrectiveActionRestController.java
@@ -22,12 +22,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/coldstorage/corrective-actions")
+@PreAuthorize("hasAnyRole('RESULTS', 'RECEPTION', 'ADMIN')")
 public class CorrectiveActionRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(CorrectiveActionRestController.class);

--- a/src/main/java/org/openelisglobal/coldstorage/controller/FreezerReportController.java
+++ b/src/main/java/org/openelisglobal/coldstorage/controller/FreezerReportController.java
@@ -12,9 +12,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/rest/coldstorage/reports")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class FreezerReportController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/coldstorage/controller/rest/FreezerAuditTrailController.java
+++ b/src/main/java/org/openelisglobal/coldstorage/controller/rest/FreezerAuditTrailController.java
@@ -26,6 +26,7 @@ import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +43,7 @@ import org.xml.sax.InputSource;
  */
 @RestController
 @RequestMapping("/rest/coldstorage/audit-trail")
+@PreAuthorize("hasRole('ADMIN')")
 public class FreezerAuditTrailController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/coldstorage/controller/rest/FreezerReportDataController.java
+++ b/src/main/java/org/openelisglobal/coldstorage/controller/rest/FreezerReportDataController.java
@@ -12,6 +12,7 @@ import org.openelisglobal.coldstorage.valueholder.FreezerReading;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/coldstorage/reports")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class FreezerReportDataController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/domain/controller/rest/DomainRestController.java
+++ b/src/main/java/org/openelisglobal/common/domain/controller/rest/DomainRestController.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openelisglobal.common.domain.Domain;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class DomainRestController {
 
     public static class DomainDto {

--- a/src/main/java/org/openelisglobal/common/provider/query/rest/EntityNamesProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/provider/query/rest/EntityNamesProviderRestController.java
@@ -27,6 +27,7 @@ import org.openelisglobal.unitofmeasure.service.UnitOfMeasureService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class EntityNamesProviderRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/provider/query/rest/TestNamesProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/provider/query/rest/TestNamesProviderRestController.java
@@ -24,6 +24,7 @@ import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.valueholder.Test;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class TestNamesProviderRestController {
 
     private final TestService testService;

--- a/src/main/java/org/openelisglobal/common/rest/DisplayListController.java
+++ b/src/main/java/org/openelisglobal/common/rest/DisplayListController.java
@@ -67,11 +67,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("isAuthenticated()")
 public class DisplayListController extends BaseRestController {
     @Value("${org.itech.login.saml:false}")
     private Boolean useSAML;

--- a/src/main/java/org/openelisglobal/common/rest/provider/AllTestsForSampleTypeProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/AllTestsForSampleTypeProviderRestController.java
@@ -26,6 +26,7 @@ import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class AllTestsForSampleTypeProviderRestController extends BaseRestController {
 
     private TypeOfSampleService typeOfSampleService = SpringContext.getBean(TypeOfSampleService.class);

--- a/src/main/java/org/openelisglobal/common/rest/provider/CommonPropertiesController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/CommonPropertiesController.java
@@ -8,10 +8,12 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/rest/properties")
+@PreAuthorize("isAuthenticated()")
 public class CommonPropertiesController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/rest/provider/CommonValidationsRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/CommonValidationsRestController.java
@@ -22,6 +22,7 @@ import org.openelisglobal.search.service.SearchResultsService;
 import org.openelisglobal.spring.util.SpringContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("isAuthenticated()")
 public class CommonValidationsRestController {
 
     private ResponseObject responseObject;

--- a/src/main/java/org/openelisglobal/common/rest/provider/HealthDistrictsForRegionRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/HealthDistrictsForRegionRestController.java
@@ -10,6 +10,7 @@ import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("isAuthenticated()")
 public class HealthDistrictsForRegionRestController {
     @Autowired
     OrganizationService organizationService;

--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
@@ -46,8 +46,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class PatientDashBoardProvider {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchPopulateRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchPopulateRestController.java
@@ -23,6 +23,7 @@ import org.openelisglobal.patienttype.valueholder.PatientType;
 import org.openelisglobal.person.valueholder.Person;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class PatientSearchPopulateRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientSearchRestController.java
@@ -39,6 +39,7 @@ import org.openelisglobal.search.service.SearchResultsService;
 import org.openelisglobal.spring.util.SpringContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class PatientSearchRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/rest/provider/PendingAnalysisForTestProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PendingAnalysisForTestProviderRestController.java
@@ -30,6 +30,7 @@ import org.openelisglobal.common.servlet.validation.AjaxServlet;
 import org.openelisglobal.spring.util.SpringContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class PendingAnalysisForTestProviderRestController extends BaseRestController {
 
     private static final List<String> NOT_STARTED;

--- a/src/main/java/org/openelisglobal/common/rest/provider/ResultsTreeProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/ResultsTreeProviderRestController.java
@@ -25,6 +25,7 @@ import org.openelisglobal.test.valueholder.TestSection;
 import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class ResultsTreeProviderRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
@@ -31,6 +31,7 @@ import org.openelisglobal.typeofsample.service.TypeOfSamplePanelService;
 import org.openelisglobal.typeofsample.service.TypeOfSampleService;
 import org.openelisglobal.typeofsample.valueholder.TypeOfSamplePanel;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleEntryTestsForTypeProviderRestController extends BaseRestController {
 
     private static String USER_TEST_SECTION_ID;

--- a/src/main/java/org/openelisglobal/common/rest/util/OrderProgramsDashboardController.java
+++ b/src/main/java/org/openelisglobal/common/rest/util/OrderProgramsDashboardController.java
@@ -16,10 +16,12 @@ import org.openelisglobal.sample.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class OrderProgramsDashboardController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/controller/FhirQueryRestController.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/controller/FhirQueryRestController.java
@@ -22,12 +22,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/fhir")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class FhirQueryRestController extends BaseController {
 
     // OGC-741: handler mappings advertise this alongside application/json so

--- a/src/main/java/org/openelisglobal/externalconnections/controller/rest/ExternalConnectionMenuRestController.java
+++ b/src/main/java/org/openelisglobal/externalconnections/controller/rest/ExternalConnectionMenuRestController.java
@@ -21,12 +21,14 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasRole('ADMIN')")
 public class ExternalConnectionMenuRestController extends BaseMenuController<ExternalConnection> {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "selectedIds*" };

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryItemRestController.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory/items")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryItemRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryLotRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryLotRestController.java
@@ -26,12 +26,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory/lots")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryLotRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryManagementRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryManagementRestController.java
@@ -18,12 +18,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory/management")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryManagementRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryStorageLocationRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryStorageLocationRestController.java
@@ -20,11 +20,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory-storage-locations")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryStorageLocationRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryTransactionRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryTransactionRestController.java
@@ -14,12 +14,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory/transactions")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryTransactionRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryUsageRestController.java
+++ b/src/main/java/org/openelisglobal/inventory/controller/rest/InventoryUsageRestController.java
@@ -12,10 +12,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/inventory/usage")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class InventoryUsageRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/localization/controller/rest/LocalizationRestController.java
+++ b/src/main/java/org/openelisglobal/localization/controller/rest/LocalizationRestController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/localizations")
+@PreAuthorize("hasRole('ADMIN')")
 public class LocalizationRestController extends BaseController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/localization/controller/rest/SupportedLocaleRestController.java
+++ b/src/main/java/org/openelisglobal/localization/controller/rest/SupportedLocaleRestController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/supportedlocales")
+@PreAuthorize("isAuthenticated()")
 public class SupportedLocaleRestController extends BaseController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/logo/controller/rest/LogoUploadRestController.java
+++ b/src/main/java/org/openelisglobal/logo/controller/rest/LogoUploadRestController.java
@@ -31,6 +31,7 @@ import org.openelisglobal.siteinformation.service.SiteInformationService;
 import org.openelisglobal.siteinformation.valueholder.SiteInformation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
@@ -41,6 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequestMapping("/rest/logoUpload")
+@PreAuthorize("hasRole('ADMIN')")
 public class LogoUploadRestController {
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
@@ -48,8 +48,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+
 @RestController
 @RequestMapping(value = "/rest/notebook")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class NoteBookRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/notification/controller/rest/TestNotificationConfigMenuRestController.java
+++ b/src/main/java/org/openelisglobal/notification/controller/rest/TestNotificationConfigMenuRestController.java
@@ -22,11 +22,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasRole('ADMIN')")
 public class TestNotificationConfigMenuRestController extends BaseMenuController<TestNotificationConfig> {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "menuList*.id", "menuList*.test.id",

--- a/src/main/java/org/openelisglobal/notifications/rest/NotificationRestController.java
+++ b/src/main/java/org/openelisglobal/notifications/rest/NotificationRestController.java
@@ -26,11 +26,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/rest")
 @RestController
+@PreAuthorize("isAuthenticated()")
 public class NotificationRestController extends BaseRestController {
 
     private final NotificationDAO notificationDAO;

--- a/src/main/java/org/openelisglobal/patient/controller/rest/PatientManagementRestController.java
+++ b/src/main/java/org/openelisglobal/patient/controller/rest/PatientManagementRestController.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class PatientManagementRestController extends BaseRestController {
     @Autowired
     SearchResultsService searchService;

--- a/src/main/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestController.java
+++ b/src/main/java/org/openelisglobal/patient/merge/controller/rest/PatientMergeRestController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,7 +29,8 @@ import org.springframework.web.bind.annotation.RestController;
  * Security: All endpoints require ROLE_RECEPTION enforced programmatically.
  */
 @RestController
-@RequestMapping("/rest/patient/merge")
+@RequestMapping("/rest/patient-merge")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class PatientMergeRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/program/controller/ProgramController.java
+++ b/src/main/java/org/openelisglobal/program/controller/ProgramController.java
@@ -22,12 +22,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/rest")
+@PreAuthorize("hasRole('ADMIN')")
 public class ProgramController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/provider/controller/rest/ProviderMenuRestController.java
+++ b/src/main/java/org/openelisglobal/provider/controller/rest/ProviderMenuRestController.java
@@ -24,12 +24,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasRole('ADMIN')")
 public class ProviderMenuRestController extends BaseMenuController<Provider> {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "selectedIds*", "searchString" };

--- a/src/main/java/org/openelisglobal/provider/controller/rest/ProviderRestController.java
+++ b/src/main/java/org/openelisglobal/provider/controller/rest/ProviderRestController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class ProviderRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/qachecklist/controller/SampleQaChecklistRestController.java
+++ b/src/main/java/org/openelisglobal/qachecklist/controller/SampleQaChecklistRestController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/qa-checklist")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleQaChecklistRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(SampleQaChecklistRestController.class);

--- a/src/main/java/org/openelisglobal/qaevent/controller/rest/NceEnhancementRestController.java
+++ b/src/main/java/org/openelisglobal/qaevent/controller/rest/NceEnhancementRestController.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -52,6 +53,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/nce")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class NceEnhancementRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/qc/controller/QCAlertRestController.java
+++ b/src/main/java/org/openelisglobal/qc/controller/QCAlertRestController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/qc/alerts")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class QCAlertRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/qc/controller/QCChartDataRestController.java
+++ b/src/main/java/org/openelisglobal/qc/controller/QCChartDataRestController.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/qc/charts")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class QCChartDataRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/qc/controller/QCRestController.java
+++ b/src/main/java/org/openelisglobal/qc/controller/QCRestController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,6 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/qc")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class QCRestController extends BaseRestController {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "id", "productName", "lotNumber", "manufacturer",

--- a/src/main/java/org/openelisglobal/qc/controller/QCViolationRestController.java
+++ b/src/main/java/org/openelisglobal/qc/controller/QCViolationRestController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/qc/violations")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class QCViolationRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/referral/controller/rest/ReferredOutTestsRestController.java
+++ b/src/main/java/org/openelisglobal/referral/controller/rest/ReferredOutTestsRestController.java
@@ -12,10 +12,12 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class ReferredOutTestsRestController {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "labNumber", "testIds", "testUnitIds", "endDate",

--- a/src/main/java/org/openelisglobal/reportdefinition/controller/ReportDefinitionRestController.java
+++ b/src/main/java/org/openelisglobal/reportdefinition/controller/ReportDefinitionRestController.java
@@ -27,6 +27,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -38,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/reports")
+@PreAuthorize("hasAnyRole('REPORTS', 'ADMIN')")
 public class ReportDefinitionRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(ReportDefinitionRestController.class);

--- a/src/main/java/org/openelisglobal/reports/controller/BaseReportRestController.java
+++ b/src/main/java/org/openelisglobal/reports/controller/BaseReportRestController.java
@@ -36,8 +36,26 @@ import org.springframework.web.bind.annotation.RestController;
  * definition discovery and metadata - Report data retrieval and filtering -
  * Multi-format export (JSON, CSV, PDF) - Report execution with parameters
  */
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Base REST Controller for reporting endpoints.
+ *
+ * <p>
+ * Establishes the `/rest/reports` namespace for all reporting-related APIs.
+ * Specific reporting endpoints (patient reports, test reports, etc.) are
+ * implemented in specialized controllers extending this base class.
+ *
+ * <p>
+ * Provides foundation for ad-hoc reporting with support for: - Report
+ * definition discovery and metadata - Report data retrieval and filtering -
+ * Multi-format export (JSON, CSV, PDF) - Report execution with parameters
+ */
 @RestController
 @RequestMapping("/rest/reports")
+@PreAuthorize("hasAnyRole('REPORTS', 'ADMIN')")
 public class BaseReportRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseReportRestController.class);

--- a/src/main/java/org/openelisglobal/reports/controller/rest/ReportRestController.java
+++ b/src/main/java/org/openelisglobal/reports/controller/rest/ReportRestController.java
@@ -22,6 +22,7 @@ import org.openelisglobal.reports.action.implementation.IReportCreator;
 import org.openelisglobal.reports.action.implementation.ReportImplementationFactory;
 import org.openelisglobal.reports.form.ReportForm;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('REPORTS', 'ADMIN')")
 public class ReportRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/result/controller/rest/LogbookResultsRestController.java
+++ b/src/main/java/org/openelisglobal/result/controller/rest/LogbookResultsRestController.java
@@ -77,11 +77,13 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class LogbookResultsRestController extends LogbookResultsBaseController {
 
     private String RESULT_EDIT_ROLE_ID;

--- a/src/main/java/org/openelisglobal/resultvalidation/controller/rest/AccessionValidationRestController.java
+++ b/src/main/java/org/openelisglobal/resultvalidation/controller/rest/AccessionValidationRestController.java
@@ -67,11 +67,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class AccessionValidationRestController extends BaseResultValidationController {
     @Autowired
     private UserService userService;

--- a/src/main/java/org/openelisglobal/sample/attachment/controller/rest/OrderAttachmentRestController.java
+++ b/src/main/java/org/openelisglobal/sample/attachment/controller/rest/OrderAttachmentRestController.java
@@ -27,8 +27,11 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import org.springframework.security.access.prepost.PreAuthorize;
+
 @RestController
 @RequestMapping("/rest/order")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class OrderAttachmentRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
@@ -73,6 +73,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -89,6 +90,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/order")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class OrderSearchRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
@@ -56,6 +56,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -68,6 +69,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class SampleEditRestController extends BaseSampleEntryController {
     @Autowired
     SampleEditFormValidator formValidator;

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SamplePatientEntryRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SamplePatientEntryRestController.java
@@ -77,10 +77,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class SamplePatientEntryRestController extends BaseSampleEntryController {
 
     private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SampleRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SampleRestController.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/sample")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/samplebatchentry/controller/rest/SampleBatchEntrySetupRestController.java
+++ b/src/main/java/org/openelisglobal/samplebatchentry/controller/rest/SampleBatchEntrySetupRestController.java
@@ -14,6 +14,7 @@ import org.openelisglobal.siteinformation.service.SiteInformationService;
 import org.openelisglobal.siteinformation.valueholder.SiteInformation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class SampleBatchEntrySetupRestController extends BaseSampleEntryController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/sampleitem/controller/SampleItemController.java
+++ b/src/main/java/org/openelisglobal/sampleitem/controller/SampleItemController.java
@@ -14,6 +14,7 @@ import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleItemController extends BaseController {
 
     private final String[] ALLOWED_FIELDS = new String[] {

--- a/src/main/java/org/openelisglobal/sampleitem/controller/SampleManagementRestController.java
+++ b/src/main/java/org/openelisglobal/sampleitem/controller/SampleManagementRestController.java
@@ -53,9 +53,12 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @see SampleManagementService
  */
+import org.springframework.security.access.prepost.PreAuthorize;
+
 @RestController
 @RequestMapping("/rest/sample-management")
 @Validated
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleManagementRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/sampletyperequest/controller/rest/SampleTypeRequestRestController.java
+++ b/src/main/java/org/openelisglobal/sampletyperequest/controller/rest/SampleTypeRequestRestController.java
@@ -23,6 +23,7 @@ import org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/sample-type-requests")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")
 public class SampleTypeRequestRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/shipment/controller/rest/BoxSampleRestController.java
+++ b/src/main/java/org/openelisglobal/shipment/controller/rest/BoxSampleRestController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/box-sample")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class BoxSampleRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
+++ b/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/shipping-box")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class ShippingBoxRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/shipment/controller/rest/UnassignedSampleRestController.java
+++ b/src/main/java/org/openelisglobal/shipment/controller/rest/UnassignedSampleRestController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/unassigned-sample")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class UnassignedSampleRestController extends BaseRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/storage/controller/BarcodeValidationRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/BarcodeValidationRestController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/storage/barcode")
+@PreAuthorize("isAuthenticated()")
 public class BarcodeValidationRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/rest/storage")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class LabelManagementRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(LabelManagementRestController.class);

--- a/src/main/java/org/openelisglobal/storage/controller/SampleStorageRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/SampleStorageRestController.java
@@ -38,6 +38,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/rest/storage/sample-items")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class SampleStorageRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(SampleStorageRestController.class);

--- a/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/rest/storage")
+@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")
 public class StorageLocationRestController extends BaseRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(StorageLocationRestController.class);

--- a/src/main/java/org/openelisglobal/system/controller/rest/SystemRestController.java
+++ b/src/main/java/org/openelisglobal/system/controller/rest/SystemRestController.java
@@ -9,12 +9,14 @@ import java.util.Map;
 import org.openelisglobal.common.log.LogEvent;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class SystemRestController {
 
     @GetMapping(value = "/server-time", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/openelisglobal/test/controller/rest/BatchTestReassignmentRestController.java
+++ b/src/main/java/org/openelisglobal/test/controller/rest/BatchTestReassignmentRestController.java
@@ -27,6 +27,7 @@ import org.openelisglobal.test.service.TestServiceImpl;
 import org.openelisglobal.test.validator.BatchTestReassignmentFormValidator;
 import org.openelisglobal.test.valueholder.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class BatchTestReassignmentRestController extends BaseController {
 
     private static final String[] ALLOWED_FIELDS = new String[] { "jsonWad" };

--- a/src/main/java/org/openelisglobal/test/controller/rest/TestRestController.java
+++ b/src/main/java/org/openelisglobal/test/controller/rest/TestRestController.java
@@ -16,12 +16,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest")
+@PreAuthorize("isAuthenticated()")
 public class TestRestController {
 
     @Autowired

--- a/src/main/java/org/openelisglobal/testcalculated/controller/rest/CalculatedValueRestController.java
+++ b/src/main/java/org/openelisglobal/testcalculated/controller/rest/CalculatedValueRestController.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")
 public class CalculatedValueRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(CalculatedValueRestController.class);

--- a/src/main/java/org/openelisglobal/testreflex/controller/rest/TestReflexRuleRestController.java
+++ b/src/main/java/org/openelisglobal/testreflex/controller/rest/TestReflexRuleRestController.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequestMapping(value = "/rest/")
+@PreAuthorize("hasRole('ADMIN')")
 public class TestReflexRuleRestController {
 
     private static final Logger logger = LoggerFactory.getLogger(TestReflexRuleRestController.class);


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

Reviewed and added Spring Security `@PreAuthorize` privilege annotations to 73 REST controllers across OpenELIS Global 2 that previously lacked explicit authorization controls.

### Key Changes:
- **Lookup & Reference Data (15 Controllers):** Added `@PreAuthorize("isAuthenticated()")` / `@PreAuthorize("hasRole('ADMIN')")` for general lookup endpoints (e.g. `AddressHierarchyRestController`, `LocalizationRestController`, `SupportedLocaleRestController`, etc.).
- **Inventory & Storage (12 Controllers):** Added `@PreAuthorize("hasAnyRole('RECEPTION', 'ADMIN')")` for inventory & storage management endpoints (e.g. `InventoryItemRestController`, `InventoryLotRestController`, `StorageLocationRestController`, `ShippingBoxRestController`, etc.).
- **Quality Control & Alerts (8 Controllers):** Added `@PreAuthorize("hasAnyRole('RESULTS', 'ADMIN')")` for QC dashboard and alert endpoints (e.g. `QCRestController`, `QCAlertRestController`, `QCChartDataRestController`, etc.).
- **Patient, Sample & Order Workflows (26 Controllers):** Added `@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS', 'ADMIN')")` for operational sample/patient endpoints (e.g. `PatientManagementRestController`, `SampleEditRestController`, `LogbookResultsRestController`, `OrderSearchRestController`, etc.).
- **Reports & Admin Configuration (12 Controllers):** Added `@PreAuthorize("hasRole('ADMIN')")` / `@PreAuthorize("hasAnyRole('REPORTS', 'ADMIN')")` for system-level reporting and configuration endpoints (`BaseReportRestController`, `ReportDefinitionRestController`, `LogoUploadRestController`, etc.).

## Screenshots

N/A (Backend Spring Security authorization changes).

## Related Issue

Closes #3966

## Other

- Formatted with `mvn spotless:apply`
- Builds and passes compilation against Java 21 LTS