### PR TITLE
fix: dedupe interpretation-note write (develop CI red) + null-safe dashboard patient lookup (testing 500)

### DIFF
--- a/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/PatientDashBoardProvider.java
@@ -30,6 +30,7 @@ import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.order.valueholder.ElectronicOrder;
 import org.openelisglobal.dataexchange.service.order.ElectronicOrderService;
+import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.samplehuman.service.SampleHumanService;
@@ -193,7 +194,11 @@ public class PatientDashBoardProvider {
                     if (sample != null) {
                         orderBean.setPriority(sample.getPriority() != null ? sample.getPriority().toString() : "");
                         orderBean.setLabNumber(sample.getAccessionNumber() != null ? sample.getAccessionNumber() : "");
-                        orderBean.setPatientId(sampleHumanService.getPatientForSample(sample).getNationalId());
+                        // non-human samples (environmental/vector) legitimately have no
+                        // patient — one such order must not 500 the whole dashboard card
+                        Patient patient = sampleHumanService.getPatientForSample(sample);
+                        orderBean.setPatientId(
+                                patient != null && patient.getNationalId() != null ? patient.getNationalId() : "");
                     }
                     orderBean.setOrderDate(analysis.getStartedDateForDisplay());
                     orderBean.setTestName(analysis.getTest() != null ? analysis.getTest().getLocalizedName() : "");

--- a/src/main/java/org/openelisglobal/result/action/util/ResultUtil.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultUtil.java
@@ -377,14 +377,6 @@ public class ResultUtil {
                         ControllerUtills.getSysUserId(request)), testResultItem));
             }
 
-            // OGC-1026 (R7, FR-G1): the clinical interpretation goes with the
-            // result to the report — an EXTERNAL note under its own subject
-            if (!GenericValidator.isBlankOrNull(testResultItem.getInterpretation())) {
-                actionDataSet.addToNoteList(noteService.createSavableNote(analysis, NoteType.EXTERNAL,
-                        testResultItem.getInterpretation().trim(), INTERPRETATION_SUBJECT,
-                        ControllerUtills.getSysUserId(request)));
-            }
-
             if (testResultItem.isShadowRejected()) {
                 testResultItem.setResultValue("");
                 testResultItem.setShadowResultValue("");

--- a/src/test/java/org/openelisglobal/analyzerresults/service/AnalyzerResultsAcceptHoldIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/analyzerresults/service/AnalyzerResultsAcceptHoldIntegrationTest.java
@@ -89,6 +89,13 @@ public class AnalyzerResultsAcceptHoldIntegrationTest extends BaseWebContextSens
                     + " = ? AND name = ?)", status[1], status[0], status[1], status[0], status[1]);
         }
         statusService.refreshCache();
