### PR TITLE
issue-3743: add Clear action for Active Alerts and improve Acknowledge functionality

### DIFF
--- a/frontend/playwright/helpers/seed-freezer-alert.ts
+++ b/frontend/playwright/helpers/seed-freezer-alert.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from "child_process";
+import { resolveDbContainer } from "./db-container";
+
+const SCHEMA = "clinlims";
+
+function psql(sql: string): void {
+  const container = resolveDbContainer();
+  execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      "clinlims",
+      "-d",
+      "clinlims",
+      "-c",
+      sql,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+function esc(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Seed a freezer with one OPEN critical alert directly in the database.
+ * Alerts have no create API (they are raised by the monitoring service), so the
+ * rows are inserted via docker exec psql against the compose DB container.
+ * The alert references the freezer by name (subquery) rather than capturing an
+ * id from psql output, and sets last_updated because the alert entity uses it
+ * as an optimistic-lock @Version (a NULL there makes resolve/acknowledge fail).
+ * Idempotent: any prior row with the same name is removed first.
+ */
+export function seedFreezerWithOpenAlert(name: string): void {
+  cleanupFreezerAlert(name);
+  psql(
+    `INSERT INTO ${SCHEMA}.freezer ` +
+      `(id, name, protocol, slave_id, temperature_register, target_temperature, warning_threshold, critical_threshold, active) ` +
+      `VALUES ((SELECT COALESCE(MAX(id), 0) + 1 FROM ${SCHEMA}.freezer), ` +
+      `${esc(name)}, 'RTU', 1, 0, -20, -15, -10, true);`,
+  );
+  psql(
+    `INSERT INTO ${SCHEMA}.alert ` +
+      `(id, alert_type, alert_entity_type, alert_entity_id, severity, status, start_time, last_updated, message, duplicate_count) ` +
+      `VALUES ((SELECT COALESCE(MAX(id), 0) + 1 FROM ${SCHEMA}.alert), ` +
+      `'FREEZER_TEMPERATURE', 'Freezer', (SELECT id FROM ${SCHEMA}.freezer WHERE name = ${esc(name)}), ` +
+      `'CRITICAL', 'OPEN', now(), now(), 'E2E cold-storage alert', 0);`,
+  );
+}
+
+export function cleanupFreezerAlert(name: string): void {
+  try {
+    psql(
+      `DELETE FROM ${SCHEMA}.alert WHERE alert_entity_type = 'Freezer' ` +
+        `AND alert_entity_id IN (SELECT id FROM ${SCHEMA}.freezer WHERE name = ${esc(name)}); ` +
+        `DELETE FROM ${SCHEMA}.freezer WHERE name = ${esc(name)};`,
+    );
+  } catch (e) {
+    console.warn(`cleanupFreezerAlert failed for "${name}": ${e}`);
+  }
+}

--- a/frontend/playwright/tests/foundational/core/cold-storage-alert-clear.spec.ts
+++ b/frontend/playwright/tests/foundational/core/cold-storage-alert-clear.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "../../../helpers/test-base";
+import { NAV_TIMEOUT } from "../../../helpers/timeouts";
+import {
+  seedFreezerWithOpenAlert,
+  cleanupFreezerAlert,
+} from "../../../helpers/seed-freezer-alert";
+
+const FREEZER_NAME = "E2E-CLR-FRZ";
+
+test.describe("Cold Storage — clear an active alert", () => {
+  test.afterEach(() => {
+    cleanupFreezerAlert(FREEZER_NAME);
+  });
+
+  test("an active alert exposes a Clear action that removes it from the list", async ({
+    page,
+  }) => {
+    seedFreezerWithOpenAlert(FREEZER_NAME);
+
+    await page.goto("/FreezerMonitoring", { waitUntil: "domcontentloaded" });
+
+    const alertRow = page
+      .getByRole("row")
+      .filter({ hasText: FREEZER_NAME })
+      .filter({ has: page.getByRole("button", { name: "Clear" }) });
+    await expect(alertRow).toBeVisible({ timeout: NAV_TIMEOUT });
+
+    await alertRow.getByRole("button", { name: "Clear" }).click();
+
+    await expect(alertRow).toHaveCount(0, { timeout: NAV_TIMEOUT });
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(alertRow).toHaveCount(0, { timeout: NAV_TIMEOUT });
+  });
+});

--- a/frontend/src/components/coldStorage/FreezerMonitoringDashboard.jsx
+++ b/frontend/src/components/coldStorage/FreezerMonitoringDashboard.jsx
@@ -54,6 +54,7 @@ import DeviceHistoryExpansion from "./DeviceHistoryExpansion";
 import { toDate, formatDuration } from "./shared/timeUtils";
 import { AlertDialog, NotificationKinds } from "../common/CustomNotification";
 import { NotificationContext } from "../layout/Layout";
+import UserSessionDetailsContext from "../../UserSessionDetailsContext";
 
 const COLUMNS = [
   { key: "id", header: "Unit ID" },
@@ -167,6 +168,7 @@ const formatTemperatureDisplay = (value) =>
 function FreezerMonitoringDashboard({ intl }) {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
+  const { userSessionDetails } = useContext(UserSessionDetailsContext);
   const notify = useCallback(
     ({ kind = NotificationKinds.info, title, subtitle, message }) => {
       setNotificationVisible(true);
@@ -279,7 +281,9 @@ function FreezerMonitoringDashboard({ intl }) {
           [];
 
       setStorageUnits(unitsArray.map(normalizeUnit));
-      setActiveAlerts(alertsArray.map(normalizeAlert));
+      setActiveAlerts(
+        alertsArray.map(normalizeAlert).filter((a) => a.status !== "RESOLVED"),
+      );
       setLastUpdated(new Date().toISOString());
     } catch (error) {
       notify({
@@ -304,16 +308,30 @@ function FreezerMonitoringDashboard({ intl }) {
 
   const handleAlertAction = useCallback(
     async (alertId, action) => {
+      const userId = userSessionDetails?.userId;
+      if (userId == null) {
+        notify({
+          kind: NotificationKinds.error,
+          title: "Error",
+          subtitle:
+            "Unable to determine the current user. Please reload and try again.",
+        });
+        return;
+      }
       setActionInFlight(alertId);
       try {
         if (action === "acknowledge") {
           await acknowledgeAlert(
             alertId,
-            1,
+            userId,
             "Acknowledged via Cold Storage dashboard",
           );
         } else {
-          await resolveAlert(alertId, 1, "Resolved via Cold Storage dashboard");
+          await resolveAlert(
+            alertId,
+            userId,
+            "Resolved via Cold Storage dashboard",
+          );
         }
         await loadDashboardData();
         notify({
@@ -331,7 +349,7 @@ function FreezerMonitoringDashboard({ intl }) {
         setActionInFlight(null);
       }
     },
-    [loadDashboardData, notify],
+    [loadDashboardData, notify, userSessionDetails],
   );
 
   const handleAcknowledgeAlert = useCallback(
@@ -827,9 +845,32 @@ function FreezerMonitoringDashboard({ intl }) {
                                                         );
                                                       }}
                                                     >
-                                                      Acknowledge
+                                                      {intl.formatMessage({
+                                                        id: "coldstorage.alert.acknowledge",
+                                                        defaultMessage:
+                                                          "Acknowledge",
+                                                      })}
                                                     </Button>
                                                   )}
+                                                  <Button
+                                                    kind="danger--ghost"
+                                                    size="sm"
+                                                    disabled={
+                                                      actionInFlight ===
+                                                      alert.id
+                                                    }
+                                                    onClick={(e) => {
+                                                      e.stopPropagation();
+                                                      handleResolveAlert(
+                                                        alert.id,
+                                                      );
+                                                    }}
+                                                  >
+                                                    {intl.formatMessage({
+                                                      id: "coldstorage.alert.clear",
+                                                      defaultMessage: "Clear",
+                                                    })}
+                                                  </Button>
                                                 </div>
                                               </TableCell>
                                             </TableRow>

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -1636,6 +1636,8 @@
   "error.informedConsent.formReferenceMaxLength": "Consent form reference must be 100 characters or fewer",
   "error.informedConsent.formReferenceInvalidChars": "Only letters, numbers, hyphens, and spaces are allowed",
   "coldstorage.label.dashboard": "Cold Storage Dashboard",
+  "coldstorage.alert.acknowledge": "Acknowledge",
+  "coldstorage.alert.clear": "Clear",
   "collection.date": "Collection Date",
   "collector": "Collector",
   "collector.label": "Collector",


### PR DESCRIPTION
@Agaba-derrick @mozzy11 @reagan-meant , this Addresses **item 2** of #3743 where Active Alerts could be acknowledged but never removed. (#3763 covers item 1, the merged #3811 covered item 3, so this should not auto-close the issue.)

**Background**
The Active Alerts table already had an **Acknowledge** action, but Acknowledge only marks an alert as seen so the alert *stays* in the list (and the Acknowledge button then disappears, since it only applies while the alert is `OPEN`). There was no way to actually take a handled alert off the list, so alerts accumulated indefinitely.

**What this adds**
- A **Clear** action on each Active Alerts row that **resolves** the alert and removes it from the list thus complementing Acknowledge rather than replacing it:
  - **Acknowledge** → "I've seen this" (alert remains active/acknowledged).
  - **Clear** → "this is handled" (alert is resolved and leaves the list; it stays gone after refresh, since resolved alerts are now filtered out of the active list).
- Alert actions (both acknowledge and resolve) now use the **logged-in user** (`userSessionDetails.userId`) instead of a hardcoded `1`, so they're attributed to the actual operator rather than always admin. (Attribution correctness is not a crash fix; acknowledge/resolve already work on real alerts.)
- A Playwright E2E (`cold-storage-alert-clear.spec.ts`) that seeds an open alert, clicks **Clear**, and asserts it leaves the list and stays gone after reload as also seen in the screen recording below

Screen recording of the fix attached.


https://github.com/user-attachments/assets/3605a253-be20-4cf6-93f1-910411502869




Coordination: @mherman22's draft #3828 also touches item 2; per his note he'll rebase #3828 to drop what this covers. Happy to adjust to whatever lands first.