### PR TITLE
fix: use Accept header instead of URL path for HTML vs JSON response negotiation

### DIFF
--- a/frontend/src/components/utils/Utils.ts
+++ b/frontend/src/components/utils/Utils.ts
@@ -111,6 +111,7 @@ export const getFromOpenElisServer = <T = LegacyApiResponse>(
       method: "GET",
       signal: signal,
       headers: {
+        Accept: "application/json",
         "Accept-Language": getAcceptLanguageHeader(),
       },
     },
@@ -153,6 +154,7 @@ export const postToOpenElisServer = <TExtra = unknown>(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
         "X-CSRF-Token": csrfToken(),
         "Accept-Language": getAcceptLanguageHeader(),
       },
@@ -185,6 +187,7 @@ export const postToOpenElisServerFullResponse = <TExtra = unknown>(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
         "X-CSRF-Token": csrfToken(),
         "Accept-Language": getAcceptLanguageHeader(),
       },
@@ -212,6 +215,7 @@ export const postToOpenElisServerFormData = <TExtra = unknown>(
       credentials: "include",
       method: "POST",
       headers: {
+        Accept: "application/json",
         "X-CSRF-Token": csrfToken(),
         "Accept-Language": getAcceptLanguageHeader(),
       },
@@ -247,6 +251,7 @@ export const postToOpenElisServerJsonResponse = <
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
         "X-CSRF-Token": csrfToken(),
         "Accept-Language": getAcceptLanguageHeader(),
       },
@@ -376,6 +381,7 @@ export const putToOpenElisServer = (
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/json",
       "X-CSRF-Token": csrfToken(),
       "Accept-Language": getAcceptLanguageHeader(),
     },
@@ -410,6 +416,7 @@ export const putToOpenElisServerFullResponse = <TExtra = unknown>(
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/json",
       "X-CSRF-Token": csrfToken(),
       "Accept-Language": getAcceptLanguageHeader(),
     },
@@ -433,6 +440,7 @@ export const deleteFromOpenElisServer = (
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/json",
       "X-CSRF-Token": csrfToken(),
       "Accept-Language": getAcceptLanguageHeader(),
     },
@@ -459,6 +467,7 @@ export const deleteFromOpenElisServerFullResponse = <TExtra = unknown>(
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
+      Accept: "application/json",
       "X-CSRF-Token": csrfToken(),
       "Accept-Language": getAcceptLanguageHeader(),
     },
@@ -517,6 +526,7 @@ export const patchToOpenElisServerJsonResponse = <
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
         "X-CSRF-Token": csrfToken(),
         "Accept-Language": getAcceptLanguageHeader(),
       },

--- a/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
+++ b/src/main/java/org/openelisglobal/interceptor/ModuleAuthenticationInterceptor.java
@@ -13,6 +13,7 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.validator.BaseErrors;
 import org.openelisglobal.login.dao.UserModuleService;
 import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.security.SecurityResponseUtils;
 import org.openelisglobal.systemmodule.service.SystemModuleUrlService;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleParam;
 import org.openelisglobal.systemmodule.valueholder.SystemModuleUrl;