+        // The accept path also writes observation_history through its sequence;
+        // fixture datasets (observation-history.xml, result-facade.xml, ...) seed
+        // explicit low ids without advancing it, so under full-suite ordering the
+        // next sequence value can collide with a seeded PK — same drift the
+        // person/provider/patient singletons below guard against.
+        jdbc.queryForObject("SELECT setval('clinlims.observation_history_seq', CAST((SELECT COALESCE(MAX(id), 0) + 1"
+                + " FROM clinlims.observation_history) AS BIGINT), false)", Long.class);
     }
 
     /**

--- a/src/test/java/org/openelisglobal/common/rest/provider/PatientDashBoardProviderIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/common/rest/provider/PatientDashBoardProviderIntegrationTest.java
@@ -1,0 +1,82 @@
+package org.openelisglobal.common.rest.provider;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.common.rest.provider.bean.homedashboard.DashBoardTile;
+import org.openelisglobal.common.rest.provider.form.PatientDashBoardForm;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Home-dashboard order tiles against a real DB (fixture: result.xml). The
+ * provider lives in a package the test context does not scan, so it is
+ * constructed directly with the services the exercised tile needs (they are
+ * package-private, and this test shares the package).
+ */
+public class PatientDashBoardProviderIntegrationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private IStatusService statusService;
+
+    @Autowired
+    private SampleHumanService sampleHumanService;
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    private PatientDashBoardProvider provider;
+
+    private JdbcTemplate jdbc;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/result.xml");
+        jdbc = new JdbcTemplate(dataSource);
+        provider = new PatientDashBoardProvider();
+        provider.analysisService = analysisService;
+        provider.iStatusService = statusService;
+        provider.sampleHumanService = sampleHumanService;
+        // result.xml carries only the Finalized ANALYSIS status; the tile query
+        // resolves NotStarted by name (StatusService.addToAnalysisMap).
+        Long notTested = jdbc.queryForObject("SELECT count(*) FROM clinlims.status_of_sample WHERE name = 'Not Tested'",
+                Long.class);
+        if (notTested == 0) {
+            jdbc.update("INSERT INTO clinlims.status_of_sample (id, name, code, status_type, is_active, display_key,"
+                    + " description, lastupdated) VALUES (9101, 'Not Tested', 4, 'ANALYSIS', 'Y', 'status.9101',"
+                    + " 'Not Tested', NOW())");
+        }
+        // the status map caches at first use, which may predate the seed above
+        statusService.refreshCache();
+    }
+
+    /**
+     * Regression for the 500 on /rest/home-dashboard/ORDERS_IN_PROGRESS: a sample
+     * with no patient link (environmental/vector orders legitimately have none;
+     * legacy data can too) NPE'd the bean conversion and took down the whole tile.
+     * The orphan order must be served with a blank patient id instead.
+     */
+    @Test
+    public void ordersInProgress_toleratesSampleWithoutPatientLink() throws Exception {
+        jdbc.update("UPDATE clinlims.analysis SET status_id = ?::numeric WHERE id = 1",
+                statusService.getStatusID(AnalysisStatus.NotStarted));
+        jdbc.update("DELETE FROM clinlims.sample_human WHERE samp_id = 1");
+
+        PatientDashBoardForm form = provider.getDashBoardDisplayList(new MockHttpServletRequest(),
+                DashBoardTile.TileType.ORDERS_IN_PROGRESS, null);
+
+        assertTrue("the patient-less order must be served with a blank patient id", form.getDisplayItems().stream()
+                .anyMatch(bean -> "12345".equals(bean.getLabNumber()) && "".equals(bean.getPatientId())));
+    }
+}


### PR DESCRIPTION
## Two production fixes in one PR

### 1. develop backend CI is red — duplicate interpretation-note write (since #4036)

Bisect: `ResultEntryRestControllerTest` is green at 3916243a1 (#4024) and red at 6caeae873 (#4036). The regression sweep's merge left the OGC-1026 interpretation-note block **duplicated** in `ResultUtil.java` — the new component-scoped copy was added without removing the unscoped original. Every result save carrying an interpretation queued the same EXTERNAL note twice; the second insert failed `duplicateNoteExists` → `LIMSDuplicateRecordException` → 500.

**Fix:** remove the stale unscoped block. `ResultEntryRestControllerTest` is 27/27 again.

### 2. `/rest/home-dashboard/ORDERS_IN_PROGRESS` returns 500 on testing

`PatientDashBoardProvider` line 196 called `.getNationalId()` on `getPatientForSample(sample)` with no null guard — a single sample with no patient link (legitimate for environmental/vector orders; also possible in legacy data) takes down the whole dashboard tile:

```
NullPointerException: Cannot invoke Patient.getNationalId() because
getPatientForSample(Sample) is null — PatientDashBoardProvider.java:196
```

**Fix:** null-safe lookup returning a blank patient id, matching the defensive style of every surrounding field. New `PatientDashBoardProviderIntegrationTest` **reproduces the exact production NPE without the fix** (inversion-verified: same line, same message) and passes with it. The testing server heals on its next redeploy — no data repair needed.

## Testing

- Full backend suite: **4885 tests, 0 failures, 0 errors**.
- Both failure modes reproduced locally before fixing; both fixes verified by the exact previously-failing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)