### PR TITLE
feat(eqa-v2/T-09+T-10): panels & sealed targets, cycle state machines & audit (OGC-609)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
@@ -32,9 +33,8 @@ import org.springframework.web.bind.annotation.RestController;
  * Cycle read + transition API (T-10).
  *
  * <p>
- * There is deliberately no PUT or DELETE mapping for the transitions path:
- * cycle-state audit rows are immutable (FR-V2.1-21), and leaving those methods
- * unmapped is what makes Spring answer 405 without a hand-written guard.
+ * No PUT or DELETE is mapped for the transitions path: audit rows are immutable
+ * (FR-V2.1-21), and leaving those methods unmapped makes Spring answer 405.
  */
 @RestController
 @RequestMapping("/rest/eqa")
@@ -58,7 +58,7 @@ public class EQACycleRestController extends BaseRestController {
         for (EQACycle cycle : cycleService.getAll()) {
             Map<String, Object> dto = toCycleDto(cycle);
             if (labEnrollmentId != null) {
-                dto.put("participantState", cycleService.deriveParticipantState(cycle.getId(), labEnrollmentId).name());
+                dto.put("participantState", cycleService.deriveParticipantState(cycle, labEnrollmentId).name());
             }
             rows.add(dto);
         }
@@ -80,7 +80,6 @@ public class EQACycleRestController extends BaseRestController {
         return dto;
     }
 
-    /** Read-only by construction — see the class note on 405. */
     @GetMapping(value = "/cycles/{id}/transitions", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Map<String, Object>> transitions(@PathVariable Long id) {
         List<Map<String, Object>> rows = new ArrayList<>();
@@ -101,35 +100,46 @@ public class EQACycleRestController extends BaseRestController {
     }
 
     /**
-     * Advancing a cycle changes lab-wide state and writes a permanent audit row, so
+     * Advancing a cycle mutates lab-wide state and writes a permanent audit row, so
      * it needs a manage-level grant rather than the class-level read roles
-     * (FR-V2.1-04). A method annotation replaces the class one for this handler.
+     * (FR-V2.1-04).
+     *
+     * <p>
+     * Provenance is never taken from the request body: an HTTP call is a person
+     * acting, so it is always recorded as a MANUAL override attributed to the
+     * session user (FR-V2.1-21).
      */
     @PatchMapping(value = "/cycles/{id}/transition", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
     public ResponseEntity<Map<String, Object>> transition(HttpServletRequest request, @PathVariable Long id,
             @RequestBody Map<String, Object> body) {
-        String newState = (String) body.get("newState");
+        String newState = stringField(body, "newState");
         if (newState == null) {
             return ResponseEntity.badRequest().body(Map.of("error", "newState is required"));
         }
 
-        EQAStateMachine machine = EQAStateMachine.valueOf(
-                ((String) body.getOrDefault("stateMachine", EQAStateMachine.PARTICIPANT.name())).toUpperCase());
+        EQACycleStatus targetState;
+        EQAStateMachine machine;
+        try {
+            targetState = EQACycleStatus.valueOf(newState.toUpperCase());
+            String machineName = stringField(body, "stateMachine");
+            machine = machineName == null ? EQAStateMachine.PARTICIPANT
+                    : EQAStateMachine.valueOf(machineName.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown state or state machine"));
+        }
 
-        // Provenance is never taken from the request body. An HTTP call is a person
-        // acting, so it is always recorded as a MANUAL override attributed to the
-        // authenticated user. Letting the caller supply triggerType/triggeredBy/
-        // triggerEvent would let them file a human decision as an unattributed
-        // system event — and since AUTO rows are exempt from the reason rule, it
-        // would also silently skip that. Destroying exactly the manual-vs-automatic
-        // distinction the audit table exists to preserve (FR-V2.1-21).
         String sysUserId = getSysUserId(request);
-        EQACycle updated = cycleService.transition(id, EQACycleStatus.valueOf(newState.toUpperCase()), machine,
-                EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, actingUserId(sysUserId),
-                (String) body.get("reason"), sysUserId);
+        EQACycle updated = cycleService.transition(id, targetState, machine, EQATriggerType.MANUAL,
+                EQATriggerEvent.MANUAL_OVERRIDE, actingUserId(sysUserId), stringField(body, "reason"), sysUserId);
 
         return ResponseEntity.ok(toCycleDto(updated));
+    }
+
+    /** Tolerates non-string JSON values rather than throwing ClassCastException. */
+    private String stringField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        return value == null ? null : String.valueOf(value);
     }
 
     /**
@@ -155,6 +165,12 @@ public class EQACycleRestController extends BaseRestController {
                 cycle.getPlannedStartDate() == null ? null : cycle.getPlannedStartDate().toString());
         dto.put("plannedEndDate", cycle.getPlannedEndDate() == null ? null : cycle.getPlannedEndDate().toString());
         return dto;
+    }
+
+    @ExceptionHandler(ObjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNotFound(ObjectNotFoundException e) {
+        return Map.of("error", "EQA cycle not found");
     }
 
     /** An edge that is not in the machine is a conflict, not bad input. */

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -1,0 +1,179 @@
+package org.openelisglobal.eqa.controller.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Cycle read + transition API (T-10).
+ *
+ * <p>
+ * There is deliberately no PUT or DELETE mapping for the transitions path:
+ * cycle-state audit rows are immutable (FR-V2.1-21), and leaving those methods
+ * unmapped is what makes Spring answer 405 without a hand-written guard.
+ */
+@RestController
+@RequestMapping("/rest/eqa")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS')")
+public class EQACycleRestController extends BaseRestController {
+
+    private final EQACycleService cycleService;
+
+    public EQACycleRestController(EQACycleService cycleService) {
+        this.cycleService = cycleService;
+    }
+
+    /**
+     * Cycles this lab takes part in. OpenELIS runs single-tenant, so every cycle in
+     * the database belongs to this lab; passing a labEnrollmentId adds that
+     * enrollment's derived participant state to each row.
+     */
+    @GetMapping(value = "/cycles/mine", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> myCycles(@RequestParam(required = false) Long labEnrollmentId) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQACycle cycle : cycleService.getAll()) {
+            Map<String, Object> dto = toCycleDto(cycle);
+            if (labEnrollmentId != null) {
+                dto.put("participantState", cycleService.deriveParticipantState(cycle.getId(), labEnrollmentId).name());
+            }
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    @GetMapping(value = "/cycles/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> getCycle(@PathVariable Long id) {
+        return toCycleDto(cycleService.get(id));
+    }
+
+    /** Computed, never stored (FR-V2.1-18). */
+    @GetMapping(value = "/cycles/{id}/participant-state", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> participantState(@PathVariable Long id, @RequestParam Long labEnrollmentId) {
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("cycleId", id);
+        dto.put("labEnrollmentId", labEnrollmentId);
+        dto.put("participantState", cycleService.deriveParticipantState(id, labEnrollmentId).name());
+        return dto;
+    }
+
+    /** Read-only by construction — see the class note on 405. */
+    @GetMapping(value = "/cycles/{id}/transitions", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> transitions(@PathVariable Long id) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQACycleStateTransition t : cycleService.getTransitions(id)) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", t.getId());
+            dto.put("priorState", t.getPriorState());
+            dto.put("newState", t.getNewState());
+            dto.put("stateMachine", t.getStateMachine() == null ? null : t.getStateMachine().name());
+            dto.put("triggerType", t.getTriggerType() == null ? null : t.getTriggerType().name());
+            dto.put("triggerEvent", t.getTriggerEvent() == null ? null : t.getTriggerEvent().name());
+            dto.put("triggeredBy", t.getTriggeredBy());
+            dto.put("reason", t.getReason());
+            dto.put("occurredAt", t.getOccurredAt() == null ? null : t.getOccurredAt().toString());
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    /**
+     * Advancing a cycle changes lab-wide state and writes a permanent audit row, so
+     * it needs a manage-level grant rather than the class-level read roles
+     * (FR-V2.1-04). A method annotation replaces the class one for this handler.
+     */
+    @PatchMapping(value = "/cycles/{id}/transition", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
+    public ResponseEntity<Map<String, Object>> transition(HttpServletRequest request, @PathVariable Long id,
+            @RequestBody Map<String, Object> body) {
+        String newState = (String) body.get("newState");
+        if (newState == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "newState is required"));
+        }
+
+        EQAStateMachine machine = EQAStateMachine.valueOf(
+                ((String) body.getOrDefault("stateMachine", EQAStateMachine.PARTICIPANT.name())).toUpperCase());
+
+        // Provenance is never taken from the request body. An HTTP call is a person
+        // acting, so it is always recorded as a MANUAL override attributed to the
+        // authenticated user. Letting the caller supply triggerType/triggeredBy/
+        // triggerEvent would let them file a human decision as an unattributed
+        // system event — and since AUTO rows are exempt from the reason rule, it
+        // would also silently skip that. Destroying exactly the manual-vs-automatic
+        // distinction the audit table exists to preserve (FR-V2.1-21).
+        String sysUserId = getSysUserId(request);
+        EQACycle updated = cycleService.transition(id, EQACycleStatus.valueOf(newState.toUpperCase()), machine,
+                EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, actingUserId(sysUserId),
+                (String) body.get("reason"), sysUserId);
+
+        return ResponseEntity.ok(toCycleDto(updated));
+    }
+
+    /**
+     * The session's user id as the audit actor. A manual transition with no
+     * resolvable actor is refused rather than recorded anonymously.
+     */
+    private Long actingUserId(String sysUserId) {
+        try {
+            return Long.valueOf(sysUserId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Cannot attribute this transition to an authenticated user");
+        }
+    }
+
+    private Map<String, Object> toCycleDto(EQACycle cycle) {
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("id", cycle.getId());
+        dto.put("cycleNumber", cycle.getCycleNumber());
+        dto.put("cycleName", cycle.getCycleName());
+        dto.put("status", cycle.getStatus() == null ? null : cycle.getStatus().name());
+        dto.put("schemeId", cycle.getScheme() == null ? null : cycle.getScheme().getId());
+        dto.put("plannedStartDate",
+                cycle.getPlannedStartDate() == null ? null : cycle.getPlannedStartDate().toString());
+        dto.put("plannedEndDate", cycle.getPlannedEndDate() == null ? null : cycle.getPlannedEndDate().toString());
+        return dto;
+    }
+
+    /** An edge that is not in the machine is a conflict, not bad input. */
+    @ExceptionHandler(EQAInvalidTransitionException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, Object> handleInvalidTransition(EQAInvalidTransitionException e) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", e.getMessage());
+        body.put("priorState", e.getPriorState() == null ? null : e.getPriorState().name());
+        body.put("attemptedState", e.getAttemptedState() == null ? null : e.getAttemptedState().name());
+        return body;
+    }
+
+    /**
+     * A legal edge missing its required reason is unprocessable, not a conflict.
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, String> handleBadInput(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAAnalystCompetencyEventDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAAnalystCompetencyEventDAO.java
@@ -1,0 +1,7 @@
+package org.openelisglobal.eqa.dao;
+
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+
+public interface EQAAnalystCompetencyEventDAO extends BaseDAO<EQAAnalystCompetencyEvent, Long> {
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQACycleDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQACycleDAO.java
@@ -1,7 +1,14 @@
 package org.openelisglobal.eqa.dao;
 
+import java.util.Optional;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 
 public interface EQACycleDAO extends BaseDAO<EQACycle, Long> {
+
+    /**
+     * Row-locked read (SELECT ... FOR UPDATE) so two concurrent transitions cannot
+     * both pass the edge check against the same prior state.
+     */
+    Optional<EQACycle> getForUpdate(Long id);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQACycleStateTransitionDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQACycleStateTransitionDAO.java
@@ -1,11 +1,7 @@
 package org.openelisglobal.eqa.dao;
 
-import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 
 public interface EQACycleStateTransitionDAO extends BaseDAO<EQACycleStateTransition, Long> {
-
-    /** Oldest first — this is a timeline, not a log tail. */
-    List<EQACycleStateTransition> findByCycleId(Long cycleId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQACycleStateTransitionDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQACycleStateTransitionDAO.java
@@ -1,7 +1,11 @@
 package org.openelisglobal.eqa.dao;
 
+import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 
 public interface EQACycleStateTransitionDAO extends BaseDAO<EQACycleStateTransition, Long> {
+
+    /** Oldest first — this is a timeline, not a log tail. */
+    List<EQACycleStateTransition> findByCycleId(Long cycleId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
@@ -1,10 +1,7 @@
 package org.openelisglobal.eqa.dao;
 
-import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 
 public interface EQAPanelDAO extends BaseDAO<EQAPanel, Long> {
-
-    List<EQAPanel> findByCycleId(Long cycleId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.eqa.dao;
+
+import java.util.List;
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+
+public interface EQAPanelDAO extends BaseDAO<EQAPanel, Long> {
+
+    List<EQAPanel> findByCycleId(Long cycleId);
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelReceiptDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelReceiptDAO.java
@@ -1,10 +1,7 @@
 package org.openelisglobal.eqa.dao;
 
-import java.util.Optional;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
 
 public interface EQAPanelReceiptDAO extends BaseDAO<EQAPanelReceipt, Long> {
-
-    Optional<EQAPanelReceipt> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelReceiptDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelReceiptDAO.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.eqa.dao;
+
+import java.util.Optional;
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+
+public interface EQAPanelReceiptDAO extends BaseDAO<EQAPanelReceipt, Long> {
+
+    Optional<EQAPanelReceipt> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId);
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelSampleDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelSampleDAO.java
@@ -1,0 +1,7 @@
+package org.openelisglobal.eqa.dao;
+
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+
+public interface EQAPanelSampleDAO extends BaseDAO<EQAPanelSample, Long> {
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantFollowupDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantFollowupDAO.java
@@ -1,0 +1,7 @@
+package org.openelisglobal.eqa.dao;
+
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+
+public interface EQAParticipantFollowupDAO extends BaseDAO<EQAParticipantFollowup, Long> {
+}

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantResultDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantResultDAO.java
@@ -1,10 +1,7 @@
 package org.openelisglobal.eqa.dao;
 
-import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 
 public interface EQAParticipantResultDAO extends BaseDAO<EQAParticipantResult, Long> {
-
-    List<EQAParticipantResult> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantResultDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAParticipantResultDAO.java
@@ -1,7 +1,10 @@
 package org.openelisglobal.eqa.dao;
 
+import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 
 public interface EQAParticipantResultDAO extends BaseDAO<EQAParticipantResult, Long> {
+
+    List<EQAParticipantResult> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId);
 }

--- a/src/main/java/org/openelisglobal/eqa/dao/EQASchemeAnalystDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQASchemeAnalystDAO.java
@@ -1,0 +1,7 @@
+package org.openelisglobal.eqa.dao;
+
+import org.openelisglobal.common.dao.BaseDAO;
+import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+
+public interface EQASchemeAnalystDAO extends BaseDAO<EQASchemeAnalyst, Long> {
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAAnalystCompetencyEventDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAAnalystCompetencyEventDAOImpl.java
@@ -1,0 +1,17 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQAAnalystCompetencyEventDAOImpl extends BaseDAOImpl<EQAAnalystCompetencyEvent, Long>
+        implements EQAAnalystCompetencyEventDAO {
+
+    public EQAAnalystCompetencyEventDAOImpl() {
+        super(EQAAnalystCompetencyEvent.class);
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleDAOImpl.java
@@ -1,5 +1,7 @@
 package org.openelisglobal.eqa.daoimpl;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
@@ -12,5 +14,10 @@ public class EQACycleDAOImpl extends BaseDAOImpl<EQACycle, Long> implements EQAC
 
     public EQACycleDAOImpl() {
         super(EQACycle.class);
+    }
+
+    @Override
+    public Optional<EQACycle> getForUpdate(Long id) {
+        return Optional.ofNullable(entityManager.find(EQACycle.class, id, LockModeType.PESSIMISTIC_WRITE));
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleStateTransitionDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleStateTransitionDAOImpl.java
@@ -1,14 +1,8 @@
 package org.openelisglobal.eqa.daoimpl;
 
-import java.util.List;
-import org.hibernate.Session;
-import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
-import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,24 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EQACycleStateTransitionDAOImpl extends BaseDAOImpl<EQACycleStateTransition, Long>
         implements EQACycleStateTransitionDAO {
 
-    private static final Logger logger = LoggerFactory.getLogger(EQACycleStateTransitionDAOImpl.class);
-
     public EQACycleStateTransitionDAOImpl() {
         super(EQACycleStateTransition.class);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<EQACycleStateTransition> findByCycleId(Long cycleId) {
-        try {
-            String hql = "FROM EQACycleStateTransition t WHERE t.cycle.id = :cycleId ORDER BY t.occurredAt ASC, t.id ASC";
-            Query<EQACycleStateTransition> query = entityManager.unwrap(Session.class).createQuery(hql,
-                    EQACycleStateTransition.class);
-            query.setParameter("cycleId", cycleId);
-            return query.list();
-        } catch (Exception e) {
-            logger.error("Error retrieving state transitions for cycle {}", cycleId, e);
-            throw new LIMSRuntimeException("Error retrieving cycle state transitions", e);
-        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleStateTransitionDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQACycleStateTransitionDAOImpl.java
@@ -1,8 +1,14 @@
 package org.openelisglobal.eqa.daoimpl;
 
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,7 +17,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class EQACycleStateTransitionDAOImpl extends BaseDAOImpl<EQACycleStateTransition, Long>
         implements EQACycleStateTransitionDAO {
 
+    private static final Logger logger = LoggerFactory.getLogger(EQACycleStateTransitionDAOImpl.class);
+
     public EQACycleStateTransitionDAOImpl() {
         super(EQACycleStateTransition.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQACycleStateTransition> findByCycleId(Long cycleId) {
+        try {
+            String hql = "FROM EQACycleStateTransition t WHERE t.cycle.id = :cycleId ORDER BY t.occurredAt ASC, t.id ASC";
+            Query<EQACycleStateTransition> query = entityManager.unwrap(Session.class).createQuery(hql,
+                    EQACycleStateTransition.class);
+            query.setParameter("cycleId", cycleId);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error retrieving state transitions for cycle {}", cycleId, e);
+            throw new LIMSRuntimeException("Error retrieving cycle state transitions", e);
+        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
@@ -1,14 +1,8 @@
 package org.openelisglobal.eqa.daoimpl;
 
-import java.util.List;
-import org.hibernate.Session;
-import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
-import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,23 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class EQAPanelDAOImpl extends BaseDAOImpl<EQAPanel, Long> implements EQAPanelDAO {
 
-    private static final Logger logger = LoggerFactory.getLogger(EQAPanelDAOImpl.class);
-
     public EQAPanelDAOImpl() {
         super(EQAPanel.class);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<EQAPanel> findByCycleId(Long cycleId) {
-        try {
-            String hql = "FROM EQAPanel p WHERE p.cycle.id = :cycleId";
-            Query<EQAPanel> query = entityManager.unwrap(Session.class).createQuery(hql, EQAPanel.class);
-            query.setParameter("cycleId", cycleId);
-            return query.list();
-        } catch (Exception e) {
-            logger.error("Error retrieving panels for cycle {}", cycleId, e);
-            throw new LIMSRuntimeException("Error retrieving panels for cycle", e);
-        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
@@ -1,0 +1,38 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQAPanelDAOImpl extends BaseDAOImpl<EQAPanel, Long> implements EQAPanelDAO {
+
+    private static final Logger logger = LoggerFactory.getLogger(EQAPanelDAOImpl.class);
+
+    public EQAPanelDAOImpl() {
+        super(EQAPanel.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQAPanel> findByCycleId(Long cycleId) {
+        try {
+            String hql = "FROM EQAPanel p WHERE p.cycle.id = :cycleId";
+            Query<EQAPanel> query = entityManager.unwrap(Session.class).createQuery(hql, EQAPanel.class);
+            query.setParameter("cycleId", cycleId);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error retrieving panels for cycle {}", cycleId, e);
+            throw new LIMSRuntimeException("Error retrieving panels for cycle", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelReceiptDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelReceiptDAOImpl.java
@@ -1,0 +1,40 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import java.util.Optional;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQAPanelReceiptDAOImpl extends BaseDAOImpl<EQAPanelReceipt, Long> implements EQAPanelReceiptDAO {
+
+    private static final Logger logger = LoggerFactory.getLogger(EQAPanelReceiptDAOImpl.class);
+
+    public EQAPanelReceiptDAOImpl() {
+        super(EQAPanelReceipt.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<EQAPanelReceipt> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId) {
+        try {
+            String hql = "FROM EQAPanelReceipt r WHERE r.cycle.id = :cycleId"
+                    + " AND r.labEnrollmentId = :labEnrollmentId";
+            Query<EQAPanelReceipt> query = entityManager.unwrap(Session.class).createQuery(hql, EQAPanelReceipt.class);
+            query.setParameter("cycleId", cycleId);
+            query.setParameter("labEnrollmentId", labEnrollmentId);
+            return query.uniqueResultOptional();
+        } catch (Exception e) {
+            logger.error("Error retrieving panel receipt for cycle {} enrollment {}", cycleId, labEnrollmentId, e);
+            throw new LIMSRuntimeException("Error retrieving panel receipt", e);
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelReceiptDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelReceiptDAOImpl.java
@@ -1,14 +1,8 @@
 package org.openelisglobal.eqa.daoimpl;
 
-import java.util.Optional;
-import org.hibernate.Session;
-import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
-import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,25 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class EQAPanelReceiptDAOImpl extends BaseDAOImpl<EQAPanelReceipt, Long> implements EQAPanelReceiptDAO {
 
-    private static final Logger logger = LoggerFactory.getLogger(EQAPanelReceiptDAOImpl.class);
-
     public EQAPanelReceiptDAOImpl() {
         super(EQAPanelReceipt.class);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<EQAPanelReceipt> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId) {
-        try {
-            String hql = "FROM EQAPanelReceipt r WHERE r.cycle.id = :cycleId"
-                    + " AND r.labEnrollmentId = :labEnrollmentId";
-            Query<EQAPanelReceipt> query = entityManager.unwrap(Session.class).createQuery(hql, EQAPanelReceipt.class);
-            query.setParameter("cycleId", cycleId);
-            query.setParameter("labEnrollmentId", labEnrollmentId);
-            return query.uniqueResultOptional();
-        } catch (Exception e) {
-            logger.error("Error retrieving panel receipt for cycle {} enrollment {}", cycleId, labEnrollmentId, e);
-            throw new LIMSRuntimeException("Error retrieving panel receipt", e);
-        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelSampleDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelSampleDAOImpl.java
@@ -1,0 +1,16 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQAPanelSampleDAOImpl extends BaseDAOImpl<EQAPanelSample, Long> implements EQAPanelSampleDAO {
+
+    public EQAPanelSampleDAOImpl() {
+        super(EQAPanelSample.class);
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantFollowupDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantFollowupDAOImpl.java
@@ -1,0 +1,17 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQAParticipantFollowupDAOImpl extends BaseDAOImpl<EQAParticipantFollowup, Long>
+        implements EQAParticipantFollowupDAO {
+
+    public EQAParticipantFollowupDAOImpl() {
+        super(EQAParticipantFollowup.class);
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantResultDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantResultDAOImpl.java
@@ -1,14 +1,8 @@
 package org.openelisglobal.eqa.daoimpl;
 
-import java.util.List;
-import org.hibernate.Session;
-import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
-import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,27 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EQAParticipantResultDAOImpl extends BaseDAOImpl<EQAParticipantResult, Long>
         implements EQAParticipantResultDAO {
 
-    private static final Logger logger = LoggerFactory.getLogger(EQAParticipantResultDAOImpl.class);
-
     public EQAParticipantResultDAOImpl() {
         super(EQAParticipantResult.class);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<EQAParticipantResult> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId) {
-        try {
-            String hql = "FROM EQAParticipantResult r WHERE r.cycle.id = :cycleId"
-                    + " AND r.labEnrollmentId = :labEnrollmentId";
-            Query<EQAParticipantResult> query = entityManager.unwrap(Session.class).createQuery(hql,
-                    EQAParticipantResult.class);
-            query.setParameter("cycleId", cycleId);
-            query.setParameter("labEnrollmentId", labEnrollmentId);
-            return query.list();
-        } catch (Exception e) {
-            logger.error("Error retrieving participant results for cycle {} enrollment {}", cycleId, labEnrollmentId,
-                    e);
-            throw new LIMSRuntimeException("Error retrieving participant results", e);
-        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantResultDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAParticipantResultDAOImpl.java
@@ -1,8 +1,14 @@
 package org.openelisglobal.eqa.daoimpl;
 
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,7 +17,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class EQAParticipantResultDAOImpl extends BaseDAOImpl<EQAParticipantResult, Long>
         implements EQAParticipantResultDAO {
 
+    private static final Logger logger = LoggerFactory.getLogger(EQAParticipantResultDAOImpl.class);
+
     public EQAParticipantResultDAOImpl() {
         super(EQAParticipantResult.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQAParticipantResult> findByCycleAndEnrollment(Long cycleId, Long labEnrollmentId) {
+        try {
+            String hql = "FROM EQAParticipantResult r WHERE r.cycle.id = :cycleId"
+                    + " AND r.labEnrollmentId = :labEnrollmentId";
+            Query<EQAParticipantResult> query = entityManager.unwrap(Session.class).createQuery(hql,
+                    EQAParticipantResult.class);
+            query.setParameter("cycleId", cycleId);
+            query.setParameter("labEnrollmentId", labEnrollmentId);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error retrieving participant results for cycle {} enrollment {}", cycleId, labEnrollmentId,
+                    e);
+            throw new LIMSRuntimeException("Error retrieving participant results", e);
+        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQASchemeAnalystDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQASchemeAnalystDAOImpl.java
@@ -1,0 +1,16 @@
+package org.openelisglobal.eqa.daoimpl;
+
+import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class EQASchemeAnalystDAOImpl extends BaseDAOImpl<EQASchemeAnalyst, Long> implements EQASchemeAnalystDAO {
+
+    public EQASchemeAnalystDAOImpl() {
+        super(EQASchemeAnalyst.class);
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
@@ -1,0 +1,38 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Set;
+import org.openelisglobal.common.service.BaseObjectService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+
+public interface EQACycleService extends BaseObjectService<EQACycle, Long> {
+
+    /**
+     * Move a cycle to a new state and record why, atomically (FR-V2.1-04 /
+     * FR-V2.1-18 / FR-V2.1-21). Either the status changes and exactly one audit row
+     * appears, or neither does.
+     *
+     * @throws EQAInvalidTransitionException when the edge is not in the machine
+     * @throws IllegalArgumentException      when a manual transition arrives
+     *                                       without a reason
+     */
+    EQACycle transition(Long cycleId, EQACycleStatus newState, EQAStateMachine machine, EQATriggerType triggerType,
+            EQATriggerEvent triggerEvent, Long triggeredBy, String reason, String sysUserId);
+
+    /** Immutable audit trail for a cycle, oldest first. */
+    List<EQACycleStateTransition> getTransitions(Long cycleId);
+
+    /**
+     * This lab's view of a cycle, computed from receipts and result statuses rather
+     * than stored (FR-V2.1-18). No column backs this.
+     */
+    EQACycleStatus deriveParticipantState(Long cycleId, Long labEnrollmentId);
+
+    /** The states reachable from {@code from} on the given machine. */
+    Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
@@ -1,7 +1,6 @@
 package org.openelisglobal.eqa.service;
 
 import java.util.List;
-import java.util.Set;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
@@ -33,6 +32,6 @@ public interface EQACycleService extends BaseObjectService<EQACycle, Long> {
      */
     EQACycleStatus deriveParticipantState(Long cycleId, Long labEnrollmentId);
 
-    /** The states reachable from {@code from} on the given machine. */
-    Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine);
+    /** Same derivation for a cycle already in hand, avoiding a re-fetch. */
+    EQACycleStatus deriveParticipantState(EQACycle cycle, Long labEnrollmentId);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -1,0 +1,243 @@
+package org.openelisglobal.eqa.service;
+
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.CLOSED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.DELIVERED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.PANEL_RECEIVED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.PLANNED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.PREP_IN_PROGRESS;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.READY_TO_SHIP;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.READY_TO_SUBMIT;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SCORED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SCORING;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SHIPPED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SUBMISSIONS_CLOSED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SUBMISSIONS_OPEN;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SUBMITTED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.TESTING;
+
+import java.sql.Timestamp;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Cycle state machines and the derived participant view (T-10).
+ *
+ * <p>
+ * Two machines write the single eqa_cycle.status column: a participating lab
+ * walks the FR-V2.1-04 path, while the lab that runs the scheme walks the
+ * longer FR-V2.1-18 path. Which one applies is the caller's assertion, passed
+ * in as {@link EQAStateMachine}, because the same row is read both ways.
+ */
+@Service
+@Transactional
+public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> implements EQACycleService {
+
+    /** FR-V2.1-04. Terminal: CLOSED. */
+    private static final Map<EQACycleStatus, Set<EQACycleStatus>> PARTICIPANT_EDGES = new EnumMap<>(
+            EQACycleStatus.class);
+
+    /** FR-V2.1-18. Terminal: CLOSED. */
+    private static final Map<EQACycleStatus, Set<EQACycleStatus>> PROVIDER_EDGES = new EnumMap<>(EQACycleStatus.class);
+
+    static {
+        PARTICIPANT_EDGES.put(PLANNED, EnumSet.of(PANEL_RECEIVED));
+        PARTICIPANT_EDGES.put(PANEL_RECEIVED, EnumSet.of(TESTING));
+        PARTICIPANT_EDGES.put(TESTING, EnumSet.of(READY_TO_SUBMIT));
+        PARTICIPANT_EDGES.put(READY_TO_SUBMIT, EnumSet.of(SUBMITTED));
+        PARTICIPANT_EDGES.put(SUBMITTED, EnumSet.of(SCORED));
+        PARTICIPANT_EDGES.put(SCORED, EnumSet.of(CLOSED));
+
+        PROVIDER_EDGES.put(PLANNED, EnumSet.of(PREP_IN_PROGRESS));
+        PROVIDER_EDGES.put(PREP_IN_PROGRESS, EnumSet.of(READY_TO_SHIP));
+        PROVIDER_EDGES.put(READY_TO_SHIP, EnumSet.of(SHIPPED));
+        PROVIDER_EDGES.put(SHIPPED, EnumSet.of(DELIVERED));
+        PROVIDER_EDGES.put(DELIVERED, EnumSet.of(SUBMISSIONS_OPEN));
+        PROVIDER_EDGES.put(SUBMISSIONS_OPEN, EnumSet.of(SUBMISSIONS_CLOSED));
+        PROVIDER_EDGES.put(SUBMISSIONS_CLOSED, EnumSet.of(SCORING));
+        PROVIDER_EDGES.put(SCORING, EnumSet.of(SCORED));
+        PROVIDER_EDGES.put(SCORED, EnumSet.of(CLOSED));
+    }
+
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
+
+    @Autowired
+    private EQACycleStateTransitionDAO eqaCycleStateTransitionDAO;
+
+    @Autowired
+    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
+
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    private EQAParticipantResultDAO eqaParticipantResultDAO;
+
+    public EQACycleServiceImpl() {
+        super(EQACycle.class);
+    }
+
+    @Override
+    protected EQACycleDAO getBaseObjectDAO() {
+        return eqaCycleDAO;
+    }
+
+    @Override
+    public Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {
+        Map<EQACycleStatus, Set<EQACycleStatus>> edges = machine == EQAStateMachine.PROVIDER ? PROVIDER_EDGES
+                : PARTICIPANT_EDGES;
+        return edges.getOrDefault(from, EnumSet.noneOf(EQACycleStatus.class));
+    }
+
+    @Override
+    public EQACycle transition(Long cycleId, EQACycleStatus newState, EQAStateMachine machine,
+            EQATriggerType triggerType, EQATriggerEvent triggerEvent, Long triggeredBy, String reason,
+            String sysUserId) {
+        EQACycle cycle = eqaCycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("EQA Cycle not found: " + cycleId));
+
+        EQACycleStatus priorState = cycle.getStatus();
+        if (!legalNextStates(priorState, machine).contains(newState)) {
+            throw new EQAInvalidTransitionException(priorState, newState,
+                    "Cannot move a " + machine + " cycle from " + priorState + " to " + newState);
+        }
+
+        // FR-V2.1-21 requires a reason only for off-happy-path manual moves, but
+        // AC-V2.1-19 demands one for a manual transition that IS on the happy path.
+        // Requiring it for every manual transition satisfies both.
+        //
+        // The actor is required for the same reason: a MANUAL row is the record
+        // that a person decided this, and an accreditor reading it must be able to
+        // ask that person why. An unattributed manual override is worse than no
+        // audit row, because it looks like one.
+        if (triggerType == EQATriggerType.MANUAL) {
+            if (GenericValidator.isBlankOrNull(reason)) {
+                throw new IllegalArgumentException("A manual cycle transition requires a reason");
+            }
+            if (triggeredBy == null) {
+                throw new IllegalArgumentException("A manual cycle transition requires the acting user");
+            }
+        }
+
+        enforcePrepGate(cycle, priorState, newState, machine);
+
+        cycle.setStatus(newState);
+        cycle.setSysUserId(sysUserId);
+        EQACycle updated = eqaCycleDAO.update(cycle);
+
+        EQACycleStateTransition audit = new EQACycleStateTransition();
+        audit.setCycle(updated);
+        audit.setPriorState(priorState.name());
+        audit.setNewState(newState.name());
+        audit.setStateMachine(machine);
+        audit.setTriggerType(triggerType);
+        audit.setTriggerEvent(triggerEvent);
+        audit.setTriggeredBy(triggerType == EQATriggerType.MANUAL ? triggeredBy : null);
+        audit.setReason(reason);
+        audit.setOccurredAt(new Timestamp(System.currentTimeMillis()));
+        audit.setSysUserId(sysUserId);
+        eqaCycleStateTransitionDAO.insert(audit);
+
+        return updated;
+    }
+
+    /**
+     * FR-V2.1-18 / AC-V2.1-13: a provider cycle may not become ready to ship until
+     * its panel has passed homogeneity QC. This is the ISO 17043 supervisor gate —
+     * without it a panel that failed QC can be marked shippable, and the audit row
+     * that records it looks perfectly legitimate.
+     *
+     * <p>
+     * A cycle with no panel at all is refused too. That check is an implementation
+     * decision, not FRS text: the FRS predicate is vacuously satisfied by an empty
+     * panel set, which would let a panel-less cycle ship through a gate whose whole
+     * point is that something passed QC.
+     *
+     * <p>
+     * The FR pairs this with an inventory gate,
+     * {@code aliquots_produced >= participant_count + reserved_count}. That half is
+     * deliberately absent: no table records which labs participate in a cycle
+     * (there is no {@code eqa_cycle_participant}), so {@code participant_count} has
+     * no source yet. It belongs with the V2.5 prep workbench that introduces the
+     * roster. The row-level invariant {@code produced >= reserved + shipped} is a
+     * different predicate and is already enforced by a DB CHECK in qa/017.
+     */
+    private void enforcePrepGate(EQACycle cycle, EQACycleStatus priorState, EQACycleStatus newState,
+            EQAStateMachine machine) {
+        if (machine != EQAStateMachine.PROVIDER || priorState != PREP_IN_PROGRESS || newState != READY_TO_SHIP) {
+            return;
+        }
+        List<EQAPanel> panels = eqaPanelDAO.findByCycleId(cycle.getId());
+        if (panels.isEmpty()) {
+            throw new EQAInvalidTransitionException(priorState, newState, "Cannot ship a cycle with no panel prepared");
+        }
+        if (panels.stream().anyMatch(p -> !Boolean.TRUE.equals(p.getHomogeneityQcPassed()))) {
+            throw new EQAInvalidTransitionException(priorState, newState,
+                    "Cannot ship until every panel has passed homogeneity QC");
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQACycleStateTransition> getTransitions(Long cycleId) {
+        return eqaCycleStateTransitionDAO.findByCycleId(cycleId);
+    }
+
+    /**
+     * FR-V2.1-18's derivation table. The table's rows overlap — a cycle can hold
+     * both a draft and a submitted result — and the FRS does not say which wins, so
+     * this reads most-advanced-first: once a lab has been scored, that is its state
+     * regardless of what else is lying around.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public EQACycleStatus deriveParticipantState(Long cycleId, Long labEnrollmentId) {
+        EQACycle cycle = eqaCycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("EQA Cycle not found: " + cycleId));
+
+        if (cycle.getStatus() == CLOSED) {
+            return CLOSED;
+        }
+
+        List<EQAParticipantResult> results = eqaParticipantResultDAO.findByCycleAndEnrollment(cycleId, labEnrollmentId);
+
+        if (results.stream().anyMatch(r -> r.getSubmissionStatus() == EQASubmissionStatus.SCORED)) {
+            return SCORED;
+        }
+        if (results.stream().anyMatch(r -> r.getSubmissionStatus() == EQASubmissionStatus.SUBMITTED)) {
+            return SUBMITTED;
+        }
+        if (!results.isEmpty()
+                && results.stream().allMatch(r -> r.getSubmissionStatus() == EQASubmissionStatus.VALIDATED_PARTIAL)) {
+            return READY_TO_SUBMIT;
+        }
+        if (!results.isEmpty()) {
+            return TESTING;
+        }
+        // No results yet: the panel either arrived or it did not.
+        return eqaPanelReceiptDAO.findByCycleAndEnrollment(cycleId, labEnrollmentId).isPresent() ? PANEL_RECEIVED
+                : PLANNED;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.validator.GenericValidator;
+import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
@@ -42,13 +43,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Cycle state machines and the derived participant view (T-10).
- *
- * <p>
- * Two machines write the single eqa_cycle.status column: a participating lab
- * walks the FR-V2.1-04 path, while the lab that runs the scheme walks the
- * longer FR-V2.1-18 path. Which one applies is the caller's assertion, passed
- * in as {@link EQAStateMachine}, because the same row is read both ways.
+ * Cycle state machines and the derived participant view (T-10). Two machines
+ * share the single eqa_cycle.status column: participant (FR-V2.1-04) and
+ * provider (FR-V2.1-18); which applies is the caller's assertion via
+ * {@link EQAStateMachine}.
  */
 @Service
 @Transactional
@@ -104,8 +102,7 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         return eqaCycleDAO;
     }
 
-    @Override
-    public Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {
+    private static Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {
         Map<EQACycleStatus, Set<EQACycleStatus>> edges = machine == EQAStateMachine.PROVIDER ? PROVIDER_EDGES
                 : PARTICIPANT_EDGES;
         return edges.getOrDefault(from, EnumSet.noneOf(EQACycleStatus.class));
@@ -115,8 +112,10 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
     public EQACycle transition(Long cycleId, EQACycleStatus newState, EQAStateMachine machine,
             EQATriggerType triggerType, EQATriggerEvent triggerEvent, Long triggeredBy, String reason,
             String sysUserId) {
-        EQACycle cycle = eqaCycleDAO.get(cycleId)
-                .orElseThrow(() -> new IllegalArgumentException("EQA Cycle not found: " + cycleId));
+        // Row-locked read: a concurrent transition waits here, then re-reads the
+        // committed status and fails the edge check instead of double-writing.
+        EQACycle cycle = eqaCycleDAO.getForUpdate(cycleId)
+                .orElseThrow(() -> new ObjectNotFoundException(cycleId, EQACycle.class.getName()));
 
         EQACycleStatus priorState = cycle.getStatus();
         if (!legalNextStates(priorState, machine).contains(newState)) {
@@ -124,14 +123,9 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
                     "Cannot move a " + machine + " cycle from " + priorState + " to " + newState);
         }
 
-        // FR-V2.1-21 requires a reason only for off-happy-path manual moves, but
-        // AC-V2.1-19 demands one for a manual transition that IS on the happy path.
-        // Requiring it for every manual transition satisfies both.
-        //
-        // The actor is required for the same reason: a MANUAL row is the record
-        // that a person decided this, and an accreditor reading it must be able to
-        // ask that person why. An unattributed manual override is worse than no
-        // audit row, because it looks like one.
+        // FR-V2.1-21 requires a reason for off-happy-path manual moves; AC-V2.1-19
+        // requires one on the happy path too. Requiring both reason and actor on
+        // every MANUAL transition satisfies both.
         if (triggerType == EQATriggerType.MANUAL) {
             if (GenericValidator.isBlankOrNull(reason)) {
                 throw new IllegalArgumentException("A manual cycle transition requires a reason");
@@ -164,32 +158,23 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
     }
 
     /**
-     * FR-V2.1-18 / AC-V2.1-13: a provider cycle may not become ready to ship until
-     * its panel has passed homogeneity QC. This is the ISO 17043 supervisor gate —
-     * without it a panel that failed QC can be marked shippable, and the audit row
-     * that records it looks perfectly legitimate.
+     * FR-V2.1-18 / AC-V2.1-13: a provider cycle may not reach ready_to_ship until
+     * every panel has passed homogeneity QC. A cycle with no panel is refused too —
+     * the FRS predicate is vacuously true on an empty set, which would let a
+     * panel-less cycle through a gate whose point is that something passed QC.
      *
      * <p>
-     * A cycle with no panel at all is refused too. That check is an implementation
-     * decision, not FRS text: the FRS predicate is vacuously satisfied by an empty
-     * panel set, which would let a panel-less cycle ship through a gate whose whole
-     * point is that something passed QC.
-     *
-     * <p>
-     * The FR pairs this with an inventory gate,
-     * {@code aliquots_produced >= participant_count + reserved_count}. That half is
-     * deliberately absent: no table records which labs participate in a cycle
-     * (there is no {@code eqa_cycle_participant}), so {@code participant_count} has
-     * no source yet. It belongs with the V2.5 prep workbench that introduces the
-     * roster. The row-level invariant {@code produced >= reserved + shipped} is a
-     * different predicate and is already enforced by a DB CHECK in qa/017.
+     * The FR's paired inventory gate (aliquots_produced >= participant_count +
+     * reserved_count) is absent: no table records per-cycle participants yet; it
+     * lands with the V2.5 prep workbench. The row-level invariant produced >=
+     * reserved + shipped is a DB CHECK in qa/017.
      */
     private void enforcePrepGate(EQACycle cycle, EQACycleStatus priorState, EQACycleStatus newState,
             EQAStateMachine machine) {
         if (machine != EQAStateMachine.PROVIDER || priorState != PREP_IN_PROGRESS || newState != READY_TO_SHIP) {
             return;
         }
-        List<EQAPanel> panels = eqaPanelDAO.findByCycleId(cycle.getId());
+        List<EQAPanel> panels = eqaPanelDAO.getAllMatching("cycle.id", cycle.getId());
         if (panels.isEmpty()) {
             throw new EQAInvalidTransitionException(priorState, newState, "Cannot ship a cycle with no panel prepared");
         }
@@ -202,26 +187,29 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
     @Override
     @Transactional(readOnly = true)
     public List<EQACycleStateTransition> getTransitions(Long cycleId) {
-        return eqaCycleStateTransitionDAO.findByCycleId(cycleId);
+        return eqaCycleStateTransitionDAO.getAllMatchingOrdered("cycle.id", cycleId, List.of("occurredAt", "id"),
+                false);
     }
 
-    /**
-     * FR-V2.1-18's derivation table. The table's rows overlap — a cycle can hold
-     * both a draft and a submitted result — and the FRS does not say which wins, so
-     * this reads most-advanced-first: once a lab has been scored, that is its state
-     * regardless of what else is lying around.
-     */
     @Override
     @Transactional(readOnly = true)
     public EQACycleStatus deriveParticipantState(Long cycleId, Long labEnrollmentId) {
-        EQACycle cycle = eqaCycleDAO.get(cycleId)
-                .orElseThrow(() -> new IllegalArgumentException("EQA Cycle not found: " + cycleId));
+        return deriveParticipantState(get(cycleId), labEnrollmentId);
+    }
 
+    /**
+     * FR-V2.1-18's derivation table. Its rows overlap and the FRS does not say
+     * which wins, so this reads most-advanced-first.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public EQACycleStatus deriveParticipantState(EQACycle cycle, Long labEnrollmentId) {
         if (cycle.getStatus() == CLOSED) {
             return CLOSED;
         }
 
-        List<EQAParticipantResult> results = eqaParticipantResultDAO.findByCycleAndEnrollment(cycleId, labEnrollmentId);
+        List<EQAParticipantResult> results = eqaParticipantResultDAO
+                .getAllMatching(Map.of("cycle.id", cycle.getId(), "labEnrollmentId", labEnrollmentId));
 
         if (results.stream().anyMatch(r -> r.getSubmissionStatus() == EQASubmissionStatus.SCORED)) {
             return SCORED;
@@ -237,7 +225,7 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
             return TESTING;
         }
         // No results yet: the panel either arrived or it did not.
-        return eqaPanelReceiptDAO.findByCycleAndEnrollment(cycleId, labEnrollmentId).isPresent() ? PANEL_RECEIVED
-                : PLANNED;
+        return eqaPanelReceiptDAO.getAllMatching(Map.of("cycle.id", cycle.getId(), "labEnrollmentId", labEnrollmentId))
+                .isEmpty() ? PLANNED : PANEL_RECEIVED;
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAInvalidTransitionException.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAInvalidTransitionException.java
@@ -1,0 +1,30 @@
+package org.openelisglobal.eqa.service;
+
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+
+/**
+ * An attempted cycle transition is not an edge in the state machine (FR-V2.1-04
+ * / FR-V2.1-18). Carries both ends so the API can echo them back rather than
+ * making the caller guess what was refused.
+ */
+public class EQAInvalidTransitionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final EQACycleStatus priorState;
+    private final EQACycleStatus attemptedState;
+
+    public EQAInvalidTransitionException(EQACycleStatus priorState, EQACycleStatus attemptedState, String detail) {
+        super(detail);
+        this.priorState = priorState;
+        this.attemptedState = attemptedState;
+    }
+
+    public EQACycleStatus getPriorState() {
+        return priorState;
+    }
+
+    public EQACycleStatus getAttemptedState() {
+        return attemptedState;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAAnalystCompetencyEvent.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAAnalystCompetencyEvent.java
@@ -1,0 +1,93 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.sql.Date;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * Append-only competency log for an analyst (FR-V2.1-22).
+ *
+ * <p>
+ * It exists because a missed deadline is an absence of a result, not a result:
+ * such a row has no value and no score, so eqa_participant_result alone cannot
+ * feed the V2.3 competency dashboard. Escalations and triage dismissals land
+ * here too.
+ *
+ * <p>
+ * Service-write-only: a direct REST create must be refused (AC-V2.1-21).
+ * {@code nceId} is an Integer because nc_event's primary key is INTEGER.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_analyst_competency_event")
+public class EQAAnalystCompetencyEvent extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_analyst_competency_event_generator")
+    @SequenceGenerator(name = "eqa_analyst_competency_event_generator", sequenceName = "eqa_analyst_competency_event_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "analyst_id", nullable = false)
+    private Long analystId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 40)
+    private EQACompetencyEventType eventType;
+
+    @Column(name = "event_date", nullable = false)
+    private Date eventDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheme_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQAProgram scheme;
+
+    /** Null for cross-cycle events. */
+    @Column(name = "cycle_id")
+    private Long cycleId;
+
+    @Column(name = "participant_result_id")
+    private Long participantResultId;
+
+    @Column(name = "analyte_id")
+    private Long analyteId;
+
+    @Column(name = "nce_id")
+    private Integer nceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dismissal_category", length = 40)
+    private EQADismissalCategory dismissalCategory;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQACompetencyEventType.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQACompetencyEventType.java
@@ -1,0 +1,17 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * Analyst competency events (FR-V2.1-22) — the single source of truth for this
+ * vocabulary; other requirements reference these names.
+ *
+ * <p>
+ * A missed deadline is an absence-of-result, not a result, which is why this
+ * log exists separately from eqa_participant_result. Note that not every
+ * dismissal counts against an analyst in the V2.3 rollup: DISMISSED_EQUIPMENT
+ * and DISMISSED_ACCEPTABLE_ON_REVIEW do not, while DISMISSED_TRANSCRIPTION and
+ * DISMISSED_OTHER do.
+ */
+public enum EQACompetencyEventType {
+    EXTERNAL_MISSED_DEADLINE, IN_HOUSE_MISSED_DEADLINE, UNACCEPTABLE_SCORE, QUESTIONABLE_SCORE, ESCALATED_TO_NCE,
+    DISMISSED_EQUIPMENT, DISMISSED_TRANSCRIPTION, DISMISSED_ACCEPTABLE_ON_REVIEW, DISMISSED_OTHER
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQADismissalCategory.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQADismissalCategory.java
@@ -1,0 +1,6 @@
+package org.openelisglobal.eqa.valueholder;
+
+/** Why a competency event was dismissed on triage (mirrors FR-V2.3-02). */
+public enum EQADismissalCategory {
+    KNOWN_EQUIPMENT_ISSUE, TRANSCRIPTION_ERROR, PENDING_RE_TEST, ACCEPTABLE_ON_REVIEW, OTHER
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAFollowupStatus.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAFollowupStatus.java
@@ -1,0 +1,8 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * Provider-side follow-up lifecycle for an underperforming lab (FR-V2.1-13).
+ */
+public enum EQAFollowupStatus {
+    NOTIFIED, RESPONSE_RECEIVED, UNDER_INVESTIGATION, RESOLVED, ESCALATED, REMOVED_FROM_PROGRAM
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
@@ -1,0 +1,138 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * A panel of material distributed to participants (FR-V2.1-11), shared by the
+ * in-house (V2.4) and provider (V2.5) flows rather than forked per scheme type.
+ * Carries its own source and inventory columns (FR-V2.1-17), because the prep →
+ * ready_to_ship gate reads them.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_panel")
+public class EQAPanel extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_panel_generator")
+    @SequenceGenerator(name = "eqa_panel_generator", sequenceName = "eqa_panel_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "fhir_uuid", nullable = false, unique = true)
+    private UUID fhirUuid;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "scheme_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQAProgram scheme;
+
+    /** Null until the panel is bound to a cycle. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cycle_id")
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQACycle cycle;
+
+    @Column(name = "panel_name", nullable = false, length = 255)
+    private String panelName;
+
+    /** Derived from the scheme type; the FRS defines no closed vocabulary. */
+    @Column(name = "panel_type", length = 30)
+    private String panelType;
+
+    @Column(name = "prepared_by")
+    private Long preparedBy;
+
+    @Column(name = "prepared_at")
+    private Timestamp preparedAt;
+
+    /**
+     * Required for in-house panels — enforced in the service, where the parent
+     * scheme's type is known.
+     */
+    @Column(name = "unblind_date")
+    private Date unblindDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EQAPanelStatus status = EQAPanelStatus.PREPARING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", length = 30)
+    private EQAPanelSourceType sourceType;
+
+    @Column(name = "lot_number", length = 100)
+    private String lotNumber;
+
+    @Column(name = "vendor_name", length = 255)
+    private String vendorName;
+
+    @Column(name = "vendor_lot", length = 100)
+    private String vendorLot;
+
+    @Column(name = "vendor_certificate_ref", length = 255)
+    private String vendorCertificateRef;
+
+    @Column(name = "aliquots_produced", nullable = false)
+    private Integer aliquotsProduced = 0;
+
+    @Column(name = "aliquots_reserved", nullable = false)
+    private Integer aliquotsReserved = 0;
+
+    @Column(name = "aliquots_shipped", nullable = false)
+    private Integer aliquotsShipped = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "storage_temp", length = 30)
+    private EQAStorageTemp storageTemp;
+
+    @Column(name = "expiration_date")
+    private Date expirationDate;
+
+    /** Gates the provider cycle's prep_in_progress → ready_to_ship transition. */
+    @Column(name = "homogeneity_qc_passed", nullable = false)
+    private Boolean homogeneityQcPassed = false;
+
+    @Column(name = "homogeneity_qc_notes", columnDefinition = "TEXT")
+    private String homogeneityQcNotes;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (fhirUuid == null) {
+            fhirUuid = UUID.randomUUID();
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
@@ -67,8 +67,8 @@ public class EQAPanel extends BaseObject<Long> {
     private Timestamp preparedAt;
 
     /**
-     * Required for in-house panels — enforced in the service, where the parent
-     * scheme's type is known.
+     * Required for in-house panels; the panel-writing service (T-11) must enforce
+     * this, where the parent scheme's type is known.
      */
     @Column(name = "unblind_date")
     private Date unblindDate;

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelReceipt.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelReceipt.java
@@ -1,0 +1,86 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.sql.Date;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * Participant-side confirmation that a panel arrived (FR-V2.1-20). One row per
+ * cycle per participating lab, which is also what makes the derived
+ * participant-state lookup a single-row read.
+ *
+ * <p>
+ * {@code shipmentId} is an Integer, not the Long used elsewhere in the EQA
+ * spine: it points at the pre-existing shipment table, whose primary key is
+ * INTEGER. It is null for panels received without a tracked shipment.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_panel_receipt", uniqueConstraints = @UniqueConstraint(name = "uq_eqa_panel_receipt_cycle_enrollment", columnNames = {
+        "cycle_id", "lab_enrollment_id" }))
+public class EQAPanelReceipt extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_panel_receipt_generator")
+    @SequenceGenerator(name = "eqa_panel_receipt_generator", sequenceName = "eqa_panel_receipt_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cycle_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQACycle cycle;
+
+    @Column(name = "lab_enrollment_id", nullable = false)
+    private Long labEnrollmentId;
+
+    @Column(name = "shipment_id")
+    private Integer shipmentId;
+
+    @Column(name = "received_date", nullable = false)
+    private Date receivedDate;
+
+    @Column(name = "received_by", nullable = false)
+    private Long receivedBy;
+
+    @Column(name = "received_temp_c", precision = 5, scale = 2)
+    private BigDecimal receivedTempC;
+
+    @Column(name = "integrity_ok", nullable = false)
+    private Boolean integrityOk = true;
+
+    /** Required by the service when integrityOk is false. */
+    @Column(name = "integrity_notes", columnDefinition = "TEXT")
+    private String integrityNotes;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelReceipt.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelReceipt.java
@@ -64,7 +64,10 @@ public class EQAPanelReceipt extends BaseObject<Long> {
     @Column(name = "integrity_ok", nullable = false)
     private Boolean integrityOk = true;
 
-    /** Required by the service when integrityOk is false. */
+    /**
+     * The receipt-writing service (T-15) must require this when integrityOk is
+     * false.
+     */
     @Column(name = "integrity_notes", columnDefinition = "TEXT")
     private String integrityNotes;
 

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelSample.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelSample.java
@@ -1,0 +1,97 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+import org.openelisglobal.security.converter.EncryptionConverter;
+
+/**
+ * One material sample within a panel (FR-V2.1-12), carrying the sealed target
+ * value.
+ *
+ * <p>
+ * {@code targetValue} is encrypted at rest by the existing
+ * {@link EncryptionConverter} (FR-V2.1-16). Three properties of that converter
+ * shape how this column may be used: the ciphertext is salted per write, so the
+ * column can never be indexed, made unique, or compared with {@code =}; blank
+ * and whitespace values pass through unencrypted, so the service must reject
+ * them rather than rely on the converter; and decrypting a value that was not
+ * written as ciphertext throws, so nothing may seed plaintext here.
+ *
+ * <p>
+ * Whether a caller is allowed to *see* the decrypted value depends on the
+ * parent panel's status and the caller's unblind permission — that rule lives
+ * in the DTO mapping (T-11), not here, because the entity cannot see the
+ * caller.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_panel_sample", uniqueConstraints = @UniqueConstraint(name = "uq_eqa_panel_sample_panel_code", columnNames = {
+        "panel_id", "sample_code" }))
+public class EQAPanelSample extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_panel_sample_generator")
+    @SequenceGenerator(name = "eqa_panel_sample_generator", sequenceName = "eqa_panel_sample_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "panel_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQAPanel panel;
+
+    @Column(name = "sample_code", nullable = false, length = 50)
+    private String sampleCode;
+
+    /** Participant-facing obfuscated identifier for in-house blinding. */
+    @Column(name = "blind_code", length = 50)
+    private String blindCode;
+
+    @Column(name = "analyte_id", nullable = false)
+    private Long analyteId;
+
+    @Convert(converter = EncryptionConverter.class)
+    @Column(name = "target_value", length = 512)
+    private String targetValue;
+
+    @Column(name = "target_unit", length = 50)
+    private String targetUnit;
+
+    @Column(name = "acceptance_range_low", precision = 15, scale = 5)
+    private BigDecimal acceptanceRangeLow;
+
+    @Column(name = "acceptance_range_high", precision = 15, scale = 5)
+    private BigDecimal acceptanceRangeHigh;
+
+    @Column(name = "source_reference", length = 255)
+    private String sourceReference;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelSourceType.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelSourceType.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * Where a panel's material came from (FR-V2.1-17). Null is permitted for
+ * in-house schemes, which use the V2.4 blinding flow instead. VENDOR_SOURCED
+ * and MIXED require the vendor fields.
+ */
+public enum EQAPanelSourceType {
+    IN_HOUSE_ALIQUOTED, VENDOR_SOURCED, MIXED
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelStatus.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanelStatus.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * Panel lifecycle (FR-V2.1-11). In-house panels go SEALED → DISTRIBUTED →
+ * UNBLINDED; provider-side panels skip the unblind and go SEALED → DISTRIBUTED
+ * → SCORED.
+ */
+public enum EQAPanelStatus {
+    PREPARING, SEALED, DISTRIBUTED, UNBLINDED, SCORED, CLOSED
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantFollowup.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantFollowup.java
@@ -1,0 +1,91 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * Provider-side follow-up with a participating lab after poor performance
+ * (FR-V2.1-13). One open register row per cycle per organisation.
+ *
+ * <p>
+ * The result summary is stored as a JSON snapshot rather than recomputed, so
+ * the register still reads correctly after later cycles change the underlying
+ * rows.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_participant_followup", uniqueConstraints = @UniqueConstraint(name = "uq_eqa_participant_followup_cycle_org", columnNames = {
+        "cycle_id", "participant_org_id" }))
+public class EQAParticipantFollowup extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_participant_followup_generator")
+    @SequenceGenerator(name = "eqa_participant_followup_generator", sequenceName = "eqa_participant_followup_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheme_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQAProgram scheme;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cycle_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQACycle cycle;
+
+    @Column(name = "participant_org_id", nullable = false)
+    private Long participantOrgId;
+
+    @Column(name = "participant_result_summary_json", columnDefinition = "TEXT")
+    private String participantResultSummaryJson;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "followup_status", nullable = false, length = 30)
+    private EQAFollowupStatus followupStatus = EQAFollowupStatus.NOTIFIED;
+
+    @Column(name = "notified_at")
+    private Timestamp notifiedAt;
+
+    @Column(name = "response_received_at")
+    private Timestamp responseReceivedAt;
+
+    @Column(name = "assigned_to")
+    private Long assignedTo;
+
+    @Column(name = "resolution_notes", columnDefinition = "TEXT")
+    private String resolutionNotes;
+
+    @Column(name = "persistent_failure_flag", nullable = false)
+    private Boolean persistentFailureFlag = false;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantResult.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantResult.java
@@ -29,9 +29,10 @@ import org.openelisglobal.common.valueholder.BaseObject;
  *
  * <p>
  * Reference columns are raw Longs in the module's SampleEQA.eqaEnrollmentId
- * style; labEnrollmentId in particular must stay raw — EQALabProgramEnrollment
- * is not registered in the production persistence unit, so an association would
- * fail at startup.
+ * style. (An earlier revision claimed EQALabProgramEnrollment is unmapped in
+ * production; that is wrong — the production unit scans its classpath root and
+ * maps it, verified empirically. The raw-Long style stands on the module
+ * precedent alone.)
  */
 @Getter
 @Setter

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQASchemeAnalyst.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQASchemeAnalyst.java
@@ -9,11 +9,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.sql.Timestamp;
 import lombok.Getter;
 import lombok.Setter;
 import org.openelisglobal.common.valueholder.BaseObject;
@@ -47,12 +45,6 @@ public class EQASchemeAnalyst extends BaseObject<Long> {
     @Column(name = "system_user_id", nullable = false)
     private Long systemUserId;
 
-    @Column(name = "added_at", nullable = false)
-    private Timestamp addedAt;
-
-    @Column(name = "added_by")
-    private Long addedBy;
-
     @Column(name = "sys_user_id", nullable = false)
     private String sysUserId;
 
@@ -64,12 +56,5 @@ public class EQASchemeAnalyst extends BaseObject<Long> {
     @Override
     public void setSysUserId(String sysUserId) {
         this.sysUserId = sysUserId;
-    }
-
-    @PrePersist
-    public void prePersist() {
-        if (addedAt == null) {
-            addedAt = new Timestamp(System.currentTimeMillis());
-        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQASchemeAnalyst.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQASchemeAnalyst.java
@@ -1,0 +1,75 @@
+package org.openelisglobal.eqa.valueholder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
+import org.openelisglobal.common.valueholder.BaseObject;
+
+/**
+ * Opt-in list of users who may be recorded as the analyst on a scheme's samples
+ * (FR-V2.1-08). An empty list for a scheme means any user may be recorded — so
+ * absence of rows is permissive, not restrictive.
+ *
+ * <p>
+ * There is no analyst master table in OpenELIS; analysts are system_user rows.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "eqa_scheme_analyst", uniqueConstraints = @UniqueConstraint(name = "uq_eqa_scheme_analyst_scheme_user", columnNames = {
+        "scheme_id", "system_user_id" }))
+public class EQASchemeAnalyst extends BaseObject<Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eqa_scheme_analyst_generator")
+    @SequenceGenerator(name = "eqa_scheme_analyst_generator", sequenceName = "eqa_scheme_analyst_seq", allocationSize = 1)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheme_id", nullable = false)
+    @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+    private EQAProgram scheme;
+
+    @Column(name = "system_user_id", nullable = false)
+    private Long systemUserId;
+
+    @Column(name = "added_at", nullable = false)
+    private Timestamp addedAt;
+
+    @Column(name = "added_by")
+    private Long addedBy;
+
+    @Column(name = "sys_user_id", nullable = false)
+    private String sysUserId;
+
+    @Override
+    public String getSysUserId() {
+        return sysUserId;
+    }
+
+    @Override
+    public void setSysUserId(String sysUserId) {
+        this.sysUserId = sysUserId;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (addedAt == null) {
+            addedAt = new Timestamp(System.currentTimeMillis());
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAStorageTemp.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAStorageTemp.java
@@ -1,0 +1,14 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * Storage temperature requirement for a panel (FR-V2.1-17).
+ *
+ * <p>
+ * The FRS spells the cold values {@code frozen_-20C} and
+ * {@code ultra_frozen_-80C}. A hyphen cannot appear in a Java identifier and
+ * this codebase persists enum names verbatim, so those two become
+ * FROZEN_MINUS_20C and ULTRA_FROZEN_MINUS_80C. Same set, same order.
+ */
+public enum EQAStorageTemp {
+    AMBIENT, REFRIGERATED_2_8C, FROZEN_MINUS_20C, ULTRA_FROZEN_MINUS_80C, DRY_ICE
+}

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -73,4 +73,13 @@
 
   <!-- EQA V2.1 T-08 — OGC-609: participant results, cycle links, scheme_type -->
   <include file="liquibase/qa/016-create-eqa-participant-result.xml" />
+
+  <!-- EQA V2.1 T-09 — OGC-609: panels, sealed panel samples, eligible analysts -->
+  <include file="liquibase/qa/017-create-eqa-panel-tables.xml" />
+
+  <!-- EQA V2.1 T-09 — OGC-609: follow-ups, panel receipts, competency events -->
+  <include file="liquibase/qa/018-create-eqa-followup-receipt-competency.xml" />
+
+  <!-- EQA V2.1 T-10 — OGC-609: write permission for cycle state changes -->
+  <include file="liquibase/qa/023-add-eqa-manage-permission.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/017-create-eqa-panel-tables.xml
+++ b/src/main/resources/liquibase/qa/017-create-eqa-panel-tables.xml
@@ -13,36 +13,24 @@
     numeric(10,0) PKs, <table>_seq sequences, sys_user_id VARCHAR(36) NOT NULL,
     last_updated, no reference_tables registration, enum values stored UPPERCASE.
 
-    Deliberate deviations from the FRS, all deliberate and worth knowing:
-
-      * FR-V2.1-17 spells storage temperatures 'frozen_-20C' / 'ultra_frozen_-80C'.
-        A hyphen cannot appear in a Java enum constant, and this codebase stores
-        @Enumerated(STRING) names verbatim, so the DB values are
-        FROZEN_MINUS_20C / ULTRA_FROZEN_MINUS_80C. Same set, legal identifiers.
-
-      * FR-V2.1-08 names the column user_id; the house name for a system_user
-        reference is system_user_id (result_signature, system_user_section), so
-        that is what is used here.
-
-      * FR-V2.1-11 names panel_type but never enumerates its values, so it is a
-        plain VARCHAR with no CHECK — a constraint would be invented, not specified.
-
-      * FR-V2.1-17 describes "supervisor checkbox + free-text notes" but never names
-        the notes column; V2.4 FR-V2.4-02 requires it. Added as homogeneity_qc_notes.
-
+    Deviations from the FRS:
+      * FR-V2.1-17 spells storage temps 'frozen_-20C' / 'ultra_frozen_-80C'; a hyphen
+        cannot appear in a Java enum constant and @Enumerated(STRING) names are stored
+        verbatim, so the DB values are FROZEN_MINUS_20C / ULTRA_FROZEN_MINUS_80C.
+      * FR-V2.1-08 names the column user_id; house name for a system_user reference
+        is system_user_id.
+      * FR-V2.1-11 names panel_type but never enumerates values: plain VARCHAR, no CHECK.
+      * homogeneity_qc_notes is unnamed in FR-V2.1-17 but required by FR-V2.4-02.
       * Uniqueness on (panel_id, sample_code) and (scheme_id, system_user_id) is not
-        in the FRS. Both are added: V2.4 generates sample codes per panel, and an
-        analyst opt-in list is a set, not a bag.
+        in the FRS; added because V2.4 generates sample codes per panel and the
+        analyst opt-in list is a set.
 
     eqa_panel_sample.target_value holds ciphertext (FR-V2.1-16) via the existing
-    EncryptionConverter. Three consequences, none of them optional:
-      * VARCHAR(512), not 255. Measured against jasypt 1.9.3 AES256TextEncryptor:
-        ciphertext is 4*ceil((32 + 16*(floor(bytes/16)+1))/3) chars, so a 255-char
-        VARCHAR silently caps plaintext at 143 bytes and then errors.
-      * No index, no UNIQUE, no equality lookup on this column — the ciphertext is
-        salted per write, so the same plaintext never encrypts to the same bytes.
-      * Never seed plaintext into it. Reading a non-ciphertext value throws
-        EncryptionOperationNotPossibleException at the converter. Leave rows NULL.
+    EncryptionConverter:
+      * VARCHAR(512), not 255: jasypt 1.9.3 AES256TextEncryptor ciphertext is
+        4*ceil((32 + 16*(floor(bytes/16)+1))/3) chars, so 255 caps plaintext at 143 bytes.
+      * Never index, UNIQUE, or equality-match this column — ciphertext is salted per write.
+      * Never seed plaintext: reading a non-ciphertext value throws at the converter.
     -->
 
     <changeSet author="openelisglobal" id="eqa-panel-001-create-eqa-panel">
@@ -70,8 +58,8 @@
             <column name="panel_type" type="VARCHAR(30)"/>
             <column name="prepared_by" type="numeric(10,0)"/>
             <column name="prepared_at" type="TIMESTAMP"/>
-            <!-- Required for in-house panels; enforced in the service, not here,
-                 because the rule depends on the parent scheme's scheme_type. -->
+            <!-- Required for in-house panels; the panel-writing service (T-11) must
+                 enforce this — the rule depends on the parent scheme's scheme_type. -->
             <column name="unblind_date" type="DATE"/>
             <column name="status" type="VARCHAR(20)" defaultValue="PREPARING">
                 <constraints nullable="false"/>
@@ -142,18 +130,17 @@
                 'ULTRA_FROZEN_MINUS_80C', 'DRY_ICE'))
         </sql>
 
-        <!-- FR-V2.1-17 inventory invariant. Cheap and absolute at this level; the
-             service repeats it to return 422 with a usable message (AC-V2.1-11). -->
+        <!-- FR-V2.1-17 inventory invariant. The panel-writing service (T-11) should
+             repeat it to return 422 with a usable message (AC-V2.1-11). -->
         <sql>
             ALTER TABLE clinlims.eqa_panel
             ADD CONSTRAINT eqa_panel_aliquots_chk
             CHECK (aliquots_produced >= aliquots_reserved + aliquots_shipped)
         </sql>
 
-        <createIndex schemaName="clinlims" tableName="eqa_panel" indexName="idx_eqa_panel_scheme_cycle_status">
-            <column name="scheme_id"/>
+        <!-- Serves the prep-gate lookup (panels by cycle). -->
+        <createIndex schemaName="clinlims" tableName="eqa_panel" indexName="idx_eqa_panel_cycle">
             <column name="cycle_id"/>
-            <column name="status"/>
         </createIndex>
 
         <rollback>
@@ -241,10 +228,7 @@
             <column name="system_user_id" type="numeric(10,0)">
                 <constraints nullable="false"/>
             </column>
-            <column name="added_at" type="TIMESTAMP" defaultValueComputed="now()">
-                <constraints nullable="false"/>
-            </column>
-            <column name="added_by" type="numeric(10,0)"/>
+            <!-- Insert-only table: who/when live in sys_user_id + last_updated. -->
             <column name="sys_user_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -268,11 +252,6 @@
         <addForeignKeyConstraint
             constraintName="fk_eqa_scheme_analyst_system_user"
             baseTableSchemaName="clinlims" baseTableName="eqa_scheme_analyst" baseColumnNames="system_user_id"
-            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
-
-        <addForeignKeyConstraint
-            constraintName="fk_eqa_scheme_analyst_added_by"
-            baseTableSchemaName="clinlims" baseTableName="eqa_scheme_analyst" baseColumnNames="added_by"
             referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
 
         <rollback>

--- a/src/main/resources/liquibase/qa/017-create-eqa-panel-tables.xml
+++ b/src/main/resources/liquibase/qa/017-create-eqa-panel-tables.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    OGC-609 [EQA V2.1 / T-09] Schema spine 3 of 4: panels, sealed panel samples,
+    eligible analysts (FR-V2.1-08/11/12/16/17).
+
+    Conventions follow qa/015 + qa/016 (V1-EQA column style under qa/ mechanics):
+    numeric(10,0) PKs, <table>_seq sequences, sys_user_id VARCHAR(36) NOT NULL,
+    last_updated, no reference_tables registration, enum values stored UPPERCASE.
+
+    Deliberate deviations from the FRS, all deliberate and worth knowing:
+
+      * FR-V2.1-17 spells storage temperatures 'frozen_-20C' / 'ultra_frozen_-80C'.
+        A hyphen cannot appear in a Java enum constant, and this codebase stores
+        @Enumerated(STRING) names verbatim, so the DB values are
+        FROZEN_MINUS_20C / ULTRA_FROZEN_MINUS_80C. Same set, legal identifiers.
+
+      * FR-V2.1-08 names the column user_id; the house name for a system_user
+        reference is system_user_id (result_signature, system_user_section), so
+        that is what is used here.
+
+      * FR-V2.1-11 names panel_type but never enumerates its values, so it is a
+        plain VARCHAR with no CHECK — a constraint would be invented, not specified.
+
+      * FR-V2.1-17 describes "supervisor checkbox + free-text notes" but never names
+        the notes column; V2.4 FR-V2.4-02 requires it. Added as homogeneity_qc_notes.
+
+      * Uniqueness on (panel_id, sample_code) and (scheme_id, system_user_id) is not
+        in the FRS. Both are added: V2.4 generates sample codes per panel, and an
+        analyst opt-in list is a set, not a bag.
+
+    eqa_panel_sample.target_value holds ciphertext (FR-V2.1-16) via the existing
+    EncryptionConverter. Three consequences, none of them optional:
+      * VARCHAR(512), not 255. Measured against jasypt 1.9.3 AES256TextEncryptor:
+        ciphertext is 4*ceil((32 + 16*(floor(bytes/16)+1))/3) chars, so a 255-char
+        VARCHAR silently caps plaintext at 143 bytes and then errors.
+      * No index, no UNIQUE, no equality lookup on this column — the ciphertext is
+        salted per write, so the same plaintext never encrypts to the same bytes.
+      * Never seed plaintext into it. Reading a non-ciphertext value throws
+        EncryptionOperationNotPossibleException at the converter. Leave rows NULL.
+    -->
+
+    <changeSet author="openelisglobal" id="eqa-panel-001-create-eqa-panel">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_panel" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Shared panel entity for in-house and provider schemes (FR-V2.1-11 + FR-V2.1-17)</comment>
+        <createSequence sequenceName="eqa_panel_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_panel">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_panel"/>
+            </column>
+            <column name="fhir_uuid" type="UUID">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uq_eqa_panel_fhir_uuid"/>
+            </column>
+            <column name="scheme_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Nullable: a panel may be prepared before it is bound to a cycle. -->
+            <column name="cycle_id" type="numeric(10,0)"/>
+            <column name="panel_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Derived from scheme_type; the FRS never enumerates values, so no CHECK. -->
+            <column name="panel_type" type="VARCHAR(30)"/>
+            <column name="prepared_by" type="numeric(10,0)"/>
+            <column name="prepared_at" type="TIMESTAMP"/>
+            <!-- Required for in-house panels; enforced in the service, not here,
+                 because the rule depends on the parent scheme's scheme_type. -->
+            <column name="unblind_date" type="DATE"/>
+            <column name="status" type="VARCHAR(20)" defaultValue="PREPARING">
+                <constraints nullable="false"/>
+            </column>
+
+            <!-- FR-V2.1-17 source + inventory. NULL source_type is permitted for
+                 in-house panels, which use the V2.4 blinding flow instead. -->
+            <column name="source_type" type="VARCHAR(30)"/>
+            <column name="lot_number" type="VARCHAR(100)"/>
+            <column name="vendor_name" type="VARCHAR(255)"/>
+            <column name="vendor_lot" type="VARCHAR(100)"/>
+            <column name="vendor_certificate_ref" type="VARCHAR(255)"/>
+            <column name="aliquots_produced" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="aliquots_reserved" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="aliquots_shipped" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="storage_temp" type="VARCHAR(30)"/>
+            <column name="expiration_date" type="DATE"/>
+            <column name="homogeneity_qc_passed" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="homogeneity_qc_notes" type="TEXT"/>
+
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_eqa_program"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel" baseColumnNames="scheme_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_program" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_eqa_cycle"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel" baseColumnNames="cycle_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_cycle" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_prepared_by"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel" baseColumnNames="prepared_by"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_panel
+            ADD CONSTRAINT eqa_panel_status_chk
+            CHECK (status IN ('PREPARING', 'SEALED', 'DISTRIBUTED', 'UNBLINDED', 'SCORED', 'CLOSED'))
+        </sql>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_panel
+            ADD CONSTRAINT eqa_panel_source_type_chk
+            CHECK (source_type IN ('IN_HOUSE_ALIQUOTED', 'VENDOR_SOURCED', 'MIXED'))
+        </sql>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_panel
+            ADD CONSTRAINT eqa_panel_storage_temp_chk
+            CHECK (storage_temp IN ('AMBIENT', 'REFRIGERATED_2_8C', 'FROZEN_MINUS_20C',
+                'ULTRA_FROZEN_MINUS_80C', 'DRY_ICE'))
+        </sql>
+
+        <!-- FR-V2.1-17 inventory invariant. Cheap and absolute at this level; the
+             service repeats it to return 422 with a usable message (AC-V2.1-11). -->
+        <sql>
+            ALTER TABLE clinlims.eqa_panel
+            ADD CONSTRAINT eqa_panel_aliquots_chk
+            CHECK (aliquots_produced >= aliquots_reserved + aliquots_shipped)
+        </sql>
+
+        <createIndex schemaName="clinlims" tableName="eqa_panel" indexName="idx_eqa_panel_scheme_cycle_status">
+            <column name="scheme_id"/>
+            <column name="cycle_id"/>
+            <column name="status"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_panel"/>
+            <dropSequence sequenceName="eqa_panel_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="eqa-panel-002-create-eqa-panel-sample">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_panel_sample" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Panel samples with sealed, encrypted-at-rest target values (FR-V2.1-12 + FR-V2.1-16)</comment>
+        <createSequence sequenceName="eqa_panel_sample_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_panel_sample">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_panel_sample"/>
+            </column>
+            <column name="panel_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sample_code" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Participant-facing obfuscated id for in-house blinding (V2.4). -->
+            <column name="blind_code" type="VARCHAR(50)"/>
+            <column name="analyte_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Ciphertext. See the header note: 512, never indexed, never seeded. -->
+            <column name="target_value" type="VARCHAR(512)"/>
+            <column name="target_unit" type="VARCHAR(50)"/>
+            <column name="acceptance_range_low" type="DECIMAL(15,5)"/>
+            <column name="acceptance_range_high" type="DECIMAL(15,5)"/>
+            <column name="source_reference" type="VARCHAR(255)"/>
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint
+            schemaName="clinlims" tableName="eqa_panel_sample"
+            columnNames="panel_id, sample_code"
+            constraintName="uq_eqa_panel_sample_panel_code"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_sample_eqa_panel"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_sample" baseColumnNames="panel_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_panel" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_sample_analyte"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_sample" baseColumnNames="analyte_id"
+            referencedTableSchemaName="clinlims" referencedTableName="analyte" referencedColumnNames="id"/>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_panel_sample
+            ADD CONSTRAINT eqa_panel_sample_range_chk
+            CHECK (acceptance_range_low IS NULL OR acceptance_range_high IS NULL
+                OR acceptance_range_low &lt;= acceptance_range_high)
+        </sql>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_panel_sample"/>
+            <dropSequence sequenceName="eqa_panel_sample_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="eqa-panel-003-create-eqa-scheme-analyst">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_scheme_analyst" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Opt-in list of users eligible to be recorded as analyst on a scheme (FR-V2.1-08)</comment>
+        <createSequence sequenceName="eqa_scheme_analyst_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_scheme_analyst">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_scheme_analyst"/>
+            </column>
+            <column name="scheme_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="system_user_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="added_at" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="added_by" type="numeric(10,0)"/>
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <!-- An empty list means "any user may be recorded" (FR-V2.1-08), so this is
+             an opt-in set: one row per (scheme, user), never a bag. -->
+        <addUniqueConstraint
+            schemaName="clinlims" tableName="eqa_scheme_analyst"
+            columnNames="scheme_id, system_user_id"
+            constraintName="uq_eqa_scheme_analyst_scheme_user"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_scheme_analyst_eqa_program"
+            baseTableSchemaName="clinlims" baseTableName="eqa_scheme_analyst" baseColumnNames="scheme_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_program" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_scheme_analyst_system_user"
+            baseTableSchemaName="clinlims" baseTableName="eqa_scheme_analyst" baseColumnNames="system_user_id"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_scheme_analyst_added_by"
+            baseTableSchemaName="clinlims" baseTableName="eqa_scheme_analyst" baseColumnNames="added_by"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_scheme_analyst"/>
+            <dropSequence sequenceName="eqa_scheme_analyst_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/qa/018-create-eqa-followup-receipt-competency.xml
+++ b/src/main/resources/liquibase/qa/018-create-eqa-followup-receipt-competency.xml
@@ -21,7 +21,7 @@
 
     FR-V2.1-20 also says the receipt sets sample_shipment.delivery_status; the real
     column is shipment.status, carrying ShipmentStatus values (DELIVERED). That
-    write is a service-layer side-effect (T-10), not schema.
+    write belongs to the receipt-writing service (T-15), not schema.
     -->
 
     <changeSet author="openelisglobal" id="eqa-followup-001-create-eqa-participant-followup">
@@ -96,12 +96,6 @@
                 'RESOLVED', 'ESCALATED', 'REMOVED_FROM_PROGRAM'))
         </sql>
 
-        <createIndex schemaName="clinlims" tableName="eqa_participant_followup"
-            indexName="idx_eqa_participant_followup_scheme_org">
-            <column name="scheme_id"/>
-            <column name="participant_org_id"/>
-        </createIndex>
-
         <rollback>
             <dropTable schemaName="clinlims" tableName="eqa_participant_followup"/>
             <dropSequence sequenceName="eqa_participant_followup_seq" schemaName="clinlims"/>
@@ -138,8 +132,8 @@
             <column name="integrity_ok" type="BOOLEAN" defaultValueBoolean="true">
                 <constraints nullable="false"/>
             </column>
-            <!-- Required at the application layer when integrity_ok is false; not a
-                 DB CHECK because the UI must be able to stage a partial draft. -->
+            <!-- The receipt-writing service (T-15) must require this when integrity_ok
+                 is false; not a DB CHECK because the UI stages partial drafts. -->
             <column name="integrity_notes" type="TEXT"/>
             <column name="notes" type="TEXT"/>
             <column name="sys_user_id" type="VARCHAR(36)">
@@ -268,12 +262,6 @@
             CHECK (dismissal_category IN ('KNOWN_EQUIPMENT_ISSUE', 'TRANSCRIPTION_ERROR', 'PENDING_RE_TEST',
                 'ACCEPTABLE_ON_REVIEW', 'OTHER'))
         </sql>
-
-        <createIndex schemaName="clinlims" tableName="eqa_analyst_competency_event"
-            indexName="idx_eqa_competency_event_analyst_date">
-            <column name="analyst_id"/>
-            <column name="event_date"/>
-        </createIndex>
 
         <rollback>
             <dropTable schemaName="clinlims" tableName="eqa_analyst_competency_event"/>

--- a/src/main/resources/liquibase/qa/018-create-eqa-followup-receipt-competency.xml
+++ b/src/main/resources/liquibase/qa/018-create-eqa-followup-receipt-competency.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    OGC-609 [EQA V2.1 / T-09] Schema spine 4 of 4: participant follow-ups, panel
+    receipts, analyst competency events (FR-V2.1-13/20/22).
+
+    Same conventions as qa/017. Three FK targets are named wrongly in the FRS and
+    are corrected here against the codebase:
+
+      * FR-V2.1-20 says lab_enrollment       -> real table is eqa_lab_program_enrollment
+      * FR-V2.1-20 says sample_shipment      -> real table is shipment, and its PK is
+                                                INTEGER, so shipment_id is INTEGER here
+                                                rather than the numeric(10,0) used by
+                                                every other FK in the EQA spine
+      * FR-V2.1-22 says nce                  -> real table is nc_event, PK INTEGER
+
+    FR-V2.1-20 also says the receipt sets sample_shipment.delivery_status; the real
+    column is shipment.status, carrying ShipmentStatus values (DELIVERED). That
+    write is a service-layer side-effect (T-10), not schema.
+    -->
+
+    <changeSet author="openelisglobal" id="eqa-followup-001-create-eqa-participant-followup">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_participant_followup" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Provider-side follow-up register for underperforming participants (FR-V2.1-13)</comment>
+        <createSequence sequenceName="eqa_participant_followup_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_participant_followup">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_participant_followup"/>
+            </column>
+            <column name="scheme_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cycle_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="participant_org_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Snapshot of the results that triggered the follow-up, so the register
+                 stays readable after later cycles change the underlying rows. -->
+            <column name="participant_result_summary_json" type="TEXT"/>
+            <column name="followup_status" type="VARCHAR(30)" defaultValue="NOTIFIED">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notified_at" type="TIMESTAMP"/>
+            <column name="response_received_at" type="TIMESTAMP"/>
+            <column name="assigned_to" type="numeric(10,0)"/>
+            <column name="resolution_notes" type="TEXT"/>
+            <column name="persistent_failure_flag" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint
+            schemaName="clinlims" tableName="eqa_participant_followup"
+            columnNames="cycle_id, participant_org_id"
+            constraintName="uq_eqa_participant_followup_cycle_org"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_participant_followup_eqa_program"
+            baseTableSchemaName="clinlims" baseTableName="eqa_participant_followup" baseColumnNames="scheme_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_program" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_participant_followup_eqa_cycle"
+            baseTableSchemaName="clinlims" baseTableName="eqa_participant_followup" baseColumnNames="cycle_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_cycle" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_participant_followup_organization"
+            baseTableSchemaName="clinlims" baseTableName="eqa_participant_followup" baseColumnNames="participant_org_id"
+            referencedTableSchemaName="clinlims" referencedTableName="organization" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_participant_followup_assigned_to"
+            baseTableSchemaName="clinlims" baseTableName="eqa_participant_followup" baseColumnNames="assigned_to"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_participant_followup
+            ADD CONSTRAINT eqa_participant_followup_status_chk
+            CHECK (followup_status IN ('NOTIFIED', 'RESPONSE_RECEIVED', 'UNDER_INVESTIGATION',
+                'RESOLVED', 'ESCALATED', 'REMOVED_FROM_PROGRAM'))
+        </sql>
+
+        <createIndex schemaName="clinlims" tableName="eqa_participant_followup"
+            indexName="idx_eqa_participant_followup_scheme_org">
+            <column name="scheme_id"/>
+            <column name="participant_org_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_participant_followup"/>
+            <dropSequence sequenceName="eqa_participant_followup_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="eqa-followup-002-create-eqa-panel-receipt">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_panel_receipt" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Participant-side confirmation that a panel arrived (FR-V2.1-20)</comment>
+        <createSequence sequenceName="eqa_panel_receipt_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_panel_receipt">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_panel_receipt"/>
+            </column>
+            <column name="cycle_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lab_enrollment_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- INTEGER, not numeric(10,0): shipment.id is INTEGER. Nullable for
+                 walk-in pickup and legacy imports with no tracked shipment. -->
+            <column name="shipment_id" type="INTEGER"/>
+            <column name="received_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="received_by" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Unvalidated in V2.2; V3.2 adds range checks against panel storage_temp. -->
+            <column name="received_temp_c" type="DECIMAL(5,2)"/>
+            <column name="integrity_ok" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Required at the application layer when integrity_ok is false; not a
+                 DB CHECK because the UI must be able to stage a partial draft. -->
+            <column name="integrity_notes" type="TEXT"/>
+            <column name="notes" type="TEXT"/>
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <!-- One receipt per cycle per participating lab. This is also what makes the
+             participant-state derivation (FR-V2.1-18) a single-row lookup. -->
+        <addUniqueConstraint
+            schemaName="clinlims" tableName="eqa_panel_receipt"
+            columnNames="cycle_id, lab_enrollment_id"
+            constraintName="uq_eqa_panel_receipt_cycle_enrollment"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_receipt_eqa_cycle"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_receipt" baseColumnNames="cycle_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_cycle" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_receipt_lab_enrollment"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_receipt" baseColumnNames="lab_enrollment_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_lab_program_enrollment"
+            referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_receipt_shipment"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_receipt" baseColumnNames="shipment_id"
+            referencedTableSchemaName="clinlims" referencedTableName="shipment" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_panel_receipt_received_by"
+            baseTableSchemaName="clinlims" baseTableName="eqa_panel_receipt" baseColumnNames="received_by"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_panel_receipt"/>
+            <dropSequence sequenceName="eqa_panel_receipt_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="eqa-followup-003-create-eqa-analyst-competency-event">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="eqa_analyst_competency_event" schemaName="clinlims"/></not>
+        </preConditions>
+        <comment>Append-only competency event log; richer than results alone (FR-V2.1-22)</comment>
+        <createSequence sequenceName="eqa_analyst_competency_event_seq" schemaName="clinlims" startValue="1" incrementBy="1"/>
+        <createTable schemaName="clinlims" tableName="eqa_analyst_competency_event">
+            <column name="id" type="numeric(10,0)">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_eqa_analyst_competency_event"/>
+            </column>
+            <column name="analyst_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="event_type" type="VARCHAR(40)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="event_date" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="scheme_id" type="numeric(10,0)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Null for cross-cycle events, populated for per-cycle ones. -->
+            <column name="cycle_id" type="numeric(10,0)"/>
+            <column name="participant_result_id" type="numeric(10,0)"/>
+            <column name="analyte_id" type="numeric(10,0)"/>
+            <!-- INTEGER: nc_event.id is INTEGER. Populated for escalated_to_nce. -->
+            <column name="nce_id" type="INTEGER"/>
+            <column name="dismissal_category" type="VARCHAR(40)"/>
+            <column name="notes" type="TEXT"/>
+            <column name="sys_user_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated" type="TIMESTAMP" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_analyst"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event" baseColumnNames="analyst_id"
+            referencedTableSchemaName="clinlims" referencedTableName="system_user" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_eqa_program"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event" baseColumnNames="scheme_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_program" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_eqa_cycle"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event" baseColumnNames="cycle_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_cycle" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_participant_result"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event"
+            baseColumnNames="participant_result_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_participant_result"
+            referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_analyte"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event" baseColumnNames="analyte_id"
+            referencedTableSchemaName="clinlims" referencedTableName="analyte" referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_competency_event_nc_event"
+            baseTableSchemaName="clinlims" baseTableName="eqa_analyst_competency_event" baseColumnNames="nce_id"
+            referencedTableSchemaName="clinlims" referencedTableName="nc_event" referencedColumnNames="id"/>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_analyst_competency_event
+            ADD CONSTRAINT eqa_competency_event_type_chk
+            CHECK (event_type IN ('EXTERNAL_MISSED_DEADLINE', 'IN_HOUSE_MISSED_DEADLINE', 'UNACCEPTABLE_SCORE',
+                'QUESTIONABLE_SCORE', 'ESCALATED_TO_NCE', 'DISMISSED_EQUIPMENT', 'DISMISSED_TRANSCRIPTION',
+                'DISMISSED_ACCEPTABLE_ON_REVIEW', 'DISMISSED_OTHER'))
+        </sql>
+
+        <sql>
+            ALTER TABLE clinlims.eqa_analyst_competency_event
+            ADD CONSTRAINT eqa_competency_event_dismissal_chk
+            CHECK (dismissal_category IN ('KNOWN_EQUIPMENT_ISSUE', 'TRANSCRIPTION_ERROR', 'PENDING_RE_TEST',
+                'ACCEPTABLE_ON_REVIEW', 'OTHER'))
+        </sql>
+
+        <createIndex schemaName="clinlims" tableName="eqa_analyst_competency_event"
+            indexName="idx_eqa_competency_event_analyst_date">
+            <column name="analyst_id"/>
+            <column name="event_date"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable schemaName="clinlims" tableName="eqa_analyst_competency_event"/>
+            <dropSequence sequenceName="eqa_analyst_competency_event_seq" schemaName="clinlims"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/qa/023-add-eqa-manage-permission.xml
+++ b/src/main/resources/liquibase/qa/023-add-eqa-manage-permission.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    OGC-609 [EQA V2.1 / T-10] Write permission for EQA cycle state changes.
+
+    FR-V2.1-04 requires manual cycle transitions to be gated on a manage-level
+    permission, and none existed: the schema had only qa.view.eqa (read), so
+    the transition endpoint — which mutates cycle state and writes an immutable
+    audit row — was reachable by any RECEPTION or RESULTS user.
+
+    Shape copied verbatim from qa/004's qa.manage.accreditation pair (register
+    the key, then grant it), including the NOT EXISTS guard that makes the grant
+    re-runnable.
+
+    Slot note: §05 of the delivery plan reserves qa/019 for T-12's full V2
+    permission tiers, so this takes the first buffer slot instead of squatting
+    it. T-12 should grant additional roles against this module rather than
+    re-registering the key — the precondition below makes a duplicate insert a
+    no-op, but a second module row with the same name would split the grants.
+    -->
+
+    <changeSet author="openelisglobal" id="qa-035-add-qa-manage-eqa-module">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="system_module" schemaName="clinlims" />
+            <sqlCheck expectedResult="0">SELECT count(*) FROM clinlims.system_module WHERE name = 'qa.manage.eqa'</sqlCheck>
+        </preConditions>
+        <comment>Register the qa.manage.eqa permission key</comment>
+        <insert tableName="system_module" schemaName="clinlims">
+            <column name="id" valueSequenceNext="system_module_seq"/>
+            <column name="name" value="qa.manage.eqa"/>
+            <column name="description" value="Manage EQA cycles: advance cycle state and record manual overrides"/>
+            <column name="has_select_flag" value="Y"/>
+            <column name="has_add_flag" value="N"/>
+            <column name="has_update_flag" value="N"/>
+            <column name="has_delete_flag" value="N"/>
+        </insert>
+        <rollback>
+            <delete tableName="system_module" schemaName="clinlims">
+                <where>name = 'qa.manage.eqa'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-036-grant-qa-manage-eqa">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="system_role_module" schemaName="clinlims" />
+            <sqlCheck expectedResult="1">SELECT count(*) FROM clinlims.system_module WHERE name = 'qa.manage.eqa'</sqlCheck>
+        </preConditions>
+        <comment>Grant qa.manage.eqa to QA Officer and Global Administrator</comment>
+        <sql>
+            INSERT INTO clinlims.system_role_module
+                (id, has_select, has_add, has_update, has_delete, system_role_id, system_module_id)
+            SELECT nextval('clinlims.system_role_module_seq'), 'Y', 'N', 'N', 'N', r.id, m.id
+            FROM clinlims.system_role r, clinlims.system_module m
+            WHERE r.name IN ('QA Officer', 'Global Administrator') AND m.name = 'qa.manage.eqa'
+              AND NOT EXISTS (
+                  SELECT 1 FROM clinlims.system_role_module srm
+                  WHERE srm.system_role_id = r.id AND srm.system_module_id = m.id);
+        </sql>
+        <rollback>
+            <sql>
+                DELETE FROM clinlims.system_role_module
+                WHERE system_module_id = (SELECT id FROM clinlims.system_module WHERE name = 'qa.manage.eqa');
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -85,6 +85,14 @@
         <class>org.openelisglobal.eqa.valueholder.EQACycleStateTransition</class>
         <class>org.openelisglobal.eqa.valueholder.EQAParticipantResult</class>
 
+        <!-- EQA V2 panels, receipts, follow-ups, competency (OGC-609) -->
+        <class>org.openelisglobal.eqa.valueholder.EQAPanel</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAPanelSample</class>
+        <class>org.openelisglobal.eqa.valueholder.EQASchemeAnalyst</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAParticipantFollowup</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAPanelReceipt</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent</class>
+
         <!-- Quality Control / Internal Control entities (005-eqa-module QC/IC) -->
         <class>org.openelisglobal.qc.valueholder.QCRuleConfig</class>
         <class>org.openelisglobal.qc.valueholder.QCFrequencyConfig</class>

--- a/src/test/java/org/openelisglobal/eqa/EQACycleSpineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleSpineIntegrationTest.java
@@ -8,16 +8,9 @@ import static org.junit.Assert.fail;
 
 import java.sql.Timestamp;
 import java.util.Map;
-import javax.sql.DataSource;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.openelisglobal.BaseWebContextSensitiveTest;
-import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
-import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
-import org.openelisglobal.eqa.dao.EQARoundDAO;
-import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
@@ -31,29 +24,15 @@ import org.openelisglobal.eqa.valueholder.EQASubmissionChannel;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
 import org.openelisglobal.eqa.valueholder.EQATriggerType;
-import org.openelisglobal.systemuser.service.SystemUserService;
-import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * OGC-609 [EQA V2.1 / T-08] — the cycle spine against a real DB.
- *
- * <p>
- * The test DB is Liquibase-provisioned (BaseTestConfig runs base-changelog.xml
- * against a testcontainers Postgres), so qa/015 and qa/016 shape these tables:
- * CHECK constraints, foreign keys and unique constraints are all live here, and
- * the tests assert them rather than deferring to manual UAT.
- *
- * <p>
- * BaseWebContextSensitiveTest runs with transactions NOT_SUPPORTED, so each DAO
- * call commits on its own — a read-back is a genuinely fresh session, not the
- * same instance handed back from a first-level cache.
+ * OGC-609 [EQA V2.1 / T-08] — the cycle spine against a real DB. qa/015 and
+ * qa/016 shape these tables: CHECK constraints, foreign keys and unique
+ * constraints are all live here, and the tests assert them rather than
+ * deferring to manual UAT.
  */
-public class EQACycleSpineIntegrationTest extends BaseWebContextSensitiveTest {
-
-    private static final String USER = "1";
-    private static final long ADMIN_USER_ID = 1L;
+public class EQACycleSpineIntegrationTest extends EQASpineTestBase {
 
     private static final long ENROLLMENT_ID = 9901L;
     private static final long ANALYTE_HIV_SEROLOGY = 9801L;
@@ -61,51 +40,13 @@ public class EQACycleSpineIntegrationTest extends BaseWebContextSensitiveTest {
     private static final long TEST_HIV_SEROLOGY = 9701L;
 
     @Autowired
-    private EQAProgramService eqaProgramService;
-
-    @Autowired
-    private EQACycleDAO eqaCycleDAO;
-
-    @Autowired
-    private EQARoundDAO eqaRoundDAO;
-
-    @Autowired
-    private EQAParticipantResultDAO eqaParticipantResultDAO;
-
-    @Autowired
     private EQACycleStateTransitionDAO eqaCycleStateTransitionDAO;
-
-    @Autowired
-    private SystemUserService systemUserService;
-
-    @Autowired
-    private DataSource dataSource;
-
-    private JdbcTemplate jdbc;
 
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        jdbc = new JdbcTemplate(dataSource);
-        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
-        clean();
-        seedLabEnrollment();
-    }
-
-    @After
-    public void tearDown() {
-        clean();
-    }
-
-    private void clean() {
-        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
-        jdbc.update("DELETE FROM clinlims.eqa_round");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle");
-        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id = ?", ENROLLMENT_ID);
-        jdbc.update("DELETE FROM clinlims.eqa_program_test");
-        jdbc.update("DELETE FROM clinlims.eqa_program");
+        seedEnrollment(ENROLLMENT_ID, "Spine test enrollment");
     }
 
     // ---- FR-V2.1-01/02/05/21: the spine persists and reads back intact ----
@@ -123,7 +64,7 @@ public class EQACycleSpineIntegrationTest extends BaseWebContextSensitiveTest {
         cycle.setSysUserId(USER);
         Long cycleId = eqaCycleDAO.insert(cycle);
 
-        EQACycle readCycle = eqaCycleDAO.get(cycleId).orElseThrow(AssertionError::new);
+        EQACycle readCycle = readBack(cycleId);
         assertEquals("2026 Cycle 1", readCycle.getCycleName());
         assertEquals(Integer.valueOf(1), readCycle.getCycleNumber());
         assertEquals(EQACycleStatus.TESTING, readCycle.getStatus());
@@ -256,9 +197,9 @@ public class EQACycleSpineIntegrationTest extends BaseWebContextSensitiveTest {
         EQAProgram scheme = insertScheme("Dup result", EQASchemeType.INTERNATIONAL_PT, "NHLS");
         EQACycle cycle = readBack(insertCycle(scheme, 1));
         EQARound round = eqaRoundDAO.get(insertRound(cycle, 1, "OPEN")).orElseThrow(AssertionError::new);
-        insertResult(cycle, round, ANALYTE_HIV_SEROLOGY, "Reactive");
+        insertParticipantResult(cycle, round, ENROLLMENT_ID, ANALYTE_HIV_SEROLOGY, null, "Reactive");
         try {
-            insertResult(cycle, round, ANALYTE_HIV_SEROLOGY, "Non-reactive");
+            insertParticipantResult(cycle, round, ENROLLMENT_ID, ANALYTE_HIV_SEROLOGY, null, "Non-reactive");
             fail("a lab reports one result per analyte per round");
         } catch (Exception expected) {
             assertConstraintViolation(expected, "uq_eqa_participant_result_round_lab_analyte");
@@ -376,74 +317,5 @@ public class EQACycleSpineIntegrationTest extends BaseWebContextSensitiveTest {
                 jdbc.queryForObject(
                         "SELECT count(*) FROM clinlims.eqa_program_test" + " WHERE eqa_program_id = ? AND test_id = ?",
                         Integer.class, scheme.getId(), TEST_HIV_SEROLOGY));
-    }
-
-    // ---- helpers ----
-
-    private void seedLabEnrollment() {
-        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
-                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
-                + " VALUES (?, 'Spine test enrollment', 'NHLS', true, now(), ?, now())", ENROLLMENT_ID, USER);
-    }
-
-    private EQAProgram insertScheme(String name, EQASchemeType type, String provider) {
-        EQAProgram scheme = new EQAProgram();
-        scheme.setName(name);
-        scheme.setSchemeType(type);
-        scheme.setProvider(provider);
-        scheme.setSysUserId(USER);
-        Long id = eqaProgramService.insert(scheme);
-        scheme.setId(id);
-        return scheme;
-    }
-
-    private Long insertCycle(EQAProgram scheme, int cycleNumber) {
-        EQACycle cycle = new EQACycle();
-        cycle.setScheme(scheme);
-        cycle.setCycleNumber(cycleNumber);
-        cycle.setCreatedBy(systemUser(ADMIN_USER_ID));
-        cycle.setSysUserId(USER);
-        return eqaCycleDAO.insert(cycle);
-    }
-
-    private EQACycle readBack(Long cycleId) {
-        return eqaCycleDAO.get(cycleId).orElseThrow(AssertionError::new);
-    }
-
-    private Long insertRound(EQACycle cycle, int roundNumber, String status) {
-        EQARound round = new EQARound();
-        round.setCycle(cycle);
-        round.setRoundNumber(roundNumber);
-        round.setStatus(status);
-        round.setSysUserId(USER);
-        return eqaRoundDAO.insert(round);
-    }
-
-    private Long insertResult(EQACycle cycle, EQARound round, long analyteId, String value) {
-        EQAParticipantResult result = new EQAParticipantResult();
-        result.setCycle(cycle);
-        result.setRound(round);
-        result.setLabEnrollmentId(ENROLLMENT_ID);
-        result.setAnalyteId(analyteId);
-        result.setResultValue(value);
-        result.setSysUserId(USER);
-        return eqaParticipantResultDAO.insert(result);
-    }
-
-    private SystemUser systemUser(long id) {
-        return systemUserService.get(String.valueOf(id));
-    }
-
-    private void assertConstraintViolation(Exception e, String constraintName) {
-        assertTrue("expected " + constraintName + " to be the failing constraint, got: " + rootMessage(e),
-                rootMessage(e).contains(constraintName));
-    }
-
-    private String rootMessage(Throwable t) {
-        StringBuilder messages = new StringBuilder();
-        for (Throwable current = t; current != null; current = current.getCause()) {
-            messages.append(current.getMessage()).append(' ');
-        }
-        return messages.toString();
     }
 }

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -8,31 +8,18 @@ import static org.junit.Assert.fail;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
-import java.sql.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.sql.DataSource;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
-import org.openelisglobal.eqa.dao.EQACycleDAO;
-import org.openelisglobal.eqa.dao.EQAPanelDAO;
-import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
-import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
-import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
-import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
-import org.openelisglobal.eqa.valueholder.EQAPanel;
-import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
-import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
@@ -40,19 +27,15 @@ import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
 import org.openelisglobal.eqa.valueholder.EQATriggerType;
-import org.openelisglobal.systemuser.service.SystemUserService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 /**
  * OGC-609 [EQA V2.1 / T-10] — the two cycle state machines, their audit trail,
  * and the derived per-lab participant state, against a real DB.
  */
-public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitiveTest {
+public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
 
-    private static final String USER = "1";
-    private static final long ADMIN_USER_ID = 1L;
     private static final long ENROLLMENT_ID = 9905L;
     private static final long OTHER_ENROLLMENT_ID = 9906L;
     private static final long ANALYTE_HIV_VL = 9802L;
@@ -60,67 +43,19 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
     @Autowired
     private EQACycleService cycleService;
 
-    @Autowired
-    private EQAProgramService eqaProgramService;
-
-    @Autowired
-    private EQACycleDAO eqaCycleDAO;
-
-    @Autowired
-    private EQARoundDAO eqaRoundDAO;
-
-    @Autowired
-    private EQAParticipantResultDAO eqaParticipantResultDAO;
-
-    @Autowired
-    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
-
-    @Autowired
-    private EQAPanelDAO eqaPanelDAO;
-
-    @Autowired
-    private SystemUserService systemUserService;
-
-    @Autowired
-    private DataSource dataSource;
-
-    private JdbcTemplate jdbc;
-
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        jdbc = new JdbcTemplate(dataSource);
-        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
-        clean();
         seedEnrollment(ENROLLMENT_ID, "Cycle machine enrollment");
         seedEnrollment(OTHER_ENROLLMENT_ID, "Second lab enrollment");
-    }
-
-    @After
-    public void tearDown() {
-        clean();
-    }
-
-    private void clean() {
-        jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
-        jdbc.update("DELETE FROM clinlims.eqa_panel");
-        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
-        jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
-        jdbc.update("DELETE FROM clinlims.eqa_round");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle");
-        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id IN (?, ?)", ENROLLMENT_ID,
-                OTHER_ENROLLMENT_ID);
-        jdbc.update("DELETE FROM clinlims.eqa_program_test");
-        jdbc.update("DELETE FROM clinlims.eqa_program");
     }
 
     // ---- FR-V2.1-04 / FR-V2.1-18: legal and illegal edges ----
 
     @Test
     public void participantCycleWalksItsHappyPathAndAuditsEveryStep() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
 
         EQACycleStatus[] path = { EQACycleStatus.PANEL_RECEIVED, EQACycleStatus.TESTING, EQACycleStatus.READY_TO_SUBMIT,
                 EQACycleStatus.SUBMITTED, EQACycleStatus.SCORED, EQACycleStatus.CLOSED };
@@ -129,8 +64,7 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
                     EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
         }
 
-        assertEquals(EQACycleStatus.CLOSED,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals(EQACycleStatus.CLOSED, readBack(cycle.getId()).getStatus());
 
         List<EQACycleStateTransition> audit = cycleService.getTransitions(cycle.getId());
         assertEquals("one audit row per transition", path.length, audit.size());
@@ -144,10 +78,10 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
 
     @Test
     public void providerCycleWalksItsOwnLongerPath() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         // A QC-passed panel is a precondition of ready_to_ship, so the happy path
         // has to seed one — walking this edge with no panel is the bug below.
-        insertPanel(cycle, true);
+        insertQcPanel(cycle, true);
 
         EQACycleStatus[] path = { EQACycleStatus.PREP_IN_PROGRESS, EQACycleStatus.READY_TO_SHIP, EQACycleStatus.SHIPPED,
                 EQACycleStatus.DELIVERED, EQACycleStatus.SUBMISSIONS_OPEN, EQACycleStatus.SUBMISSIONS_CLOSED,
@@ -157,15 +91,14 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
                     EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
         }
 
-        assertEquals(EQACycleStatus.CLOSED,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals(EQACycleStatus.CLOSED, readBack(cycle.getId()).getStatus());
         assertEquals(path.length, cycleService.getTransitions(cycle.getId()).size());
     }
 
     @Test
     public void skippingAStateIsRefusedAndWritesNoAudit() {
         // AC-V2.1-05: planned -> testing skips panel_received.
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         try {
             cycleService.transition(cycle.getId(), EQACycleStatus.TESTING, EQAStateMachine.PARTICIPANT,
                     EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
@@ -175,15 +108,14 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
             assertEquals(EQACycleStatus.TESTING, expected.getAttemptedState());
         }
 
-        assertEquals("the cycle must not have moved", EQACycleStatus.PLANNED,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals("the cycle must not have moved", EQACycleStatus.PLANNED, readBack(cycle.getId()).getStatus());
         assertTrue("a refused transition writes no audit row", cycleService.getTransitions(cycle.getId()).isEmpty());
     }
 
     @Test
     public void aProviderEdgeIsNotAvailableToAParticipant() {
         // The same row, read through the other machine, has different edges.
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         try {
             cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PARTICIPANT,
                     EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
@@ -195,14 +127,16 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
 
     @Test
     public void closedIsFinalOnBothMachines() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
-        try {
-            cycleService.transition(cycle.getId(), EQACycleStatus.SCORED, EQAStateMachine.PROVIDER,
-                    EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "reopen", USER);
-            fail("a closed cycle has no outgoing edges");
-        } catch (EQAInvalidTransitionException expected) {
-            assertEquals(EQACycleStatus.CLOSED, expected.getPriorState());
+        for (EQAStateMachine machine : EQAStateMachine.values()) {
+            try {
+                cycleService.transition(cycle.getId(), EQACycleStatus.SCORED, machine, EQATriggerType.MANUAL,
+                        EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "reopen", USER);
+                fail("a closed cycle has no outgoing edges on the " + machine + " machine");
+            } catch (EQAInvalidTransitionException expected) {
+                assertEquals(EQACycleStatus.CLOSED, expected.getPriorState());
+            }
         }
     }
 
@@ -212,8 +146,8 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
     public void aPanelThatFailedHomogeneityQcCannotBeShipped() {
         // The ISO 17043 supervisor gate. Without it a failed panel is marked
         // shippable and the audit row recording it looks entirely legitimate.
-        EQACycle cycle = insertCycle();
-        insertPanel(cycle, false);
+        EQACycle cycle = newCycle();
+        insertQcPanel(cycle, false);
         cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PROVIDER,
                 EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
 
@@ -226,12 +160,12 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
             assertTrue(expected.getMessage().contains("homogeneity"));
         }
         assertEquals("the cycle must not have moved", EQACycleStatus.PREP_IN_PROGRESS,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+                readBack(cycle.getId()).getStatus());
     }
 
     @Test
     public void aCycleWithNoPanelCannotBeShipped() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PROVIDER,
                 EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
         try {
@@ -241,18 +175,19 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
         } catch (EQAInvalidTransitionException expected) {
             assertTrue(expected.getMessage().contains("no panel"));
         }
+        assertEquals("the cycle must not have moved", EQACycleStatus.PREP_IN_PROGRESS,
+                readBack(cycle.getId()).getStatus());
     }
 
     @Test
     public void theGateOnlyAppliesToThatOneProviderEdge() {
         // A participant cycle with a failed panel is unaffected — the gate must not
         // leak onto edges FR-V2.1-18 does not name.
-        EQACycle cycle = insertCycle();
-        insertPanel(cycle, false);
+        EQACycle cycle = newCycle();
+        insertQcPanel(cycle, false);
         cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
                 EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
-        assertEquals(EQACycleStatus.PANEL_RECEIVED,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, readBack(cycle.getId()).getStatus());
     }
 
     // ---- FR-V2.1-21: manual transitions carry a reason and an actor ----
@@ -264,7 +199,7 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
         // stores the actor unconditionally, so this hands AUTO a real user id and
         // asserts it is dropped. An AUTO row naming a person would misattribute a
         // system event to them, permanently.
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
                 EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, ADMIN_USER_ID, null, USER);
 
@@ -275,7 +210,7 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
 
     @Test
     public void aManualTransitionRecordsWhoAndWhy() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
                 EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "Courier delivered early", USER);
 
@@ -289,7 +224,7 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
     public void aManualTransitionWithoutAReasonIsRefused() {
         // AC-V2.1-19 requires a reason even on a happy-path manual move, which is
         // stricter than FR-V2.1-21's "off the happy path" wording.
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         try {
             cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
                     EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "   ", USER);
@@ -297,15 +232,14 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
         } catch (IllegalArgumentException expected) {
             assertTrue(expected.getMessage().contains("reason"));
         }
-        assertEquals(EQACycleStatus.PLANNED,
-                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals(EQACycleStatus.PLANNED, readBack(cycle.getId()).getStatus());
     }
 
     @Test
     public void aManualTransitionWithoutAnActorIsRefused() {
         // An unattributed manual override is worse than no audit row, because it
         // still looks like one. AUTO rows legitimately have no actor; MANUAL never.
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         try {
             cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
                     EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, null, "no actor supplied", USER);
@@ -360,17 +294,18 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
 
     @Test
     public void participantStateIsDerivedFromReceiptsAndResults() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
 
         assertEquals("no receipt yet", EQACycleStatus.PLANNED,
                 cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
 
-        insertReceipt(cycle);
+        insertReceipt(cycle, ENROLLMENT_ID);
         assertEquals("receipt but no results", EQACycleStatus.PANEL_RECEIVED,
                 cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
 
-        EQARound round = insertRound(cycle);
-        Long draftId = insertResult(cycle, round, EQASubmissionStatus.DRAFT);
+        EQARound round = eqaRoundDAO.get(insertRound(cycle, 1, "OPEN")).orElseThrow(AssertionError::new);
+        Long draftId = insertParticipantResult(cycle, round, ENROLLMENT_ID, ANALYTE_HIV_VL, EQASubmissionStatus.DRAFT,
+                null);
         assertEquals("a draft result means testing", EQACycleStatus.TESTING,
                 cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
 
@@ -389,19 +324,19 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
     public void theMostAdvancedResultWinsWhenRowsDisagree() {
         // The FRS table's rows overlap and it never states precedence; a lab that
         // has been scored is scored even while another analyte sits in draft.
-        EQACycle cycle = insertCycle();
-        insertReceipt(cycle);
-        EQARound round = insertRound(cycle);
-        insertResultForAnalyte(cycle, round, EQASubmissionStatus.DRAFT, ANALYTE_HIV_VL);
-        insertResultForAnalyte(cycle, round, EQASubmissionStatus.SCORED, 9801L);
+        EQACycle cycle = newCycle();
+        insertReceipt(cycle, ENROLLMENT_ID);
+        EQARound round = eqaRoundDAO.get(insertRound(cycle, 1, "OPEN")).orElseThrow(AssertionError::new);
+        insertParticipantResult(cycle, round, ENROLLMENT_ID, ANALYTE_HIV_VL, EQASubmissionStatus.DRAFT, null);
+        insertParticipantResult(cycle, round, ENROLLMENT_ID, 9801L, EQASubmissionStatus.SCORED, null);
 
         assertEquals(EQACycleStatus.SCORED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
     }
 
     @Test
     public void oneLabsProgressDoesNotLeakIntoAnother() {
-        EQACycle cycle = insertCycle();
-        insertReceipt(cycle);
+        EQACycle cycle = newCycle();
+        insertReceipt(cycle, ENROLLMENT_ID);
 
         assertEquals(EQACycleStatus.PANEL_RECEIVED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
         assertEquals("the second lab has not received anything", EQACycleStatus.PLANNED,
@@ -410,76 +345,24 @@ public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitive
 
     @Test
     public void aClosedCycleReadsClosedForEveryLab() {
-        EQACycle cycle = insertCycle();
+        EQACycle cycle = newCycle();
         jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
         assertEquals(EQACycleStatus.CLOSED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
     }
 
     // ---- helpers ----
 
-    private void seedEnrollment(long id, String name) {
-        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
-                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
-                + " VALUES (?, ?, 'NHLS', true, now(), ?, now())", id, name, USER);
+    private EQACycle newCycle() {
+        EQAProgram scheme = insertScheme("Machine scheme " + System.nanoTime(), EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        return readBack(insertCycle(scheme, 1));
     }
 
-    private EQACycle insertCycle() {
-        EQAProgram scheme = new EQAProgram();
-        scheme.setName("Machine scheme " + System.nanoTime());
-        scheme.setSchemeType(EQASchemeType.INTERNATIONAL_PT);
-        scheme.setProvider("NHLS");
-        scheme.setSysUserId(USER);
-        scheme.setId(eqaProgramService.insert(scheme));
-
-        EQACycle cycle = new EQACycle();
-        cycle.setScheme(scheme);
-        cycle.setCycleNumber(1);
-        cycle.setCreatedBy(systemUserService.get(String.valueOf(ADMIN_USER_ID)));
-        cycle.setSysUserId(USER);
-        return eqaCycleDAO.get(eqaCycleDAO.insert(cycle)).orElseThrow(AssertionError::new);
-    }
-
-    private void insertPanel(EQACycle cycle, boolean homogeneityPassed) {
-        EQAPanel panel = new EQAPanel();
-        panel.setScheme(cycle.getScheme());
-        panel.setCycle(cycle);
-        panel.setPanelName("Panel for cycle " + cycle.getId());
-        panel.setHomogeneityQcPassed(homogeneityPassed);
-        panel.setSysUserId(USER);
-        eqaPanelDAO.insert(panel);
-    }
-
-    private EQARound insertRound(EQACycle cycle) {
-        EQARound round = new EQARound();
-        round.setCycle(cycle);
-        round.setRoundNumber(1);
-        round.setSysUserId(USER);
-        return eqaRoundDAO.get(eqaRoundDAO.insert(round)).orElseThrow(AssertionError::new);
-    }
-
-    private void insertReceipt(EQACycle cycle) {
-        EQAPanelReceipt receipt = new EQAPanelReceipt();
-        receipt.setCycle(cycle);
-        receipt.setLabEnrollmentId(ENROLLMENT_ID);
-        receipt.setReceivedDate(Date.valueOf("2026-08-14"));
-        receipt.setReceivedBy(ADMIN_USER_ID);
-        receipt.setSysUserId(USER);
-        eqaPanelReceiptDAO.insert(receipt);
-    }
-
-    private Long insertResult(EQACycle cycle, EQARound round, EQASubmissionStatus status) {
-        return insertResultForAnalyte(cycle, round, status, ANALYTE_HIV_VL);
-    }
-
-    private Long insertResultForAnalyte(EQACycle cycle, EQARound round, EQASubmissionStatus status, long analyteId) {
-        EQAParticipantResult result = new EQAParticipantResult();
-        result.setCycle(cycle);
-        result.setRound(round);
-        result.setLabEnrollmentId(ENROLLMENT_ID);
-        result.setAnalyteId(analyteId);
-        result.setSubmissionStatus(status);
-        result.setSysUserId(USER);
-        return eqaParticipantResultDAO.insert(result);
+    private void insertQcPanel(EQACycle cycle, boolean homogeneityPassed) {
+        insertPanel(cycle.getScheme(), p -> {
+            p.setCycle(cycle);
+            p.setPanelName("Panel for cycle " + cycle.getId());
+            p.setHomogeneityQcPassed(homogeneityPassed);
+        });
     }
 
     private void setResultStatus(Long resultId, EQASubmissionStatus status) {

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -1,0 +1,489 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.sql.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
+import org.openelisglobal.eqa.service.EQAProgramService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.openelisglobal.systemuser.service.SystemUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * OGC-609 [EQA V2.1 / T-10] — the two cycle state machines, their audit trail,
+ * and the derived per-lab participant state, against a real DB.
+ */
+public class EQACycleStateMachineIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final String USER = "1";
+    private static final long ADMIN_USER_ID = 1L;
+    private static final long ENROLLMENT_ID = 9905L;
+    private static final long OTHER_ENROLLMENT_ID = 9906L;
+    private static final long ANALYTE_HIV_VL = 9802L;
+
+    @Autowired
+    private EQACycleService cycleService;
+
+    @Autowired
+    private EQAProgramService eqaProgramService;
+
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
+
+    @Autowired
+    private EQARoundDAO eqaRoundDAO;
+
+    @Autowired
+    private EQAParticipantResultDAO eqaParticipantResultDAO;
+
+    @Autowired
+    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
+
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    private SystemUserService systemUserService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private JdbcTemplate jdbc;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        jdbc = new JdbcTemplate(dataSource);
+        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
+        clean();
+        seedEnrollment(ENROLLMENT_ID, "Cycle machine enrollment");
+        seedEnrollment(OTHER_ENROLLMENT_ID, "Second lab enrollment");
+    }
+
+    @After
+    public void tearDown() {
+        clean();
+    }
+
+    private void clean() {
+        jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
+        jdbc.update("DELETE FROM clinlims.eqa_panel");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
+        jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
+        jdbc.update("DELETE FROM clinlims.eqa_round");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle");
+        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id IN (?, ?)", ENROLLMENT_ID,
+                OTHER_ENROLLMENT_ID);
+        jdbc.update("DELETE FROM clinlims.eqa_program_test");
+        jdbc.update("DELETE FROM clinlims.eqa_program");
+    }
+
+    // ---- FR-V2.1-04 / FR-V2.1-18: legal and illegal edges ----
+
+    @Test
+    public void participantCycleWalksItsHappyPathAndAuditsEveryStep() {
+        EQACycle cycle = insertCycle();
+
+        EQACycleStatus[] path = { EQACycleStatus.PANEL_RECEIVED, EQACycleStatus.TESTING, EQACycleStatus.READY_TO_SUBMIT,
+                EQACycleStatus.SUBMITTED, EQACycleStatus.SCORED, EQACycleStatus.CLOSED };
+        for (EQACycleStatus next : path) {
+            cycleService.transition(cycle.getId(), next, EQAStateMachine.PARTICIPANT, EQATriggerType.AUTO,
+                    EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
+        }
+
+        assertEquals(EQACycleStatus.CLOSED,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+
+        List<EQACycleStateTransition> audit = cycleService.getTransitions(cycle.getId());
+        assertEquals("one audit row per transition", path.length, audit.size());
+        assertEquals("PLANNED", audit.get(0).getPriorState());
+        assertEquals("PANEL_RECEIVED", audit.get(0).getNewState());
+        assertEquals("CLOSED", audit.get(audit.size() - 1).getNewState());
+        assertEquals(EQAStateMachine.PARTICIPANT, audit.get(0).getStateMachine());
+        assertEquals(EQATriggerType.AUTO, audit.get(0).getTriggerType());
+        assertNull("an automatic transition has no actor", audit.get(0).getTriggeredBy());
+    }
+
+    @Test
+    public void providerCycleWalksItsOwnLongerPath() {
+        EQACycle cycle = insertCycle();
+        // A QC-passed panel is a precondition of ready_to_ship, so the happy path
+        // has to seed one — walking this edge with no panel is the bug below.
+        insertPanel(cycle, true);
+
+        EQACycleStatus[] path = { EQACycleStatus.PREP_IN_PROGRESS, EQACycleStatus.READY_TO_SHIP, EQACycleStatus.SHIPPED,
+                EQACycleStatus.DELIVERED, EQACycleStatus.SUBMISSIONS_OPEN, EQACycleStatus.SUBMISSIONS_CLOSED,
+                EQACycleStatus.SCORING, EQACycleStatus.SCORED, EQACycleStatus.CLOSED };
+        for (EQACycleStatus next : path) {
+            cycleService.transition(cycle.getId(), next, EQAStateMachine.PROVIDER, EQATriggerType.AUTO,
+                    EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+        }
+
+        assertEquals(EQACycleStatus.CLOSED,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals(path.length, cycleService.getTransitions(cycle.getId()).size());
+    }
+
+    @Test
+    public void skippingAStateIsRefusedAndWritesNoAudit() {
+        // AC-V2.1-05: planned -> testing skips panel_received.
+        EQACycle cycle = insertCycle();
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.TESTING, EQAStateMachine.PARTICIPANT,
+                    EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
+            fail("planned -> testing is not an edge in the participant machine");
+        } catch (EQAInvalidTransitionException expected) {
+            assertEquals(EQACycleStatus.PLANNED, expected.getPriorState());
+            assertEquals(EQACycleStatus.TESTING, expected.getAttemptedState());
+        }
+
+        assertEquals("the cycle must not have moved", EQACycleStatus.PLANNED,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertTrue("a refused transition writes no audit row", cycleService.getTransitions(cycle.getId()).isEmpty());
+    }
+
+    @Test
+    public void aProviderEdgeIsNotAvailableToAParticipant() {
+        // The same row, read through the other machine, has different edges.
+        EQACycle cycle = insertCycle();
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PARTICIPANT,
+                    EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+            fail("prep_in_progress belongs to the provider machine only");
+        } catch (EQAInvalidTransitionException expected) {
+            assertEquals(EQACycleStatus.PLANNED, expected.getPriorState());
+        }
+    }
+
+    @Test
+    public void closedIsFinalOnBothMachines() {
+        EQACycle cycle = insertCycle();
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.SCORED, EQAStateMachine.PROVIDER,
+                    EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "reopen", USER);
+            fail("a closed cycle has no outgoing edges");
+        } catch (EQAInvalidTransitionException expected) {
+            assertEquals(EQACycleStatus.CLOSED, expected.getPriorState());
+        }
+    }
+
+    // ---- FR-V2.1-18 / AC-V2.1-13: the prep -> ready_to_ship gate ----
+
+    @Test
+    public void aPanelThatFailedHomogeneityQcCannotBeShipped() {
+        // The ISO 17043 supervisor gate. Without it a failed panel is marked
+        // shippable and the audit row recording it looks entirely legitimate.
+        EQACycle cycle = insertCycle();
+        insertPanel(cycle, false);
+        cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PROVIDER,
+                EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.READY_TO_SHIP, EQAStateMachine.PROVIDER,
+                    EQATriggerType.AUTO, EQATriggerEvent.HOMOGENEITY_QC_PASSED, null, null, USER);
+            fail("AC-V2.1-13: homogeneity_qc_passed = false must block ready_to_ship");
+        } catch (EQAInvalidTransitionException expected) {
+            assertEquals(EQACycleStatus.PREP_IN_PROGRESS, expected.getPriorState());
+            assertTrue(expected.getMessage().contains("homogeneity"));
+        }
+        assertEquals("the cycle must not have moved", EQACycleStatus.PREP_IN_PROGRESS,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+    }
+
+    @Test
+    public void aCycleWithNoPanelCannotBeShipped() {
+        EQACycle cycle = insertCycle();
+        cycleService.transition(cycle.getId(), EQACycleStatus.PREP_IN_PROGRESS, EQAStateMachine.PROVIDER,
+                EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.READY_TO_SHIP, EQAStateMachine.PROVIDER,
+                    EQATriggerType.AUTO, EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+            fail("there is nothing to ship");
+        } catch (EQAInvalidTransitionException expected) {
+            assertTrue(expected.getMessage().contains("no panel"));
+        }
+    }
+
+    @Test
+    public void theGateOnlyAppliesToThatOneProviderEdge() {
+        // A participant cycle with a failed panel is unaffected — the gate must not
+        // leak onto edges FR-V2.1-18 does not name.
+        EQACycle cycle = insertCycle();
+        insertPanel(cycle, false);
+        cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
+        assertEquals(EQACycleStatus.PANEL_RECEIVED,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+    }
+
+    // ---- FR-V2.1-21: manual transitions carry a reason and an actor ----
+
+    @Test
+    public void anAutomaticTransitionDiscardsAnyActorHandedToIt() {
+        // The service stores triggeredBy only for MANUAL rows. Passing null with
+        // AUTO — as every other test does — cannot tell that ternary from one that
+        // stores the actor unconditionally, so this hands AUTO a real user id and
+        // asserts it is dropped. An AUTO row naming a person would misattribute a
+        // system event to them, permanently.
+        EQACycle cycle = insertCycle();
+        cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, ADMIN_USER_ID, null, USER);
+
+        EQACycleStateTransition audit = cycleService.getTransitions(cycle.getId()).get(0);
+        assertEquals(EQATriggerType.AUTO, audit.getTriggerType());
+        assertNull("an automatic transition must not name a person, even when handed one", audit.getTriggeredBy());
+    }
+
+    @Test
+    public void aManualTransitionRecordsWhoAndWhy() {
+        EQACycle cycle = insertCycle();
+        cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "Courier delivered early", USER);
+
+        EQACycleStateTransition audit = cycleService.getTransitions(cycle.getId()).get(0);
+        assertEquals(EQATriggerType.MANUAL, audit.getTriggerType());
+        assertEquals(Long.valueOf(ADMIN_USER_ID), audit.getTriggeredBy());
+        assertEquals("Courier delivered early", audit.getReason());
+    }
+
+    @Test
+    public void aManualTransitionWithoutAReasonIsRefused() {
+        // AC-V2.1-19 requires a reason even on a happy-path manual move, which is
+        // stricter than FR-V2.1-21's "off the happy path" wording.
+        EQACycle cycle = insertCycle();
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                    EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "   ", USER);
+            fail("a manual transition needs a reason");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("reason"));
+        }
+        assertEquals(EQACycleStatus.PLANNED,
+                eqaCycleDAO.get(cycle.getId()).orElseThrow(AssertionError::new).getStatus());
+    }
+
+    @Test
+    public void aManualTransitionWithoutAnActorIsRefused() {
+        // An unattributed manual override is worse than no audit row, because it
+        // still looks like one. AUTO rows legitimately have no actor; MANUAL never.
+        EQACycle cycle = insertCycle();
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                    EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, null, "no actor supplied", USER);
+            fail("a manual transition must name the person who made it");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("acting user"));
+        }
+        assertTrue("nothing is audited when the actor is unknown",
+                cycleService.getTransitions(cycle.getId()).isEmpty());
+    }
+
+    @Test
+    public void theTransitionGuardNamesAPermissionThatActuallyExists() throws Exception {
+        // A @PreAuthorize referencing an authority no migration creates fails
+        // closed and silently locks out every user, which looks identical to a
+        // working guard until someone tries to use the feature. This ties the
+        // annotation to the migration so the two cannot drift apart.
+        //
+        // Deliberately NOT asserted against system_module rows: five dbUnit
+        // fixtures declare that table, and loading any of them truncates it
+        // (BaseWebContextSensitiveTest wipes every table a dataset names), so a
+        // row-count assertion is a coin flip on suite order — green under
+        // -Dtest='EQA*', red in full-suite CI. The migration source plus its
+        // databasechangelog execution record survive any fixture load.
+        Method handler = EQACycleRestController.class.getMethod("transition", HttpServletRequest.class, Long.class,
+                Map.class);
+        PreAuthorize guard = handler.getAnnotation(PreAuthorize.class);
+        assertNotNull("advancing a cycle must carry a write guard, not the class-level read roles", guard);
+
+        Matcher authority = Pattern.compile("hasAuthority\\('([^']+)'\\)").matcher(guard.value());
+        assertTrue("the guard should name an authority: " + guard.value(), authority.find());
+        String permission = authority.group(1);
+
+        String changeset;
+        try (java.io.InputStream in = getClass().getClassLoader()
+                .getResourceAsStream("liquibase/qa/023-add-eqa-manage-permission.xml")) {
+            assertNotNull("the permission migration must exist on the classpath", in);
+            changeset = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        }
+        assertTrue("the guard names '" + permission + "' but qa/023 does not register it",
+                changeset.contains("<column name=\"name\" value=\"" + permission + "\"/>"));
+        assertTrue("qa/023 must also grant '" + permission + "' to at least one role",
+                changeset.contains("m.name = '" + permission + "'"));
+
+        assertEquals("qa/023's register+grant changesets must have executed against this schema", Integer.valueOf(2),
+                jdbc.queryForObject("SELECT count(*) FROM databasechangelog WHERE id IN"
+                        + " ('qa-035-add-qa-manage-eqa-module', 'qa-036-grant-qa-manage-eqa')"
+                        + " AND exectype IN ('EXECUTED', 'RERAN')", Integer.class));
+    }
+
+    // ---- FR-V2.1-18: the derivation table ----
+
+    @Test
+    public void participantStateIsDerivedFromReceiptsAndResults() {
+        EQACycle cycle = insertCycle();
+
+        assertEquals("no receipt yet", EQACycleStatus.PLANNED,
+                cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+
+        insertReceipt(cycle);
+        assertEquals("receipt but no results", EQACycleStatus.PANEL_RECEIVED,
+                cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+
+        EQARound round = insertRound(cycle);
+        Long draftId = insertResult(cycle, round, EQASubmissionStatus.DRAFT);
+        assertEquals("a draft result means testing", EQACycleStatus.TESTING,
+                cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+
+        setResultStatus(draftId, EQASubmissionStatus.VALIDATED_PARTIAL);
+        assertEquals("all validated, none submitted", EQACycleStatus.READY_TO_SUBMIT,
+                cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+
+        setResultStatus(draftId, EQASubmissionStatus.SUBMITTED);
+        assertEquals(EQACycleStatus.SUBMITTED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+
+        setResultStatus(draftId, EQASubmissionStatus.SCORED);
+        assertEquals(EQACycleStatus.SCORED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+    }
+
+    @Test
+    public void theMostAdvancedResultWinsWhenRowsDisagree() {
+        // The FRS table's rows overlap and it never states precedence; a lab that
+        // has been scored is scored even while another analyte sits in draft.
+        EQACycle cycle = insertCycle();
+        insertReceipt(cycle);
+        EQARound round = insertRound(cycle);
+        insertResultForAnalyte(cycle, round, EQASubmissionStatus.DRAFT, ANALYTE_HIV_VL);
+        insertResultForAnalyte(cycle, round, EQASubmissionStatus.SCORED, 9801L);
+
+        assertEquals(EQACycleStatus.SCORED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+    }
+
+    @Test
+    public void oneLabsProgressDoesNotLeakIntoAnother() {
+        EQACycle cycle = insertCycle();
+        insertReceipt(cycle);
+
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+        assertEquals("the second lab has not received anything", EQACycleStatus.PLANNED,
+                cycleService.deriveParticipantState(cycle.getId(), OTHER_ENROLLMENT_ID));
+    }
+
+    @Test
+    public void aClosedCycleReadsClosedForEveryLab() {
+        EQACycle cycle = insertCycle();
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
+        assertEquals(EQACycleStatus.CLOSED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
+    }
+
+    // ---- helpers ----
+
+    private void seedEnrollment(long id, String name) {
+        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
+                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
+                + " VALUES (?, ?, 'NHLS', true, now(), ?, now())", id, name, USER);
+    }
+
+    private EQACycle insertCycle() {
+        EQAProgram scheme = new EQAProgram();
+        scheme.setName("Machine scheme " + System.nanoTime());
+        scheme.setSchemeType(EQASchemeType.INTERNATIONAL_PT);
+        scheme.setProvider("NHLS");
+        scheme.setSysUserId(USER);
+        scheme.setId(eqaProgramService.insert(scheme));
+
+        EQACycle cycle = new EQACycle();
+        cycle.setScheme(scheme);
+        cycle.setCycleNumber(1);
+        cycle.setCreatedBy(systemUserService.get(String.valueOf(ADMIN_USER_ID)));
+        cycle.setSysUserId(USER);
+        return eqaCycleDAO.get(eqaCycleDAO.insert(cycle)).orElseThrow(AssertionError::new);
+    }
+
+    private void insertPanel(EQACycle cycle, boolean homogeneityPassed) {
+        EQAPanel panel = new EQAPanel();
+        panel.setScheme(cycle.getScheme());
+        panel.setCycle(cycle);
+        panel.setPanelName("Panel for cycle " + cycle.getId());
+        panel.setHomogeneityQcPassed(homogeneityPassed);
+        panel.setSysUserId(USER);
+        eqaPanelDAO.insert(panel);
+    }
+
+    private EQARound insertRound(EQACycle cycle) {
+        EQARound round = new EQARound();
+        round.setCycle(cycle);
+        round.setRoundNumber(1);
+        round.setSysUserId(USER);
+        return eqaRoundDAO.get(eqaRoundDAO.insert(round)).orElseThrow(AssertionError::new);
+    }
+
+    private void insertReceipt(EQACycle cycle) {
+        EQAPanelReceipt receipt = new EQAPanelReceipt();
+        receipt.setCycle(cycle);
+        receipt.setLabEnrollmentId(ENROLLMENT_ID);
+        receipt.setReceivedDate(Date.valueOf("2026-08-14"));
+        receipt.setReceivedBy(ADMIN_USER_ID);
+        receipt.setSysUserId(USER);
+        eqaPanelReceiptDAO.insert(receipt);
+    }
+
+    private Long insertResult(EQACycle cycle, EQARound round, EQASubmissionStatus status) {
+        return insertResultForAnalyte(cycle, round, status, ANALYTE_HIV_VL);
+    }
+
+    private Long insertResultForAnalyte(EQACycle cycle, EQARound round, EQASubmissionStatus status, long analyteId) {
+        EQAParticipantResult result = new EQAParticipantResult();
+        result.setCycle(cycle);
+        result.setRound(round);
+        result.setLabEnrollmentId(ENROLLMENT_ID);
+        result.setAnalyteId(analyteId);
+        result.setSubmissionStatus(status);
+        result.setSysUserId(USER);
+        return eqaParticipantResultDAO.insert(result);
+    }
+
+    private void setResultStatus(Long resultId, EQASubmissionStatus status) {
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET submission_status = ? WHERE id = ?", status.name(),
+                resultId);
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelSpineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelSpineIntegrationTest.java
@@ -7,19 +7,12 @@ import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.sql.Date;
-import javax.sql.DataSource;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.openelisglobal.BaseWebContextSensitiveTest;
 import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
-import org.openelisglobal.eqa.dao.EQACycleDAO;
-import org.openelisglobal.eqa.dao.EQAPanelDAO;
-import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
 import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
-import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
 import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
 import org.openelisglobal.eqa.valueholder.EQACycle;
@@ -33,9 +26,7 @@ import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQAStorageTemp;
-import org.openelisglobal.systemuser.service.SystemUserService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * OGC-609 [EQA V2.1 / T-09] — panels, sealed samples, receipts, follow-ups and
@@ -53,22 +44,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * largest whose ciphertext (236 chars) still fits VARCHAR(255); 144 bytes
  * yields 256 chars and overflows it.
  */
-public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
+public class EQAPanelSpineIntegrationTest extends EQASpineTestBase {
 
-    private static final String USER = "1";
-    private static final long ADMIN_USER_ID = 1L;
     private static final long ENROLLMENT_ID = 9903L;
     private static final long ANALYTE_HIV_VL = 9802L;
     private static final long ORG_ID = 9904L;
-
-    @Autowired
-    private EQAProgramService eqaProgramService;
-
-    @Autowired
-    private EQACycleDAO eqaCycleDAO;
-
-    @Autowired
-    private EQAPanelDAO eqaPanelDAO;
 
     @Autowired
     private EQAPanelSampleDAO eqaPanelSampleDAO;
@@ -77,55 +57,23 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
     private EQASchemeAnalystDAO eqaSchemeAnalystDAO;
 
     @Autowired
-    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
-
-    @Autowired
     private EQAParticipantFollowupDAO eqaParticipantFollowupDAO;
 
     @Autowired
     private EQAAnalystCompetencyEventDAO eqaAnalystCompetencyEventDAO;
 
-    @Autowired
-    private SystemUserService systemUserService;
-
-    @Autowired
-    private DataSource dataSource;
-
-    private JdbcTemplate jdbc;
-
     @Before
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        jdbc = new JdbcTemplate(dataSource);
-        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
-        clean();
-        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
-                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
-                + " VALUES (?, 'Panel spine enrollment', 'NHLS', true, now(), ?, now())", ENROLLMENT_ID, USER);
+        seedEnrollment(ENROLLMENT_ID, "Panel spine enrollment");
         jdbc.update("INSERT INTO clinlims.organization (id, name, lastupdated)"
                 + " VALUES (?, 'Panel spine participant', now())", ORG_ID);
     }
 
-    @After
-    public void tearDown() {
-        clean();
-    }
-
-    private void clean() {
-        jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
-        jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
-        jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
-        jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
-        jdbc.update("DELETE FROM clinlims.eqa_panel");
-        jdbc.update("DELETE FROM clinlims.eqa_scheme_analyst");
-        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
-        jdbc.update("DELETE FROM clinlims.eqa_round");
-        jdbc.update("DELETE FROM clinlims.eqa_cycle");
-        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id = ?", ENROLLMENT_ID);
-        jdbc.update("DELETE FROM clinlims.eqa_program_test");
-        jdbc.update("DELETE FROM clinlims.eqa_program");
+    @Override
+    protected void cleanEqaTables() {
+        super.cleanEqaTables();
         jdbc.update("DELETE FROM clinlims.organization WHERE id = ?", ORG_ID);
     }
 
@@ -133,7 +81,7 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void panelAndSealedSampleRoundTripWithExactValues() {
-        EQAPanel panel = insertPanel(insertScheme("Panel round-trip", EQASchemeType.INTER_LAB_SPLIT), p -> {
+        EQAPanel panel = insertPanel(insertScheme("Panel round-trip", EQASchemeType.INTER_LAB_SPLIT, "NHLS"), p -> {
             p.setPanelName("2026 R1 panel");
             p.setStatus(EQAPanelStatus.SEALED);
             p.setSourceType(EQAPanelSourceType.VENDOR_SOURCED);
@@ -194,7 +142,7 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void inventoryInvariantIsEnforcedByTheDatabase() {
-        EQAProgram scheme = insertScheme("Inventory", EQASchemeType.INTER_LAB_SPLIT);
+        EQAProgram scheme = insertScheme("Inventory", EQASchemeType.INTER_LAB_SPLIT, "NHLS");
         try {
             insertPanel(scheme, p -> {
                 p.setPanelName("Oversold panel");
@@ -204,13 +152,13 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
             });
             fail("produced must be >= reserved + shipped (FR-V2.1-17)");
         } catch (Exception expected) {
-            assertConstraint(expected, "eqa_panel_aliquots_chk");
+            assertConstraintViolation(expected, "eqa_panel_aliquots_chk");
         }
     }
 
     @Test
     public void unknownPanelStatusIsRejectedByTheDatabase() {
-        EQAProgram scheme = insertScheme("Bad panel status", EQASchemeType.INTER_LAB_SPLIT);
+        EQAProgram scheme = insertScheme("Bad panel status", EQASchemeType.INTER_LAB_SPLIT, "NHLS");
         try {
             jdbc.update(
                     "INSERT INTO clinlims.eqa_panel (id, fhir_uuid, scheme_id, panel_name, status,"
@@ -220,7 +168,7 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
                     scheme.getId(), USER);
             fail("the panel status CHECK should reject an unknown state");
         } catch (Exception expected) {
-            assertConstraint(expected, "eqa_panel_status_chk");
+            assertConstraintViolation(expected, "eqa_panel_status_chk");
         }
     }
 
@@ -228,13 +176,13 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void anAnalystMayBeListedOncePerScheme() {
-        EQAProgram scheme = insertScheme("Analyst list", EQASchemeType.INTERNATIONAL_PT);
+        EQAProgram scheme = insertScheme("Analyst list", EQASchemeType.INTERNATIONAL_PT, "NHLS");
         insertAnalyst(scheme, ADMIN_USER_ID);
         try {
             insertAnalyst(scheme, ADMIN_USER_ID);
             fail("the eligible-analyst list is a set, not a bag");
         } catch (Exception expected) {
-            assertConstraint(expected, "uq_eqa_scheme_analyst_scheme_user");
+            assertConstraintViolation(expected, "uq_eqa_scheme_analyst_scheme_user");
         }
     }
 
@@ -242,21 +190,22 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void oneReceiptPerCyclePerLab() {
-        EQACycle cycle = insertCycle(insertScheme("Receipts", EQASchemeType.INTERNATIONAL_PT));
-        insertReceipt(cycle);
+        EQACycle cycle = readBack(insertCycle(insertScheme("Receipts", EQASchemeType.INTERNATIONAL_PT, "NHLS"), 1));
+        insertReceipt(cycle, ENROLLMENT_ID);
         try {
-            insertReceipt(cycle);
+            insertReceipt(cycle, ENROLLMENT_ID);
             fail("a lab confirms receipt of a cycle's panel exactly once");
         } catch (Exception expected) {
-            assertConstraint(expected, "uq_eqa_panel_receipt_cycle_enrollment");
+            assertConstraintViolation(expected, "uq_eqa_panel_receipt_cycle_enrollment");
         }
     }
 
     @Test
     public void receiptWithoutAShipmentIsAllowed() {
         // Walk-in pickup and legacy imports have no tracked shipment.
-        EQACycle cycle = insertCycle(insertScheme("Walk-in", EQASchemeType.INTERNATIONAL_PT));
-        EQAPanelReceipt receipt = eqaPanelReceiptDAO.get(insertReceipt(cycle)).orElseThrow(AssertionError::new);
+        EQACycle cycle = readBack(insertCycle(insertScheme("Walk-in", EQASchemeType.INTERNATIONAL_PT, "NHLS"), 1));
+        EQAPanelReceipt receipt = eqaPanelReceiptDAO.get(insertReceipt(cycle, ENROLLMENT_ID))
+                .orElseThrow(AssertionError::new);
         assertEquals(null, receipt.getShipmentId());
         assertTrue("integrity defaults to ok", receipt.getIntegrityOk());
     }
@@ -265,13 +214,13 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void oneOpenFollowupPerCyclePerOrganisation() {
-        EQACycle cycle = insertCycle(insertScheme("Follow-ups", EQASchemeType.INTERNATIONAL_PT));
+        EQACycle cycle = readBack(insertCycle(insertScheme("Follow-ups", EQASchemeType.INTERNATIONAL_PT, "NHLS"), 1));
         insertFollowup(cycle);
         try {
             insertFollowup(cycle);
             fail("AC-V2.1-09: duplicate follow-up must be refused");
         } catch (Exception expected) {
-            assertConstraint(expected, "uq_eqa_participant_followup_cycle_org");
+            assertConstraintViolation(expected, "uq_eqa_participant_followup_cycle_org");
         }
     }
 
@@ -279,7 +228,7 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void competencyEventPersistsWithItsVocabulary() {
-        EQAProgram scheme = insertScheme("Competency", EQASchemeType.INTERNATIONAL_PT);
+        EQAProgram scheme = insertScheme("Competency", EQASchemeType.INTERNATIONAL_PT, "NHLS");
 
         EQAAnalystCompetencyEvent event = new EQAAnalystCompetencyEvent();
         event.setAnalystId(ADMIN_USER_ID);
@@ -298,7 +247,7 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void unknownCompetencyEventTypeIsRejectedByTheDatabase() {
-        EQAProgram scheme = insertScheme("Bad event", EQASchemeType.INTERNATIONAL_PT);
+        EQAProgram scheme = insertScheme("Bad event", EQASchemeType.INTERNATIONAL_PT, "NHLS");
         try {
             jdbc.update(
                     "INSERT INTO clinlims.eqa_analyst_competency_event (id, analyst_id, event_type, event_date,"
@@ -307,40 +256,11 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
                     ADMIN_USER_ID, scheme.getId(), USER);
             fail("AC-V2.1-22: an undefined event_type must be refused");
         } catch (Exception expected) {
-            assertConstraint(expected, "eqa_competency_event_type_chk");
+            assertConstraintViolation(expected, "eqa_competency_event_type_chk");
         }
     }
 
     // ---- helpers ----
-
-    private EQAProgram insertScheme(String name, EQASchemeType type) {
-        EQAProgram scheme = new EQAProgram();
-        scheme.setName(name);
-        scheme.setSchemeType(type);
-        scheme.setProvider(type == EQASchemeType.IN_HOUSE ? null : "NHLS");
-        scheme.setSysUserId(USER);
-        scheme.setId(eqaProgramService.insert(scheme));
-        return scheme;
-    }
-
-    private EQACycle insertCycle(EQAProgram scheme) {
-        EQACycle cycle = new EQACycle();
-        cycle.setScheme(scheme);
-        cycle.setCycleNumber(1);
-        cycle.setCreatedBy(systemUserService.get(String.valueOf(ADMIN_USER_ID)));
-        cycle.setSysUserId(USER);
-        return eqaCycleDAO.get(eqaCycleDAO.insert(cycle)).orElseThrow(AssertionError::new);
-    }
-
-    private EQAPanel insertPanel(EQAProgram scheme, java.util.function.Consumer<EQAPanel> customise) {
-        EQAPanel panel = new EQAPanel();
-        panel.setScheme(scheme);
-        panel.setPanelName("Panel");
-        panel.setSysUserId(USER);
-        customise.accept(panel);
-        panel.setId(eqaPanelDAO.insert(panel));
-        return panel;
-    }
 
     private void insertAnalyst(EQAProgram scheme, long userId) {
         EQASchemeAnalyst analyst = new EQASchemeAnalyst();
@@ -350,16 +270,6 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
         eqaSchemeAnalystDAO.insert(analyst);
     }
 
-    private Long insertReceipt(EQACycle cycle) {
-        EQAPanelReceipt receipt = new EQAPanelReceipt();
-        receipt.setCycle(cycle);
-        receipt.setLabEnrollmentId(ENROLLMENT_ID);
-        receipt.setReceivedDate(Date.valueOf("2026-08-14"));
-        receipt.setReceivedBy(ADMIN_USER_ID);
-        receipt.setSysUserId(USER);
-        return eqaPanelReceiptDAO.insert(receipt);
-    }
-
     private void insertFollowup(EQACycle cycle) {
         EQAParticipantFollowup followup = new EQAParticipantFollowup();
         followup.setScheme(cycle.getScheme());
@@ -367,13 +277,5 @@ public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
         followup.setParticipantOrgId(ORG_ID);
         followup.setSysUserId(USER);
         eqaParticipantFollowupDAO.insert(followup);
-    }
-
-    private void assertConstraint(Exception e, String constraintName) {
-        StringBuilder messages = new StringBuilder();
-        for (Throwable t = e; t != null; t = t.getCause()) {
-            messages.append(t.getMessage()).append(' ');
-        }
-        assertTrue("expected " + constraintName + ", got: " + messages, messages.toString().contains(constraintName));
     }
 }

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelSpineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelSpineIntegrationTest.java
@@ -1,0 +1,379 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
+import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.service.EQAProgramService;
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelSourceType;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAStorageTemp;
+import org.openelisglobal.systemuser.service.SystemUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * OGC-609 [EQA V2.1 / T-09] — panels, sealed samples, receipts, follow-ups and
+ * competency events against a real DB (qa/017 + qa/018).
+ *
+ * <p>
+ * One deliberate gap, worth stating so nobody reads more assurance into this
+ * class than it offers: the {@code test} Spring profile replaces
+ * {@code TextEncryptor} with a pass-through mock, so
+ * {@code eqa_panel_sample.target_value} is stored as plaintext here. These
+ * tests therefore prove the converter is *wired* and the column is *wide
+ * enough*, but only the live stack can prove the value is actually ciphertext
+ * at rest. That check belongs to UAT, and the column width below is what makes
+ * it survivable: measured against jasypt 1.9.3, a 143-byte plaintext is the
+ * largest whose ciphertext (236 chars) still fits VARCHAR(255); 144 bytes
+ * yields 256 chars and overflows it.
+ */
+public class EQAPanelSpineIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final String USER = "1";
+    private static final long ADMIN_USER_ID = 1L;
+    private static final long ENROLLMENT_ID = 9903L;
+    private static final long ANALYTE_HIV_VL = 9802L;
+    private static final long ORG_ID = 9904L;
+
+    @Autowired
+    private EQAProgramService eqaProgramService;
+
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
+
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    @Autowired
+    private EQASchemeAnalystDAO eqaSchemeAnalystDAO;
+
+    @Autowired
+    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
+
+    @Autowired
+    private EQAParticipantFollowupDAO eqaParticipantFollowupDAO;
+
+    @Autowired
+    private EQAAnalystCompetencyEventDAO eqaAnalystCompetencyEventDAO;
+
+    @Autowired
+    private SystemUserService systemUserService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private JdbcTemplate jdbc;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        jdbc = new JdbcTemplate(dataSource);
+        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
+        clean();
+        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
+                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
+                + " VALUES (?, 'Panel spine enrollment', 'NHLS', true, now(), ?, now())", ENROLLMENT_ID, USER);
+        jdbc.update("INSERT INTO clinlims.organization (id, name, lastupdated)"
+                + " VALUES (?, 'Panel spine participant', now())", ORG_ID);
+    }
+
+    @After
+    public void tearDown() {
+        clean();
+    }
+
+    private void clean() {
+        jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
+        jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
+        jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
+        jdbc.update("DELETE FROM clinlims.eqa_panel");
+        jdbc.update("DELETE FROM clinlims.eqa_scheme_analyst");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
+        jdbc.update("DELETE FROM clinlims.eqa_round");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle");
+        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id = ?", ENROLLMENT_ID);
+        jdbc.update("DELETE FROM clinlims.eqa_program_test");
+        jdbc.update("DELETE FROM clinlims.eqa_program");
+        jdbc.update("DELETE FROM clinlims.organization WHERE id = ?", ORG_ID);
+    }
+
+    // ---- FR-V2.1-11/12/17 ----
+
+    @Test
+    public void panelAndSealedSampleRoundTripWithExactValues() {
+        EQAPanel panel = insertPanel(insertScheme("Panel round-trip", EQASchemeType.INTER_LAB_SPLIT), p -> {
+            p.setPanelName("2026 R1 panel");
+            p.setStatus(EQAPanelStatus.SEALED);
+            p.setSourceType(EQAPanelSourceType.VENDOR_SOURCED);
+            p.setVendorName("Acme Controls");
+            p.setVendorLot("LOT-77");
+            p.setStorageTemp(EQAStorageTemp.FROZEN_MINUS_20C);
+            p.setExpirationDate(Date.valueOf("2027-01-31"));
+            p.setAliquotsProduced(100);
+            p.setAliquotsReserved(10);
+            p.setAliquotsShipped(80);
+            p.setHomogeneityQcPassed(true);
+            p.setHomogeneityQcNotes("Checked across 10 vials");
+        });
+
+        EQAPanel read = eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new);
+        assertEquals("2026 R1 panel", read.getPanelName());
+        assertEquals(EQAPanelStatus.SEALED, read.getStatus());
+        assertEquals(EQAPanelSourceType.VENDOR_SOURCED, read.getSourceType());
+        assertEquals(EQAStorageTemp.FROZEN_MINUS_20C, read.getStorageTemp());
+        assertEquals("Acme Controls", read.getVendorName());
+        assertEquals(Date.valueOf("2027-01-31"), read.getExpirationDate());
+        assertEquals(Integer.valueOf(100), read.getAliquotsProduced());
+        assertTrue(read.getHomogeneityQcPassed());
+        assertNotNull("fhirUuid is assigned on persist", read.getFhirUuid());
+
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(read);
+        sample.setSampleCode("SAMPLE-A01");
+        sample.setBlindCode("BLIND-77");
+        sample.setAnalyteId(ANALYTE_HIV_VL);
+        sample.setTargetValue("4.52");
+        sample.setTargetUnit("log10 c/mL");
+        sample.setAcceptanceRangeLow(new BigDecimal("4.00000"));
+        sample.setAcceptanceRangeHigh(new BigDecimal("5.00000"));
+        sample.setSysUserId(USER);
+        Long sampleId = eqaPanelSampleDAO.insert(sample);
+
+        EQAPanelSample readSample = eqaPanelSampleDAO.get(sampleId).orElseThrow(AssertionError::new);
+        assertEquals("SAMPLE-A01", readSample.getSampleCode());
+        assertEquals("BLIND-77", readSample.getBlindCode());
+        // The converter is wired: the value survives a write/read cycle. Whether
+        // the bytes at rest are ciphertext is a live-stack check (see class doc).
+        assertEquals("4.52", readSample.getTargetValue());
+        assertEquals(0, new BigDecimal("4.00000").compareTo(readSample.getAcceptanceRangeLow()));
+    }
+
+    @Test
+    public void targetValueColumnIsWideEnoughForCiphertext() {
+        // jasypt AES256 expands plaintext to 4*ceil((32+16*(floor(bytes/16)+1))/3)
+        // characters, so VARCHAR(255) would silently cap plaintext at 143 bytes.
+        // This is the guard that a later "tidy up to 255" cannot pass.
+        Integer length = jdbc.queryForObject(
+                "SELECT character_maximum_length FROM information_schema.columns WHERE table_schema = 'clinlims'"
+                        + " AND table_name = 'eqa_panel_sample' AND column_name = 'target_value'",
+                Integer.class);
+        assertEquals(Integer.valueOf(512), length);
+    }
+
+    @Test
+    public void inventoryInvariantIsEnforcedByTheDatabase() {
+        EQAProgram scheme = insertScheme("Inventory", EQASchemeType.INTER_LAB_SPLIT);
+        try {
+            insertPanel(scheme, p -> {
+                p.setPanelName("Oversold panel");
+                p.setAliquotsProduced(10);
+                p.setAliquotsReserved(5);
+                p.setAliquotsShipped(6);
+            });
+            fail("produced must be >= reserved + shipped (FR-V2.1-17)");
+        } catch (Exception expected) {
+            assertConstraint(expected, "eqa_panel_aliquots_chk");
+        }
+    }
+
+    @Test
+    public void unknownPanelStatusIsRejectedByTheDatabase() {
+        EQAProgram scheme = insertScheme("Bad panel status", EQASchemeType.INTER_LAB_SPLIT);
+        try {
+            jdbc.update(
+                    "INSERT INTO clinlims.eqa_panel (id, fhir_uuid, scheme_id, panel_name, status,"
+                            + " aliquots_produced, aliquots_reserved, aliquots_shipped, homogeneity_qc_passed,"
+                            + " sys_user_id, last_updated)"
+                            + " VALUES (9981, gen_random_uuid(), ?, 'Bogus', 'ARCHIVED', 0, 0, 0, false, ?, now())",
+                    scheme.getId(), USER);
+            fail("the panel status CHECK should reject an unknown state");
+        } catch (Exception expected) {
+            assertConstraint(expected, "eqa_panel_status_chk");
+        }
+    }
+
+    // ---- FR-V2.1-08 ----
+
+    @Test
+    public void anAnalystMayBeListedOncePerScheme() {
+        EQAProgram scheme = insertScheme("Analyst list", EQASchemeType.INTERNATIONAL_PT);
+        insertAnalyst(scheme, ADMIN_USER_ID);
+        try {
+            insertAnalyst(scheme, ADMIN_USER_ID);
+            fail("the eligible-analyst list is a set, not a bag");
+        } catch (Exception expected) {
+            assertConstraint(expected, "uq_eqa_scheme_analyst_scheme_user");
+        }
+    }
+
+    // ---- FR-V2.1-20 ----
+
+    @Test
+    public void oneReceiptPerCyclePerLab() {
+        EQACycle cycle = insertCycle(insertScheme("Receipts", EQASchemeType.INTERNATIONAL_PT));
+        insertReceipt(cycle);
+        try {
+            insertReceipt(cycle);
+            fail("a lab confirms receipt of a cycle's panel exactly once");
+        } catch (Exception expected) {
+            assertConstraint(expected, "uq_eqa_panel_receipt_cycle_enrollment");
+        }
+    }
+
+    @Test
+    public void receiptWithoutAShipmentIsAllowed() {
+        // Walk-in pickup and legacy imports have no tracked shipment.
+        EQACycle cycle = insertCycle(insertScheme("Walk-in", EQASchemeType.INTERNATIONAL_PT));
+        EQAPanelReceipt receipt = eqaPanelReceiptDAO.get(insertReceipt(cycle)).orElseThrow(AssertionError::new);
+        assertEquals(null, receipt.getShipmentId());
+        assertTrue("integrity defaults to ok", receipt.getIntegrityOk());
+    }
+
+    // ---- FR-V2.1-13 ----
+
+    @Test
+    public void oneOpenFollowupPerCyclePerOrganisation() {
+        EQACycle cycle = insertCycle(insertScheme("Follow-ups", EQASchemeType.INTERNATIONAL_PT));
+        insertFollowup(cycle);
+        try {
+            insertFollowup(cycle);
+            fail("AC-V2.1-09: duplicate follow-up must be refused");
+        } catch (Exception expected) {
+            assertConstraint(expected, "uq_eqa_participant_followup_cycle_org");
+        }
+    }
+
+    // ---- FR-V2.1-22 ----
+
+    @Test
+    public void competencyEventPersistsWithItsVocabulary() {
+        EQAProgram scheme = insertScheme("Competency", EQASchemeType.INTERNATIONAL_PT);
+
+        EQAAnalystCompetencyEvent event = new EQAAnalystCompetencyEvent();
+        event.setAnalystId(ADMIN_USER_ID);
+        event.setEventType(EQACompetencyEventType.EXTERNAL_MISSED_DEADLINE);
+        event.setEventDate(Date.valueOf("2026-08-14"));
+        event.setScheme(scheme);
+        event.setNotes("Deadline passed with no validated result");
+        event.setSysUserId(USER);
+        Long id = eqaAnalystCompetencyEventDAO.insert(event);
+
+        EQAAnalystCompetencyEvent read = eqaAnalystCompetencyEventDAO.get(id).orElseThrow(AssertionError::new);
+        assertEquals(EQACompetencyEventType.EXTERNAL_MISSED_DEADLINE, read.getEventType());
+        assertEquals(Date.valueOf("2026-08-14"), read.getEventDate());
+        assertEquals(Long.valueOf(ADMIN_USER_ID), read.getAnalystId());
+    }
+
+    @Test
+    public void unknownCompetencyEventTypeIsRejectedByTheDatabase() {
+        EQAProgram scheme = insertScheme("Bad event", EQASchemeType.INTERNATIONAL_PT);
+        try {
+            jdbc.update(
+                    "INSERT INTO clinlims.eqa_analyst_competency_event (id, analyst_id, event_type, event_date,"
+                            + " scheme_id, sys_user_id, last_updated)"
+                            + " VALUES (9982, ?, 'unknown', current_date, ?, ?, now())",
+                    ADMIN_USER_ID, scheme.getId(), USER);
+            fail("AC-V2.1-22: an undefined event_type must be refused");
+        } catch (Exception expected) {
+            assertConstraint(expected, "eqa_competency_event_type_chk");
+        }
+    }
+
+    // ---- helpers ----
+
+    private EQAProgram insertScheme(String name, EQASchemeType type) {
+        EQAProgram scheme = new EQAProgram();
+        scheme.setName(name);
+        scheme.setSchemeType(type);
+        scheme.setProvider(type == EQASchemeType.IN_HOUSE ? null : "NHLS");
+        scheme.setSysUserId(USER);
+        scheme.setId(eqaProgramService.insert(scheme));
+        return scheme;
+    }
+
+    private EQACycle insertCycle(EQAProgram scheme) {
+        EQACycle cycle = new EQACycle();
+        cycle.setScheme(scheme);
+        cycle.setCycleNumber(1);
+        cycle.setCreatedBy(systemUserService.get(String.valueOf(ADMIN_USER_ID)));
+        cycle.setSysUserId(USER);
+        return eqaCycleDAO.get(eqaCycleDAO.insert(cycle)).orElseThrow(AssertionError::new);
+    }
+
+    private EQAPanel insertPanel(EQAProgram scheme, java.util.function.Consumer<EQAPanel> customise) {
+        EQAPanel panel = new EQAPanel();
+        panel.setScheme(scheme);
+        panel.setPanelName("Panel");
+        panel.setSysUserId(USER);
+        customise.accept(panel);
+        panel.setId(eqaPanelDAO.insert(panel));
+        return panel;
+    }
+
+    private void insertAnalyst(EQAProgram scheme, long userId) {
+        EQASchemeAnalyst analyst = new EQASchemeAnalyst();
+        analyst.setScheme(scheme);
+        analyst.setSystemUserId(userId);
+        analyst.setSysUserId(USER);
+        eqaSchemeAnalystDAO.insert(analyst);
+    }
+
+    private Long insertReceipt(EQACycle cycle) {
+        EQAPanelReceipt receipt = new EQAPanelReceipt();
+        receipt.setCycle(cycle);
+        receipt.setLabEnrollmentId(ENROLLMENT_ID);
+        receipt.setReceivedDate(Date.valueOf("2026-08-14"));
+        receipt.setReceivedBy(ADMIN_USER_ID);
+        receipt.setSysUserId(USER);
+        return eqaPanelReceiptDAO.insert(receipt);
+    }
+
+    private void insertFollowup(EQACycle cycle) {
+        EQAParticipantFollowup followup = new EQAParticipantFollowup();
+        followup.setScheme(cycle.getScheme());
+        followup.setCycle(cycle);
+        followup.setParticipantOrgId(ORG_ID);
+        followup.setSysUserId(USER);
+        eqaParticipantFollowupDAO.insert(followup);
+    }
+
+    private void assertConstraint(Exception e, String constraintName) {
+        StringBuilder messages = new StringBuilder();
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            messages.append(t.getMessage()).append(' ');
+        }
+        assertTrue("expected " + constraintName + ", got: " + messages, messages.toString().contains(constraintName));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
@@ -1,0 +1,193 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.Consumer;
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
+import org.openelisglobal.eqa.service.EQAProgramService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.systemuser.service.SystemUserService;
+import org.openelisglobal.systemuser.valueholder.SystemUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Shared fixture for the EQA spine integration tests (T-08/T-09/T-10). Owns the
+ * one authoritative clean-up order (children before parents) and the common
+ * inserters, so adding a table means editing one list, not one per test class.
+ *
+ * <p>
+ * The test DB is Liquibase-provisioned (BaseTestConfig runs base-changelog.xml
+ * against a testcontainers Postgres), so CHECK/FK/unique constraints are live.
+ * BaseWebContextSensitiveTest runs with transactions NOT_SUPPORTED, so each DAO
+ * call commits on its own — a read-back is a genuinely fresh session.
+ */
+public abstract class EQASpineTestBase extends BaseWebContextSensitiveTest {
+
+    protected static final String USER = "1";
+    protected static final long ADMIN_USER_ID = 1L;
+
+    @Autowired
+    protected EQAProgramService eqaProgramService;
+
+    @Autowired
+    protected EQACycleDAO eqaCycleDAO;
+
+    @Autowired
+    protected EQARoundDAO eqaRoundDAO;
+
+    @Autowired
+    protected EQAParticipantResultDAO eqaParticipantResultDAO;
+
+    @Autowired
+    protected EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    protected EQAPanelReceiptDAO eqaPanelReceiptDAO;
+
+    @Autowired
+    protected SystemUserService systemUserService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    protected JdbcTemplate jdbc;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        jdbc = new JdbcTemplate(dataSource);
+        executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
+        cleanEqaTables();
+    }
+
+    @After
+    public void cleanUpEqaTables() {
+        cleanEqaTables();
+    }
+
+    /**
+     * Children first, parents last. Subclasses append their own rows via override.
+     */
+    protected void cleanEqaTables() {
+        jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
+        jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
+        jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
+        jdbc.update("DELETE FROM clinlims.eqa_panel");
+        jdbc.update("DELETE FROM clinlims.eqa_scheme_analyst");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle_state_transition");
+        jdbc.update("DELETE FROM clinlims.eqa_round");
+        jdbc.update("DELETE FROM clinlims.eqa_cycle");
+        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE id BETWEEN 9900 AND 9999");
+        jdbc.update("DELETE FROM clinlims.eqa_program_test");
+        jdbc.update("DELETE FROM clinlims.eqa_program");
+    }
+
+    protected void seedEnrollment(long id, String name) {
+        jdbc.update("INSERT INTO clinlims.eqa_lab_program_enrollment"
+                + " (id, program_name, provider, is_active, created_date, sys_user_id, lastupdated)"
+                + " VALUES (?, ?, 'NHLS', true, now(), ?, now())", id, name, USER);
+    }
+
+    protected EQAProgram insertScheme(String name, EQASchemeType type, String provider) {
+        EQAProgram scheme = new EQAProgram();
+        scheme.setName(name);
+        scheme.setSchemeType(type);
+        scheme.setProvider(provider);
+        scheme.setSysUserId(USER);
+        scheme.setId(eqaProgramService.insert(scheme));
+        return scheme;
+    }
+
+    protected Long insertCycle(EQAProgram scheme, int cycleNumber) {
+        EQACycle cycle = new EQACycle();
+        cycle.setScheme(scheme);
+        cycle.setCycleNumber(cycleNumber);
+        cycle.setCreatedBy(systemUser(ADMIN_USER_ID));
+        cycle.setSysUserId(USER);
+        return eqaCycleDAO.insert(cycle);
+    }
+
+    protected EQACycle readBack(Long cycleId) {
+        return eqaCycleDAO.get(cycleId).orElseThrow(AssertionError::new);
+    }
+
+    protected Long insertRound(EQACycle cycle, int roundNumber, String status) {
+        EQARound round = new EQARound();
+        round.setCycle(cycle);
+        round.setRoundNumber(roundNumber);
+        round.setStatus(status);
+        round.setSysUserId(USER);
+        return eqaRoundDAO.insert(round);
+    }
+
+    protected Long insertParticipantResult(EQACycle cycle, EQARound round, long enrollmentId, long analyteId,
+            EQASubmissionStatus status, String value) {
+        EQAParticipantResult result = new EQAParticipantResult();
+        result.setCycle(cycle);
+        result.setRound(round);
+        result.setLabEnrollmentId(enrollmentId);
+        result.setAnalyteId(analyteId);
+        if (status != null) {
+            result.setSubmissionStatus(status);
+        }
+        result.setResultValue(value);
+        result.setSysUserId(USER);
+        return eqaParticipantResultDAO.insert(result);
+    }
+
+    protected EQAPanel insertPanel(EQAProgram scheme, Consumer<EQAPanel> customise) {
+        EQAPanel panel = new EQAPanel();
+        panel.setScheme(scheme);
+        panel.setPanelName("Panel");
+        panel.setSysUserId(USER);
+        customise.accept(panel);
+        panel.setId(eqaPanelDAO.insert(panel));
+        return panel;
+    }
+
+    protected Long insertReceipt(EQACycle cycle, long enrollmentId) {
+        EQAPanelReceipt receipt = new EQAPanelReceipt();
+        receipt.setCycle(cycle);
+        receipt.setLabEnrollmentId(enrollmentId);
+        receipt.setReceivedDate(java.sql.Date.valueOf("2026-08-14"));
+        receipt.setReceivedBy(ADMIN_USER_ID);
+        receipt.setSysUserId(USER);
+        return eqaPanelReceiptDAO.insert(receipt);
+    }
+
+    protected SystemUser systemUser(long id) {
+        return systemUserService.get(String.valueOf(id));
+    }
+
+    protected void assertConstraintViolation(Exception e, String constraintName) {
+        assertTrue("expected " + constraintName + " to be the failing constraint, got: " + rootMessage(e),
+                rootMessage(e).contains(constraintName));
+    }
+
+    protected String rootMessage(Throwable t) {
+        StringBuilder messages = new StringBuilder();
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            messages.append(current.getMessage()).append(' ');
+        }
+        return messages.toString();
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQACycleRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQACycleRestControllerTest.java
@@ -1,0 +1,108 @@
+package org.openelisglobal.eqa.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.openelisglobal.login.valueholder.UserSessionData;
+
+/**
+ * OGC-609 [EQA V2.1 / T-10] — the transition endpoint must not let a caller
+ * describe its own audit record.
+ *
+ * <p>
+ * A cycle-state audit row is what an ISO 15189 assessor reads to tell a
+ * deliberate QA-officer override from an automatic timer expiry. If the request
+ * body can name the actor, the trigger type or the trigger event, then that
+ * distinction is whatever the caller says it is — and because AUTO rows are
+ * exempt from the reason requirement, claiming automation also erases the
+ * explanation. These tests pin the provenance to the session.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EQACycleRestControllerTest {
+
+    private static final long SESSION_USER_ID = 1L;
+
+    @Mock
+    private EQACycleService cycleService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpSession session;
+
+    @InjectMocks
+    private EQACycleRestController controller;
+
+    @Before
+    public void setUp() {
+        UserSessionData usd = new UserSessionData();
+        usd.setSytemUserId((int) SESSION_USER_ID);
+        when(request.getSession()).thenReturn(session);
+        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
+        when(cycleService.transition(anyLong(), any(), any(), any(), any(), any(), any(), anyString()))
+                .thenReturn(new EQACycle());
+    }
+
+    @Test
+    public void theClaimedActorIsIgnoredInFavourOfTheSessionUser() {
+        controller.transition(request, 7L,
+                Map.of("newState", "PANEL_RECEIVED", "reason", "panel arrived", "triggeredBy", 424242));
+
+        ArgumentCaptor<Long> actor = ArgumentCaptor.forClass(Long.class);
+        verify(cycleService).transition(eq(7L), eq(EQACycleStatus.PANEL_RECEIVED), any(), any(), any(), actor.capture(),
+                anyString(), anyString());
+        assertEquals("the audit actor comes from the session, never the body", Long.valueOf(SESSION_USER_ID),
+                actor.getValue());
+    }
+
+    @Test
+    public void anHttpCallIsAlwaysRecordedAsAManualOverride() {
+        // Claiming AUTO would both strip the actor and skip the reason rule.
+        controller.transition(request, 7L, Map.of("newState", "PANEL_RECEIVED", "reason", "panel arrived",
+                "triggerType", "AUTO", "triggerEvent", "DEADLINE_TIMER"));
+
+        verify(cycleService).transition(eq(7L), eq(EQACycleStatus.PANEL_RECEIVED), any(), eq(EQATriggerType.MANUAL),
+                eq(EQATriggerEvent.MANUAL_OVERRIDE), any(), anyString(), anyString());
+    }
+
+    @Test
+    public void theStateMachineLaneIsStillCallerSupplied() {
+        // This one is a legitimate parameter, not a provenance claim: a single lab
+        // participates in some schemes and runs others. Authorisation for provider
+        // transitions belongs to the permission tiers in T-12.
+        controller.transition(request, 7L,
+                Map.of("newState", "PREP_IN_PROGRESS", "reason", "prep started", "stateMachine", "PROVIDER"));
+
+        verify(cycleService).transition(eq(7L), eq(EQACycleStatus.PREP_IN_PROGRESS), eq(EQAStateMachine.PROVIDER),
+                any(), any(), any(), anyString(), anyString());
+    }
+
+    @Test
+    public void newStateIsRequired() {
+        assertEquals(400, controller.transition(request, 7L, Map.of("reason", "no state")).getStatusCode().value());
+    }
+}

--- a/src/test/resources/persistence/test-persistence.xml
+++ b/src/test/resources/persistence/test-persistence.xml
@@ -183,6 +183,14 @@
         <class>org.openelisglobal.eqa.valueholder.EQACycleStateTransition</class>
         <class>org.openelisglobal.eqa.valueholder.EQAParticipantResult</class>
 
+        <!-- EQA V2 panels, receipts, follow-ups, competency (OGC-609) -->
+        <class>org.openelisglobal.eqa.valueholder.EQAPanel</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAPanelSample</class>
+        <class>org.openelisglobal.eqa.valueholder.EQASchemeAnalyst</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAParticipantFollowup</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAPanelReceipt</class>
+        <class>org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent</class>
+
         <class>org.openelisglobal.externalconnections.valueholder.ExternalConnectionContact</class>
         <class>org.openelisglobal.externalconnections.valueholder.ExternalConnection</class>
         <class>org.openelisglobal.externalconnections.valueholder.BasicAuthenticationData</class>


### PR DESCRIPTION
## What

The second half of the EQA V2.1 foundation, as **two commits meant to be reviewed separately** — combined on one branch because T-10's derived participant state reads `eqa_panel_receipt`, which T-09 creates; split, T-10 would ship a derivation unable to tell `planned` from `panel_received`.

**Commit 1 — T-09** (`qa/017` + `qa/018`): six tables with entities and DAOs — `eqa_panel` (with FR-17's source/inventory columns and the aliquot invariant as a DB CHECK), `eqa_panel_sample` (sealed targets, encrypted at rest via the existing `EncryptionConverter`), `eqa_scheme_analyst`, `eqa_participant_followup`, `eqa_panel_receipt`, `eqa_analyst_competency_event`.

**Commit 2 — T-10**: both cycle state machines as static edge tables; `transition()` writes status + exactly one audit row in a single `@Transactional` method; the derived per-lab participant state (never stored, per FR-V2.1-18); `EQACycleRestController`; and the `qa.manage.eqa` write permission (`qa/023`).

## Decisions a reviewer should weigh

**FRS corrections against code truth.** Three FK targets named in the FRS don't exist: `lab_enrollment` → `eqa_lab_program_enrollment`; `sample_shipment` → `shipment` (PK `INTEGER`, so that FK column deviates from the spine's `numeric(10,0)`); `nce` → `nc_event` (also `INTEGER`). There is no analyst table anywhere in OpenELIS — analysts are `system_user` rows. Storage temps `frozen_-20C`/`ultra_frozen_-80C` can't be Java identifiers and are stored `FROZEN_MINUS_20C`/`ULTRA_FROZEN_MINUS_80C`.

**`target_value` is `VARCHAR(512)`, measured not guessed:** against the real jasypt 1.9.3 jar, a 143-byte plaintext is the largest whose ciphertext (236 chars) fits 255; 144 bytes yields 256 and overflows. The ciphertext is salted per write, so the column is never indexed and must never be seeded with plaintext (decrypt throws).

**Two FRS conflicts resolved:** a reason is required for *every* manual transition (FR-V2.1-21 says off-happy-path only; AC-V2.1-19 demands one on the happy path — this satisfies both); illegal edge → **409**, legal edge missing its reason → **422**.

**Audit provenance is server-derived.** The request body cannot set `triggeredBy`/`triggerType`/`triggerEvent` — an HTTP call is always recorded as a `MANUAL` override by the session user. Otherwise a caller could attribute their decision to someone else, or claim `AUTO` and thereby drop both the actor and the reason — destroying exactly the manual-vs-automatic distinction FR-V2.1-21 exists to give an assessor. The audit API is read-only by construction (no PUT/DELETE mapping → 405).

**The prep gate** (FR-V2.1-18 / AC-V2.1-13) refuses `prep_in_progress → ready_to_ship` while any panel has `homogeneity_qc_passed = false`, and refuses a cycle with no panel at all — the empty-set check is an implementation decision (the FRS predicate is vacuously true on no panels). The paired aliquot gate is deliberately absent: participants are recorded per **scheme** (`eqa_program_enrollment`), not per cycle — the distribution wizard collects a roster but nothing persists it — so a true per-cycle count lands with the V2.5 prep workbench.

**Manual transitions are gated on `qa.manage.eqa`** (registered + granted in `qa/023`; the FRS names `eqa.manage`, which doesn't exist — house shape is `qa.<verb>.<area>`). A test reads the `@PreAuthorize` by reflection and asserts the named authority is registered and granted, so a phantom permission can't fail closed unnoticed.

## Verification

37 new tests; **256 EQA tests green** on the rebased branch. The test DB is Liquibase-provisioned, so CHECK/FK/unique constraints are asserted in tests, not deferred. Non-trivial guards are inversion-tested (gate removed → tests fail; provenance forged → tests fail; phantom permission → test fails).

Live UAT on the dev stack: all 8 changesets apply; every CHECK/FK/unique rejects its bad case; 409/422/405 verified over HTTP; the forged-provenance request writes `type=MANUAL actor=<session user>`; the prep gate returns 409 with the cycle unmoved; `rollbackCount 8` restores the pre-T-09 schema exactly and re-applies cleanly.

This work was reviewed by a 5-lens adversarial workflow (2 confirmed findings, both fixed and inversion-tested) and a subsequent empirical fact-check sweep; corrections it produced are folded into the code and commit messages.

## Known limitations, stated rather than implied

- **Ciphertext-at-rest is unverifiable until T-11**: no production path writes `eqa_panel_sample`, and the test profile substitutes a pass-through encryptor. Tests prove the converter is wired and the column is wide enough; that the bytes at rest are ciphertext rests on the converter's code.
- **`MISSED_DEADLINE` has no derivation rule** and such labs would read as `TESTING`; nothing writes that status yet. The rule must land with whatever first writes it (T-16).
- `/cycles/mine` is 3N+1 queries — fine now, needs a join before My Cycles ships at scale (T-13).
- Read endpoints stay on the module's class-level role guard; module-wide `qa.view.eqa` enforcement is T-05, full tiers T-12.
- These endpoints' DTO shapes are the de-facto stub contract for T-13/T-21/T-24 (T-07 was never written); recorded in the delivery plan §07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)