@@ -57,15 +58,15 @@ public class ModuleAuthenticationInterceptor implements HandlerInterceptor {
             LogEvent.logInfo("ModuleAuthenticationInterceptor", "preHandle()",
                     "======> NOT ALLOWED ACCESS TO THIS MODULE");
             LogEvent.logInfo(this.getClass().getSimpleName(), "preHandle", "has no permission"); //
-            if (isRestFullPath(path)) {
+            if (SecurityResponseUtils.isHtmlRequest(request)) {
+                redirectStrategy.sendRedirect(request, response, "/Home?access=denied");
+            } else {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.setCharacterEncoding("UTF-8");
                 String jsonResponse = "{ \"status\": 401, \"message\": \"Not Authorized\" }";
                 response.getWriter().write(jsonResponse);
                 response.getWriter().flush();
-            } else {
-                redirectStrategy.sendRedirect(request, response, "/Home?access=denied");
             }
             return false;
         }

--- a/src/main/java/org/openelisglobal/security/SecurityConfig.java
+++ b/src/main/java/org/openelisglobal/security/SecurityConfig.java
@@ -436,8 +436,9 @@ public class SecurityConfig {
                         .sessionFixation().migrateSession())
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/ValidateLogin"))
                 .exceptionHandling(ex -> ex.accessDeniedHandler((request, response, accessDeniedException) -> {
-                    String path = request.getRequestURI().substring(request.getContextPath().length());
-                    if (path.startsWith("/rest") || path.startsWith("/api") || path.startsWith("/Provider")) {
+                    if (SecurityResponseUtils.isHtmlRequest(request)) {
+                        response.sendRedirect(request.getContextPath() + "/Home?access=denied");
+                    } else {
                         response.setStatus(403);
                         response.setContentType("application/json");
                         response.setCharacterEncoding("UTF-8");
@@ -445,8 +446,6 @@ public class SecurityConfig {
                                 ? "CSRF token missing or invalid"
                                 : "Access denied";
                         response.getWriter().write("{ \"status\": 403, \"message\": \"" + message + "\" }");
-                    } else {
-                        response.sendRedirect(request.getContextPath() + "/Home?access=denied");
                     }
                 }))
                 // add security headers

--- a/src/main/java/org/openelisglobal/security/SecurityResponseUtils.java
+++ b/src/main/java/org/openelisglobal/security/SecurityResponseUtils.java
@@ -1,0 +1,25 @@
+package org.openelisglobal.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Set;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.web.accept.HeaderContentNegotiationStrategy;
+
+/**
+ * Content negotiation helper for the security subsystem. Determines whether a
+ * request wants an HTML (browser navigation) response or a JSON (API/Fetch)
+ * response based on the {@code Accept} header, rather than the URL path.
+ */
+public final class SecurityResponseUtils {
+
+    private SecurityResponseUtils() {
+    }
+
+    public static boolean isHtmlRequest(HttpServletRequest request) {
+        MediaTypeRequestMatcher htmlMatcher = new MediaTypeRequestMatcher(new HeaderContentNegotiationStrategy(),
+                MediaType.TEXT_HTML);
+        htmlMatcher.setIgnoredMediaTypes(Set.of(MediaType.ALL));
+        return htmlMatcher.matches(request);
+    }
+}

--- a/src/test/java/org/openelisglobal/security/SecurityResponseUtilsTest.java
+++ b/src/test/java/org/openelisglobal/security/SecurityResponseUtilsTest.java
@@ -1,0 +1,41 @@
+package org.openelisglobal.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class SecurityResponseUtilsTest {
+
+    @Test
+    public void isHtmlRequest_browserAcceptHeader_returnsTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+
+        assertTrue(SecurityResponseUtils.isHtmlRequest(request));
+    }
+
+    @Test
+    public void isHtmlRequest_fetchDefaultAcceptHeader_returnsFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept", "*/*");
+
+        assertFalse(SecurityResponseUtils.isHtmlRequest(request));
+    }
+
+    @Test
+    public void isHtmlRequest_explicitJsonAcceptHeader_returnsFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept", "application/json");
+
+        assertFalse(SecurityResponseUtils.isHtmlRequest(request));
+    }
+
+    @Test
+    public void isHtmlRequest_noAcceptHeader_returnsFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertFalse(SecurityResponseUtils.isHtmlRequest(request));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3965.

A couple of places in the security subsystem decided whether to return an
HTML redirect or a JSON error by inspecting the request's URL path
(`/rest`, `/api`, `/Provider`, ...). This violates REST content negotiation
principles — the response format should be negotiated via the `Accept`
header, not guessed from the path.

- Added `SecurityResponseUtils.isHtmlRequest(request)`, which uses
  `MediaTypeRequestMatcher` + `HeaderContentNegotiationStrategy` to check
  whether the client is asking for `text/html` (treating `*/*` as "not
  HTML", per the pattern suggested in the issue).
- `SecurityConfig`'s `accessDeniedHandler` now uses this helper instead of
  `path.startsWith("/rest"|"/api"|"/Provider")`.
- `ModuleAuthenticationInterceptor#preHandle` now uses the same helper
  instead of `isRestFullPath(path)` for its 401 response. (The unrelated
  use of `isRestFullPath` for the REST-module-permission fallback in
  `hasPermissionForUrl` was left untouched — that's authorization logic,
  not response-format negotiation.)

**Bonus (per issue addenda):** all JSON-returning fetch helpers in
`frontend/src/components/utils/Utils.ts` (`getFromOpenElisServer`,
`postToOpenElisServer*`, `putToOpenElisServer*`,
`deleteFromOpenElisServer*`, `patchToOpenElisServerJsonResponse`) now
explicitly set `Accept: application/json`, so the client requests JSON
rather than relying on the browser's default `Accept: */*`. The two
binary-response helpers (`postToOpenElisServerForBlob`,
`postToOpenElisServerForPDF`) were left as-is since they intentionally
expect non-JSON responses.

## Test plan

- [x] Added `SecurityResponseUtilsTest` covering: browser `Accept: text/html,...`
      → HTML redirect path; `Accept: */*` (fetch default) → JSON; explicit
      `Accept: application/json` → JSON; missing `Accept` header → JSON.
- [x] `mvn compile` succeeds.
- [x] `mvn spotless:apply` run, tree clean.
- [x] Verified `npm run typecheck` errors on the frontend are pre-existing
      on `develop` (unrelated to this change).
- [ ] Manual check: browser navigation to a protected page while
      unauthenticated/unauthorized still redirects to `/Home?access=denied`.
- [ ] Manual check: a `fetch()` call to a protected REST endpoint still
      receives a JSON 401/403 body.

@ibacher  @Ariho-Seth @caseyi @muiruri  please you can review and suggest changes where possible 
