### PR TITLE
fix(eqa): stop reporting enrollment success when the write failed (T-01)

### DIFF
--- a/frontend/src/components/eqa/EQAProgram/ParticipantsTab.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ParticipantsTab.jsx
@@ -30,8 +30,9 @@ import {
 import { useIntl } from "react-intl";
 import {
   getFromOpenElisServer,
-  postToOpenElisServerJsonResponse,
-  putToOpenElisServer,
+  postToOpenElisServerFullResponse,
+  putToOpenElisServerFullResponse,
+  resolveApiErrorMessage,
 } from "../../utils/Utils";
 
 const ENROLLMENT_STATUS_TAG = {
@@ -92,40 +93,56 @@ const ParticipantsTab = ({ programs }) => {
     fetchOrganizations();
   }, [fetchOrganizations]);
 
+  // the server answers failures with a JSON body ({error}/{message}/fieldErrors);
+  // surface it instead of letting a 4xx pass for success
+  const notifyServerError = (response) => {
+    Promise.resolve(response ? response.json().catch(() => null) : null).then(
+      (body) =>
+        setNotification({
+          kind: "error",
+          message: resolveApiErrorMessage(intl, body, "error.save.failed"),
+        }),
+    );
+  };
+
   const handleEnrollSubmit = () => {
     if (selectedOrgs.length === 0 || !selectedProgramId) return;
-    const orgIds = selectedOrgs.map((o) => o.id);
-    postToOpenElisServerJsonResponse(
+    const orgIds = selectedOrgs.map((o) => Number(o.id));
+    postToOpenElisServerFullResponse(
       `/rest/eqa/programs/${selectedProgramId}/enrollments`,
       JSON.stringify({ organizationIds: orgIds }),
       (response) => {
-        if (response) {
-          setEnrollModalOpen(false);
-          setSelectedOrgs([]);
-          setNotification({
-            kind: "success",
-            message: intl.formatMessage(
-              { id: "eqa.enrollment.success" },
-              { count: orgIds.length },
-            ),
-          });
-          fetchEnrollments();
+        if (!response || !response.ok) {
+          notifyServerError(response);
+          return;
         }
+        setEnrollModalOpen(false);
+        setSelectedOrgs([]);
+        setNotification({
+          kind: "success",
+          message: intl.formatMessage(
+            { id: "eqa.enrollment.success" },
+            { count: orgIds.length },
+          ),
+        });
+        fetchEnrollments();
       },
     );
   };
 
   const handleStatusChange = (enrollmentId, newStatus, reason) => {
-    putToOpenElisServer(
+    putToOpenElisServerFullResponse(
       `/rest/eqa/programs/${selectedProgramId}/enrollments/${enrollmentId}`,
       JSON.stringify({ status: newStatus, reason: reason || "" }),
-      (status) => {
-        if (status === 200) {
-          setWithdrawModalOpen(false);
-          setWithdrawReason("");
-          setSelectedEnrollment(null);
-          fetchEnrollments();
+      (response) => {
+        if (!response || !response.ok) {
+          notifyServerError(response);
+          return;
         }
+        setWithdrawModalOpen(false);
+        setWithdrawReason("");
+        setSelectedEnrollment(null);
+        fetchEnrollments();
       },
     );
   };

--- a/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
@@ -1,9 +1,16 @@
 import React, { useState } from "react";
-import { Modal, TextInput, TextArea, Toggle } from "@carbon/react";
+import {
+  Modal,
+  TextInput,
+  TextArea,
+  Toggle,
+  InlineNotification,
+} from "@carbon/react";
 import { useIntl } from "react-intl";
 import {
-  postToOpenElisServerJsonResponse,
-  putToOpenElisServer,
+  postToOpenElisServerFullResponse,
+  putToOpenElisServerFullResponse,
+  resolveApiErrorMessage,
 } from "../../utils/Utils";
 
 const ProgramForm = ({ program, onClose }) => {
@@ -16,6 +23,19 @@ const ProgramForm = ({ program, onClose }) => {
   const [isActive, setIsActive] = useState(program?.isActive !== false);
   const [nameError, setNameError] = useState("");
   const [providerError, setProviderError] = useState("");
+  const [saveError, setSaveError] = useState("");
+
+  // keep the modal open and show why the server refused, instead of closing as if saved
+  const handleResponse = (response) => {
+    if (response && response.ok) {
+      if (onClose) onClose();
+      return;
+    }
+    Promise.resolve(response ? response.json().catch(() => null) : null).then(
+      (body) =>
+        setSaveError(resolveApiErrorMessage(intl, body, "error.save.failed")),
+    );
+  };
 
   const handleSubmit = () => {
     let valid = true;
@@ -39,23 +59,18 @@ const ProgramForm = ({ program, onClose }) => {
       description,
     };
 
+    setSaveError("");
     if (isEditing) {
-      putToOpenElisServer(
+      putToOpenElisServerFullResponse(
         `/rest/eqa/programs/${program.id}`,
         JSON.stringify({ ...payload, isActive }),
-        () => {
-          if (onClose) onClose();
-        },
+        handleResponse,
       );
     } else {
-      postToOpenElisServerJsonResponse(
+      postToOpenElisServerFullResponse(
         "/rest/eqa/programs",
         JSON.stringify(payload),
-        (response) => {
-          if (response && !response.error) {
-            if (onClose) onClose();
-          }
-        },
+        handleResponse,
       );
     }
   };
@@ -78,6 +93,13 @@ const ProgramForm = ({ program, onClose }) => {
       onSecondarySubmit={onClose}
     >
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        {saveError && (
+          <InlineNotification
+            kind="error"
+            title={saveError}
+            onCloseButtonClick={() => setSaveError("")}
+          />
+        )}
         <TextInput
           id="program-name"
           labelText={intl.formatMessage({ id: "eqa.program.name" })}

--- a/frontend/src/components/eqa/EQAProgram/SystemSettingsTab.jsx
+++ b/frontend/src/components/eqa/EQAProgram/SystemSettingsTab.jsx
@@ -14,7 +14,8 @@ import { Save } from "@carbon/icons-react";
 import { useIntl } from "react-intl";
 import {
   getFromOpenElisServer,
-  postToOpenElisServerJsonResponse,
+  postToOpenElisServerFullResponse,
+  resolveApiErrorMessage,
 } from "../../utils/Utils";
 
 const SystemSettingsTab = () => {
@@ -126,22 +127,30 @@ const SystemSettingsTab = () => {
       generateReports: generateReports,
     };
 
-    postToOpenElisServerJsonResponse(
+    postToOpenElisServerFullResponse(
       "/rest/alert-notification-config",
       JSON.stringify(payload),
       (response) => {
         setSaving(false);
-        if (response) {
-          setNotification({
-            kind: "success",
-            message: intl.formatMessage({ id: "eqa.settings.saveSuccess" }),
-          });
-        } else {
-          setNotification({
-            kind: "error",
-            message: intl.formatMessage({ id: "eqa.settings.saveError" }),
-          });
+        if (!response || !response.ok) {
+          Promise.resolve(
+            response ? response.json().catch(() => null) : null,
+          ).then((body) =>
+            setNotification({
+              kind: "error",
+              message: resolveApiErrorMessage(
+                intl,
+                body,
+                "eqa.settings.saveError",
+              ),
+            }),
+          );
+          return;
         }
+        setNotification({
+          kind: "success",
+          message: intl.formatMessage({ id: "eqa.settings.saveSuccess" }),
+        });
       },
     );
   };

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ParticipantsTab.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ParticipantsTab.test.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../../languages/en.json";
+import ParticipantsTab from "../ParticipantsTab";
+import {
+  getFromOpenElisServer,
+  postToOpenElisServerFullResponse,
+} from "../../../utils/Utils";
+
+vi.mock("../../../utils/Utils", async () => {
+  const actual = await vi.importActual("../../../utils/Utils");
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+    postToOpenElisServerFullResponse: vi.fn(),
+    putToOpenElisServerFullResponse: vi.fn(),
+  };
+});
+
+const programs = [{ id: 1, name: "Chemistry PT", isActive: true }];
+
+const organizations = [
+  { id: 100, organizationName: "Hospital A", isActive: "Y" },
+];
+
+const renderTab = () =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <ParticipantsTab programs={programs} />
+    </IntlProvider>,
+  );
+
+const jsonResponse = (ok, status, body) => ({
+  ok,
+  status,
+  json: () => Promise.resolve(body),
+});
+
+const selectProgram = (container) =>
+  fireEvent.change(container.querySelector("#participant-program-selector"), {
+    target: { value: "1" },
+  });
+
+// open the enroll modal, pick the only organization and submit
+const enrollHospitalA = () => {
+  fireEvent.click(screen.getByRole("button", { name: "Enroll Participant" }));
+  fireEvent.click(screen.getByPlaceholderText("Search organizations..."));
+  fireEvent.click(screen.getByText("Hospital A"));
+  fireEvent.click(screen.getByText("Enroll Selected"));
+};
+
+const enrollmentFetchCount = () =>
+  getFromOpenElisServer.mock.calls.filter(([url]) =>
+    url.includes("enrollments"),
+  ).length;
+
+describe("ParticipantsTab enrollment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFromOpenElisServer.mockImplementation((url, callback) => {
+      callback(url.includes("/enrollments") ? [] : organizations);
+    });
+  });
+
+  test("sends numeric organization ids", () => {
+    postToOpenElisServerFullResponse.mockImplementation(() => {});
+    const { container } = renderTab();
+    selectProgram(container);
+
+    enrollHospitalA();
+
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload)).toEqual({ organizationIds: [100] });
+  });
+
+  test("surfaces the server error instead of reporting success", async () => {
+    postToOpenElisServerFullResponse.mockImplementation(
+      (url, payload, callback) =>
+        callback(
+          jsonResponse(false, 400, { error: "Organization already enrolled" }),
+        ),
+    );
+    const { container } = renderTab();
+    selectProgram(container);
+    const fetchesBefore = enrollmentFetchCount();
+
+    enrollHospitalA();
+
+    expect(
+      await screen.findByText("Organization already enrolled"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment successful")).toBeNull();
+    expect(enrollmentFetchCount()).toBe(fetchesBefore);
+  });
+
+  test("falls back to a generic message when the error body is unreadable", async () => {
+    postToOpenElisServerFullResponse.mockImplementation(
+      (url, payload, callback) =>
+        callback({ ok: false, status: 403, json: () => Promise.reject() }),
+    );
+    const { container } = renderTab();
+    selectProgram(container);
+
+    enrollHospitalA();
+
+    expect(await screen.findByText("Failed to save")).toBeInTheDocument();
+  });
+
+  test("reports success and refreshes on 201", async () => {
+    postToOpenElisServerFullResponse.mockImplementation(
+      (url, payload, callback) =>
+        callback(jsonResponse(true, 201, [{ id: 5 }])),
+    );
+    const { container } = renderTab();
+    selectProgram(container);
+    const fetchesBefore = enrollmentFetchCount();
+
+    enrollHospitalA();
+
+    expect(
+      await screen.findByText("Enrollment successful"),
+    ).toBeInTheDocument();
+    expect(enrollmentFetchCount()).toBeGreaterThan(fetchesBefore);
+  });
+});

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
@@ -15,11 +15,15 @@ vi.mock("../../../../components/common/PageBreadCrumb", () => {
   };
 });
 
-vi.mock("../../../utils/Utils", () => ({
-  getFromOpenElisServer: vi.fn(),
-  postToOpenElisServerJsonResponse: vi.fn(),
-  putToOpenElisServer: vi.fn(),
-}));
+vi.mock("../../../utils/Utils", async () => {
+  const actual = await vi.importActual("../../../utils/Utils");
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+    postToOpenElisServerFullResponse: vi.fn(),
+    putToOpenElisServerFullResponse: vi.fn(),
+  };
+});
 
 // Replaced inline utils require
 

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAEnrollmentRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAEnrollmentRestController.java
@@ -47,13 +47,20 @@ public class EQAEnrollmentRestController extends ControllerUtills {
     public ResponseEntity<?> createEnrollments(HttpServletRequest request, @PathVariable Long programId,
             @RequestBody Map<String, Object> body) {
         try {
-            @SuppressWarnings("unchecked")
-            List<Number> orgIds = (List<Number>) body.get("organizationIds");
-            if (orgIds == null || orgIds.isEmpty()) {
+            Object rawIds = body.get("organizationIds");
+            if (!(rawIds instanceof List) || ((List<?>) rawIds).isEmpty()) {
                 return ResponseEntity.badRequest().body(Map.of("error", "organizationIds list is required"));
             }
 
-            List<Long> organizationIds = orgIds.stream().map(Number::longValue).collect(Collectors.toList());
+            List<Long> organizationIds;
+            try {
+                // ids arrive as JSON numbers or as strings depending on the caller - accept
+                // both
+                organizationIds = ((List<?>) rawIds).stream().map(id -> Long.valueOf(String.valueOf(id)))
+                        .collect(Collectors.toList());
+            } catch (NumberFormatException e) {
+                return ResponseEntity.badRequest().body(Map.of("error", "organizationIds must be numeric"));
+            }
             String sysUserId = getSysUserId(request);
 
             List<EQAProgramEnrollment> enrolled = enrollmentService.bulkEnroll(programId, organizationIds, sysUserId);

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
@@ -90,6 +90,30 @@ public class EQAEnrollmentRestControllerTest {
     }
 
     @Test
+    public void testCreateEnrollments_AcceptsStringOrgIds() {
+        when(enrollmentService.bulkEnroll(eq(1L), eq(List.of(100L)), eq("1")))
+                .thenReturn(List.of(enrollment1));
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("organizationIds", List.of("100"));
+
+        ResponseEntity<?> response = controller.createEnrollments(request, 1L, body);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+
+    @Test
+    public void testCreateEnrollments_NonNumericOrgIds() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("organizationIds", List.of("abc"));
+
+        ResponseEntity<?> response = controller.createEnrollments(request, 1L, body);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("organizationIds must be numeric", ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    @Test
     public void testCreateEnrollments_MissingOrgIds() {
         Map<String, Object> body = new HashMap<>();
 


### PR DESCRIPTION
## Problem

Enrolling participant organizations from **EQA Management → Participants** toasted "Enrollment successful" while `eqa_program_enrollment` stayed empty (live defect D-LIVE-1; the table reads 0 rows on the dev stack after a "successful" enrollment).

Two independent defects lined up:

1. **Backend.** The tab's multiselect items carry string ids, so the body is `{"organizationIds":["100"]}`. `createEnrollments` cast that to `List<Number>` — an erased cast, so it only blows up later at `Number::longValue` — and the `ClassCastException` was swallowed by the blanket `catch (Exception)` and returned as `400 {error: "class java.lang.String cannot be cast to ..."}`. The standalone `/qa/eqa/participants` page sends numeric ids, which is exactly why it worked and the tab did not.
2. **Frontend.** `postToOpenElisServerJsonResponse` resolves error bodies too (it parses 4xx JSON and injects `status`), so `if (response)` counted every failure as a success.

## Change

- `EQAEnrollmentRestController.createEnrollments` accepts numeric **and** string ids; non-numeric input returns `organizationIds must be numeric` instead of a stringified `ClassCastException`.
- `ParticipantsTab` sends numeric ids, moves POST/PUT to the `*FullResponse` helpers, gates the success path on `response.ok`, and renders the server's own message via `resolveApiErrorMessage` on failure. The status-change PUT previously failed silently.
- Swept the same accept-any-JSON-as-success pattern out of `SystemSettingsTab` (any response counted as saved) and `ProgramForm` (the edit PUT ignored the status entirely and closed the modal as if saved; it now stays open with an inline error).

No new i18n keys — reuses `error.save.failed` and `eqa.settings.saveError`.

Left alone deliberately: `MyProgramsPage` and `EQAParticipantsPage` already branch on `response.error`, and `CreateDistribution.jsx` belongs to the next task on this lane (T-03) — touching it here would just cause a merge conflict.

## Tests

- New `ParticipantsTab.test.jsx`: numeric payload on the wire, server error surfaced with no refetch, generic fallback when the error body is unreadable, success + refetch on 201.
- Two new controller cases: string ids → 201, non-numeric ids → 400 with the clear message.
- Inversion checked on both sides: reverting the frontend fix fails 3 of the 4 new frontend tests; stashing the controller fix gives `expected:<201 CREATED> but was:<400 BAD_REQUEST>` — the live defect reproduced in a test.
- Full `src/components/eqa` suite: 75 passed. `EQAEnrollmentRestControllerTest`: 10 passed.

## Manual verification

Not yet run end-to-end on the dev stack: the backend half needs a rebuild, and the browser profile was held by another session. DB baseline (`select count(*) from eqa_program_enrollment` = 0) confirms the write never landed pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)