### PR TITLE
OGC-1054 E0: define clean analyzer profile consumer boundary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,6 +573,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.5.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>
             <version>2.7.3</version>

--- a/specs/015-ogc-1054-analyzer-contract-migration/README.md
+++ b/specs/015-ogc-1054-analyzer-contract-migration/README.md
@@ -1,0 +1,19 @@
+# OGC-1054 E0 Contracts
+
+This directory contains OpenELIS-owned executable contract fixtures for the E0
+boundary defined by the canonical OGC-1054 specification and roadmap.
+
+- `openelis-analyzer-reference.schema.json` permits only the Bridge connection
+  reference and LIMS-owned lab units, catalog binding, verification, and
+  activation acknowledgement.
+- `analyzer-migration-manifest.schema.json` describes the one-time
+  plan/apply/verify result. Every released source analyzer receives one explicit
+  outcome, and any selected profile revision is recorded as a human selection.
+
+Bridge-owned profile, connection, command, and normalized-traffic contracts are
+consumed directly from `tools/openelis-analyzer-bridge/contracts/analyzer/v1`.
+No copied profile, full-state registration, all-profile publication gate, or
+runtime compatibility contract belongs here.
+
+E0 defines and tests the boundary only. The migration executable and runtime
+cutover are implemented and qualified in M3.

--- a/specs/015-ogc-1054-analyzer-contract-migration/contracts/analyzer-migration-manifest.schema.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/contracts/analyzer-migration-manifest.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openelis-global.org/contracts/analyzer/v1/analyzer-migration-manifest.schema.json",
+  "title": "One-time OpenELIS analyzer migration manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "mode",
+    "sourceSnapshotFingerprint",
+    "startedAt",
+    "completedAt",
+    "outcomes"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "runId": { "type": "string", "minLength": 1 },
+    "mode": { "enum": ["PLAN", "APPLY", "VERIFY"] },
+    "sourceSnapshotFingerprint": { "$ref": "#/$defs/fingerprint" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" },
+    "outcomes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/outcome" }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "mode": { "const": "PLAN" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "outcomes": {
+            "items": {
+              "properties": {
+                "outcome": {
+                  "enum": [
+                    "READY",
+                    "NEEDS_CORRECTION",
+                    "INTENTIONALLY_EXCLUDED"
+                  ]
+                }
+              },
+              "required": ["outcome"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "mode": { "enum": ["APPLY", "VERIFY"] } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": {
+          "outcomes": {
+            "items": {
+              "properties": {
+                "outcome": {
+                  "enum": [
+                    "MIGRATED",
+                    "NEEDS_CORRECTION",
+                    "INTENTIONALLY_EXCLUDED"
+                  ]
+                }
+              },
+              "required": ["outcome"]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "profileRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileId", "revision", "fingerprint"],
+      "properties": {
+        "profileId": { "type": "string", "minLength": 1 },
+        "revision": { "type": "integer", "minimum": 1 },
+        "fingerprint": { "$ref": "#/$defs/fingerprint" }
+      }
+    },
+    "profileSelection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "profileRef", "selectedBy", "selectedAt"],
+      "properties": {
+        "method": { "const": "EXPLICIT" },
+        "profileRef": { "$ref": "#/$defs/profileRef" },
+        "selectedBy": { "type": "string", "minLength": 1 },
+        "selectedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "migrationKey",
+        "sourceAnalyzerId",
+        "sourceConfigFingerprint",
+        "outcome"
+      ],
+      "properties": {
+        "migrationKey": { "type": "string", "minLength": 1 },
+        "sourceAnalyzerId": { "type": "string", "minLength": 1 },
+        "sourceConfigFingerprint": { "$ref": "#/$defs/fingerprint" },
+        "outcome": {
+          "enum": [
+            "READY",
+            "MIGRATED",
+            "NEEDS_CORRECTION",
+            "INTENTIONALLY_EXCLUDED"
+          ]
+        },
+        "profileSelection": { "$ref": "#/$defs/profileSelection" },
+        "bridgeConnectionId": { "type": "string", "minLength": 1 },
+        "bridgeConfigRevision": { "type": "integer", "minimum": 1 },
+        "reasonCode": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "outcome": { "enum": ["READY", "MIGRATED"] } },
+            "required": ["outcome"]
+          },
+          "then": { "required": ["profileSelection"] }
+        },
+        {
+          "if": {
+            "properties": { "outcome": { "const": "MIGRATED" } },
+            "required": ["outcome"]
+          },
+          "then": { "required": ["bridgeConnectionId", "bridgeConfigRevision"] }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "enum": ["NEEDS_CORRECTION", "INTENTIONALLY_EXCLUDED"]
+              }
+            },
+            "required": ["outcome"]
+          },
+          "then": { "required": ["reasonCode"] }
+        }
+      ]
+    }
+  }
+}

