### PR TITLE
fix: rename Validation result-table column header from "Save" to "Val…

### DIFF
--- a/frontend/src/components/validation/Validation.jsx
+++ b/frontend/src/components/validation/Validation.jsx
@@ -82,7 +82,7 @@ const Validation = (props) => {
     },
     {
       id: "save",
-      name: intl.formatMessage({ id: "column.name.save" }),
+      name: intl.formatMessage({ id: "label.button.validate" }),
       cell: (row, index, column, id) => {
         return renderCell(row, index, column, id);
       },


### PR DESCRIPTION
On the validation results page (opened after searching a lab number on Ready For Validation), the column holding the accept checkbox was labeled "Save", which was misleading — ticking a row is what feeds the Validate action at the bottom of the page. Point the column at the existing translatable key `label.button.validate` so it reads "Validate" and stays Transifex-managed.
