### PR TITLE
fix(order): add missing Collect step to environmental workflow (OGC-1050)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -676,6 +676,12 @@ export default function App() {
                           role={Roles.RECEPTION}
                         />
                         <SecureRoute
+                          path={`${match.path}/collect`}
+                          exact
+                          component={() => <OrderCollect />}
+                          role={Roles.RECEPTION}
+                        />
+                        <SecureRoute
                           path={`${match.path}/label`}
                           exact
                           component={() => <OrderLabel />}

--- a/frontend/src/components/order/OrderStepper.jsx
+++ b/frontend/src/components/order/OrderStepper.jsx
@@ -8,7 +8,7 @@ import { useOrderContext } from "./OrderContext";
  * OrderStepper - Progress indicator for the order workflow.
  *
  * Clinical: Enter → Collect → Label → QA (4 steps)
- * Environmental: Enter → Label → QA (3 steps)
+ * Environmental: Enter → Collect → Label → QA (4 steps)
  * Vector: Enter → Label → QA (3 steps)
  *
  * Step completion is based on:
@@ -34,6 +34,11 @@ const ENVIRONMENTAL_ORDER_STEPS = [
     label: "order.step.enter",
     path: "/order/environmental/enter",
     key: "enter",
+  },
+  {
+    label: "order.step.collect",
+    path: "/order/environmental/collect",
+    key: "collect",
   },
   {
     label: "order.step.label",

--- a/frontend/src/components/order/OrderStepper.test.jsx
+++ b/frontend/src/components/order/OrderStepper.test.jsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../languages/en.json";
+
+// Stable mocks so useHistory()/useLocation() return the same objects across
+// renders — the stepper asserts against history.push.
+const { historyMock, locationMock, orderContextValue } = vi.hoisted(() => ({
+  historyMock: { push: () => {}, replace: () => {} },
+  locationMock: { pathname: "/order/clinical/enter", search: "" },
+  orderContextValue: {
+    samples: [],
+    storageSkipped: false,
+    labNumber: "",
+    stepProgress: {},
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  useHistory: () => historyMock,
+  useLocation: () => locationMock,
+}));
+
+vi.mock("./OrderContext", () => ({
+  useOrderContext: () => orderContextValue,
+}));
+
+import OrderStepper, {
+  CLINICAL_ORDER_STEPS,
+  ENVIRONMENTAL_ORDER_STEPS,
+  VECTOR_ORDER_STEPS,
+} from "./OrderStepper";
+
+const renderAt = (pathname) => {
+  locationMock.pathname = pathname;
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <OrderStepper />
+    </IntlProvider>,
+  );
+};
+
+// Each Carbon ProgressStep renders a button whose title is the step label; the
+// li also carries assistive text ("Complete"/"Incomplete"), so read the title.
+const stepLabels = () =>
+  screen.getAllByRole("button").map((button) => button.getAttribute("title"));
+
+const currentStepLabel = (container) =>
+  container
+    .querySelector(".cds--progress-step--current button")
+    .getAttribute("title");
+
+describe("OrderStepper workflow step sets", () => {
+  beforeEach(() => {
+    historyMock.push = vi.fn();
+    orderContextValue.labNumber = "";
+  });
+
+  test("environmental workflow exposes Collect between Enter and Label", () => {
+    expect(ENVIRONMENTAL_ORDER_STEPS.map((s) => s.key)).toEqual([
+      "enter",
+      "collect",
+      "label",
+      "qa",
+    ]);
+    expect(ENVIRONMENTAL_ORDER_STEPS[1].path).toBe(
+      "/order/environmental/collect",
+    );
+  });
+
+  test("environmental stepper renders 4 steps including Collect", () => {
+    renderAt("/order/environmental/enter");
+
+    expect(stepLabels()).toEqual([
+      "Enter Order",
+      "Collect",
+      "Label & Store",
+      "QA Review",
+    ]);
+  });
+
+  test("environmental Collect step is the active step on its own URL", () => {
+    const { container } = renderAt("/order/environmental/collect");
+
+    expect(currentStepLabel(container)).toBe("Collect");
+  });
+
+  test("clicking the environmental Collect step navigates to its route", () => {
+    orderContextValue.labNumber = "ENV-42";
+    renderAt("/order/environmental/enter");
+
+    fireEvent.click(screen.getByText("Collect"));
+
+    expect(historyMock.push).toHaveBeenCalledWith(
+      "/order/environmental/collect?order=ENV-42",
+    );
+  });
+
+  test("clinical workflow keeps its own Collect route", () => {
+    expect(CLINICAL_ORDER_STEPS.map((s) => s.key)).toEqual([
+      "enter",
+      "collect",
+      "label",
+      "qa",
+    ]);
+    expect(CLINICAL_ORDER_STEPS[1].path).toBe("/order/clinical/collect");
+  });
+
+  test("vector workflow has no Collect step", () => {
+    expect(VECTOR_ORDER_STEPS.map((s) => s.key)).not.toContain("collect");
+
+    renderAt("/order/vector/enter");
+
+    expect(stepLabels()).not.toContain("Collect");
+  });
+});

--- a/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
+++ b/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
@@ -231,8 +231,8 @@ const EnvironmentalOrderEnter = () => {
       markStepComplete("enter");
       history.push(
         labNumber
-          ? `/order/environmental/label?order=${encodeURIComponent(labNumber)}`
-          : "/order/environmental/label",
+          ? `/order/environmental/collect?order=${encodeURIComponent(labNumber)}`
+          : "/order/environmental/collect",
       );
     } catch (error) {
       addNotification({

--- a/frontend/src/components/order/steps/EnvironmentalOrderEnter.test.jsx
+++ b/frontend/src/components/order/steps/EnvironmentalOrderEnter.test.jsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../languages/en.json";
+
+// Stable mocks so each useHistory()/useContext() call returns the same fns
+// across renders — these tests assert against history.push.
+const { historyMock, notificationMock, orderContextValue } = vi.hoisted(() => ({
+  historyMock: { push: () => {}, replace: () => {} },
+  notificationMock: {
+    notificationVisible: false,
+    setNotificationVisible: () => {},
+    addNotification: () => {},
+  },
+  orderContextValue: {
+    // Shape must satisfy canSave: lab number + a sampling site + every
+    // sample-typed row carrying at least one test.
+    orderData: {
+      sampleOrderItems: {
+        labNo: "ENV-100",
+        environmentalFields: {
+          workflowType: "environmental",
+          samplingSiteName: "Well 3",
+        },
+      },
+      patientProperties: {},
+    },
+    setOrderData: () => {},
+    samples: [{ sampleTypeId: "5", tests: [{ id: "1" }], panels: [] }],
+    setSamples: () => {},
+    labNumber: "ENV-100",
+    saveOrder: () => Promise.resolve({ samples: [] }),
+    markStepComplete: () => {},
+    isReadOnly: false,
+    isEditMode: false,
+    resetOrder: () => {},
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  useHistory: () => historyMock,
+  // ?order= present so the mount guard treats this as an existing order and
+  // skips resetOrder(), matching a user who has already saved a draft.
+  useLocation: () => ({
+    search: "?order=ENV-100",
+    pathname: "/order/environmental/enter",
+  }),
+}));
+
+vi.mock("../OrderContext", () => ({
+  useOrderContext: () => orderContextValue,
+}));
+
+vi.mock("../../layout/Layout", () => ({
+  NotificationContext: React.createContext(notificationMock),
+}));
+
+vi.mock("../../common/CustomNotification", () => ({
+  AlertDialog: () => null,
+  NotificationKinds: { success: "success", error: "error" },
+}));
+
+vi.mock("../../utils/Utils", () => ({
+  getFromOpenElisServer: vi.fn(),
+}));
+
+vi.mock("../../nonconform/common/InlineNceForm", () => ({
+  default: () => null,
+}));
+
+// The workflow chrome owns the Save & Next button; expose just that control so
+// the test drives the same handler the real footer wires up.
+vi.mock("../OrderWorkflowLayout", () => ({
+  default: ({ children, onSaveAndNext, canProceed }) => (
+    <div>
+      <button
+        type="button"
+        disabled={!canProceed}
+        onClick={onSaveAndNext}
+        data-testid="save-and-next"
+      >
+        Save and Next
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./sections/VectorSection", () => ({ default: () => null }));
+vi.mock("./sections/CollectionConditionsSection", () => ({
+  default: () => null,
+}));
+vi.mock("./sections/ProgramSection", () => ({ default: () => null }));
+vi.mock("./sections/RequesterSection", () => ({ default: () => null }));
+vi.mock("./sections/SampleTestSection", () => ({ default: () => null }));
+vi.mock("./sections/ComplianceStandardsSection", () => ({
+  default: () => null,
+}));
+
+import EnvironmentalOrderEnter from "./EnvironmentalOrderEnter";
+
+const renderWithIntl = () =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <EnvironmentalOrderEnter />
+    </IntlProvider>,
+  );
+
+describe("EnvironmentalOrderEnter Save & Next navigation", () => {
+  beforeEach(() => {
+    historyMock.push = vi.fn();
+    orderContextValue.markStepComplete = vi.fn();
+    orderContextValue.saveOrder = vi.fn(() => Promise.resolve({ samples: [] }));
+  });
+
+  test("advances to the Collect step, not straight to Label", async () => {
+    renderWithIntl();
+
+    fireEvent.click(await screen.findByTestId("save-and-next"));
+
+    await waitFor(() => expect(historyMock.push).toHaveBeenCalled());
+    const target = historyMock.push.mock.calls[0][0];
+    expect(target).toContain("/order/environmental/collect");
+    expect(target).not.toContain("/order/environmental/label");
+  });
+
+  test("carries the lab number so the Collect step rehydrates the order", async () => {
+    renderWithIntl();
+
+    fireEvent.click(await screen.findByTestId("save-and-next"));
+
+    await waitFor(() =>
+      expect(historyMock.push).toHaveBeenCalledWith(
+        "/order/environmental/collect?order=ENV-100",
+      ),
+    );
+    expect(orderContextValue.markStepComplete).toHaveBeenCalledWith("enter");
+  });
+});


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Fixes the QA report that `/order/environmental/collect` renders a blank page
(header + sidenav only, no empty state, no redirect).

**Root cause: the route was never an orphan — the router was missing, not the
menu.**

The nav menu has always been seeded for a 4-step environmental workflow.
Liquibase changeset `nav-015-create-environmental-collect` in
`025-split-workflow-menus.xml` inserts a menu row with
`action_url = /order/environmental/collect` at `presentation_order = 2`, sitting
between enter (1) and label (3). But:

- `App.jsx` registered only ``, `/enter`, `/label` and `/qa` under
  `/order/environmental`. React Router's `Switch` renders nothing when no child
  matches, so `Layout` painted the chrome and the content area stayed empty —
  exactly the reported symptom.
- `ENVIRONMENTAL_ORDER_STEPS` had 3 entries, so the wizard surfaced no Collect
  step either.

So the menu, the stepper and the router all disagreed. This PR resolves the
disagreement in favour of the menu, which was right all along.

### Changes

- `App.jsx` — register `/order/environmental/collect`, rendering the existing
  `OrderCollect` step under `Roles.RECEPTION` like its siblings. `OrderCollect`
  is already workflow-agnostic (it routes via `useWorkflowPrefix()` with no
  clinical-specific branching), so no component changes were needed.
- `OrderStepper.jsx` — add the `collect` entry to `ENVIRONMENTAL_ORDER_STEPS`
  between enter and label, so the wizard shows Enter → Collect → Label → QA.
- `EnvironmentalOrderEnter.jsx` — `handleSaveAndNext` advanced straight to
  `/label`. Without this the stepper would show 4 steps while the wizard's own
  Next button jumped 1 → 3, leaving Collect reachable only via the stepper or
  menu and never firing `markStepComplete("collect")`.

Vector surveillance is untouched and still has no Collect step.

The resulting chain, with every step-complete marker firing on the happy path:

| Step    | Navigates to                     | Marks complete |
| ------- | -------------------------------- | -------------- |
| Enter   | `/order/environmental/collect`   | `enter`        |
| Collect | `${workflowPrefix}/label`        | `collect`      |
| Label   | `${workflowPrefix}/qa`           | `label`        |

### Why the blank page is genuinely gone

The QA repro visits the URL with no order in context. `OrderCollect` has no
early `return null` — it always renders `OrderWorkflowLayout`, and with no
ordered tests it shows the `collect.noTestsWarning` notification pointing back
to Step 1. Blank page becomes real content plus guidance.

## Tests

Two new vitest suites, 8 tests, all passing. Both were verified by inversion —
reverting the source change makes them fail:

- `OrderStepper.test.jsx` — environmental step set is
  enter → collect → label → qa; the stepper renders 4 steps; Collect is active
  on its own URL; clicking it pushes the right route with `?order=`. Also pins
  the workflow differences: clinical keeps its own Collect route, vector has
  none.
- `EnvironmentalOrderEnter.test.jsx` — Save & Next advances to `/collect` and
  not to `/label`, carrying the lab number so the Collect step rehydrates.

Reverting the stepper entry fails 4 of the 6 stepper tests while leaving the
clinical and vector assertions green; reverting the `/collect` push fails both
navigation tests.

Full `src/components/order` suite: 66 passed.

### Not covered

The route registration in `App.jsx` itself is not unit-tested — the environmental
routes are defined inline in a component that needs the full session/auth
provider tree to render, so asserting on them in isolation isn't practical. That
specific regression (menu path with no matching route) is E2E territory; a
Playwright spec walking the environmental wizard would be the honest guard and is
worth adding separately.

## Screenshots

Not included — I don't have a running instance of this branch to capture the
rendered Collect step. Worth a reviewer check against
`indonesiadev.openelis-global.org` before merge, since that is where QA found it.

## Related Issue

https://uwdigi.atlassian.net/browse/OGC-1050