--- a/specs/015-ogc-1054-analyzer-contract-migration/contracts/openelis-analyzer-reference.schema.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/contracts/openelis-analyzer-reference.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openelis-global.org/contracts/analyzer/v1/openelis-analyzer-reference.schema.json",
+  "title": "OpenELIS analyzer reference and LIMS-owned state v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "analyzerId",
+    "name",
+    "labUnitIds",
+    "bridgeConnectionId",
+    "bindingRef",
+    "verification",
+    "activation"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "analyzerId": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "labUnitIds": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "bridgeConnectionId": { "type": "string", "minLength": 1 },
+    "bindingRef": { "$ref": "#/$defs/bindingRef" },
+    "verification": { "$ref": "#/$defs/verification" },
+    "activation": { "$ref": "#/$defs/activation" }
+  },
+  "$defs": {
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "profileRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileId", "revision", "fingerprint"],
+      "properties": {
+        "profileId": { "type": "string", "minLength": 1 },
+        "revision": { "type": "integer", "minimum": 1 },
+        "fingerprint": { "$ref": "#/$defs/fingerprint" }
+      }
+    },
+    "bindingRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bindingId", "profileRef", "revision", "fingerprint"],
+      "properties": {
+        "bindingId": { "type": "string", "minLength": 1 },
+        "profileRef": { "$ref": "#/$defs/profileRef" },
+        "revision": { "type": "integer", "minimum": 1 },
+        "fingerprint": { "$ref": "#/$defs/fingerprint" }
+      }
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "display"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "display": { "type": "string", "minLength": 1 }
+      }
+    },
+    "rowState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rowKey", "state"],
+      "properties": {
+        "rowKey": { "type": "string", "minLength": 1 },
+        "state": { "enum": ["BOUND", "ACKNOWLEDGED_INCOMPLETE"] },
+        "testId": { "type": "string", "minLength": 1 },
+        "resultOptionIds": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "state": { "const": "BOUND" } },
+            "required": ["state"]
+          },
+          "then": { "required": ["testId", "resultOptionIds"] }
+        },
+        {
+          "if": {
+            "properties": { "state": { "const": "ACKNOWLEDGED_INCOMPLETE" } },
+            "required": ["state"]
+          },
+          "then": {
+            "not": {
+              "anyOf": [
+                { "required": ["testId"] },
+                { "required": ["resultOptionIds"] }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "profileRef",
+        "bindingRevision",
+        "bindingFingerprint",
+        "recognitionFingerprint",
+        "rowStates",
+        "actor",
+        "verifiedAt"
+      ],
+      "properties": {
+        "status": { "enum": ["UNVERIFIED", "VERIFIED", "STALE"] },
+        "profileRef": { "$ref": "#/$defs/profileRef" },
+        "bindingRevision": { "type": "integer", "minimum": 1 },
+        "bindingFingerprint": { "$ref": "#/$defs/fingerprint" },
+        "recognitionFingerprint": { "$ref": "#/$defs/fingerprint" },
+        "rowStates": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/rowState" }
+        },
+        "actor": { "$ref": "#/$defs/actor" },
+        "verifiedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "runtimeAcknowledgement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commandId",
+        "connectionId",
+        "profileRef",
+        "configRevision",
+        "configFingerprint",
+        "runtimeRevision",
+        "runtimeFingerprint",
+        "actualRuntimeState",
+        "acknowledgedAt"
+      ],
+      "properties": {
+        "commandId": { "type": "string", "minLength": 1 },
+        "connectionId": { "type": "string", "minLength": 1 },
+        "profileRef": { "$ref": "#/$defs/profileRef" },
+        "configRevision": { "type": "integer", "minimum": 1 },
+        "configFingerprint": { "$ref": "#/$defs/fingerprint" },
+        "runtimeRevision": { "type": "integer", "minimum": 1 },
+        "runtimeFingerprint": { "$ref": "#/$defs/fingerprint" },
+        "actualRuntimeState": { "enum": ["ACTIVE", "INACTIVE"] },
+        "acknowledgedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "activation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent", "acknowledgement"],
+      "properties": {
+        "intent": { "enum": ["ACTIVE", "INACTIVE"] },
+        "acknowledgement": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/runtimeAcknowledgement" }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-apply.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-apply.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "migration-fixture-apply",
+  "mode": "APPLY",
+  "sourceSnapshotFingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "startedAt": "2026-08-24T18:05:00Z",
+  "completedAt": "2026-08-24T18:05:03Z",
+  "outcomes": [
+    {
+      "migrationKey": "oe-analyzer-42:aaaaaaaa",
+      "sourceAnalyzerId": "oe-analyzer-42",
+      "sourceConfigFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outcome": "MIGRATED",
+      "profileSelection": {
+        "method": "EXPLICIT",
+        "profileRef": {
+          "profileId": "fixture.synthetic-socket",
+          "revision": 2,
+          "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        },
+        "selectedBy": "user-7",
+        "selectedAt": "2026-08-24T17:55:00Z"
+      },
+      "bridgeConnectionId": "bridge-connection-7f3c",
+      "bridgeConfigRevision": 1
+    },
+    {
+      "migrationKey": "oe-analyzer-43:bbbbbbbb",
+      "sourceAnalyzerId": "oe-analyzer-43",
+      "sourceConfigFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "outcome": "NEEDS_CORRECTION",
+      "reasonCode": "EXPLICIT_PROFILE_SELECTION_REQUIRED"
+    },
+    {
+      "migrationKey": "oe-analyzer-44:cccccccc",
+      "sourceAnalyzerId": "oe-analyzer-44",
+      "sourceConfigFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "outcome": "INTENTIONALLY_EXCLUDED",
+      "reasonCode": "DECOMMISSIONED_BEFORE_CUTOVER"
+    }
+  ]
+}

--- a/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-plan.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-plan.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "migration-fixture-plan",
+  "mode": "PLAN",
+  "sourceSnapshotFingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "startedAt": "2026-08-24T18:00:00Z",
+  "completedAt": "2026-08-24T18:00:02Z",
+  "outcomes": [
+    {
+      "migrationKey": "oe-analyzer-42:aaaaaaaa",
+      "sourceAnalyzerId": "oe-analyzer-42",
+      "sourceConfigFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outcome": "READY",
+      "profileSelection": {
+        "method": "EXPLICIT",
+        "profileRef": {
+          "profileId": "fixture.synthetic-socket",
+          "revision": 2,
+          "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        },
+        "selectedBy": "user-7",
+        "selectedAt": "2026-08-24T17:55:00Z"
+      }
+    },
+    {
+      "migrationKey": "oe-analyzer-43:bbbbbbbb",
+      "sourceAnalyzerId": "oe-analyzer-43",
+      "sourceConfigFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "outcome": "NEEDS_CORRECTION",
+      "reasonCode": "EXPLICIT_PROFILE_SELECTION_REQUIRED"
+    },
+    {
+      "migrationKey": "oe-analyzer-44:cccccccc",
+      "sourceAnalyzerId": "oe-analyzer-44",
+      "sourceConfigFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "outcome": "INTENTIONALLY_EXCLUDED",
+      "reasonCode": "DECOMMISSIONED_BEFORE_CUTOVER"
+    }
+  ]
+}

--- a/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-verify.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/fixtures/analyzer-migration-verify.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "1.0",
+  "runId": "migration-fixture-verify",
+  "mode": "VERIFY",
+  "sourceSnapshotFingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+  "startedAt": "2026-08-24T18:10:00Z",
+  "completedAt": "2026-08-24T18:10:03Z",
+  "outcomes": [
+    {
+      "migrationKey": "oe-analyzer-42:aaaaaaaa",
+      "sourceAnalyzerId": "oe-analyzer-42",
+      "sourceConfigFingerprint": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outcome": "MIGRATED",
+      "profileSelection": {
+        "method": "EXPLICIT",
+        "profileRef": {
+          "profileId": "fixture.synthetic-socket",
+          "revision": 2,
+          "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        },
+        "selectedBy": "user-7",
+        "selectedAt": "2026-08-24T17:55:00Z"
+      },
+      "bridgeConnectionId": "bridge-connection-7f3c",
+      "bridgeConfigRevision": 1
+    },
+    {
+      "migrationKey": "oe-analyzer-43:bbbbbbbb",
+      "sourceAnalyzerId": "oe-analyzer-43",
+      "sourceConfigFingerprint": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "outcome": "NEEDS_CORRECTION",
+      "reasonCode": "EXPLICIT_PROFILE_SELECTION_REQUIRED"
+    },
+    {
+      "migrationKey": "oe-analyzer-44:cccccccc",
+      "sourceAnalyzerId": "oe-analyzer-44",
+      "sourceConfigFingerprint": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "outcome": "INTENTIONALLY_EXCLUDED",
+      "reasonCode": "DECOMMISSIONED_BEFORE_CUTOVER"
+    }
+  ]
+}

--- a/specs/015-ogc-1054-analyzer-contract-migration/fixtures/openelis-analyzer-reference.json
+++ b/specs/015-ogc-1054-analyzer-contract-migration/fixtures/openelis-analyzer-reference.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0",
+  "analyzerId": "oe-analyzer-42",
+  "name": "Synthetic chemistry analyzer",
+  "labUnitIds": ["lab-unit-chemistry"],
+  "bridgeConnectionId": "bridge-connection-7f3c",
+  "bindingRef": {
+    "bindingId": "site-binding-42",
+    "profileRef": {
+      "profileId": "fixture.synthetic-socket",
+      "revision": 2,
+      "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "revision": 5,
+    "fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "verification": {
+    "status": "VERIFIED",
+    "profileRef": {
+      "profileId": "fixture.synthetic-socket",
+      "revision": 2,
+      "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "bindingRevision": 5,
+    "bindingFingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "recognitionFingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "rowStates": [
+      {
+        "rowKey": "fixture-result-a",
+        "state": "BOUND",
+        "testId": "openelis-test-17",
+        "resultOptionIds": ["result-option-positive", "result-option-negative"]
+      },
+      {
+        "rowKey": "fixture-result-b",
+        "state": "ACKNOWLEDGED_INCOMPLETE"
+      }
+    ],
+    "actor": {
+      "id": "user-7",
+      "display": "Lab Supervisor"
+    },
+    "verifiedAt": "2026-08-24T19:04:00Z"
+  },
+  "activation": {
+    "intent": "ACTIVE",
+    "acknowledgement": {
+      "commandId": "activate-fixture-004",
+      "connectionId": "bridge-connection-7f3c",
+      "profileRef": {
+        "profileId": "fixture.synthetic-socket",
+        "revision": 2,
+        "fingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "configRevision": 4,
+      "configFingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "runtimeRevision": 9,
+      "runtimeFingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "actualRuntimeState": "ACTIVE",
+      "acknowledgedAt": "2026-08-24T19:05:05Z"
+    }
+  }
+}

--- a/src/test/java/org/openelisglobal/analyzer/contract/AnalyzerBridgeContractConsumerTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/contract/AnalyzerBridgeContractConsumerTest.java
@@ -1,0 +1,185 @@
+package org.openelisglobal.analyzer.contract;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.StrictErrorHandler;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.Test;
+
+/**
+ * Consumer-side executable contract for Bridge-owned OGC-1054 v1 artifacts.
+ *
+ * <p>
+ * This validates schemas and representative profile-data fixtures. It does not
+ * claim that the current Bridge runtime emits them; BR-M1, BR-M2, and BR-M4 own
+ * that production conformance.
+ */
+public class AnalyzerBridgeContractConsumerTest {
+
+    private static final Path CONTRACT_ROOT = Path.of("tools", "openelis-analyzer-bridge", "contracts", "analyzer",
+            "v1");
+    private static final Path FIXTURE_ROOT = CONTRACT_ROOT.resolve("fixtures");
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final JsonSchemaFactory SCHEMAS = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+    private static final FhirContext FHIR = FhirContext.forR4();
+    private static final String FINGERPRINT_PATTERN = "sha256:[0-9a-f]{64}";
+    private static final String RAW_CODE_SYSTEM = "https://openelis-global.org/fhir/CodeSystem/analyzer-raw-code";
+    private static final String RAW_VALUE_EXTENSION = "https://openelis-global.org/fhir/StructureDefinition/analyzer-raw-value";
+    private static final String RESULT_CLASSIFICATION_EXTENSION = "https://openelis-global.org/fhir/StructureDefinition/analyzer-result-classification";
+    private static final String CONTROL_RECOGNITION_EXTENSION = "https://openelis-global.org/fhir/StructureDefinition/analyzer-control-recognition";
+
+    @Test
+    public void establishedProfilesRetainRuntimeCommunicationAndInstanceDefaults() throws IOException {
+        JsonNode socketProfile = fixture("analyzer-profile-astm.json");
+        JsonNode fileProfile = fixture("analyzer-profile-file.json");
+
+        assertConforms("analyzer-profile.schema.json", socketProfile);
+        assertConforms("analyzer-profile.schema.json", fileProfile);
+        for (JsonNode profile : new JsonNode[] { socketProfile, fileProfile }) {
+            assertTrue(profile.path("catalog").path("revisionFingerprint").asText().matches(FINGERPRINT_PATTERN));
+            assertTrue(profile.path("catalog").path("recognitionFingerprint").asText().matches(FINGERPRINT_PATTERN));
+            assertFalse(profile.path("protocol").path("name").asText().isBlank());
+            assertTrue(profile.path("configDefaults").isObject());
+            assertTrue(profile.path("configDefaults").size() > 0);
+            assertFalse(profile.has("qcIdentification"));
+        }
+        assertTrue(socketProfile.path("communication").isObject());
+        assertTrue(socketProfile.path("transport").size() > 0);
+        assertTrue(socketProfile.path("default_test_mappings").size() > 0);
+        assertTrue(fileProfile.path("supported_extensions").size() > 0);
+        assertTrue(fileProfile.path("column_mapping").size() > 0);
+
+        String schema = Files.readString(CONTRACT_ROOT.resolve("analyzer-profile.schema.json"));
+        assertFalse(schema.contains("openelisTestId"));
+        assertFalse(schema.contains("openelisResultOptionId"));
+        assertFalse(schema.contains("labUnitId"));
+    }
+
+    @Test
+    public void durableConnectionContractsExposeGenericFieldsAndOptimisticConcurrency() throws IOException {
+        JsonNode create = fixture("connection-create.json");
+        JsonNode update = fixture("connection-update.json");
+        JsonNode connection = fixture("analyzer-connection.json");
+
+        assertConforms("connection-create.schema.json", create);
+        assertConforms("connection-update.schema.json", update);
+        assertConforms("analyzer-connection.schema.json", connection);
+
+        assertEquals(create.path("clientAnalyzerId"), connection.path("clientAnalyzerId"));
+        assertEquals(create.path("profileRef"), connection.path("profileRef"));
+        assertEquals(update.path("expectedConfigRevision").asInt() + 1, connection.path("configRevision").asInt());
+        assertTrue(connection.path("configFingerprint").asText().matches(FINGERPRINT_PATTERN));
+        assertTrue(connection.path("fields").isArray());
+        assertTrue(connection.path("fields").size() > 0);
+        assertFalse(connection.has("connection"));
+        assertFalse(connection.has("settings"));
+    }
+
+    @Test
+    public void probeAndActivationAcknowledgeTheExactSavedConnection() throws IOException {
+        JsonNode probeRequest = fixture("connection-probe-request.json");
+        JsonNode probeResult = fixture("connection-probe-result.json");
+        JsonNode command = fixture("connection-activate.json");
+        JsonNode acknowledgement = fixture("connection-activate-ack.json");
+
+        assertConforms("connection-probe-request.schema.json", probeRequest);
+        assertConforms("connection-probe-result.schema.json", probeResult);
+        assertConforms("connection-runtime-command.schema.json", command);
+        assertConforms("connection-runtime-ack.schema.json", acknowledgement);
+
+        assertEquals(probeRequest.path("requestId"), probeResult.path("requestId"));
+        assertEquals(probeRequest.path("connectionId"), probeResult.path("connectionId"));
+        assertTrue(probeResult.path("nonMutating").asBoolean());
+        assertEquals(command.path("commandId"), acknowledgement.path("commandId"));
+        assertEquals(command.path("connectionId"), acknowledgement.path("connectionId"));
+        assertEquals(command.path("expectedConfigRevision"), acknowledgement.path("configRevision"));
+        assertEquals("ACTIVE", acknowledgement.path("actualRuntimeState").asText());
+        assertTrue(acknowledgement.path("runtimeFingerprint").asText().matches(FINGERPRINT_PATTERN));
+    }
+
+    @Test
+    public void normalizedTrafficIsStrictR4WithRawRecognitionEvidence() throws IOException {
+        for (String name : new String[] { "normalized-known-test.fhir.json", "normalized-unknown-test.fhir.json",
+                "normalized-unknown-value.fhir.json", "normalized-qc.fhir.json", "normalized-nonmatch.fhir.json",
+                "normalized-none.fhir.json", "normalized-file.fhir.json" }) {
+            JsonNode fixture = fixture(name);
+            assertConforms("normalized-fhir-bundle.schema.json", fixture);
+
+            Bundle bundle = FHIR.newJsonParser().setParserErrorHandler(new StrictErrorHandler())
+                    .parseResource(Bundle.class, Files.readString(FIXTURE_ROOT.resolve(name)));
+            assertEquals(Bundle.BundleType.TRANSACTION, bundle.getType());
+
+            JsonNode observation = firstResource(fixture, "Observation");
+            assertTrue(hasCodingSystem(observation, RAW_CODE_SYSTEM));
+            assertTrue(hasExtension(observation, RAW_VALUE_EXTENSION));
+            assertTrue(hasExtension(observation, RESULT_CLASSIFICATION_EXTENSION));
+            assertTrue(hasExtension(observation, CONTROL_RECOGNITION_EXTENSION));
+        }
+    }
+
+    @Test
+    public void schemasRejectLocalOwnershipAndOperationalQcLeakage() throws IOException {
+        JsonNode profile = fixture("analyzer-profile-astm.json").deepCopy();
+        ((com.fasterxml.jackson.databind.node.ObjectNode) profile).put("labUnitId", "123");
+        assertFalse(validationMessages("analyzer-profile.schema.json", profile).isEmpty());
+
+        JsonNode connection = fixture("connection-create.json").deepCopy();
+        ((com.fasterxml.jackson.databind.node.ObjectNode) connection).set("operationalQc", JSON.createObjectNode());
+        assertFalse(validationMessages("connection-create.schema.json", connection).isEmpty());
+    }
+
+    @Test
+    public void noParallelProfileOrCompatibilityContractIsConsumable() {
+        for (String removed : new String[] { "portable-profile.schema.json", "legacy-registration.schema.json",
+                "compatibility.json", "registration-sync.schema.json", "registration-sync-result.schema.json",
+                "fixtures/portable-profile.json", "fixtures/portable-profile-none.json",
+                "fixtures/legacy-registration.json", "fixtures/registration-initial.json",
+                "fixtures/registration-next.json", "fixtures/registration-result.json" }) {
+            assertFalse(removed, Files.exists(CONTRACT_ROOT.resolve(removed)));
+        }
+    }
+
+    private static void assertConforms(String schemaName, JsonNode fixture) throws IOException {
+        Set<ValidationMessage> messages = validationMessages(schemaName, fixture);
+        assertTrue(schemaName + " violations: " + messages, messages.isEmpty());
+    }
+
+    private static Set<ValidationMessage> validationMessages(String schemaName, JsonNode instance) throws IOException {
+        JsonSchema schema = SCHEMAS.getSchema(JSON.readTree(CONTRACT_ROOT.resolve(schemaName).toFile()));
+        return schema.validate(instance);
+    }
+
+    private static JsonNode fixture(String name) throws IOException {
+        return JSON.readTree(FIXTURE_ROOT.resolve(name).toFile());
+    }
+
+    private static JsonNode firstResource(JsonNode bundle, String resourceType) {
+        return StreamSupport.stream(bundle.path("entry").spliterator(), false).map(entry -> entry.path("resource"))
+                .filter(resource -> resourceType.equals(resource.path("resourceType").asText())).findFirst()
+                .orElseThrow();
+    }
+
+    private static boolean hasCodingSystem(JsonNode observation, String system) {
+        return StreamSupport.stream(observation.path("code").path("coding").spliterator(), false)
+                .anyMatch(coding -> system.equals(coding.path("system").asText()));
+    }
+
+    private static boolean hasExtension(JsonNode observation, String url) {
+        return StreamSupport.stream(observation.path("extension").spliterator(), false)
+                .anyMatch(extension -> url.equals(extension.path("url").asText()));
+    }
+}

--- a/src/test/java/org/openelisglobal/analyzer/contract/AnalyzerOwnershipContractTest.java
+++ b/src/test/java/org/openelisglobal/analyzer/contract/AnalyzerOwnershipContractTest.java
@@ -1,0 +1,182 @@
+package org.openelisglobal.analyzer.contract;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Executable OE-E0 contract for reference-only persistence and one-time
+ * migration.
+ */
+public class AnalyzerOwnershipContractTest {
+
+    private static final Path ARTIFACT_ROOT = Path.of("specs", "015-ogc-1054-analyzer-contract-migration");
+    private static final Path CONTRACT_ROOT = ARTIFACT_ROOT.resolve("contracts");
+    private static final Path FIXTURE_ROOT = ARTIFACT_ROOT.resolve("fixtures");
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final JsonSchemaFactory SCHEMAS = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+    private static final String FINGERPRINT_PATTERN = "sha256:[0-9a-f]{64}";
+
+    @Test
+    public void openElisAnalyzerStoresOnlyBridgeReferenceAndLimsOwnedState() throws Exception {
+        JsonNode analyzer = localFixture("openelis-analyzer-reference.json");
+        assertLocalConforms("openelis-analyzer-reference.schema.json", analyzer);
+
+        assertFalse(analyzer.path("analyzerId").asText().isBlank());
+        assertFalse(analyzer.path("bridgeConnectionId").asText().isBlank());
+        assertTrue(analyzer.path("labUnitIds").size() > 0);
+        assertTrue(analyzer.path("bindingRef").path("revision").asInt() > 0);
+        assertTrue(analyzer.path("bindingRef").path("fingerprint").asText().matches(FINGERPRINT_PATTERN));
+        assertFalse(analyzer.path("verification").path("actor").path("id").asText().isBlank());
+        assertFalse(analyzer.path("verification").path("verifiedAt").asText().isBlank());
+        assertEquals(analyzer.path("bridgeConnectionId"),
+                analyzer.path("activation").path("acknowledgement").path("connectionId"));
+
+    }
+
+    @Test
+    public void openElisAnalyzerContractRejectsUndeclaredState() throws Exception {
+        com.fasterxml.jackson.databind.node.ObjectNode analyzer = (com.fasterxml.jackson.databind.node.ObjectNode) localFixture(
+                "openelis-analyzer-reference.json").deepCopy();
+        analyzer.put("undeclaredState", true);
+
+        assertFalse(localValidationMessages("openelis-analyzer-reference.schema.json", analyzer).isEmpty());
+    }
+
+    @Test
+    public void boundVerificationRowsRequireCompleteCatalogTargets() throws Exception {
+        for (String field : new String[] { "testId", "resultOptionIds" }) {
+            JsonNode analyzer = localFixture("openelis-analyzer-reference.json").deepCopy();
+            ((com.fasterxml.jackson.databind.node.ObjectNode) analyzer.path("verification").path("rowStates").path(0))
+                    .remove(field);
+
+            assertFalse(field, localValidationMessages("openelis-analyzer-reference.schema.json", analyzer).isEmpty());
+        }
+    }
+
+    @Test
+    public void acknowledgedIncompleteVerificationRowsRejectCatalogTargets() throws Exception {
+        JsonNode analyzer = localFixture("openelis-analyzer-reference.json").deepCopy();
+        ((com.fasterxml.jackson.databind.node.ObjectNode) analyzer.path("verification").path("rowStates").path(1))
+                .put("testId", "openelis-test-17");
+
+        assertFalse(localValidationMessages("openelis-analyzer-reference.schema.json", analyzer).isEmpty());
+    }
+
+    @Test
+    public void migrationPlanApplyAndVerifyCoverTheSameReleasedAnalyzers() throws Exception {
+        JsonNode plan = migrationFixture("analyzer-migration-plan.json");
+        JsonNode apply = migrationFixture("analyzer-migration-apply.json");
+        JsonNode verify = migrationFixture("analyzer-migration-verify.json");
+
+        assertEquals("PLAN", plan.path("mode").asText());
+        assertEquals("APPLY", apply.path("mode").asText());
+        assertEquals("VERIFY", verify.path("mode").asText());
+        assertEquals(outcomeKeys(plan), outcomeKeys(apply));
+        assertEquals(outcomeKeys(plan), outcomeKeys(verify));
+
+        Map<String, JsonNode> planByKey = outcomesByKey(plan);
+        Map<String, JsonNode> applyByKey = outcomesByKey(apply);
+        Map<String, JsonNode> verifyByKey = outcomesByKey(verify);
+        for (String migrationKey : planByKey.keySet()) {
+            assertEquals(planByKey.get(migrationKey).path("sourceAnalyzerId"),
+                    applyByKey.get(migrationKey).path("sourceAnalyzerId"));
+            assertEquals(planByKey.get(migrationKey).path("sourceConfigFingerprint"),
+                    applyByKey.get(migrationKey).path("sourceConfigFingerprint"));
+            assertEquals(applyByKey.get(migrationKey).path("sourceConfigFingerprint"),
+                    verifyByKey.get(migrationKey).path("sourceConfigFingerprint"));
+        }
+    }
+
+    @Test
+    public void finalMigrationHasOneExplicitOutcomeForEverySourceAnalyzer() throws Exception {
+        JsonNode verify = migrationFixture("analyzer-migration-verify.json");
+        Set<String> allowed = Set.of("MIGRATED", "NEEDS_CORRECTION", "INTENTIONALLY_EXCLUDED");
+        Set<String> sourceIds = new LinkedHashSet<>();
+
+        for (JsonNode outcome : verify.path("outcomes")) {
+            assertTrue(allowed.contains(outcome.path("outcome").asText()));
+            assertTrue("duplicate source analyzer", sourceIds.add(outcome.path("sourceAnalyzerId").asText()));
+            if ("MIGRATED".equals(outcome.path("outcome").asText())) {
+                assertEquals("EXPLICIT", outcome.path("profileSelection").path("method").asText());
+                assertTrue(outcome.path("profileSelection").path("profileRef").path("revision").asInt() > 0);
+                assertFalse(outcome.path("bridgeConnectionId").asText().isBlank());
+            } else {
+                assertFalse(outcome.path("reasonCode").asText().isBlank());
+            }
+        }
+    }
+
+    @Test
+    public void migrationContractRejectsInferredProfileSelection() throws Exception {
+        JsonNode plan = migrationFixture("analyzer-migration-plan.json").deepCopy();
+        JsonNode selected = outcomesByKey(plan).values().stream().filter(outcome -> outcome.has("profileSelection"))
+                .findFirst().orElseThrow();
+        ((com.fasterxml.jackson.databind.node.ObjectNode) selected.path("profileSelection")).put("method",
+                "INFERRED_BY_NAME");
+
+        assertFalse(localValidationMessages("analyzer-migration-manifest.schema.json", plan).isEmpty());
+    }
+
+    @Test
+    public void applyAndVerifyRejectPlanOnlyReadyOutcomes() throws Exception {
+        for (String fixtureName : new String[] { "analyzer-migration-apply.json", "analyzer-migration-verify.json" }) {
+            JsonNode manifest = migrationFixture(fixtureName).deepCopy();
+            ((com.fasterxml.jackson.databind.node.ObjectNode) manifest.path("outcomes").path(0)).put("outcome",
+                    "READY");
+
+            assertFalse(fixtureName,
+                    localValidationMessages("analyzer-migration-manifest.schema.json", manifest).isEmpty());
+        }
+    }
+
+    private static JsonNode migrationFixture(String name) throws IOException {
+        JsonNode fixture = localFixture(name);
+        assertLocalConforms("analyzer-migration-manifest.schema.json", fixture);
+        return fixture;
+    }
+
+    private static JsonNode localFixture(String name) throws IOException {
+        return JSON.readTree(FIXTURE_ROOT.resolve(name).toFile());
+    }
+
+    private static void assertLocalConforms(String schemaName, JsonNode fixture) throws IOException {
+        Set<ValidationMessage> messages = localValidationMessages(schemaName, fixture);
+        assertTrue(schemaName + " violations: " + messages, messages.isEmpty());
+    }
+
+    private static Set<ValidationMessage> localValidationMessages(String schemaName, JsonNode fixture)
+            throws IOException {
+        JsonSchema schema = SCHEMAS.getSchema(JSON.readTree(CONTRACT_ROOT.resolve(schemaName).toFile()));
+        return schema.validate(fixture);
+    }
+
+    private static Set<String> outcomeKeys(JsonNode manifest) {
+        return outcomesByKey(manifest).keySet();
+    }
+
+    private static Map<String, JsonNode> outcomesByKey(JsonNode manifest) {
+        Map<String, JsonNode> outcomes = new LinkedHashMap<>();
+        for (JsonNode outcome : manifest.path("outcomes")) {
+            JsonNode previous = outcomes.put(outcome.path("migrationKey").asText(), outcome);
+            assertNotNull("migration key is required", outcome.path("migrationKey").textValue());
+            assertTrue("duplicate migration key", previous == null);
+        }
+        return outcomes;
+    }
+}


### PR DESCRIPTION
## Scope

Review-ready OpenELIS E0 contract and cutover checkpoint against the established Bridge-owned analyzer profile system. It removes the discarded replacement-profile/preservation design and defines the clean OpenELIS consumer boundary without adding M1 production UI.

- Profiles remain Bridge-owned data with two jobs: define analyzer-type runtime behavior and supply defaults for a new Bridge connection.
- OpenELIS stores the Bridge connection reference, acknowledged profile ID/revision, site-owned lab context, local clinical bindings, verification, and audit; it does not copy or serve profiles.
- Published revisions never move configured connections implicitly.
- Operational QC remains independent and never gates verification or activation.
- The cutover is one-way: no `AnalyzerQcRule`, `QcRun`, OE FILE poller, dual reader/writer, per-analyzer mapping editor, or copied profile authority.
- Existing profile rows receive evidence-based retain/correct/alias/split/remove dispositions; no legacy-row domain or preservation obligation is introduced.

## TDD And Validation

- Focused E0 consumer/cutover tests: 9 passed.
- Complete analyzer and analyzer-import owning packages: 600 passed.
- Frontend profile compatibility guard: 10 passed.
- Maven Spotless and `git diff --check` passed.
- Bridge E0 companion: 24 focused contract tests and 624 full-suite tests passed; 3 environment-dependent serial tests skipped.

## Stack State

This PR is stacked on [F0 #4053](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4053) and consumes required Bridge producer [#45](https://github.com/DIGI-UW/openelis-analyzer-bridge/pull/45). No E0 mock change is required.

The canonical roadmap marks E0 `[x]`, later review-ready checkpoints `[x]`, M4 `[*]`, and G0 `[ ]`. Fresh GitHub checks are authoritative for the published head.
