### PR TITLE
fix(menu): filter navigation menu by user privileges (OGC-1151)

### DIFF
--- a/src/main/java/org/openelisglobal/common/util/URLUtil.java
+++ b/src/main/java/org/openelisglobal/common/util/URLUtil.java
@@ -10,18 +10,10 @@ public class URLUtil {
 
     /**
      * Normalizes a raw path (optionally carrying a query string) to the form stored
-     * in {@code system_module_url.url_path}.
-     *
-     * <p>
-     * Extracted from {@link #getReourcePathFromRequest(HttpServletRequest)} so
-     * callers that hold a path string rather than a request — notably the menu
-     * privilege filter, which normalizes {@code menu.action_url} — resolve paths
-     * identically to the interceptor. Divergent normalization would let the menu
-     * advertise a link the interceptor rejects.
-     *
-     * <p>
-     * The body is a verbatim move; the pre-existing {@code /rest} prefix handling
-     * is intentionally unchanged here so the extraction cannot alter behaviour.
+     * in {@code system_module_url.url_path}. Extracted verbatim from
+     * {@link #getReourcePathFromRequest(HttpServletRequest)} so the menu privilege
+     * filter resolves paths exactly as the interceptor does — divergent
+     * normalization would let the menu advertise a link the interceptor rejects.
      */
     public static String getResourcePath(String pathAndQuery) {
         String pathWithoutQuery;

--- a/src/main/java/org/openelisglobal/common/util/URLUtil.java
+++ b/src/main/java/org/openelisglobal/common/util/URLUtil.java
@@ -5,8 +5,25 @@ import jakarta.servlet.http.HttpServletRequest;
 public class URLUtil {
 
     public static String getReourcePathFromRequest(HttpServletRequest request) {
+        return getResourcePath(request.getRequestURI().substring(request.getContextPath().length()));
+    }
 
-        String pathAndQuery = request.getRequestURI().substring(request.getContextPath().length());
+    /**
+     * Normalizes a raw path (optionally carrying a query string) to the form stored
+     * in {@code system_module_url.url_path}.
+     *
+     * <p>
+     * Extracted from {@link #getReourcePathFromRequest(HttpServletRequest)} so
+     * callers that hold a path string rather than a request — notably the menu
+     * privilege filter, which normalizes {@code menu.action_url} — resolve paths
+     * identically to the interceptor. Divergent normalization would let the menu
+     * advertise a link the interceptor rejects.
+     *
+     * <p>
+     * The body is a verbatim move; the pre-existing {@code /rest} prefix handling
+     * is intentionally unchanged here so the extraction cannot alter behaviour.
+     */
+    public static String getResourcePath(String pathAndQuery) {
         String pathWithoutQuery;
         if (pathAndQuery.contains("?")) {
             pathWithoutQuery = pathAndQuery.substring(0, pathAndQuery.indexOf('?'));

--- a/src/main/java/org/openelisglobal/config/ControllerSetup.java
+++ b/src/main/java/org/openelisglobal/config/ControllerSetup.java
@@ -48,17 +48,10 @@ public class ControllerSetup extends ResponseEntityExceptionHandler {
     }
 
     /**
-     * Reports an authorization failure as 401 rather than letting the
-     * RuntimeException handler below report it as 500.
-     *
-     * <p>
-     * {@code AccessDeniedException} is a RuntimeException, so every
-     * {@code @PreAuthorize} denial on a path that
-     * {@code ModuleAuthenticationInterceptor} does not cover — i.e. any path with
-     * no {@code system_module_url} row, which includes every endpoint carrying a
-     * path variable — surfaced as a generic server error. 401 matches the status
-     * the interceptor already returns for a denied REST call, so clients see one
-     * consistent code either way.
+     * {@code AccessDeniedException} is a RuntimeException, so the catch-all below
+     * reported every {@code @PreAuthorize} denial the interceptor does not cover
+     * (any endpoint carrying a path variable) as 500. 401 matches the status the
+     * interceptor already returns for a denied REST call.
      */
     @ExceptionHandler(value = { AccessDeniedException.class })
     protected ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex, WebRequest request) {

--- a/src/main/java/org/openelisglobal/config/ControllerSetup.java
+++ b/src/main/java/org/openelisglobal/config/ControllerSetup.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -44,6 +45,26 @@ public class ControllerSetup extends ResponseEntityExceptionHandler {
         binder.registerCustomEditor(AuthType.class, new CaseInsensitiveEnumPropertyEditor<>(AuthType.class));
         binder.registerCustomEditor(ProgrammedConnection.class,
                 new CaseInsensitiveEnumPropertyEditor<>(ProgrammedConnection.class));
+    }
+
+    /**
+     * Reports an authorization failure as 401 rather than letting the
+     * RuntimeException handler below report it as 500.
+     *
+     * <p>
+     * {@code AccessDeniedException} is a RuntimeException, so every
+     * {@code @PreAuthorize} denial on a path that
+     * {@code ModuleAuthenticationInterceptor} does not cover — i.e. any path with
+     * no {@code system_module_url} row, which includes every endpoint carrying a
+     * path variable — surfaced as a generic server error. 401 matches the status
+     * the interceptor already returns for a denied REST call, so clients see one
+     * consistent code either way.
+     */
+    @ExceptionHandler(value = { AccessDeniedException.class })
+    protected ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex, WebRequest request) {
+        LogEvent.logInfo(this.getClass().getSimpleName(), "handleAccessDeniedException", ex.getMessage());
+        return new ResponseEntity<>(buildGenericErrorBody(HttpStatus.UNAUTHORIZED), new HttpHeaders(),
+                HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(value = { RuntimeException.class })

--- a/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
+++ b/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ConfigurationProperties;
@@ -16,8 +15,6 @@ import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.systemmodule.service.SystemModuleUrlService;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleParam;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleUrl;
-import org.openelisglobal.systemusermodule.service.PermissionModuleService;
-import org.openelisglobal.systemusermodule.valueholder.PermissionModule;
 import org.openelisglobal.userrole.service.UserRoleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -45,8 +42,6 @@ public class ModuleAuthenticationInterceptor implements HandlerInterceptor {
     private SystemModuleUrlService systemModuleUrlService;
     @Autowired
     private UserRoleService userRoleService;
-    @Autowired
-    private PermissionModuleService<PermissionModule> permissionModuleService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
@@ -95,8 +90,8 @@ public class ModuleAuthenticationInterceptor implements HandlerInterceptor {
         }
 
         if (accessMap == null) {
-            Set<String> permittedPages = getPermittedForms(getSysUserId(request));
-            accessMap = (HashSet<String>) permittedPages;
+            accessMap = new HashSet<>(
+                    userRoleService.getAllPermittedPagesForUser(Integer.toString(getSysUserId(request))));
         }
         List<SystemModuleUrl> sysModsByUrl = systemModuleUrlService.getByRequest(request);
 
@@ -138,20 +133,6 @@ public class ModuleAuthenticationInterceptor implements HandlerInterceptor {
             }
         }
         return filteredSysModsByUrl;
-    }
-
-    private Set<String> getPermittedForms(int systemUserId) {
-        Set<String> allPermittedPages = new HashSet<>();
-
-        List<String> roleIds = userRoleService.getRoleIdsForUser(Integer.toString(systemUserId));
-
-        for (String roleId : roleIds) {
-            Set<String> permittedPagesForRole = permissionModuleService
-                    .getAllPermittedPagesFromAgentId(Integer.parseInt(roleId));
-            allPermittedPages.addAll(permittedPagesForRole);
-        }
-
-        return allPermittedPages;
     }
 
     protected int getSysUserId(HttpServletRequest request) {

--- a/src/main/java/org/openelisglobal/menu/controller/MenuController.java
+++ b/src/main/java/org/openelisglobal/menu/controller/MenuController.java
@@ -9,6 +9,7 @@ import org.openelisglobal.menu.util.MenuItem;
 import org.openelisglobal.menu.util.MenuUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,6 +32,19 @@ public class MenuController {
         return findMenuItem(elementId, MenuUtil.getMenuTree());
     }
 
+    /**
+     * Serves the unfiltered tree for the menu configuration screens, which must be
+     * able to edit nodes the editing admin would not otherwise see.
+     *
+     * <p>
+     * Admin-only: without this the privilege filter on {@code /rest/menu} is
+     * trivially sidestepped, because any authenticated caller could read the
+     * unfiltered node here instead. The interceptor does not cover it — no
+     * {@code system_module_url} row maps this path, so {@code /rest/**} is
+     * auto-allowed. Every caller (the Billing, Patient, NonConformity and Global
+     * menu configuration screens) already sits behind a GLOBAL_ADMIN route.
+     */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/rest/admin/menu/{elementId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public Optional<MenuItem> getEditableMenuItem(@PathVariable String elementId) {
         return findMenuItem(elementId, MenuUtil.getUnfilteredMenuTree());

--- a/src/main/java/org/openelisglobal/menu/controller/MenuController.java
+++ b/src/main/java/org/openelisglobal/menu/controller/MenuController.java
@@ -33,16 +33,11 @@ public class MenuController {
     }
 
     /**
-     * Serves the unfiltered tree for the menu configuration screens, which must be
-     * able to edit nodes the editing admin would not otherwise see.
-     *
-     * <p>
-     * Admin-only: without this the privilege filter on {@code /rest/menu} is
-     * trivially sidestepped, because any authenticated caller could read the
-     * unfiltered node here instead. The interceptor does not cover it — no
-     * {@code system_module_url} row maps this path, so {@code /rest/**} is
-     * auto-allowed. Every caller (the Billing, Patient, NonConformity and Global
-     * menu configuration screens) already sits behind a GLOBAL_ADMIN route.
+     * Serves the unfiltered tree for the menu configuration screens. Admin-only:
+     * otherwise any authenticated caller could read nodes the {@code /rest/menu}
+     * filter removed — the interceptor auto-allows this path, since no
+     * {@code system_module_url} row can match a path-variable URL. All callers sit
+     * behind GLOBAL_ADMIN routes.
      */
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping(value = "/rest/admin/menu/{elementId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/openelisglobal/menu/service/MenuService.java
+++ b/src/main/java/org/openelisglobal/menu/service/MenuService.java
@@ -15,16 +15,11 @@ public interface MenuService extends BaseObjectService<Menu, String> {
     List<MenuItem> save(List<MenuItem> menuItems);
 
     /**
-     * Removes menu nodes the current user holds no privilege for.
-     *
-     * <p>
-     * A node's target ({@code action_url}) is resolved through the same
-     * {@code system_module_url} → {@code system_module} →
-     * {@code system_role_module} chain that {@code ModuleAuthenticationInterceptor}
-     * uses to authorize page access, so the menu cannot advertise a destination the
-     * interceptor would refuse. A target with no policy declared for it stays
-     * visible, which keeps deployments that have not populated the mapping
-     * unchanged.
+     * Removes menu nodes the current user holds no privilege for, resolving each
+     * node's {@code action_url} through the same module chain
+     * {@code ModuleAuthenticationInterceptor} authorizes pages against — the menu
+     * cannot advertise a destination the interceptor would refuse. A target with no
+     * declared policy stays visible.
      *
      * @param menuTree the unfiltered tree; not modified
      * @return a filtered copy, or the same tree when filtering does not apply

--- a/src/main/java/org/openelisglobal/menu/service/MenuService.java
+++ b/src/main/java/org/openelisglobal/menu/service/MenuService.java
@@ -13,4 +13,21 @@ public interface MenuService extends BaseObjectService<Menu, String> {
     MenuItem save(MenuItem menuItem);
 
     List<MenuItem> save(List<MenuItem> menuItems);
+
+    /**
+     * Removes menu nodes the current user holds no privilege for.
+     *
+     * <p>
+     * A node's target ({@code action_url}) is resolved through the same
+     * {@code system_module_url} → {@code system_module} →
+     * {@code system_role_module} chain that {@code ModuleAuthenticationInterceptor}
+     * uses to authorize page access, so the menu cannot advertise a destination the
+     * interceptor would refuse. A target with no policy declared for it stays
+     * visible, which keeps deployments that have not populated the mapping
+     * unchanged.
+     *
+     * @param menuTree the unfiltered tree; not modified
+     * @return a filtered copy, or the same tree when filtering does not apply
+     */
+    List<MenuItem> filterByPrivilege(List<MenuItem> menuTree);
 }

--- a/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
@@ -1,22 +1,61 @@
 package org.openelisglobal.menu.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
+import org.openelisglobal.common.util.URLUtil;
+import org.openelisglobal.common.util.UserContextHolder;
 import org.openelisglobal.menu.dao.MenuDAO;
 import org.openelisglobal.menu.util.MenuItem;
 import org.openelisglobal.menu.util.MenuUtil;
 import org.openelisglobal.menu.valueholder.Menu;
+import org.openelisglobal.systemmodule.service.SystemModuleUrlService;
+import org.openelisglobal.systemmodule.valueholder.SystemModuleParam;
+import org.openelisglobal.systemmodule.valueholder.SystemModuleUrl;
+import org.openelisglobal.systemusermodule.service.PermissionModuleService;
+import org.openelisglobal.systemusermodule.valueholder.PermissionModule;
+import org.openelisglobal.userrole.service.UserRoleService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String> implements MenuService {
 
+    /**
+     * Authorities that see the whole tree, mirroring the
+     * {@code || userModuleService.isUserAdmin(request)} arm of
+     * {@code ModuleAuthenticationInterceptor.hasPermission}. Both are needed:
+     * production grants them together, but some contexts grant only ROLE_ADMIN.
+     */
+    private static final Set<String> ADMIN_AUTHORITIES = Set.of("ROLE_GLOBAL_ADMIN", "ROLE_ADMIN");
+
     @Autowired
     protected MenuDAO baseObjectDAO;
+
+    @Autowired
+    private SystemModuleUrlService systemModuleUrlService;
+
+    @Autowired
+    private UserRoleService userRoleService;
+
+    @Autowired
+    private PermissionModuleService<PermissionModule> permissionModuleService;
+
+    @Autowired
+    private UserContextHolder userContextHolder;
 
     MenuServiceImpl() {
         super(Menu.class);
@@ -84,5 +123,112 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
             menuItem.getChildMenus().add(save(oldChild));
         }
         return menuItem;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MenuItem> filterByPrivilege(List<MenuItem> menuTree) {
+        if (menuTree == null || menuTree.isEmpty() || holdsAdminAuthority()) {
+            return menuTree;
+        }
+        String sysUserId = userContextHolder.getCurrentSysUserId();
+        if (GenericValidator.isBlankOrNull(sysUserId)) {
+            // No resolvable identity (anonymous or daemon context): return the tree
+            // rather than hiding every node with a declared policy.
+            return menuTree;
+        }
+
+        Set<String> permittedModules = permittedModulesForRolesOf(sysUserId);
+        Map<String, List<SystemModuleUrl>> urlsByPath = indexModuleUrlsByPath();
+        Set<String> visibleElementIds = new HashSet<>();
+        collectIndependentlyVisible(menuTree, permittedModules, urlsByPath, visibleElementIds);
+
+        // filterByIncludes already keeps any ancestor of a surviving node, so listing
+        // only the independently visible ids implements the pruning rule: a folder
+        // whose children were all removed is dropped with them.
+        return MenuUtil.filterByIncludes(menuTree, visibleElementIds, Collections.emptySet());
+    }
+
+    private boolean holdsAdminAuthority() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return true;
+        }
+        return authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .anyMatch(ADMIN_AUTHORITIES::contains);
+    }
+
+    /**
+     * ponytail: resolves privileges from the user's roles only. The USER value of
+     * the {@code permissions.agent} property is unsupported here — it is set in no
+     * deployment and {@code system_user_module} carries no rows.
+     */
+    private Set<String> permittedModulesForRolesOf(String sysUserId) {
+        Set<String> permittedModules = new HashSet<>();
+        List<String> roleIds = userRoleService.getRoleIdsForUser(sysUserId);
+        if (roleIds == null) {
+            return permittedModules;
+        }
+        for (String roleId : roleIds) {
+            if (!GenericValidator.isBlankOrNull(roleId)) {
+                permittedModules.addAll(
+                        permissionModuleService.getAllPermittedPagesFromAgentId(Integer.parseInt(roleId.trim())));
+            }
+        }
+        return permittedModules;
+    }
+
+    private Map<String, List<SystemModuleUrl>> indexModuleUrlsByPath() {
+        Map<String, List<SystemModuleUrl>> urlsByPath = new HashMap<>();
+        for (SystemModuleUrl moduleUrl : systemModuleUrlService.getAll()) {
+            urlsByPath.computeIfAbsent(moduleUrl.getUrlPath(), path -> new ArrayList<>()).add(moduleUrl);
+        }
+        return urlsByPath;
+    }
+
+    private void collectIndependentlyVisible(List<MenuItem> menuItems, Set<String> permittedModules,
+            Map<String, List<SystemModuleUrl>> urlsByPath, Set<String> visibleElementIds) {
+        for (MenuItem menuItem : menuItems) {
+            if (isIndependentlyVisible(menuItem, permittedModules, urlsByPath)) {
+                visibleElementIds.add(menuItem.getMenu().getElementId());
+            }
+            collectIndependentlyVisible(menuItem.getChildMenus(), permittedModules, urlsByPath, visibleElementIds);
+        }
+    }
+
+    private boolean isIndependentlyVisible(MenuItem menuItem, Set<String> permittedModules,
+            Map<String, List<SystemModuleUrl>> urlsByPath) {
+        String actionURL = menuItem.getMenu().getActionURL();
+        if (GenericValidator.isBlankOrNull(actionURL)) {
+            // No target to authorize. A childless node is a placeholder whose URL is
+            // supplied later by an admin (menu_billing), so it stands on its own; a node
+            // with children is a folder and survives only through a surviving child.
+            return menuItem.getChildMenus().isEmpty();
+        }
+
+        List<SystemModuleUrl> candidates = urlsByPath.get(URLUtil.getResourcePath(actionURL));
+        if (candidates == null || candidates.isEmpty()) {
+            return true;
+        }
+
+        MultiValueMap<String, String> queryParams = UriComponentsBuilder.fromUriString(actionURL).build()
+                .getQueryParams();
+        boolean anyCandidateApplies = false;
+        for (SystemModuleUrl candidate : candidates) {
+            if (!paramMatches(candidate.getParam(), queryParams)) {
+                continue;
+            }
+            anyCandidateApplies = true;
+            if (permittedModules.contains(candidate.getSystemModule().getSystemModuleName())) {
+                return true;
+            }
+        }
+        // Every candidate was ruled out by its parameter predicate, so no policy
+        // covers this exact target and the node is treated as undeclared.
+        return !anyCandidateApplies;
+    }
+
+    private boolean paramMatches(SystemModuleParam param, MultiValueMap<String, String> queryParams) {
+        return param == null || Objects.equals(param.getValue(), queryParams.getFirst(param.getName()));
     }
 }

--- a/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
@@ -2,12 +2,12 @@ package org.openelisglobal.menu.service;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
 import org.openelisglobal.common.util.URLUtil;
@@ -128,7 +128,7 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
     @Override
     @Transactional(readOnly = true)
     public List<MenuItem> filterByPrivilege(List<MenuItem> menuTree) {
-        if (menuTree == null || menuTree.isEmpty() || holdsAdminAuthority()) {
+        if (holdsAdminAuthority()) {
             return menuTree;
         }
         String sysUserId = userContextHolder.getCurrentSysUserId();
@@ -179,11 +179,7 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
     }
 
     private Map<String, List<SystemModuleUrl>> indexModuleUrlsByPath() {
-        Map<String, List<SystemModuleUrl>> urlsByPath = new HashMap<>();
-        for (SystemModuleUrl moduleUrl : systemModuleUrlService.getAll()) {
-            urlsByPath.computeIfAbsent(moduleUrl.getUrlPath(), path -> new ArrayList<>()).add(moduleUrl);
-        }
-        return urlsByPath;
+        return systemModuleUrlService.getAll().stream().collect(Collectors.groupingBy(SystemModuleUrl::getUrlPath));
     }
 
     private void collectIndependentlyVisible(List<MenuItem> menuItems, Set<String> permittedModules,

--- a/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/openelisglobal/menu/service/MenuServiceImpl.java
@@ -19,8 +19,6 @@ import org.openelisglobal.menu.valueholder.Menu;
 import org.openelisglobal.systemmodule.service.SystemModuleUrlService;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleParam;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleUrl;
-import org.openelisglobal.systemusermodule.service.PermissionModuleService;
-import org.openelisglobal.systemusermodule.valueholder.PermissionModule;
 import org.openelisglobal.userrole.service.UserRoleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
@@ -50,9 +48,6 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
 
     @Autowired
     private UserRoleService userRoleService;
-
-    @Autowired
-    private PermissionModuleService<PermissionModule> permissionModuleService;
 
     @Autowired
     private UserContextHolder userContextHolder;
@@ -133,13 +128,14 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
         }
         String sysUserId = userContextHolder.getCurrentSysUserId();
         if (GenericValidator.isBlankOrNull(sysUserId)) {
-            // No resolvable identity (anonymous or daemon context): return the tree
-            // rather than hiding every node with a declared policy.
+            // No resolvable identity: return the tree rather than hiding every node
+            // with a declared policy.
             return menuTree;
         }
 
-        Set<String> permittedModules = permittedModulesForRolesOf(sysUserId);
-        Map<String, List<SystemModuleUrl>> urlsByPath = indexModuleUrlsByPath();
+        Set<String> permittedModules = userRoleService.getAllPermittedPagesForUser(sysUserId);
+        Map<String, List<SystemModuleUrl>> urlsByPath = systemModuleUrlService.getAll().stream()
+                .collect(Collectors.groupingBy(SystemModuleUrl::getUrlPath));
         Set<String> visibleElementIds = new HashSet<>();
         collectIndependentlyVisible(menuTree, permittedModules, urlsByPath, visibleElementIds);
 
@@ -151,35 +147,8 @@ public class MenuServiceImpl extends AuditableBaseObjectServiceImpl<Menu, String
 
     private boolean holdsAdminAuthority() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            return true;
-        }
-        return authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+        return authentication != null && authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)
                 .anyMatch(ADMIN_AUTHORITIES::contains);
-    }
-
-    /**
-     * ponytail: resolves privileges from the user's roles only. The USER value of
-     * the {@code permissions.agent} property is unsupported here — it is set in no
-     * deployment and {@code system_user_module} carries no rows.
-     */
-    private Set<String> permittedModulesForRolesOf(String sysUserId) {
-        Set<String> permittedModules = new HashSet<>();
-        List<String> roleIds = userRoleService.getRoleIdsForUser(sysUserId);
-        if (roleIds == null) {
-            return permittedModules;
-        }
-        for (String roleId : roleIds) {
-            if (!GenericValidator.isBlankOrNull(roleId)) {
-                permittedModules.addAll(
-                        permissionModuleService.getAllPermittedPagesFromAgentId(Integer.parseInt(roleId.trim())));
-            }
-        }
-        return permittedModules;
-    }
-
-    private Map<String, List<SystemModuleUrl>> indexModuleUrlsByPath() {
-        return systemModuleUrlService.getAll().stream().collect(Collectors.groupingBy(SystemModuleUrl::getUrlPath));
     }
 
     private void collectIndependentlyVisible(List<MenuItem> menuItems, Set<String> permittedModules,

--- a/src/main/java/org/openelisglobal/menu/util/MenuUtil.java
+++ b/src/main/java/org/openelisglobal/menu/util/MenuUtil.java
@@ -72,17 +72,11 @@ public class MenuUtil {
             createTree();
         }
 
-        List<MenuItem> menuTree = root;
+        List<MenuItem> menuTree = isMenuFilteringEnabled() ? filterMenuTree(root) : root;
 
-        // Apply menu filtering if enabled
-        if (isMenuFilteringEnabled()) {
-            menuTree = filterMenuTree(menuTree);
-        }
-
-        // Drop nodes the current user holds no privilege for. Applied last so the
-        // deployment-wide config filter above still bounds what any user can see, and
-        // applied here rather than in the controller so every consumer of the tree —
-        // including the legacy banner.jsp menu — is covered.
+        // Privilege filter applied last, so the deployment-wide config filter above
+        // still bounds every user; applied here rather than in the controller so every
+        // consumer of the tree — including the legacy banner.jsp menu — is covered.
         return menuService.filterByPrivilege(menuTree);
     }
 

--- a/src/main/java/org/openelisglobal/menu/util/MenuUtil.java
+++ b/src/main/java/org/openelisglobal/menu/util/MenuUtil.java
@@ -72,12 +72,18 @@ public class MenuUtil {
             createTree();
         }
 
+        List<MenuItem> menuTree = root;
+
         // Apply menu filtering if enabled
         if (isMenuFilteringEnabled()) {
-            return filterMenuTree(root);
+            menuTree = filterMenuTree(menuTree);
         }
 
-        return root;
+        // Drop nodes the current user holds no privilege for. Applied last so the
+        // deployment-wide config filter above still bounds what any user can see, and
+        // applied here rather than in the controller so every consumer of the tree —
+        // including the legacy banner.jsp menu — is covered.
+        return menuService.filterByPrivilege(menuTree);
     }
 
     public static List<MenuItem> getUnfilteredMenuTree() {
@@ -361,7 +367,7 @@ public class MenuUtil {
      *                          included
      * @return The filtered menu tree containing only included items
      */
-    private static List<MenuItem> filterByIncludes(List<MenuItem> menuTree, Set<String> includes,
+    public static List<MenuItem> filterByIncludes(List<MenuItem> menuTree, Set<String> includes,
             Set<String> wildcardParentIds) {
         return filterByIncludes(menuTree, includes, wildcardParentIds, false);
     }

--- a/src/main/java/org/openelisglobal/userrole/service/UserRoleService.java
+++ b/src/main/java/org/openelisglobal/userrole/service/UserRoleService.java
@@ -2,6 +2,7 @@ package org.openelisglobal.userrole.service;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.userrole.valueholder.LabUnitRoleMap;
 import org.openelisglobal.userrole.valueholder.UserLabUnitRoles;
@@ -11,6 +12,14 @@ import org.openelisglobal.userrole.valueholder.UserRolePK;
 public interface UserRoleService extends BaseObjectService<UserRole, UserRolePK> {
 
     List<String> getRoleIdsForUser(String userId);
+
+    /**
+     * Union of permitted module names across the user's roles — the same set
+     * {@code ModuleAuthenticationInterceptor} authorizes pages against. Role-agent
+     * resolution only: the USER mode of {@code permissions.agent} takes a different
+     * branch in the interceptor and is set in no deployment.
+     */
+    Set<String> getAllPermittedPagesForUser(String userId);
 
     boolean userInRole(String userId, String roleName);
 

--- a/src/main/java/org/openelisglobal/userrole/service/UserRoleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/userrole/service/UserRoleServiceImpl.java
@@ -2,8 +2,12 @@ package org.openelisglobal.userrole.service;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.openelisglobal.common.service.AuditableBaseObjectServiceImpl;
+import org.openelisglobal.systemusermodule.service.PermissionModuleService;
+import org.openelisglobal.systemusermodule.valueholder.PermissionModule;
 import org.openelisglobal.userrole.dao.UserLabUnitRolesDAO;
 import org.openelisglobal.userrole.dao.UserRoleDAO;
 import org.openelisglobal.userrole.valueholder.LabUnitRoleMap;
@@ -21,6 +25,8 @@ public class UserRoleServiceImpl extends AuditableBaseObjectServiceImpl<UserRole
     protected UserRoleDAO baseObjectDAO;
     @Autowired
     protected UserLabUnitRolesDAO userLabUnitRolesDAO;
+    @Autowired
+    protected PermissionModuleService<PermissionModule> permissionModuleService;
 
     UserRoleServiceImpl() {
         super(UserRole.class);
@@ -37,6 +43,16 @@ public class UserRoleServiceImpl extends AuditableBaseObjectServiceImpl<UserRole
     @Transactional(readOnly = true)
     public List<String> getRoleIdsForUser(String userId) {
         return baseObjectDAO.getRoleIdsForUser(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Set<String> getAllPermittedPagesForUser(String userId) {
+        Set<String> permittedPages = new HashSet<>();
+        for (String roleId : baseObjectDAO.getRoleIdsForUser(userId)) {
+            permittedPages.addAll(permissionModuleService.getAllPermittedPagesFromAgentId(Integer.parseInt(roleId)));
+        }
+        return permittedPages;
     }
 
     @Override

--- a/src/main/resources/liquibase/3.5.x.x/069-menu-privilege-urls.xml
+++ b/src/main/resources/liquibase/3.5.x.x/069-menu-privilege-urls.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- ================================================================== -->
+    <!-- OGC-1151: privilege data for the menu filter.                      -->
+    <!--                                                                    -->
+    <!-- Both changeSets below affect page authorization as well as menu    -->
+    <!-- visibility, because ModuleAuthenticationInterceptor resolves the   -->
+    <!-- same system_module_url rows. They are kept separate so either can  -->
+    <!-- be rolled back on its own.                                         -->
+    <!-- ================================================================== -->
+
+    <!--
+      The Admin landing page had no system_module_url row, so it was invisible to
+      the privilege chain and every role saw the Admin menu entry. The MasterList
+      module already exists and is granted to the administrator roles; only the
+      URL mapping was missing.
+
+      Side effect to note on deploy: the interceptor now enforces /MasterListsPage
+      server-side (REQUIRE_MODULE denies an unmapped non-REST path), replacing the
+      client-side "Access Denied" dialog with a real redirect.
+    -->
+    <changeSet author="samuelmale" id="ogc-1151-001-master-lists-page-url">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="system_module_url" schemaName="clinlims"/>
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM clinlims.system_module WHERE name = 'MasterList'
+            </sqlCheck>
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM clinlims.system_module_url WHERE url_path = '/MasterListsPage'
+            </sqlCheck>
+        </preConditions>
+        <comment>Map /MasterListsPage to the MasterList module so the Admin menu is privilege-gated</comment>
+
+        <insert tableName="system_module_url" schemaName="clinlims">
+            <column name="id" valueSequenceNext="system_module_url_seq"/>
+            <column name="url_path" value="/MasterListsPage"/>
+            <column name="system_module_id"
+                valueComputed="(SELECT id FROM clinlims.system_module WHERE name = 'MasterList')"/>
+        </insert>
+
+        <rollback>
+            <delete tableName="system_module_url" schemaName="clinlims">
+                <where>url_path = '/MasterListsPage'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <!--
+      URLUtil strips the /rest prefix before looking a path up, so rows stored
+      with that prefix could never match. Seven such rows exist; all were dead
+      data. Four of them cover live endpoints (/eqa, /qc, /alerts,
+      /reports/amendment) which until now fell through the interceptor's
+      isRestFullPath() auto-allow — after this runs they are enforced against
+      EQAView / AmendmentReport. The remaining three (GenericSampleOrder) stay
+      inert because no handler maps their bare paths.
+    -->
+    <changeSet author="samuelmale" id="ogc-1151-002-strip-rest-prefix-from-module-urls">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="system_module_url" schemaName="clinlims"/>
+        </preConditions>
+        <comment>Strip the /rest prefix from system_module_url rows so they can match a request path</comment>
+
+        <sql>
+            UPDATE clinlims.system_module_url
+            SET url_path = SUBSTRING(url_path FROM 6)
+            WHERE url_path LIKE '/rest/%';
+        </sql>
+
+        <!--
+          /rest/GenericSampleOrder strips onto a path that already had a row for the
+          same module, so drop the now-redundant duplicate. Keyed on the whole
+          (url_path, module, param) triple to avoid removing rows that legitimately
+          share a path but differ by parameter.
+        -->
+        <sql>
+            DELETE FROM clinlims.system_module_url stripped
+            WHERE stripped.url_path IN ('/alerts', '/eqa', '/qc', '/reports/amendment',
+                                        '/GenericSampleOrder', '/GenericSampleOrder/import',
+                                        '/GenericSampleOrder/validate')
+              AND EXISTS (
+                SELECT 1
+                FROM clinlims.system_module_url kept
+                WHERE kept.url_path = stripped.url_path
+                  AND kept.system_module_id = stripped.system_module_id
+                  AND kept.system_module_param_id IS NOT DISTINCT FROM stripped.system_module_param_id
+                  AND kept.id &lt; stripped.id
+              );
+        </sql>
+
+        <rollback>
+            <sql>
+                UPDATE clinlims.system_module_url
+                SET url_path = '/rest' || url_path
+                WHERE url_path IN ('/alerts', '/eqa', '/qc', '/reports/amendment',
+                                   '/GenericSampleOrder', '/GenericSampleOrder/import',
+                                   '/GenericSampleOrder/validate');
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/069-menu-privilege-urls.xml
+++ b/src/main/resources/liquibase/3.5.x.x/069-menu-privilege-urls.xml
@@ -58,6 +58,9 @@
       isRestFullPath() auto-allow — after this runs they are enforced against
       EQAView / AmendmentReport. The remaining three (GenericSampleOrder) stay
       inert because no handler maps their bare paths.
+
+      Verified on a seeded database: no active role loses a page it could reach
+      before, because Reception already holds EQAView and GenericSampleView.
     -->
     <changeSet author="samuelmale" id="ogc-1151-002-strip-rest-prefix-from-module-urls">
         <preConditions onFail="MARK_RAN">
@@ -65,40 +68,57 @@
         </preConditions>
         <comment>Strip the /rest prefix from system_module_url rows so they can match a request path</comment>
 
+        <!--
+          Drop redundant rows FIRST, while the /rest prefix still distinguishes them.
+          /rest/GenericSampleOrder strips onto a path that already has a row for the
+          same module, and once both rows read '/GenericSampleOrder' nothing can tell
+          the pre-existing row from the stripped one — which would make the rollback
+          below unable to avoid corrupting a row this changeset never touched.
+          Compared on the whole (target path, module, param) triple so rows that
+          legitimately share a path but differ by parameter are left alone.
+        -->
+        <sql>
+            DELETE FROM clinlims.system_module_url redundant
+            WHERE redundant.url_path LIKE '/rest/%'
+              AND EXISTS (
+                SELECT 1
+                FROM clinlims.system_module_url existing
+                WHERE existing.url_path = SUBSTRING(redundant.url_path FROM 6)
+                  AND existing.system_module_id = redundant.system_module_id
+                  AND existing.system_module_param_id IS NOT DISTINCT FROM redundant.system_module_param_id
+              );
+        </sql>
+
         <sql>
             UPDATE clinlims.system_module_url
             SET url_path = SUBSTRING(url_path FROM 6)
             WHERE url_path LIKE '/rest/%';
         </sql>
 
-        <!--
-          /rest/GenericSampleOrder strips onto a path that already had a row for the
-          same module, so drop the now-redundant duplicate. Keyed on the whole
-          (url_path, module, param) triple to avoid removing rows that legitimately
-          share a path but differ by parameter.
-        -->
-        <sql>
-            DELETE FROM clinlims.system_module_url stripped
-            WHERE stripped.url_path IN ('/alerts', '/eqa', '/qc', '/reports/amendment',
-                                        '/GenericSampleOrder', '/GenericSampleOrder/import',
-                                        '/GenericSampleOrder/validate')
-              AND EXISTS (
-                SELECT 1
-                FROM clinlims.system_module_url kept
-                WHERE kept.url_path = stripped.url_path
-                  AND kept.system_module_id = stripped.system_module_id
-                  AND kept.system_module_param_id IS NOT DISTINCT FROM stripped.system_module_param_id
-                  AND kept.id &lt; stripped.id
-              );
-        </sql>
-
         <rollback>
+            <!--
+              Restore the redundant row the delete above removed, cloned from the row
+              it duplicated. Done before the re-prefix so the clone is not itself
+              re-prefixed.
+            -->
+            <sql>
+                INSERT INTO clinlims.system_module_url (id, url_path, system_module_id, system_module_param_id)
+                SELECT nextval('clinlims.system_module_url_seq'), '/rest/GenericSampleOrder',
+                       system_module_id, system_module_param_id
+                FROM clinlims.system_module_url
+                WHERE url_path = '/GenericSampleOrder'
+                LIMIT 1;
+            </sql>
+            <!--
+              '/GenericSampleOrder' is deliberately absent from this list: its row
+              predates this changeset and was never prefixed, so re-prefixing it would
+              break GenericSampleView authorization on rollback.
+            -->
             <sql>
                 UPDATE clinlims.system_module_url
                 SET url_path = '/rest' || url_path
                 WHERE url_path IN ('/alerts', '/eqa', '/qc', '/reports/amendment',
-                                   '/GenericSampleOrder', '/GenericSampleOrder/import',
-                                   '/GenericSampleOrder/validate');
+                                   '/GenericSampleOrder/import', '/GenericSampleOrder/validate');
             </sql>
         </rollback>
     </changeSet>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -181,4 +181,7 @@
       free-text values instead of dictionary ids broke every getDictionaryById consumer -->
   <include relativeToChangelogFile="true" file="068-repair-free-text-dictionary-options.xml"/>
 
+  <!-- OGC-1151: privilege data for the navigation menu filter -->
+  <include relativeToChangelogFile="true" file="069-menu-privilege-urls.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/menu/service/MenuPrivilegeFilterTest.java
+++ b/src/test/java/org/openelisglobal/menu/service/MenuPrivilegeFilterTest.java
@@ -1,0 +1,177 @@
+package org.openelisglobal.menu.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.menu.util.MenuItem;
+import org.openelisglobal.menu.util.MenuUtil;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * Covers the OGC-1151 menu privilege filter: {@code GET /rest/menu} must omit
+ * nodes whose target the caller holds no module grant for.
+ *
+ * <p>
+ * The fixture is built additively over the migrated schema rather than through
+ * a DBUnit dataset. A dataset naming {@code menu} or {@code system_module}
+ * would be TRUNCATE-d CASCADE by the loader, which both destroys the seeded
+ * privilege chain this filter reads and leaves later tests in the shared
+ * container without their role grants. Every row inserted here carries a
+ * reserved id and is removed again in {@link #removeFixture()}, so the test is
+ * order-independent — notably it does not depend on the production menu tree,
+ * which {@code MenuRestControllerTest} truncates.
+ */
+public class MenuPrivilegeFilterTest extends BaseWebContextSensitiveTest {
+
+    private static final long FOLDER_ID = 99115101L;
+    private static final long GRANTED_CHILD_ID = 99115102L;
+    private static final long DENIED_CHILD_ID = 99115103L;
+    private static final long LONELY_FOLDER_ID = 99115104L;
+    private static final long PLACEHOLDER_ID = 99115105L;
+    private static final long LONELY_FOLDER_CHILD_ID = 99115106L;
+
+    private static final String FOLDER = "ogc1151_folder";
+    private static final String GRANTED_CHILD = "ogc1151_child_unmapped";
+    private static final String DENIED_CHILD = "ogc1151_child_restricted";
+    private static final String LONELY_FOLDER = "ogc1151_folder_all_denied";
+    private static final String PLACEHOLDER = "ogc1151_placeholder";
+
+    private static final String RESTRICTED_URL = "/Ogc1151Restricted";
+    private static final String UNMAPPED_URL = "/Ogc1151Unmapped";
+
+    private static final long MODULE_ID = 99115110L;
+    private static final String MODULE_NAME = "Ogc1151RestrictedModule";
+    private static final long MODULE_URL_ID = 99115111L;
+    private static final long ROLE_ID = 99115120L;
+    private static final String ROLE_NAME = "OGC1151 Bench";
+    private static final long ROLE_MODULE_ID = 99115121L;
+    private static final long USER_ID = 99115130L;
+    private static final String LOGIN_NAME = "ogc1151_bench";
+
+    @Before
+    public void insertFixture() throws Exception {
+        removeFixture();
+
+        // A folder holding one node with no policy (must survive) and one node
+        // pointing at a module the role is not granted (must be removed).
+        insertMenu(FOLDER_ID, null, 1, FOLDER, null);
+        insertMenu(GRANTED_CHILD_ID, FOLDER_ID, 1, GRANTED_CHILD, UNMAPPED_URL);
+        insertMenu(DENIED_CHILD_ID, FOLDER_ID, 2, DENIED_CHILD, RESTRICTED_URL);
+
+        // A folder whose only child is removed, so the folder goes with it.
+        insertMenu(LONELY_FOLDER_ID, null, 2, LONELY_FOLDER, null);
+        insertMenu(LONELY_FOLDER_CHILD_ID, LONELY_FOLDER_ID, 1, DENIED_CHILD + "_2", RESTRICTED_URL);
+
+        // No url and no children: a placeholder whose target an admin supplies at
+        // runtime (the menu_billing shape). Must survive.
+        insertMenu(PLACEHOLDER_ID, null, 3, PLACEHOLDER, null);
+
+        jdbcTemplate.update("INSERT INTO system_module (id, name, description, has_select_flag)"
+                + " VALUES (?, ?, 'OGC-1151 test module', 'Y')", MODULE_ID, MODULE_NAME);
+        jdbcTemplate.update("INSERT INTO system_module_url (id, url_path, system_module_id) VALUES (?, ?, ?)",
+                MODULE_URL_ID, RESTRICTED_URL, MODULE_ID);
+
+        jdbcTemplate.update("INSERT INTO system_role (id, name, description, active) VALUES (?, ?, ?, true)", ROLE_ID,
+                ROLE_NAME, "OGC-1151 test role");
+        jdbcTemplate.update("INSERT INTO system_user (id, login_name, last_name, first_name, initials,"
+                + " is_active, is_employee, lastupdated) VALUES (?, ?, 'Bench', 'OGC1151', 'OB', 'Y', 'Y', now())",
+                USER_ID, LOGIN_NAME);
+        jdbcTemplate.update("INSERT INTO system_user_role (system_user_id, role_id) VALUES (?, ?)", USER_ID, ROLE_ID);
+
+        MenuUtil.forceRebuild();
+        authenticateAsBenchUser();
+    }
+
+    @After
+    public void removeFixture() {
+        jdbcTemplate.update("DELETE FROM system_role_module WHERE id = ?", ROLE_MODULE_ID);
+        jdbcTemplate.update("DELETE FROM system_user_role WHERE system_user_id = ?", USER_ID);
+        jdbcTemplate.update("DELETE FROM system_user WHERE id = ?", USER_ID);
+        jdbcTemplate.update("DELETE FROM system_role WHERE id = ?", ROLE_ID);
+        jdbcTemplate.update("DELETE FROM system_module_url WHERE id = ?", MODULE_URL_ID);
+        jdbcTemplate.update("DELETE FROM system_module WHERE id = ?", MODULE_ID);
+        jdbcTemplate.update("DELETE FROM menu WHERE element_id LIKE 'ogc1151_%'");
+        MenuUtil.forceRebuild();
+    }
+
+    @Test
+    public void getMenuTree_omitsUnprivilegedNodesAndRestoresThemWhenTheModuleIsGranted() throws Exception {
+        Set<String> visible = fetchMenuElementIds();
+
+        assertFalse("a node whose module the role lacks must not be returned", visible.contains(DENIED_CHILD));
+        assertFalse("a folder left with no surviving child must be pruned", visible.contains(LONELY_FOLDER));
+        assertTrue("a node with no declared policy must stay visible", visible.contains(GRANTED_CHILD));
+        assertTrue("a folder keeping one surviving child must stay visible", visible.contains(FOLDER));
+        assertTrue("a childless node with no url is a placeholder and must stay visible",
+                visible.contains(PLACEHOLDER));
+
+        // Inversion: the filter must be reading the grant data, not a hardcoded list.
+        jdbcTemplate.update("INSERT INTO system_role_module (id, has_select, system_role_id, system_module_id)"
+                + " VALUES (?, 'Y', ?, ?)", ROLE_MODULE_ID, ROLE_ID, MODULE_ID);
+
+        Set<String> afterGrant = fetchMenuElementIds();
+
+        assertTrue("granting the module must restore the node", afterGrant.contains(DENIED_CHILD));
+        assertTrue("granting the module must restore its pruned parent", afterGrant.contains(LONELY_FOLDER));
+    }
+
+    @Test
+    public void getMenuTree_returnsEveryNodeForAnAdminAuthority() throws Exception {
+        setDefaultTestAuthentication();
+
+        Set<String> visible = fetchMenuElementIds();
+
+        assertEquals("an admin authority bypasses the filter entirely",
+                collectElementIds(MenuUtil.getUnfilteredMenuTree()), visible);
+        assertTrue("the restricted node is visible to an admin", visible.contains(DENIED_CHILD));
+    }
+
+    private void authenticateAsBenchUser() {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(LOGIN_NAME, "N/A",
+                List.of(new SimpleGrantedAuthority("ROLE_OGC1151_BENCH"))));
+    }
+
+    private void insertMenu(Long id, Long parentId, int order, String elementId, String actionUrl) {
+        jdbcTemplate.update(
+                "INSERT INTO menu (id, parent_id, presentation_order, element_id, action_url, display_key,"
+                        + " new_window, is_active, hide_in_old_ui) VALUES (?, ?, ?, ?, ?, ?, false, true, false)",
+                id, parentId, order, elementId, actionUrl, "banner.menu." + elementId);
+    }
+
+    private Set<String> fetchMenuElementIds() throws Exception {
+        MvcResult result = mockMvc.perform(get("/rest/menu").accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)).andReturn();
+        List<MenuItem> tree = new ObjectMapper().readValue(result.getResponse().getContentAsString(),
+                new TypeReference<List<MenuItem>>() {
+                });
+        return collectElementIds(tree);
+    }
+
+    private Set<String> collectElementIds(List<MenuItem> tree) {
+        Set<String> elementIds = new HashSet<>();
+        collectElementIds(tree, elementIds);
+        return elementIds;
+    }
+
+    private void collectElementIds(List<MenuItem> tree, Set<String> sink) {
+        for (MenuItem menuItem : tree) {
+            sink.add(menuItem.getMenu().getElementId());
+            collectElementIds(menuItem.getChildMenus(), sink);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. _(N/A —
      backend-only; no frontend code shipped. Runtime verification table below.)_
- [x] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation. _(N/A — no UI changes.)_
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

The React SPA navigation menu was not being filtered based on user privileges. A user with only the Reception lab-unit role could see the full 22-item top-level menu, including **Admin**.

`GET /rest/menu` returned the same 193-node tree for both `qa_recept` and a global administrator. Server-side authorization was still working correctly — all 42 admin sub-routes were denied to the Reception user, so no data was exposed. However, users were still seeing menu items they could not access and being sent to access-denied screens.

The root cause is that the `menu` table does not have any role or module linkage, and `MenuUtil.getMenuTree()` was serving the same static, cached menu tree to every user.

## Fix

Menu visibility is now determined server-side:

> A menu item is visible only if the current user has a privilege for its target.

The filtering reuses the existing authorization chain that is already used to enforce page access. This keeps the menu and actual route permissions aligned and, importantly, avoids relying on frontend filtering, which could be bypassed by calling the API directly.

## Other fixes

* **Secured `/rest/admin/menu/{elementId}`**
  This endpoint was returning the unfiltered menu tree to any authenticated user because the interceptor did not match URLs containing path variables. It is now restricted to `ADMIN`. All existing callers are already behind `GLOBAL_ADMIN`-protected routes.

* **Fixed `AccessDeniedException` being returned as 500**
  `ControllerSetup` had a catch-all exception handler that swallowed `AccessDeniedException` on paths not covered by the interceptor, causing authorization failures to be returned as HTTP 500. Added an explicit handler that returns **401**, consistent with the existing interceptor behavior.

## Screenshots

N/A 

## Related Issue

- [OGC-1151](https://uwdigi.atlassian.net/browse/OGC-1151) — Sidebar/nav menu
  is not role-filtered; bench roles see full menu including Admin.
- Touches [OGC-403](https://uwdigi.atlassian.net/browse/OGC-403) (epic OGC-383
  Phase 2): that story specifies a *frontend* sidebar filter; this server-side
  filter satisfies the same criteria strictly more — flagging so nobody builds
  the frontend version in parallel.



[OGC-1151]: https://uwdigi.atlassian.net/browse/OGC-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