### PR TITLE
Add one worktree-isolated full development stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,17 @@ LETSENCRYPT_DOMAIN=localhost
 # Email for Let's Encrypt certificate notifications (required for real certs)
 LETSENCRYPT_EMAIL=admin@example.com
 
+# `scripts/dev-stack` is the supported development launcher. With
+# LETSENCRYPT_DOMAIN=localhost it binds random ports on loopback and uses the
+# generated self-signed certificate. With a real domain it binds 80/443 and
+# obtains/renews a Let's Encrypt certificate during `scripts/dev-stack up`.
+# Uncomment only when overriding those derived defaults.
+# DEV_STACK_INGRESS_BIND_ADDRESS=127.0.0.1
+# DEV_STACK_HTTP_PORT=0
+# DEV_STACK_HTTPS_PORT=0
+# DEV_STACK_TLS=self-signed
+# DEV_STACK_BUILD_FRONTEND=true
+
 # --- E2E Test Credentials (Playwright) ---
 # Required for: npm run pw:test (Playwright auth setup)
 # Use the admin user created by e2e-foundational-data.sql

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -22,6 +22,8 @@ Or manually: `git config core.hooksPath .githooks`
 
 The hook runs on **staged files only**:
 
+- **Java runtime**: Uses the `.sdkmanrc` Java candidate when it is installed,
+  then verifies that Java 21 is active before invoking Maven.
 - **Format**: Java, Markdown, Shell, XML, .gitignore, pom.xml (spotless),
   frontend (prettier), Python (ruff format). Formatted files are re-staged.
 - **Lint**: For staged Catalyst Python files, runs `ruff check` (same as
@@ -33,7 +35,8 @@ The hook runs on **staged files only**:
 2. Hook detects file types in staging area
 3. Runs appropriate formatters
 4. Re-stages formatted files
-5. Commit proceeds
+5. Stops the commit if a required runtime or formatter fails; otherwise the
+   commit proceeds
 
 ### Benefits
 
@@ -62,7 +65,8 @@ git config core.hooksPath
 # If not, run setup command above
 ```
 
-**Formatter not found?**
+**Required runtime or formatter not found?**
 
-- Ensure tools are installed (npm, maven, uv)
-- Hook gracefully skips missing formatters
+- Install Maven for Spotless-managed files and Node.js/npm for frontend files
+- Install the Java version named in `.sdkmanrc`, or activate another Java 21 JDK
+- A missing required tool or formatter failure stops the commit

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,26 @@
 
 set -e
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Prefer the repository-pinned SDKMAN JDK so hooks behave like project builds
+# even when the invoking shell has not enabled SDKMAN auto-env.
+SDKMAN_JAVA_VERSION=$(sed -n 's/^java=//p' .sdkmanrc 2>/dev/null | head -1)
+SDKMAN_JAVA_HOME="${SDKMAN_DIR:-$HOME/.sdkman}/candidates/java/$SDKMAN_JAVA_VERSION"
+if [ -n "$SDKMAN_JAVA_VERSION" ] && [ -x "$SDKMAN_JAVA_HOME/bin/java" ]; then
+    export JAVA_HOME="$SDKMAN_JAVA_HOME"
+    export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
+JAVA_MAJOR=$(java -XshowSettings:properties -version 2>&1 \
+    | awk -F= '/java.specification.version/ { gsub(/[[:space:]]/, "", $2); print $2; exit }')
+if [ "$JAVA_MAJOR" != "21" ]; then
+    echo "ERROR: OpenELIS pre-commit formatting requires Java 21 (found ${JAVA_MAJOR:-unknown})."
+    echo "Install the .sdkmanrc version or activate a Java 21 JDK before committing."
+    exit 1
+fi
+
 echo "🎨 Running auto-formatters on staged files..."
 
 # Get list of staged files
@@ -29,7 +49,7 @@ POM_FILES=$(echo "$STAGED_FILES" | grep 'pom\.xml$' || true)
 if [ -n "$JAVA_FILES" ] || [ -n "$MD_FILES" ] || [ -n "$SH_FILES" ] || [ -n "$XML_FILES" ] || [ -n "$GITIGNORE_FILES" ] || [ -n "$POM_FILES" ]; then
     echo "  → Formatting Spotless-managed files (java/md/sh/xml/gitignore/pom)..."
     # Spotless applies to entire project, but we only re-stage modified files
-    mvn spotless:apply -q 2>/dev/null || true
+    mvn spotless:apply -q
     FORMATTED=true
 fi
 
@@ -40,7 +60,7 @@ if [ -n "$FRONTEND_FILES" ]; then
     # Format only staged frontend files
     echo "$FRONTEND_FILES" | while IFS= read -r file; do
         if [ -f "$file" ]; then
-            (cd frontend && npx prettier --write "../$file" --silent 2>/dev/null) || true
+            (cd frontend && npx prettier --write "../$file")
         fi
     done
     FORMATTED=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,31 @@ exists in one of them.
 
 ## Development Workflow
 
+### Authoritative Development Stack
+
+Use `scripts/dev-stack` from the root of every clone or worktree. It is the only
+supported interactive development launcher and starts the complete core
+OpenELIS + analyzer harness with worktree-scoped containers, images, networks,
+ports, and volumes.
+
+```bash
+scripts/dev-stack up
+scripts/dev-stack status
+eval "$(scripts/dev-stack env)"  # before Playwright
+scripts/dev-stack down
+```
+
+Never invoke the development Compose files directly or invent per-task Compose
+commands. Never use SQL fixture loaders for feature setup; use property-gated
+application scenario services. `scripts/dev-stack down --volumes --yes` is the
+only supported destructive reset. CI-parity and release tooling are separate
+interfaces and are not replacements for this development path.
+
+Localhost uses random loopback ports and self-signed TLS. Domain-enabled dev
+servers use the same command after setting `LETSENCRYPT_DOMAIN` and
+`LETSENCRYPT_EMAIL` in `.env`; the stack then exposes 80/443 and uses the
+existing Let's Encrypt flow.
+
 ### Initial Setup
 
 ```bash
@@ -571,8 +596,8 @@ cd ..
 # Build OpenELIS WAR
 mvn clean install -DskipTests -Dmaven.test.skip=true
 
-# Start development containers
-docker compose -f dev.docker-compose.yml up -d
+# Start the complete isolated development stack
+scripts/dev-stack up
 ```
 
 **Access Points:**
@@ -713,8 +738,7 @@ mvn spotless:apply
 mvn spotless:check
 
 # Hot reload (after code changes)
-mvn clean install -DskipTests -Dmaven.test.skip=true
-docker compose -f dev.docker-compose.yml up -d --no-deps --force-recreate oe.openelis.org
+scripts/dev-stack up
 ```
 
 **Frontend:**
@@ -745,16 +769,16 @@ npm run cy:run
 
 ```bash
 # Start development environment
-docker compose -f dev.docker-compose.yml up -d
+scripts/dev-stack up
 
 # Stop all containers
-docker compose -f dev.docker-compose.yml down
+scripts/dev-stack down
 
-# Rebuild specific container (after code changes)
-docker compose -f dev.docker-compose.yml up -d --no-deps --force-recreate oe.openelis.org
+# Explicitly reset this worktree's data
+scripts/dev-stack down --volumes --yes
 
 # View logs
-docker compose -f dev.docker-compose.yml logs -f oe.openelis.org
+scripts/dev-stack logs -f oe.openelis.org
 ```
 
 ### Branch Strategy
@@ -1786,8 +1810,9 @@ npm run pw:test:ui
 
 **Prerequisites:**
 
-1. App running at `https://localhost` (or set `BASE_URL`)
+1. App running through `scripts/dev-stack up`
 2. Auth env vars: `TEST_USER` and `TEST_PASS`
+3. Run `eval "$(scripts/dev-stack env)"` from the repo root
 
 **Core-app tests (build stack):**
 
@@ -2290,8 +2315,7 @@ mvn clean install -DskipTests -Dmaven.test.skip=true
 mvn spotless:apply && cd frontend && npm run format && cd ..
 
 # Hot reload backend
-mvn clean install -DskipTests -Dmaven.test.skip=true
-docker compose -f dev.docker-compose.yml up -d --no-deps --force-recreate oe.openelis.org
+scripts/dev-stack up
 
 # E2E tests - ALWAYS use npm scripts (unset ELECTRON_RUN_AS_NODE is required)
 npm run cy:spec "cypress/e2e/{feature}.cy.js"  # Individual test (development)

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ scripts/dev-stack up
 ```
 
 The command initializes the required submodules, uses Java 21, builds the local
-WAR and analyzer components, and starts the complete OpenELIS + analyzer harness.
-Its Compose project, containers, images, networks, ports, and volumes are derived
-from the worktree path, so multiple worktrees can run concurrently.
+WAR and analyzer components, and starts the complete OpenELIS + analyzer
+harness. Its Compose project, containers, images, networks, ports, and volumes
+are derived from the worktree path, so multiple worktrees can run concurrently.
 The harness analyzer scenarios are created idempotently through authenticated
 application services after login readiness; startup never seeds the database
 directly. Use `--no-scenarios` only when testing an intentionally empty system.
@@ -132,10 +132,10 @@ installation commands remain separate operational interfaces.
 
 #### The Instances can be accessed at
 
-| Instance     |                   URL                   | credentials (user : password) |
-| ------------ | :-------------------------------------: | ----------------------------: |
-| Legacy UI    | `<scripts/dev-stack url>/api/OpenELIS-Global/` | admin: adminADMIN! |
-| New React UI | output of `scripts/dev-stack url`              | admin: adminADMIN! |
+| Instance     |                      URL                       | credentials (user : password) |
+| ------------ | :--------------------------------------------: | ----------------------------: |
+| Legacy UI    | `<scripts/dev-stack url>/api/OpenELIS-Global/` |            admin: adminADMIN! |
+| New React UI |       output of `scripts/dev-stack url`        |            admin: adminADMIN! |
 
 **Note:** If your browser indicates that the website is not secure after
 accessing any of these links, simply follow these steps:

--- a/README.md
+++ b/README.md
@@ -81,82 +81,61 @@ see [OpenELIS-Docker setup](https://github.com/DIGI-UW/openelis-docker)
 
 ### For Running OpenELIS Global2 from Source Code
 
-**Prerequisites for all methods below:**
-
-Before running any `docker compose` command, you must create a `.env` file with
-your environment configuration:
+Development has one supported startup path. From the root of any clone or Git
+worktree, run:
 
 ```bash
-cp .env.example .env
+scripts/dev-stack up
 ```
 
-Then edit `.env` to customize settings for your environment (database passwords,
-domain, etc.). See `.env.example` for detailed documentation of each variable.
+The command initializes the required submodules, uses Java 21, builds the local
+WAR and analyzer components, and starts the complete OpenELIS + analyzer harness.
+Its Compose project, containers, images, networks, ports, and volumes are derived
+from the worktree path, so multiple worktrees can run concurrently.
+The harness analyzer scenarios are created idempotently through authenticated
+application services after login readiness; startup never seeds the database
+directly. Use `--no-scenarios` only when testing an intentionally empty system.
 
-**IMPORTANT:** Never commit `.env` to version control as it contains secrets and
-server-specific settings. CI copies `.env.example` to `.env` before running
-docker compose.
+Useful commands:
 
-#### Running OpenELIS Global2 using docker compose With published docker images on dockerhub
+```bash
+scripts/dev-stack status
+scripts/dev-stack url
+eval "$(scripts/dev-stack env)"  # configure Playwright for this worktree
+scripts/dev-stack logs -f oe.openelis.org
+scripts/dev-stack down
+scripts/dev-stack down --volumes --yes  # explicit data reset
+```
 
-    docker compose up -d
+Local development needs no configuration: `.env` is created from `.env.example`,
+the proxy binds random loopback ports, and `scripts/dev-stack url` prints the
+browser URL. Frontend source remains hot-reloaded. Re-run `scripts/dev-stack up`
+after backend or analyzer component changes.
 
-#### Running OpenELIS Global2 using docker compose with docker images built directly from the source code
+The published development frontend dependency image is reused when
+`package.json`, `package-lock.json`, and `frontend/Dockerfile` match `develop`;
+worktree source is still mounted for hot reload. If any of those inputs differ,
+the command automatically builds an isolated frontend image. Set
+`DEV_STACK_BUILD_FRONTEND=true` only to force that rebuild.
 
-    docker compose -f build.docker-compose.yml up -d --build
+For a domain-enabled development server, set a real `LETSENCRYPT_DOMAIN` and
+`LETSENCRYPT_EMAIL` in `.env`, then run the same `scripts/dev-stack up` command.
+It binds ports 80/443, renders the named nginx hosts, and uses the existing
+Let's Encrypt HTTP-01 flow. DNS for both the primary domain and
+`bridge.<domain>` must resolve to the server. Port and bind overrides are listed
+in `.env.example` for hosts that already have an external router; those hosts
+should terminate TLS at that router and set `DEV_STACK_TLS=self-signed` for the
+private upstream.
 
-#### Running OpenELIS Global2 with docker compose For Development
-
-Here Artifacts (ie the War file and React code) are compiled/built on the local
-machine outside docker and just mounted into the docker compose setup. This
-speeds up the development process
-
-1.  Fork the
-    [OpenELIS-Global Repository](https://github.com/DIGI-UW/OpenELIS-Global-2.git)
-    and clone the forked repo. The `username` below is the `username` of your
-    Github profile.
-
-         git clone https://github.com/username/OpenELIS-Global-2.git
-
-1.  innitialize and build sub modules
-
-        cd OpenELIS-Global-2
-        git submodule update --init --recursive
-        cd dataexport
-        mvn clean install -DskipTests
-
-1.  Navigate back to the repository directory:
-
-         cd ..
-
-1.  Build the War file
-
-          mvn clean install -DskipTests -Dmaven.test.skip=true
-
-1.  Start the containers to mount the locally compiled artifacts
-
-        docker compose -f dev.docker-compose.yml up -d
-
-    Note : For Reflecting Local changes in the Running Containers ;
-
-- Any Changes to the [Front-end](./frontend/) React Source Code will be directly
-  Hot Reloaded in the UI
-- For changes to the [Back-end](./src/) Java Source code
-
-  - Run the maven build again to re-build the War file
-
-         mvn clean install -DskipTests -Dmaven.test.skip=true
-
-  - Recreate the Openelis webapp container
-
-        docker compose -f dev.docker-compose.yml up -d  --no-deps --force-recreate oe.openelis.org
+Do not invoke the development Compose layers directly. CI, release, and packaged
+installation commands remain separate operational interfaces.
 
 #### The Instances can be accessed at
 
 | Instance     |                   URL                   | credentials (user : password) |
 | ------------ | :-------------------------------------: | ----------------------------: |
-| Legacy UI    | https://localhost/api/OpenELIS-Global/  |            admin: adminADMIN! |
-| New React UI |           https://localhost/            |            admin: adminADMIN! |
+| Legacy UI    | `<scripts/dev-stack url>/api/OpenELIS-Global/` | admin: adminADMIN! |
+| New React UI | output of `scripts/dev-stack url`              | admin: adminADMIN! |
 
 **Note:** If your browser indicates that the website is not secure after
 accessing any of these links, simply follow these steps:

--- a/README.md
+++ b/README.md
@@ -101,10 +101,21 @@ Useful commands:
 ```bash
 scripts/dev-stack status
 scripts/dev-stack url
-eval "$(scripts/dev-stack env)"  # configure Playwright for this worktree
+scripts/dev-stack playwright playwright/tests/foundational/core/navbar.spec.ts
+scripts/dev-stack playwright --project=setup  # verify authentication only
 scripts/dev-stack logs -f oe.openelis.org
 scripts/dev-stack down
 scripts/dev-stack down --volumes --yes  # explicit data reset
+```
+
+The `playwright` command discovers this worktree's URL, loads credentials from
+the existing environment or `.env`, and runs the shared authentication setup
+automatically. To exercise a deployed environment with the identical path, set
+only its URL:
+
+```bash
+BASE_URL=https://amr.openelis-global.org \
+  scripts/dev-stack playwright playwright/tests/foundational/core/navbar.spec.ts
 ```
 
 Local development needs no configuration: `.env` is created from `.env.example`,

--- a/frontend/playwright/helpers/create-analyzer-from-profile.ts
+++ b/frontend/playwright/helpers/create-analyzer-from-profile.ts
@@ -21,7 +21,7 @@ import type { AnalyzerTestConfig } from "./analyzer-test-config";
 import { LONG_TIMEOUT } from "./timeouts";
 import { resolveDbContainer } from "./db-container";
 
-const SIMULATOR_URL = "http://localhost:8085";
+const SIMULATOR_URL = process.env.MOCK_SIMULATOR_URL || "http://localhost:8085";
 const ANALYZER_API_PATH = "/api/OpenELIS-Global/rest/analyzer/analyzers";
 const API_READY_TIMEOUT_MS = 15_000;
 const API_RETRY_DELAY_MS = 500;

--- a/frontend/playwright/helpers/ensure-analyzer.ts
+++ b/frontend/playwright/helpers/ensure-analyzer.ts
@@ -16,7 +16,7 @@ export const GENEXPERT_DEFAULT_ANALYZER: AnalyzerPayload = {
   name: "Cepheid GeneXpert (ASTM Mode)",
   analyzerType: "MOLECULAR",
   pluginTypeId: "generic-astm",
-  ipAddress: "10.42.20.10",
+  ipAddress: process.env.ANALYZER_GENEXPERT_IP || "10.42.20.10",
   port: 9600,
   protocolVersion: "ASTM_LIS2_A2",
   identifierPattern: "GENEXPERT|CEPHEID",

--- a/frontend/playwright/tests/demo/harness/analyzer-demo-flow.spec.ts
+++ b/frontend/playwright/tests/demo/harness/analyzer-demo-flow.spec.ts
@@ -35,7 +35,7 @@ import type {
   PushResult,
 } from "../../../helpers/analyzer-test-config";
 
-const SIMULATOR_URL = "http://localhost:8085";
+const SIMULATOR_URL = process.env.MOCK_SIMULATOR_URL || "http://localhost:8085";
 const RESULTS_TIMEOUT = 90_000;
 
 // ── Analyzer Configurations ──────────────────────────────────────

--- a/frontend/playwright/tests/demo/harness/astm-genexpert-results.spec.ts
+++ b/frontend/playwright/tests/demo/harness/astm-genexpert-results.spec.ts
@@ -18,10 +18,11 @@ import {
   LONG_TIMEOUT,
 } from "../../../helpers/timeouts";
 
-const SIMULATOR_URL = "http://localhost:8085";
+const SIMULATOR_URL = process.env.MOCK_SIMULATOR_URL || "http://localhost:8085";
 // Use the bridge IP on the dedicated GeneXpert mock subnet so the simulator
 // source IP is the registered GeneXpert mock IP (10.42.20.10).
-const BRIDGE_DESTINATION = "tcp://10.42.20.2:12001";
+const BRIDGE_DESTINATION =
+  process.env.ANALYZER_BRIDGE_DESTINATION || "tcp://10.42.20.2:12001";
 const PRELOADED_NAME = "Cepheid GeneXpert (ASTM Mode)";
 const FIXTURE_SAMPLE_ID = "DEV01261000000000001";
 const RESULTS_TIMEOUT = 90_000;

--- a/frontend/playwright/tests/foundational/harness/analyzer-hl7-simulate.spec.ts
+++ b/frontend/playwright/tests/foundational/harness/analyzer-hl7-simulate.spec.ts
@@ -8,8 +8,10 @@ test.describe("Analyzer HL7 Simulator", () => {
   test("simulates HL7 message and previews mapping for Mindray BC-5380", async ({
     page,
   }) => {
+    const simulatorUrl =
+      process.env.MOCK_SIMULATOR_URL || "http://localhost:8085";
     const simulatorRes = await page.request.post(
-      "http://localhost:8085/simulate/hl7/mindray_bc5380",
+      `${simulatorUrl}/simulate/hl7/mindray_bc5380`,
     );
     expect(simulatorRes.ok()).toBeTruthy();
 

--- a/projects/analyzer-harness/README.md
+++ b/projects/analyzer-harness/README.md
@@ -63,8 +63,8 @@ Playwright.
 
 The startup path does not execute SQL fixture loaders or use fixed primary keys.
 It creates the analyzer harness scenarios idempotently through authenticated
-application services. Feature-specific scenarios follow the same rule. CI
-parity is a separate validation command because it intentionally reproduces CI
+application services. Feature-specific scenarios follow the same rule. CI parity
+is a separate validation command because it intentionally reproduces CI
 packaging.
 
 To remove this worktree's data explicitly:

--- a/projects/analyzer-harness/README.md
+++ b/projects/analyzer-harness/README.md
@@ -49,40 +49,29 @@ local-only overrides layered on top:
 These files must not drift behaviorally from the authoritative CI harness path
 for critical analyzer flows.
 
-## Build and start from scratch
+## Development startup
 
 ```bash
-./build.sh
-./reset-env.sh --full-reset
+scripts/dev-stack up
 ```
 
-Uses `.env` from this dir or repo root (e.g.
-`LETSENCRYPT_DOMAIN=analyzers.openelis-global.org`).
+Run this from the repository root. It is the only supported interactive
+development launcher and always starts core OpenELIS together with the analyzer
+harness. It assigns worktree-specific Compose resources and random local ports.
+Use `scripts/dev-stack env` to supply its URLs and analyzer network addresses to
+Playwright.
 
-## Quick start
+The startup path does not execute SQL fixture loaders or use fixed primary keys.
+It creates the analyzer harness scenarios idempotently through authenticated
+application services. Feature-specific scenarios follow the same rule. CI
+parity is a separate validation command because it intentionally reproduces CI
+packaging.
 
-From this directory:
+To remove this worktree's data explicitly:
 
 ```bash
-cd /home/ubuntu/OpenELIS-Global-2/projects/analyzer-harness
-
-# Start core stack
-docker compose -f docker-compose.dev.yml -f docker-compose.base.yml up -d
-
-# Start analyzer test infrastructure (bridge + simulator + virtual serial)
-docker compose -f docker-compose.dev.yml -f docker-compose.base.yml -f docker-compose.analyzer-test.yml up -d
+scripts/dev-stack down --volumes --yes
 ```
-
-Then seed analyzers via the OE REST API (matches CI step
-`23_Seed analyzers via REST API`):
-
-```bash
-cd /home/ubuntu/OpenELIS-Global-2/projects/analyzer-harness
-./seed-analyzers.sh
-```
-
-`ci-parity-test.sh` also runs `seed-analyzers.sh` as part of its normal flow, so
-the explicit call above is only needed when starting the stack manually.
 
 ## Hot reload (after backend code changes)
 
@@ -91,17 +80,8 @@ container. After changing Java code, rebuild the WAR and **force-recreate** the
 container (Tomcat caches the exploded WAR; a plain `restart` will serve stale
 classes):
 
-```bash
-# From repo root
-mvn clean install -DskipTests -Dmaven.test.skip=true
-
-# From harness directory — force-recreate clears the Tomcat WAR cache
-cd projects/analyzer-harness
-docker compose -f docker-compose.dev.yml -f docker-compose.base.yml -f docker-compose.analyzer-test.yml \
-  -f docker-compose.letsencrypt.yml up -d --force-recreate oe.openelis.org
-```
-
-Frontend changes hot-reload automatically (mounted volume).
+Re-run `scripts/dev-stack up`. The command rebuilds the WAR and recreates the
+changed application services. Frontend changes hot-reload automatically.
 
 ## Resetting the test environment
 
@@ -111,21 +91,8 @@ For exact CI parity, prefer:
 ./projects/analyzer-harness/ci-parity-test.sh
 ```
 
-For local restart mode, run:
-
-```bash
-./projects/analyzer-harness/reset-env.sh [options]
-```
-
-Options:
-
-- **`--full-reset`** – Remove DB (and other) volumes before starting (wipe DB,
-  then load fixtures).
-- **`--skip-fixtures`** – Start stack only; do not load
-  foundational/storage/analyzer fixtures.
-
-Steps performed: stop stack → optionally `down -v` → start dev + analyzer-test
-compose → wait for webapp → load fixtures via direct psql to `localhost:15432`.
+`reset-env.sh` is retained only for legacy CI investigation. It is not a
+development startup interface and must not be used to seed feature data.
 
 ## Let's Encrypt (analyzers.openelis-global.org)
 
@@ -133,22 +100,20 @@ The harness **shares the repo's Let's Encrypt certs**: it mounts
 `../../volume/letsencrypt` (repo root), so valid certs generated per
 **docs/LETSENCRYPT_SETUP.md** are used automatically.
 
-From **repo root** (not harness dir), generate certs for the subdomain once:
+Set the domain and email in the worktree's `.env`:
 
 ```bash
-export LETSENCRYPT_EMAIL="your-email@example.com"
-export LETSENCRYPT_DOMAIN="analyzers.openelis-global.org"
-./scripts/generate-letsencrypt-certs.sh
+LETSENCRYPT_DOMAIN=analyzers.openelis-global.org
+LETSENCRYPT_EMAIL=your-email@example.com
 ```
 
-Then start (or restart) the harness with the letsencrypt override; the proxy
-entrypoint will use `volume/letsencrypt/live/analyzers.openelis-global.org/` if
-present, else self-signed fallback.
+Then run `scripts/dev-stack up`. Certificate issuance and the project-scoped
+proxy restart are part of that same command.
 
 ## URLs
 
-- UI: `https://localhost/`
-- Backend API: `https://localhost/api/`
+- UI: output of `scripts/dev-stack url`
+- Backend API: `<scripts/dev-stack url>/api/`
 
 Login (local-dev defaults only):
 

--- a/projects/analyzer-harness/bootstrap.sh
+++ b/projects/analyzer-harness/bootstrap.sh
@@ -237,7 +237,10 @@ if [ ! -f "$HARNESS_VOLUME/analyzer/analyzer-test-map.csv" ]; then
   touch "$HARNESS_VOLUME/analyzer/analyzer-test-map.csv"
   echo "  created placeholder analyzer/analyzer-test-map.csv"
 fi
-if [ ! -f "$HARNESS_VOLUME/menu/menu_config.json" ]; then
+if [ -f "$ROOT_VOLUME/menu/menu_config.json" ]; then
+  cp "$ROOT_VOLUME/menu/menu_config.json" "$HARNESS_VOLUME/menu/menu_config.json"
+  echo "  copied repository menu/menu_config.json"
+elif [ ! -f "$HARNESS_VOLUME/menu/menu_config.json" ]; then
   echo '{}' > "$HARNESS_VOLUME/menu/menu_config.json"
   echo "  created placeholder menu/menu_config.json"
 fi

--- a/projects/analyzer-harness/bootstrap.sh
+++ b/projects/analyzer-harness/bootstrap.sh
@@ -18,10 +18,14 @@ NC='\033[0m'
 
 FORCE_BUILD_PLUGINS=false
 FORCE_RELOAD_CONFIG=false
+LOCAL_MODE=false
+SKIP_PLUGINS=false
 for arg in "$@"; do
   case $arg in
     --force-build-plugins) FORCE_BUILD_PLUGINS=true ;;
     --force-reload-config) FORCE_RELOAD_CONFIG=true ;;
+    --local) LOCAL_MODE=true ;;
+    --skip-plugins) SKIP_PLUGINS=true ;;
   esac
 done
 
@@ -35,7 +39,9 @@ if [ -f "$HARNESS_DIR/.env" ]; then
 elif [ -f "$REPO_ROOT/.env" ]; then
   set -a; . "$REPO_ROOT/.env"; set +a
 fi
-if [ -z "${LETSENCRYPT_DOMAIN:-}" ]; then
+if [ "$LOCAL_MODE" = true ]; then
+  : "${LETSENCRYPT_DOMAIN:=localhost}"
+elif [ -z "${LETSENCRYPT_DOMAIN:-}" ]; then
   echo -e "${RED}ERROR: LETSENCRYPT_DOMAIN is not set. Add it to $REPO_ROOT/.env before running bootstrap.${NC}" >&2
   exit 1
 fi
@@ -118,7 +124,9 @@ _ensure_generic_plugins() {
   fi
 }
 
-if [ "$HARNESS_PLUGINS" = "all" ]; then
+if [ "$SKIP_PLUGINS" = true ]; then
+  echo -e "  ${YELLOW}→ Plugin build/staging delegated to scripts/dev-stack${NC}"
+elif [ "$HARNESS_PLUGINS" = "all" ]; then
   # Load all plugins (legacy + generic) from submodule
   _ensure_generic_plugins "$FORCE_BUILD_PLUGINS"
   if [ -d "$PLUGIN_SUBMODULE_DIR" ] && ls "$PLUGIN_SUBMODULE_DIR"/*.jar 1>/dev/null 2>&1; then
@@ -201,7 +209,10 @@ fi
 # nginx.conf: render from the env-driven template in the root volume so
 # ${LETSENCRYPT_DOMAIN} flows through to server_name and cert paths without
 # editing nginx.conf by hand. Fallback to plain copy if only nginx.conf exists.
-if [ -f "$ROOT_VOLUME/nginx/nginx.conf.template" ]; then
+if [ "$LOCAL_MODE" = true ] && [ -f "$ROOT_VOLUME/nginx/nginx.conf" ]; then
+  cp "$ROOT_VOLUME/nginx/nginx.conf" "$HARNESS_VOLUME/nginx/nginx.conf"
+  echo "  copied local self-signed volume/nginx/nginx.conf"
+elif [ -f "$ROOT_VOLUME/nginx/nginx.conf.template" ]; then
   if ! command -v envsubst >/dev/null 2>&1; then
     # No silent fallback — the committed nginx.conf is a stale snapshot of the
     # template and lacks the bridge vhost + env-substituted domain names.

--- a/projects/analyzer-harness/docker-compose.analyzer-test.yml
+++ b/projects/analyzer-harness/docker-compose.analyzer-test.yml
@@ -144,9 +144,6 @@ services:
       default:
       analyzer-net:
 
-  # Seed service — creates mock networks + analyzer records on startup.
-  # Runs once after OE and mock-server are healthy. Idempotent.
-  # Default: cleans stale data before seeding (--no-clean to skip).
 networks:
   analyzer-net:
     driver: bridge

--- a/projects/analyzer-harness/docker-compose.dev.yml
+++ b/projects/analyzer-harness/docker-compose.dev.yml
@@ -55,7 +55,7 @@ services:
     image: hapiproject/hapi:v6.6.0-tomcat
     depends_on:
       db.openelis.org:
-        condition: service_started
+        condition: service_healthy
       certs:
         condition: service_started
     restart: always
@@ -119,4 +119,3 @@ secrets:
     file: ./volume/properties/common.properties
   hapi_application.yaml:
     file: ./volume/properties/hapi_application.yaml
-

--- a/projects/analyzer-harness/docker-compose.worktree.yml
+++ b/projects/analyzer-harness/docker-compose.worktree.yml
@@ -1,0 +1,123 @@
+# Worktree-local analyzer harness overrides used only through scripts/dev-stack.
+services:
+  certs:
+    container_name: !reset null
+
+  db.openelis.org:
+    container_name: !reset null
+    ports: !override
+      - name: postgres
+        target: 5432
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+
+  oe.openelis.org:
+    container_name: !reset null
+    ports: !override
+      - name: http
+        target: 8080
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: https
+        target: 8443
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+    environment:
+      CATALINA_OPTS: >-
+        -Ddatasource.url=jdbc:postgresql://db.openelis.org:5432/clinlims
+        -Ddatasource.username=clinlims
+        -Dspring.liquibase.contexts=test
+        -Dorg.openelisglobal.uat.scenarios.enabled=${OE_UAT_SCENARIOS_ENABLED:-true}
+    networks: !override
+      default: {}
+      analyzer-net:
+        aliases:
+          - oe.openelis.org
+
+  fhir.openelis.org:
+    container_name: !reset null
+    ports: !override
+      - name: http
+        target: 8080
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: https
+        target: 8443
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+
+  frontend.openelis.org:
+    container_name: !reset null
+    image: ${DEV_STACK_FRONTEND_IMAGE:-itechuw/openelis-global-2-frontend-dev:develop}
+
+  proxy:
+    container_name: !reset null
+    ports: !override
+      - name: http
+        target: 80
+        published: "${DEV_STACK_HTTP_PORT:-0}"
+        host_ip: ${DEV_STACK_INGRESS_BIND_ADDRESS:-127.0.0.1}
+        protocol: tcp
+      - name: https
+        target: 443
+        published: "${DEV_STACK_HTTPS_PORT:-0}"
+        host_ip: ${DEV_STACK_INGRESS_BIND_ADDRESS:-127.0.0.1}
+        protocol: tcp
+
+  astm-simulator:
+    container_name: !reset null
+    image: ${DEV_STACK_PROJECT}-analyzer-mock:dev
+    ports: !override
+      - name: astm
+        target: 9600
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: api
+        target: 8080
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: hl7
+        target: 5380
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+    environment:
+      BRIDGE_CONTAINER_NAME: ${DEV_STACK_PROJECT}-openelis-analyzer-bridge-1
+      MOCK_CONTAINER_NAME: ${DEV_STACK_PROJECT}-astm-simulator-1
+      ANALYZER_NETWORK_NAMESPACE: ${ANALYZER_NETWORK_NAMESPACE}
+      ANALYZER_SUBNET_PREFIX: ${ANALYZER_SUBNET_PREFIX}
+    networks: !override
+      analyzer-net: {}
+
+  openelis-analyzer-bridge:
+    container_name: !reset null
+    image: ${DEV_STACK_PROJECT}-analyzer-bridge:dev
+    ports: !override
+      - name: https
+        target: 8443
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: astm
+        target: 12001
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+      - name: mllp
+        target: 2575
+        published: "0"
+        host_ip: 127.0.0.1
+        protocol: tcp
+
+networks:
+  default:
+    ipam: !reset null
+  analyzer-net:
+    ipam: !reset null

--- a/projects/analyzer-harness/scripts/generate-letsencrypt-certs.sh
+++ b/projects/analyzer-harness/scripts/generate-letsencrypt-certs.sh
@@ -73,10 +73,15 @@ echo "Preflight: both domains must resolve to this host's public IP, and TCP"
 echo "port 80 must be reachable from the internet (HTTP-01 challenge)."
 echo ""
 
-# Proxy must be running for ACME webroot (harness proxy name varies by compose project)
-if ! docker ps --format '{{.Names}}' | grep -q proxy; then
+# scripts/dev-stack supplies the exact project-scoped proxy container so
+# certificate issuance cannot accidentally target another running worktree.
+if [ -z "${DEV_STACK_PROXY_CONTAINER_ID:-}" ]; then
+  echo "ERROR: DEV_STACK_PROXY_CONTAINER_ID is required. Run scripts/dev-stack up."
+  exit 1
+fi
+if [ "$(docker inspect -f '{{.State.Running}}' "$DEV_STACK_PROXY_CONTAINER_ID" 2>/dev/null || true)" != "true" ]; then
   echo "ERROR: Proxy container must be running for ACME challenge."
-  echo "Start harness: docker compose -f docker-compose.dev.yml -f docker-compose.analyzer-test.yml -f docker-compose.letsencrypt.yml up -d proxy"
+  echo "Start this worktree through scripts/dev-stack up."
   exit 1
 fi
 

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""Worktree-isolated OpenELIS development stack interface."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import ssl
+import subprocess
+import sys
+import time
+from typing import NamedTuple, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class StackContext(NamedTuple):
+    repo_root: Path
+    project: str
+    project_dir: Path
+    compose_files: tuple[Path, ...]
+
+
+LOCAL_DOMAINS = {"localhost", "127.0.0.1", "::1"}
+
+ANALYZER_SCENARIOS = (
+    ("Cepheid GeneXpert (ASTM Mode)", "MOLECULAR", "generic-astm", "astm/genexpert-astm", "genexpert", "genexpert_astm", 9600, "ASTM_LIS2_A2", "GENEXPERT|CEPHEID"),
+    ("Mindray BC-5380", "HEMATOLOGY", "generic-hl7", "hl7/mindray-bc5380", "bc5380", "mindray_bc5380", 5380, "HL7_V2_3_1", "MINDRAY.*BC.?5380|BC.?5380"),
+    ("Mindray BS-200", "CHEMISTRY", "generic-hl7", "hl7/mindray-bs200", "bs200", "mindray_bs200", 6001, "HL7_V2_3_1", "MINDRAY.*BS.?200|BS.?200"),
+    ("QuantStudio 5", "MOLECULAR", "generic-file", "file/quantstudio", None, None, None, None, None),
+    ("QuantStudio 7", "MOLECULAR", "generic-file", "file/quantstudio", None, None, None, None, None),
+    ("FluoroCycler XT", "MOLECULAR", "generic-file", "file/fluorocycler-xt", None, None, None, None, None),
+    ("Wondfo Finecare FS-205", "IMMUNOASSAY", "generic-file", "file/wondfo-csv", None, None, None, None, None),
+    ("Tecan Infinite F50", "IMMUNOASSAY", "generic-file", "file/tecan-f50", None, None, None, None, None),
+    ("Thermo Multiskan FC", "IMMUNOASSAY", "generic-file", "file/multiskan-fc", None, None, None, None, None),
+)
+
+
+def slugify(value: str, limit: int = 28) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "worktree"
+    return slug[:limit].rstrip("-")
+
+
+def make_context(repo_root: Path) -> StackContext:
+    root = repo_root.resolve()
+    digest = hashlib.sha256(str(root).encode("utf-8")).hexdigest()[:8]
+    project = f"oe2-{slugify(root.name)}-{digest}-dev"
+    project_dir = root / "projects" / "analyzer-harness"
+    compose_files = (
+        project_dir / "docker-compose.dev.yml",
+        project_dir / "docker-compose.base.yml",
+        project_dir / "docker-compose.analyzer-test.yml",
+        project_dir / "docker-compose.letsencrypt.yml",
+        project_dir / "docker-compose.worktree.yml",
+    )
+    return StackContext(root, project, project_dir, compose_files)
+
+
+def read_dotenv(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def is_local_domain(domain: str) -> bool:
+    return domain.lower() in LOCAL_DOMAINS
+
+
+def build_environment(context: StackContext) -> dict[str, str]:
+    environment = os.environ.copy()
+    for key, value in read_dotenv(context.repo_root / ".env").items():
+        environment.setdefault(key, value)
+    environment["DEV_STACK_PROJECT"] = context.project
+    environment.setdefault("OE_UAT_SCENARIOS_ENABLED", "true")
+    domain = environment.get("LETSENCRYPT_DOMAIN", "localhost")
+    environment["LETSENCRYPT_DOMAIN"] = domain
+    environment.setdefault("LETSENCRYPT_BRIDGE_DOMAIN", f"bridge.{domain}")
+    if is_local_domain(domain):
+        environment.setdefault("DEV_STACK_INGRESS_BIND_ADDRESS", "127.0.0.1")
+        environment.setdefault("DEV_STACK_HTTP_PORT", "0")
+        environment.setdefault("DEV_STACK_HTTPS_PORT", "0")
+        environment.setdefault("DEV_STACK_TLS", "self-signed")
+    else:
+        environment.setdefault("DEV_STACK_INGRESS_BIND_ADDRESS", "0.0.0.0")
+        environment.setdefault("DEV_STACK_HTTP_PORT", "80")
+        environment.setdefault("DEV_STACK_HTTPS_PORT", "443")
+        environment.setdefault("DEV_STACK_TLS", "letsencrypt")
+    digest = int(hashlib.sha256(str(context.repo_root).encode("utf-8")).hexdigest()[:8], 16)
+    environment["ANALYZER_NETWORK_NAMESPACE"] = context.project
+    environment["ANALYZER_SUBNET_PREFIX"] = f"10.{64 + digest % 160}"
+    if frontend_dependencies_changed(context, environment):
+        environment["DEV_STACK_FRONTEND_IMAGE"] = f"{context.project}-frontend:dev"
+        environment["DEV_STACK_BUILD_FRONTEND"] = "true"
+    else:
+        environment.setdefault(
+            "DEV_STACK_FRONTEND_IMAGE",
+            "itechuw/openelis-global-2-frontend-dev:develop",
+        )
+        environment.setdefault("DEV_STACK_BUILD_FRONTEND", "false")
+    return environment
+
+
+def frontend_dependencies_changed(
+    context: StackContext, environment: dict[str, str]
+) -> bool:
+    override = environment.get("DEV_STACK_BUILD_FRONTEND")
+    if override is not None:
+        return override.lower() == "true"
+    paths = ("frontend/package.json", "frontend/package-lock.json", "frontend/Dockerfile")
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--quiet", "origin/develop", "--", *paths],
+            cwd=context.repo_root,
+            env=environment,
+            check=False,
+        )
+        return result.returncode != 0
+    except OSError:
+        return True
+
+
+def compose_command(context: StackContext, *arguments: str) -> list[str]:
+    command = [
+        "docker",
+        "compose",
+        "-p",
+        context.project,
+        "--project-directory",
+        str(context.project_dir),
+    ]
+    env_file = context.repo_root / ".env"
+    if env_file.is_file():
+        command.extend(("--env-file", str(env_file)))
+    for compose_file in context.compose_files:
+        command.extend(("-f", str(compose_file)))
+    command.extend(arguments)
+    return command
+
+
+def required_submodules() -> tuple[str, ...]:
+    return (
+        "dataexport",
+        "plugins",
+        "tools/analyzer-mock-server",
+        "tools/openelis-analyzer-bridge",
+    )
+
+
+def parse_published_port(value: str) -> int:
+    match = re.search(r":(\d+)\s*$", value)
+    if not match:
+        raise ValueError(f"Could not parse Docker published port from: {value!r}")
+    return int(match.group(1))
+
+
+def validate_down_options(remove_volumes: bool, confirmed: bool) -> None:
+    if remove_volumes and not confirmed:
+        raise ValueError("Removing stack volumes requires both --volumes and --yes")
+
+
+def run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=environment,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def ensure_local_env(context: StackContext) -> None:
+    env_file = context.repo_root / ".env"
+    example = context.repo_root / ".env.example"
+    if not env_file.exists() and example.is_file():
+        shutil.copyfile(example, env_file)
+        print(f"Created local {env_file.relative_to(context.repo_root)} from .env.example")
+
+
+def ensure_submodules(context: StackContext, environment: dict[str, str]) -> None:
+    command = ["git", "submodule", "update", "--init", "--recursive"]
+    command.extend(required_submodules())
+    run(command, cwd=context.repo_root, environment=environment)
+
+
+def heal_war_mount(context: StackContext) -> None:
+    war = context.repo_root / "target" / "OpenELIS-Global.war"
+    if war.is_dir():
+        try:
+            war.rmdir()
+        except OSError as error:
+            raise RuntimeError(f"Expected a WAR file but found a non-empty directory at {war}") from error
+
+
+def build_application(context: StackContext, environment: dict[str, str]) -> None:
+    java = context.repo_root / "scripts" / "run-java21"
+    dataexport = context.repo_root / "dataexport" / "pom.xml"
+    run(
+        [str(java), "mvn", "-q", "-f", str(dataexport), "install", "-DskipTests", "-Dmaven.test.skip=true"],
+        cwd=context.repo_root,
+        environment=environment,
+    )
+    run(
+        [str(java), "mvn", "-q", "package", "-DskipTests", "-Dmaven.test.skip=true"],
+        cwd=context.repo_root,
+        environment=environment,
+    )
+    war = context.repo_root / "target" / "OpenELIS-Global.war"
+    if not war.is_file():
+        raise RuntimeError(f"Build did not produce {war}")
+
+
+def stage_analyzer_plugins(context: StackContext, environment: dict[str, str]) -> None:
+    java = context.repo_root / "scripts" / "run-java21"
+    plugins = context.repo_root / "plugins" / "pom.xml"
+    run(
+        [str(java), "mvn", "-q", "-f", str(plugins), "install", "-DskipTests", "-Dmaven.test.skip=true"],
+        cwd=context.repo_root,
+        environment=environment,
+    )
+    destination = context.project_dir / "volume" / "plugins"
+    destination.mkdir(parents=True, exist_ok=True)
+    for existing in destination.glob("*.jar"):
+        existing.unlink()
+    jars = [
+        path
+        for path in (context.repo_root / "plugins" / "analyzers").glob("*/target/*.jar")
+        if not path.name.endswith(("-sources.jar", "-javadoc.jar"))
+    ]
+    if not jars:
+        raise RuntimeError("Analyzer plugin build produced no runtime jars")
+    for jar in jars:
+        shutil.copy2(jar, destination / jar.name)
+
+
+def bootstrap_analyzer_harness(context: StackContext, environment: dict[str, str]) -> None:
+    arguments = [str(context.project_dir / "bootstrap.sh"), "--skip-plugins"]
+    if is_local_domain(environment["LETSENCRYPT_DOMAIN"]):
+        arguments.append("--local")
+    run(
+        arguments,
+        cwd=context.project_dir,
+        environment=environment,
+    )
+
+
+def build_images(context: StackContext, environment: dict[str, str]) -> None:
+    services = ["astm-simulator", "openelis-analyzer-bridge"]
+    if environment["DEV_STACK_BUILD_FRONTEND"] == "true":
+        services.insert(0, "frontend.openelis.org")
+    run(
+        compose_command(context, "build", *services),
+        cwd=context.project_dir,
+        environment=environment,
+    )
+
+
+def published_port(context: StackContext, service: str, target: int, environment: dict[str, str]) -> int:
+    result = run(
+        compose_command(context, "port", service, str(target)),
+        cwd=context.project_dir,
+        environment=environment,
+        capture=True,
+    )
+    return parse_published_port(result.stdout)
+
+
+def endpoint_environment(context: StackContext, environment: dict[str, str]) -> dict[str, str]:
+    domain = environment["LETSENCRYPT_DOMAIN"]
+    https_port = published_port(context, "proxy", 443, environment)
+    authority = domain if https_port == 443 else f"{domain}:{https_port}"
+    endpoints = {
+        "BASE_URL": f"https://{authority}",
+        "OE_BACKEND_URL": f"https://localhost:{published_port(context, 'oe.openelis.org', 8443, environment)}",
+        "FHIR_URL": f"https://localhost:{published_port(context, 'fhir.openelis.org', 8443, environment)}",
+        "DB_PORT": str(published_port(context, "db.openelis.org", 5432, environment)),
+        "COMPOSE_PROJECT_NAME": context.project,
+    }
+    subnet_prefix = environment["ANALYZER_SUBNET_PREFIX"]
+    endpoints.update(
+        {
+            "MOCK_SIMULATOR_URL": f"http://localhost:{published_port(context, 'astm-simulator', 8080, environment)}",
+            "ANALYZER_BRIDGE_URL": f"https://localhost:{published_port(context, 'openelis-analyzer-bridge', 8443, environment)}",
+            "ANALYZER_NETWORK_NAMESPACE": context.project,
+            "ANALYZER_SUBNET_PREFIX": subnet_prefix,
+            "ANALYZER_GENEXPERT_IP": f"{subnet_prefix}.20.10",
+            "ANALYZER_BRIDGE_DESTINATION": f"tcp://{subnet_prefix}.20.2:12001",
+        }
+    )
+    return endpoints
+
+
+def configure_tls(context: StackContext, environment: dict[str, str]) -> None:
+    tls_mode = environment["DEV_STACK_TLS"].lower()
+    if tls_mode == "self-signed":
+        return
+    if tls_mode != "letsencrypt":
+        raise ValueError("DEV_STACK_TLS must be either self-signed or letsencrypt")
+    if is_local_domain(environment["LETSENCRYPT_DOMAIN"]):
+        raise ValueError("DEV_STACK_TLS=letsencrypt requires a public LETSENCRYPT_DOMAIN")
+    if not environment.get("LETSENCRYPT_EMAIL"):
+        raise ValueError("DEV_STACK_TLS=letsencrypt requires LETSENCRYPT_EMAIL")
+    proxy = run(
+        compose_command(context, "ps", "-q", "proxy"),
+        cwd=context.project_dir,
+        environment=environment,
+        capture=True,
+    ).stdout.strip()
+    if not proxy:
+        raise RuntimeError("The worktree proxy is not running")
+    tls_environment = environment.copy()
+    tls_environment["DEV_STACK_PROXY_CONTAINER_ID"] = proxy
+    run(
+        [str(context.project_dir / "scripts" / "generate-letsencrypt-certs.sh")],
+        cwd=context.project_dir,
+        environment=tls_environment,
+    )
+    run(
+        compose_command(context, "restart", "proxy"),
+        cwd=context.project_dir,
+        environment=environment,
+    )
+
+
+def print_endpoints(context: StackContext, environment: dict[str, str], shell_exports: bool = False) -> None:
+    endpoints = endpoint_environment(context, environment)
+    for name, value in endpoints.items():
+        if shell_exports:
+            print(f"export {name}={shlex.quote(value)}")
+        else:
+            print(f"{name}={value}")
+
+
+def wait_for_login(context: StackContext, environment: dict[str, str]) -> None:
+    base_url = endpoint_environment(context, environment)["BASE_URL"]
+    wait_environment = environment.copy()
+    wait_environment["BASE_URL"] = base_url
+    run(
+        [str(context.repo_root / "scripts" / "e2e" / "wait-for-openelis-login.sh")],
+        cwd=context.repo_root,
+        environment=wait_environment,
+    )
+
+
+def request_json(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, object] | None = None,
+    username: str | None = None,
+    password: str | None = None,
+) -> tuple[int, dict[str, object]]:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = Request(url, data=data, method=method)
+    request.add_header("Accept", "application/json")
+    if payload is not None:
+        request.add_header("Content-Type", "application/json")
+    if username is not None and password is not None:
+        credentials = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        request.add_header("Authorization", f"Basic {credentials}")
+    context = ssl._create_unverified_context() if url.startswith("https://") else None
+    try:
+        with urlopen(request, timeout=15, context=context) as response:
+            body = response.read().decode("utf-8")
+            return response.status, json.loads(body) if body else {}
+    except HTTPError as error:
+        body = error.read().decode("utf-8")
+        parsed = json.loads(body) if body else {}
+        return error.code, parsed
+
+
+def wait_for_mock_analyzer(mock_url: str, name: str, timeout_seconds: float = 15) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            status, body = request_json(f"{mock_url}/analyzers")
+            if status == 200:
+                for analyzer in body.get("analyzers", []):
+                    if analyzer.get("name") == name and analyzer.get("ip"):
+                        return str(analyzer["ip"])
+        except (URLError, TimeoutError):
+            pass
+        time.sleep(0.25)
+    raise RuntimeError(f"Mock analyzer {name} did not become ready")
+
+
+def ensure_mock_analyzer(mock_url: str, name: str, template: str, port: int) -> str:
+    try:
+        status, body = request_json(
+            f"{mock_url}/analyzers",
+            method="POST",
+            payload={"name": name, "template": template, "port": port},
+        )
+        if status in (200, 201) and body.get("ip"):
+            return str(body["ip"])
+        if status != 409:
+            raise RuntimeError(f"Mock analyzer {name} creation returned HTTP {status}: {body}")
+    except (URLError, TimeoutError):
+        pass
+    return wait_for_mock_analyzer(mock_url, name)
+
+
+def initialize_harness_scenarios(
+    context: StackContext, environment: dict[str, str]
+) -> None:
+    endpoints = endpoint_environment(context, environment)
+    analyzer_url = f"{endpoints['BASE_URL']}/api/OpenELIS-Global/rest/analyzer/analyzers"
+    mock_url = endpoints["MOCK_SIMULATOR_URL"]
+    username = environment.get("TEST_USER", "admin")
+    password = environment.get("TEST_PASS", "adminADMIN!")
+    status, body = request_json(analyzer_url, username=username, password=password)
+    if status != 200:
+        raise RuntimeError(f"Analyzer list returned HTTP {status}: {body}")
+    existing = {str(item.get("name")) for item in body.get("analyzers", [])}
+
+    for (
+        name,
+        analyzer_type,
+        plugin_type,
+        profile,
+        mock_name,
+        template,
+        port,
+        protocol,
+        identifier,
+    ) in ANALYZER_SCENARIOS:
+        ip_address = None
+        if mock_name and template and port:
+            ip_address = ensure_mock_analyzer(mock_url, mock_name, template, port)
+        if name in existing:
+            continue
+        payload: dict[str, object] = {
+            "name": name,
+            "analyzerType": analyzer_type,
+            "pluginTypeId": plugin_type,
+            "status": "ACTIVE",
+            "defaultConfigId": profile,
+        }
+        if ip_address and port and protocol and identifier:
+            payload.update(
+                {
+                    "ipAddress": ip_address,
+                    "port": port,
+                    "protocolVersion": protocol,
+                    "communicationMode": "ANALYZER_INITIATED",
+                    "identifierPattern": identifier,
+                }
+            )
+        create_status, create_body = request_json(
+            analyzer_url,
+            method="POST",
+            payload=payload,
+            username=username,
+            password=password,
+        )
+        if create_status not in (201, 409):
+            raise RuntimeError(f"Analyzer {name} creation returned HTTP {create_status}: {create_body}")
+
+    status, body = request_json(analyzer_url, username=username, password=password)
+    names = {str(item.get("name")) for item in body.get("analyzers", [])}
+    missing = [scenario[0] for scenario in ANALYZER_SCENARIOS if scenario[0] not in names]
+    if status != 200 or missing:
+        raise RuntimeError(f"Analyzer scenarios are incomplete: {missing}")
+    print(f"Analyzer scenarios ready through services ({len(ANALYZER_SCENARIOS)})")
+
+
+def cleanup_analyzer_networks(context: StackContext, environment: dict[str, str]) -> None:
+    try:
+        base = endpoint_environment(context, environment)["MOCK_SIMULATOR_URL"]
+        with urlopen(f"{base}/analyzers", timeout=5) as response:
+            payload = json.load(response)
+        for analyzer in payload.get("analyzers", []):
+            name = analyzer.get("name")
+            if not name:
+                continue
+            request = Request(f"{base}/analyzers/{name}", method="DELETE")
+            with urlopen(request, timeout=10):
+                pass
+    except (subprocess.CalledProcessError, URLError, TimeoutError, ValueError, KeyError) as error:
+        print(f"Warning: could not clean analyzer networks through the mock API: {error}", file=sys.stderr)
+
+
+def doctor(context: StackContext, environment: dict[str, str]) -> None:
+    for path in context.compose_files:
+        if not path.is_file():
+            raise RuntimeError(f"Missing compose file: {path}")
+    run(["docker", "info"], cwd=context.repo_root, environment=environment, capture=True)
+    run([str(context.repo_root / "scripts" / "run-java21")], cwd=context.repo_root, environment=environment)
+    if not is_local_domain(environment["LETSENCRYPT_DOMAIN"]):
+        if environment["DEV_STACK_TLS"] == "letsencrypt" and not environment.get("LETSENCRYPT_EMAIL"):
+            raise RuntimeError("Domain mode requires LETSENCRYPT_EMAIL when DEV_STACK_TLS=letsencrypt")
+    print(f"{context.project}: prerequisites are ready")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="dev-stack",
+        description="Run the full worktree-isolated OpenELIS + analyzer development stack.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    up = subparsers.add_parser("up")
+    up.add_argument("--skip-build", action="store_true")
+    up.add_argument("--no-wait", action="store_true")
+    up.add_argument("--no-scenarios", action="store_true")
+    down = subparsers.add_parser("down")
+    down.add_argument("--volumes", action="store_true")
+    down.add_argument("--yes", action="store_true")
+    subparsers.add_parser("status")
+    subparsers.add_parser("url")
+    subparsers.add_parser("env")
+    subparsers.add_parser("config")
+    subparsers.add_parser("doctor")
+    logs = subparsers.add_parser("logs")
+    logs.add_argument("services", nargs="*")
+    logs.add_argument("--follow", "-f", action="store_true")
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    context = make_context(Path(__file__).resolve().parent.parent)
+    environment = build_environment(context)
+
+    if args.command == "doctor":
+        bootstrap_analyzer_harness(context, environment)
+        doctor(context, environment)
+    elif args.command == "config":
+        bootstrap_analyzer_harness(context, environment)
+        run(compose_command(context, "config"), cwd=context.project_dir, environment=environment)
+    elif args.command == "up":
+        ensure_local_env(context)
+        ensure_submodules(context, environment)
+        bootstrap_analyzer_harness(context, environment)
+        heal_war_mount(context)
+        if not args.skip_build:
+            build_application(context, environment)
+            stage_analyzer_plugins(context, environment)
+            build_images(context, environment)
+        elif not (context.repo_root / "target" / "OpenELIS-Global.war").is_file():
+            raise RuntimeError("--skip-build requires target/OpenELIS-Global.war")
+        run(
+            compose_command(context, "up", "-d", "--remove-orphans"),
+            cwd=context.project_dir,
+            environment=environment,
+        )
+        configure_tls(context, environment)
+        if not args.no_wait:
+            wait_for_login(context, environment)
+            if not args.no_scenarios:
+                initialize_harness_scenarios(context, environment)
+        print_endpoints(context, environment)
+    elif args.command == "down":
+        validate_down_options(args.volumes, args.yes)
+        cleanup_analyzer_networks(context, environment)
+        down_args = ["down", "--remove-orphans"]
+        if args.volumes:
+            down_args.append("--volumes")
+        run(compose_command(context, *down_args), cwd=context.project_dir, environment=environment)
+    elif args.command == "status":
+        run(compose_command(context, "ps"), cwd=context.project_dir, environment=environment)
+        try:
+            print_endpoints(context, environment)
+        except subprocess.CalledProcessError:
+            pass
+    elif args.command == "url":
+        print(endpoint_environment(context, environment)["BASE_URL"])
+    elif args.command == "env":
+        print_endpoints(context, environment, shell_exports=True)
+    elif args.command == "logs":
+        log_args = ["logs"]
+        if args.follow:
+            log_args.append("--follow")
+        log_args.extend(args.services)
+        run(compose_command(context, *log_args), cwd=context.project_dir, environment=environment)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"dev-stack: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -85,11 +85,12 @@ def is_local_domain(domain: str) -> bool:
 
 
 def build_environment(context: StackContext) -> dict[str, str]:
+    uat_scenarios_enabled = os.environ.get("OE_UAT_SCENARIOS_ENABLED", "true")
     environment = os.environ.copy()
     for key, value in read_dotenv(context.repo_root / ".env").items():
         environment.setdefault(key, value)
     environment["DEV_STACK_PROJECT"] = context.project
-    environment.setdefault("OE_UAT_SCENARIOS_ENABLED", "true")
+    environment["OE_UAT_SCENARIOS_ENABLED"] = uat_scenarios_enabled
     domain = environment.get("LETSENCRYPT_DOMAIN", "localhost")
     environment["LETSENCRYPT_DOMAIN"] = domain
     environment.setdefault("LETSENCRYPT_BRIDGE_DOMAIN", f"bridge.{domain}")
@@ -124,7 +125,16 @@ def frontend_dependencies_changed(
     override = environment.get("DEV_STACK_BUILD_FRONTEND")
     if override is not None:
         return override.lower() == "true"
-    paths = ("frontend/package.json", "frontend/package-lock.json", "frontend/Dockerfile")
+    paths = (
+        "frontend/.dockerignore",
+        "frontend/.npmrc",
+        "frontend/Dockerfile",
+        "frontend/index.html",
+        "frontend/package-lock.json",
+        "frontend/package.json",
+        "frontend/tsconfig.json",
+        "frontend/vite.config.ts",
+    )
     try:
         result = subprocess.run(
             ["git", "diff", "--quiet", "origin/develop", "--", *paths],
@@ -199,6 +209,44 @@ def output(
     return run(command, cwd=cwd, environment=environment, capture=True).stdout.strip()
 
 
+def service_is_running(
+    context: StackContext, environment: dict[str, str], service: str
+) -> bool:
+    result = run(
+        compose_command(context, "ps", "--status", "running", "-q", service),
+        cwd=context.project_dir,
+        environment=environment,
+        capture=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def start_services(
+    context: StackContext,
+    environment: dict[str, str],
+    *,
+    refresh_running_backend: bool,
+) -> None:
+    run(
+        compose_command(context, "up", "-d", "--remove-orphans"),
+        cwd=context.project_dir,
+        environment=environment,
+    )
+    if refresh_running_backend:
+        run(
+            compose_command(
+                context,
+                "up",
+                "-d",
+                "--no-deps",
+                "--force-recreate",
+                "oe.openelis.org",
+            ),
+            cwd=context.project_dir,
+            environment=environment,
+        )
+
+
 def ensure_local_env(context: StackContext) -> None:
     env_file = context.repo_root / ".env"
     example = context.repo_root / ".env.example"
@@ -219,11 +267,39 @@ def submodule_repair_mode(
     return "checkout"
 
 
+def initialize_submodule(
+    context: StackContext, environment: dict[str, str], relative_path: str
+) -> None:
+    command = ["git", "submodule", "update", "--init", "--recursive", relative_path]
+    try:
+        run(command, cwd=context.repo_root, environment=environment)
+    except subprocess.CalledProcessError as error:
+        path = context.repo_root / relative_path
+        has_content = path.is_dir() and any(entry.name != ".git" for entry in path.iterdir())
+        if has_content:
+            raise RuntimeError(
+                f"Submodule initialization failed for populated checkout {relative_path}; "
+                "refusing to force it"
+            ) from error
+        run(
+            [
+                "git",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "--checkout",
+                "--force",
+                relative_path,
+            ],
+            cwd=context.repo_root,
+            environment=environment,
+        )
+
+
 def ensure_submodules(context: StackContext, environment: dict[str, str]) -> None:
-    command = ["git", "submodule", "update", "--init", "--recursive"]
-    command.extend(required_submodules())
-    run(command, cwd=context.repo_root, environment=environment)
     for relative_path in required_submodules():
+        initialize_submodule(context, environment, relative_path)
         path = context.repo_root / relative_path
         expected = output(
             ["git", "rev-parse", f"HEAD:{relative_path}"],
@@ -409,6 +485,15 @@ def configure_tls(context: StackContext, environment: dict[str, str]) -> None:
     )
 
 
+def reload_proxy(context: StackContext, environment: dict[str, str]) -> None:
+    for nginx_arguments in (["nginx", "-t"], ["nginx", "-s", "reload"]):
+        run(
+            compose_command(context, "exec", "-T", "proxy", *nginx_arguments),
+            cwd=context.project_dir,
+            environment=environment,
+        )
+
+
 def print_endpoints(context: StackContext, environment: dict[str, str], shell_exports: bool = False) -> None:
     endpoints = endpoint_environment(context, environment)
     for name, value in endpoints.items():
@@ -416,6 +501,21 @@ def print_endpoints(context: StackContext, environment: dict[str, str], shell_ex
             print(f"export {name}={shlex.quote(value)}")
         else:
             print(f"{name}={value}")
+
+
+def playwright_base_url(context: StackContext, environment: dict[str, str]) -> str:
+    return environment.get("BASE_URL") or endpoint_environment(context, environment)["BASE_URL"]
+
+
+def playwright_command(arguments: Sequence[str]) -> list[str]:
+    forwarded = list(arguments)
+    has_project = any(
+        argument == "--project" or argument.startswith("--project=")
+        for argument in forwarded
+    )
+    if not has_project:
+        forwarded.insert(0, "--project=core-app")
+    return ["npm", "run", "pw:test", "--", *forwarded]
 
 
 def wait_for_login(context: StackContext, environment: dict[str, str]) -> None:
@@ -436,6 +536,7 @@ def request_json(
     payload: dict[str, object] | None = None,
     username: str | None = None,
     password: str | None = None,
+    verify_tls: bool = True,
 ) -> tuple[int, dict[str, object]]:
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     request = Request(url, data=data, method=method)
@@ -445,7 +546,11 @@ def request_json(
     if username is not None and password is not None:
         credentials = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
         request.add_header("Authorization", f"Basic {credentials}")
-    context = ssl._create_unverified_context() if url.startswith("https://") else None
+    context = (
+        ssl._create_unverified_context()
+        if url.startswith("https://") and not verify_tls
+        else None
+    )
     try:
         with urlopen(request, timeout=15, context=context) as response:
             body = response.read().decode("utf-8")
@@ -495,7 +600,13 @@ def initialize_harness_scenarios(
     mock_url = endpoints["MOCK_SIMULATOR_URL"]
     username = environment.get("TEST_USER", "admin")
     password = environment.get("TEST_PASS", "adminADMIN!")
-    status, body = request_json(analyzer_url, username=username, password=password)
+    verify_tls = environment["DEV_STACK_TLS"].lower() != "self-signed"
+    status, body = request_json(
+        analyzer_url,
+        username=username,
+        password=password,
+        verify_tls=verify_tls,
+    )
     if status != 200:
         raise RuntimeError(f"Analyzer list returned HTTP {status}: {body}")
     existing = {str(item.get("name")) for item in body.get("analyzers", [])}
@@ -539,11 +650,17 @@ def initialize_harness_scenarios(
             payload=payload,
             username=username,
             password=password,
+            verify_tls=verify_tls,
         )
         if create_status not in (201, 409):
             raise RuntimeError(f"Analyzer {name} creation returned HTTP {create_status}: {create_body}")
 
-    status, body = request_json(analyzer_url, username=username, password=password)
+    status, body = request_json(
+        analyzer_url,
+        username=username,
+        password=password,
+        verify_tls=verify_tls,
+    )
     names = {str(item.get("name")) for item in body.get("analyzers", [])}
     missing = [scenario[0] for scenario in ANALYZER_SCENARIOS if scenario[0] not in names]
     if status != 200 or missing:
@@ -597,10 +714,19 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     subparsers.add_parser("env")
     subparsers.add_parser("config")
     subparsers.add_parser("doctor")
+    playwright = subparsers.add_parser(
+        "playwright",
+        help="Run Playwright with this worktree's URL and shared authentication setup.",
+    )
     logs = subparsers.add_parser("logs")
     logs.add_argument("services", nargs="*")
     logs.add_argument("--follow", "-f", action="store_true")
-    return parser.parse_args(list(argv))
+    args, remaining = parser.parse_known_args(list(argv))
+    if args.command == "playwright":
+        args.playwright_args = remaining
+    elif remaining:
+        parser.error(f"unrecognized arguments: {' '.join(remaining)}")
+    return args
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -618,6 +744,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         ensure_local_env(context)
         ensure_submodules(context, environment)
         bootstrap_analyzer_harness(context, environment)
+        backend_was_running = service_is_running(
+            context, environment, "oe.openelis.org"
+        )
         heal_war_mount(context)
         if not args.skip_build:
             build_application(context, environment)
@@ -625,11 +754,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             build_images(context, environment)
         elif not (context.repo_root / "target" / "OpenELIS-Global.war").is_file():
             raise RuntimeError("--skip-build requires target/OpenELIS-Global.war")
-        run(
-            compose_command(context, "up", "-d", "--remove-orphans"),
-            cwd=context.project_dir,
-            environment=environment,
+        start_services(
+            context,
+            environment,
+            refresh_running_backend=backend_was_running and not args.skip_build,
         )
+        reload_proxy(context, environment)
         configure_tls(context, environment)
         if not args.no_wait:
             wait_for_login(context, environment)
@@ -653,6 +783,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(endpoint_environment(context, environment)["BASE_URL"])
     elif args.command == "env":
         print_endpoints(context, environment, shell_exports=True)
+    elif args.command == "playwright":
+        playwright_environment = environment.copy()
+        playwright_environment["BASE_URL"] = playwright_base_url(context, environment)
+        print(f"Running Playwright against {playwright_environment['BASE_URL']}")
+        run(
+            playwright_command(args.playwright_args),
+            cwd=context.repo_root / "frontend",
+            environment=playwright_environment,
+        )
     elif args.command == "logs":
         log_args = ["logs"]
         if args.follow:

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -30,6 +30,18 @@ class StackContext(NamedTuple):
 
 LOCAL_DOMAINS = {"localhost", "127.0.0.1", "::1"}
 
+TEST_ONLY_FRONTEND_DEV_DEPENDENCIES = {
+    "@axe-core/playwright",
+    "@playwright/test",
+}
+TEST_ONLY_FRONTEND_SCRIPT_PREFIXES = (
+    "ci:",
+    "cy:",
+    "lint",
+    "pw:",
+    "test",
+)
+
 ANALYZER_SCENARIOS = (
     ("Cepheid GeneXpert (ASTM Mode)", "MOLECULAR", "generic-astm", "astm/genexpert-astm", "genexpert", "genexpert_astm", 9600, "ASTM_LIS2_A2", "GENEXPERT|CEPHEID"),
     ("Mindray BC-5380", "HEMATOLOGY", "generic-hl7", "hl7/mindray-bc5380", "bc5380", "mindray_bc5380", 5380, "HL7_V2_3_1", "MINDRAY.*BC.?5380|BC.?5380"),
@@ -124,17 +136,67 @@ def frontend_dependencies_changed(
     override = environment.get("DEV_STACK_BUILD_FRONTEND")
     if override is not None:
         return override.lower() == "true"
-    paths = ("frontend/package.json", "frontend/package-lock.json", "frontend/Dockerfile")
     try:
-        result = subprocess.run(
-            ["git", "diff", "--quiet", "origin/develop", "--", *paths],
+        dockerfile_changed = subprocess.run(
+            ["git", "diff", "--quiet", "origin/develop", "--", "frontend/Dockerfile"],
             cwd=context.repo_root,
             env=environment,
             check=False,
+        ).returncode != 0
+        lockfile_changed = subprocess.run(
+            ["git", "diff", "--quiet", "origin/develop", "--", "frontend/package-lock.json"],
+            cwd=context.repo_root,
+            env=environment,
+            check=False,
+        ).returncode != 0
+        base_package = json.loads(
+            output(
+                ["git", "show", "origin/develop:frontend/package.json"],
+                cwd=context.repo_root,
+                environment=environment,
+            )
         )
-        return result.returncode != 0
-    except OSError:
+        current_package = json.loads(
+            (context.repo_root / "frontend" / "package.json").read_text(encoding="utf-8")
+        )
+        return frontend_image_inputs_changed(
+            base_package,
+            current_package,
+            lockfile_changed=lockfile_changed,
+            dockerfile_changed=dockerfile_changed,
+        )
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
         return True
+
+
+def frontend_image_inputs_changed(
+    base_package: dict,
+    current_package: dict,
+    *,
+    lockfile_changed: bool,
+    dockerfile_changed: bool,
+) -> bool:
+    if dockerfile_changed:
+        return True
+    if base_package == current_package:
+        return lockfile_changed
+    return scrub_test_only_frontend_inputs(base_package) != scrub_test_only_frontend_inputs(
+        current_package
+    )
+
+
+def scrub_test_only_frontend_inputs(package: dict) -> dict:
+    scrubbed = json.loads(json.dumps(package))
+    dev_dependencies = scrubbed.get("devDependencies", {})
+    for dependency in TEST_ONLY_FRONTEND_DEV_DEPENDENCIES:
+        dev_dependencies.pop(dependency, None)
+    scripts = scrubbed.get("scripts", {})
+    scrubbed["scripts"] = {
+        name: command
+        for name, command in scripts.items()
+        if not name.startswith(TEST_ONLY_FRONTEND_SCRIPT_PREFIXES)
+    }
+    return scrubbed
 
 
 def compose_command(context: StackContext, *arguments: str) -> list[str]:

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -30,18 +30,6 @@ class StackContext(NamedTuple):
 
 LOCAL_DOMAINS = {"localhost", "127.0.0.1", "::1"}
 
-TEST_ONLY_FRONTEND_DEV_DEPENDENCIES = {
-    "@axe-core/playwright",
-    "@playwright/test",
-}
-TEST_ONLY_FRONTEND_SCRIPT_PREFIXES = (
-    "ci:",
-    "cy:",
-    "lint",
-    "pw:",
-    "test",
-)
-
 ANALYZER_SCENARIOS = (
     ("Cepheid GeneXpert (ASTM Mode)", "MOLECULAR", "generic-astm", "astm/genexpert-astm", "genexpert", "genexpert_astm", 9600, "ASTM_LIS2_A2", "GENEXPERT|CEPHEID"),
     ("Mindray BC-5380", "HEMATOLOGY", "generic-hl7", "hl7/mindray-bc5380", "bc5380", "mindray_bc5380", 5380, "HL7_V2_3_1", "MINDRAY.*BC.?5380|BC.?5380"),
@@ -136,67 +124,17 @@ def frontend_dependencies_changed(
     override = environment.get("DEV_STACK_BUILD_FRONTEND")
     if override is not None:
         return override.lower() == "true"
+    paths = ("frontend/package.json", "frontend/package-lock.json", "frontend/Dockerfile")
     try:
-        dockerfile_changed = subprocess.run(
-            ["git", "diff", "--quiet", "origin/develop", "--", "frontend/Dockerfile"],
+        result = subprocess.run(
+            ["git", "diff", "--quiet", "origin/develop", "--", *paths],
             cwd=context.repo_root,
             env=environment,
             check=False,
-        ).returncode != 0
-        lockfile_changed = subprocess.run(
-            ["git", "diff", "--quiet", "origin/develop", "--", "frontend/package-lock.json"],
-            cwd=context.repo_root,
-            env=environment,
-            check=False,
-        ).returncode != 0
-        base_package = json.loads(
-            output(
-                ["git", "show", "origin/develop:frontend/package.json"],
-                cwd=context.repo_root,
-                environment=environment,
-            )
         )
-        current_package = json.loads(
-            (context.repo_root / "frontend" / "package.json").read_text(encoding="utf-8")
-        )
-        return frontend_image_inputs_changed(
-            base_package,
-            current_package,
-            lockfile_changed=lockfile_changed,
-            dockerfile_changed=dockerfile_changed,
-        )
-    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
+        return result.returncode != 0
+    except OSError:
         return True
-
-
-def frontend_image_inputs_changed(
-    base_package: dict,
-    current_package: dict,
-    *,
-    lockfile_changed: bool,
-    dockerfile_changed: bool,
-) -> bool:
-    if dockerfile_changed:
-        return True
-    if base_package == current_package:
-        return lockfile_changed
-    return scrub_test_only_frontend_inputs(base_package) != scrub_test_only_frontend_inputs(
-        current_package
-    )
-
-
-def scrub_test_only_frontend_inputs(package: dict) -> dict:
-    scrubbed = json.loads(json.dumps(package))
-    dev_dependencies = scrubbed.get("devDependencies", {})
-    for dependency in TEST_ONLY_FRONTEND_DEV_DEPENDENCIES:
-        dev_dependencies.pop(dependency, None)
-    scripts = scrubbed.get("scripts", {})
-    scrubbed["scripts"] = {
-        name: command
-        for name, command in scripts.items()
-        if not name.startswith(TEST_ONLY_FRONTEND_SCRIPT_PREFIXES)
-    }
-    return scrubbed
 
 
 def compose_command(context: StackContext, *arguments: str) -> list[str]:

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -456,7 +456,7 @@ def request_json(
         return error.code, parsed
 
 
-def wait_for_mock_analyzer(mock_url: str, name: str, timeout_seconds: float = 15) -> str:
+def wait_for_mock_analyzer(mock_url: str, name: str, timeout_seconds: float = 60) -> str:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         try:

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -193,6 +193,12 @@ def run(
     )
 
 
+def output(
+    command: Sequence[str], *, cwd: Path, environment: dict[str, str]
+) -> str:
+    return run(command, cwd=cwd, environment=environment, capture=True).stdout.strip()
+
+
 def ensure_local_env(context: StackContext) -> None:
     env_file = context.repo_root / ".env"
     example = context.repo_root / ".env.example"
@@ -201,10 +207,67 @@ def ensure_local_env(context: StackContext) -> None:
         print(f"Created local {env_file.relative_to(context.repo_root)} from .env.example")
 
 
+def submodule_repair_mode(
+    expected: str, actual: str, status: str, has_content: bool
+) -> str | None:
+    if not has_content:
+        return "force"
+    if actual == expected:
+        return None
+    if status:
+        raise RuntimeError("Submodule has local changes at the wrong commit")
+    return "checkout"
+
+
 def ensure_submodules(context: StackContext, environment: dict[str, str]) -> None:
     command = ["git", "submodule", "update", "--init", "--recursive"]
     command.extend(required_submodules())
     run(command, cwd=context.repo_root, environment=environment)
+    for relative_path in required_submodules():
+        path = context.repo_root / relative_path
+        expected = output(
+            ["git", "rev-parse", f"HEAD:{relative_path}"],
+            cwd=context.repo_root,
+            environment=environment,
+        )
+        actual = output(
+            ["git", "rev-parse", "HEAD"], cwd=path, environment=environment
+        )
+        status = output(
+            ["git", "status", "--porcelain"], cwd=path, environment=environment
+        )
+        has_content = any(entry.name != ".git" for entry in path.iterdir())
+        repair_mode = submodule_repair_mode(expected, actual, status, has_content)
+        if repair_mode == "force":
+            run(
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--checkout",
+                    "--force",
+                    relative_path,
+                ],
+                cwd=context.repo_root,
+                environment=environment,
+            )
+        elif repair_mode == "checkout":
+            run(
+                ["git", "submodule", "update", "--init", "--checkout", relative_path],
+                cwd=context.repo_root,
+                environment=environment,
+            )
+        verified = output(
+            ["git", "rev-parse", "HEAD"], cwd=path, environment=environment
+        )
+        verified_status = output(
+            ["git", "status", "--porcelain"], cwd=path, environment=environment
+        )
+        if verified != expected or verified_status:
+            raise RuntimeError(
+                f"Submodule {relative_path} is not a clean checkout of {expected[:12]}"
+            )
 
 
 def heal_war_mount(context: StackContext) -> None:

--- a/scripts/run-java21
+++ b/scripts/run-java21
@@ -6,32 +6,58 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
 SDKMANRC="$PROJECT_ROOT/.sdkmanrc"
 
-if [[ ! -r "$SDKMANRC" ]]; then
-    echo "OpenELIS SDKMAN configuration is missing at $SDKMANRC" >&2
-    exit 1
+java_specification_version() {
+    "$1" -XshowSettings:properties -version 2>&1 \
+        | awk -F'= ' '/java.specification.version/ { print $2; exit }'
+}
+
+java_home_property() {
+    "$1" -XshowSettings:properties -version 2>&1 \
+        | awk -F'= ' '/java.home/ { print $2; exit }'
+}
+
+is_java21() {
+    [[ -x "$1" ]] && [[ "$(java_specification_version "$1")" == "21" ]]
+}
+
+SELECTED_JAVA_HOME=""
+if [[ -n "${JAVA_HOME_21:-}" ]]; then
+    if ! is_java21 "$JAVA_HOME_21/bin/java"; then
+        echo "JAVA_HOME_21 does not point to a Java 21 installation: $JAVA_HOME_21" >&2
+        exit 1
+    fi
+    SELECTED_JAVA_HOME="$JAVA_HOME_21"
+elif [[ -n "${JAVA_HOME:-}" ]] && is_java21 "$JAVA_HOME/bin/java"; then
+    SELECTED_JAVA_HOME="$JAVA_HOME"
+elif command -v java >/dev/null 2>&1 \
+    && [[ "$(java_specification_version "$(command -v java)")" == "21" ]]; then
+    SELECTED_JAVA_HOME="$(java_home_property "$(command -v java)")"
+else
+    if [[ ! -r "$SDKMANRC" ]]; then
+        echo "OpenELIS requires Java 21; no valid selected Java or SDKMAN configuration was found" >&2
+        exit 1
+    fi
+    JAVA_VERSION="$(awk -F= '$1 == "java" { print $2; exit }' "$SDKMANRC")"
+    SDKMAN_JAVA_HOME="$SDKMAN_DIR/candidates/java/$JAVA_VERSION"
+    if [[ -z "$JAVA_VERSION" ]] || ! is_java21 "$SDKMAN_JAVA_HOME/bin/java"; then
+        echo "Java $JAVA_VERSION is not installed under SDKMAN at $SDKMAN_JAVA_HOME" >&2
+        exit 1
+    fi
+    SELECTED_JAVA_HOME="$SDKMAN_JAVA_HOME"
 fi
 
-JAVA_VERSION="$(awk -F= '$1 == "java" { print $2; exit }' "$SDKMANRC")"
-JAVA_HOME="${JAVA_HOME_21:-$SDKMAN_DIR/candidates/java/$JAVA_VERSION}"
-
-if [[ -z "$JAVA_VERSION" || ! -x "$JAVA_HOME/bin/java" ]]; then
-    echo "Java $JAVA_VERSION is not installed under SDKMAN at $JAVA_HOME" >&2
-    exit 1
-fi
-
+JAVA_HOME="$SELECTED_JAVA_HOME"
 export JAVA_HOME
 export PATH="$JAVA_HOME/bin:$PATH"
 
-JAVA_SPECIFICATION_VERSION="$({ java -XshowSettings:properties -version; } 2>&1 \
-    | awk -F'= ' '/java.specification.version/ { print $2; exit }')"
-
+JAVA_SPECIFICATION_VERSION="$(java_specification_version "$JAVA_HOME/bin/java")"
 if [[ "$JAVA_SPECIFICATION_VERSION" != "21" ]]; then
     echo "OpenELIS requires Java 21; selected Java $JAVA_SPECIFICATION_VERSION" >&2
     exit 1
 fi
 
 if [[ "$#" -eq 0 ]]; then
-    java -version
+    "$JAVA_HOME/bin/java" -version
     exit 0
 fi
 

--- a/scripts/run-java21
+++ b/scripts/run-java21
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
+SDKMANRC="$PROJECT_ROOT/.sdkmanrc"
+
+if [[ ! -r "$SDKMANRC" ]]; then
+    echo "OpenELIS SDKMAN configuration is missing at $SDKMANRC" >&2
+    exit 1
+fi
+
+JAVA_VERSION="$(awk -F= '$1 == "java" { print $2; exit }' "$SDKMANRC")"
+JAVA_HOME="${JAVA_HOME_21:-$SDKMAN_DIR/candidates/java/$JAVA_VERSION}"
+
+if [[ -z "$JAVA_VERSION" || ! -x "$JAVA_HOME/bin/java" ]]; then
+    echo "Java $JAVA_VERSION is not installed under SDKMAN at $JAVA_HOME" >&2
+    exit 1
+fi
+
+export JAVA_HOME
+export PATH="$JAVA_HOME/bin:$PATH"
+
+JAVA_SPECIFICATION_VERSION="$({ java -XshowSettings:properties -version; } 2>&1 \
+    | awk -F'= ' '/java.specification.version/ { print $2; exit }')"
+
+if [[ "$JAVA_SPECIFICATION_VERSION" != "21" ]]; then
+    echo "OpenELIS requires Java 21; selected Java $JAVA_SPECIFICATION_VERSION" >&2
+    exit 1
+fi
+
+if [[ "$#" -eq 0 ]]; then
+    java -version
+    exit 0
+fi
+
+exec "$@"

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -1,0 +1,148 @@
+import importlib.machinery
+import importlib.util
+import pathlib
+import unittest
+from unittest.mock import patch
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "dev-stack"
+
+
+def load_dev_stack():
+    loader = importlib.machinery.SourceFileLoader("dev_stack", str(SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class DevStackContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dev_stack = load_dev_stack()
+
+    def test_project_identity_is_deterministic_per_worktree(self):
+        first = self.dev_stack.make_context(REPO_ROOT)
+        second = self.dev_stack.make_context(REPO_ROOT)
+
+        self.assertEqual(first.project, second.project)
+        self.assertRegex(first.project, r"^oe2-[a-z0-9-]+-[0-9a-f]{8}-dev$")
+
+    def test_full_harness_is_the_only_compose_path(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        self.assertEqual(
+            context.compose_files[-1],
+            REPO_ROOT
+            / "projects"
+            / "analyzer-harness"
+            / "docker-compose.worktree.yml",
+        )
+
+        self.assertIn(
+            REPO_ROOT
+            / "projects"
+            / "analyzer-harness"
+            / "docker-compose.letsencrypt.yml",
+            context.compose_files,
+        )
+
+    def test_compose_commands_are_scoped_to_the_worktree_project(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        command = self.dev_stack.compose_command(context, "ps")
+
+        self.assertEqual(command[:4], ["docker", "compose", "-p", context.project])
+        self.assertIn(str(context.compose_files[-1]), command)
+        self.assertEqual(command[-1], "ps")
+
+    def test_analyzer_environment_namespaces_dynamic_networks(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        environment = self.dev_stack.build_environment(context)
+
+        self.assertEqual(environment["ANALYZER_NETWORK_NAMESPACE"], context.project)
+        self.assertRegex(environment["ANALYZER_SUBNET_PREFIX"], r"^10\.(?:[6-9][0-9]|1[0-9]{2}|2[01][0-9]|22[0-3])$")
+        self.assertEqual(environment["OE_UAT_SCENARIOS_ENABLED"], "true")
+
+    def test_localhost_uses_random_loopback_ingress_and_self_signed_tls(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        with patch.dict(
+            self.dev_stack.os.environ,
+            {
+                "LETSENCRYPT_DOMAIN": "localhost",
+                "DEV_STACK_INGRESS_BIND_ADDRESS": "127.0.0.1",
+                "DEV_STACK_HTTP_PORT": "0",
+                "DEV_STACK_HTTPS_PORT": "0",
+                "DEV_STACK_TLS": "self-signed",
+            },
+        ):
+            environment = self.dev_stack.build_environment(context)
+
+        self.assertEqual(environment["DEV_STACK_INGRESS_BIND_ADDRESS"], "127.0.0.1")
+        self.assertEqual(environment["DEV_STACK_HTTP_PORT"], "0")
+        self.assertEqual(environment["DEV_STACK_HTTPS_PORT"], "0")
+        self.assertEqual(environment["DEV_STACK_TLS"], "self-signed")
+
+    def test_domain_uses_public_standard_ingress_and_letsencrypt(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        with patch.dict(
+            self.dev_stack.os.environ,
+            {"LETSENCRYPT_DOMAIN": "dev.example.org"},
+            clear=True,
+        ):
+            environment = self.dev_stack.build_environment(context)
+
+        self.assertEqual(environment["DEV_STACK_INGRESS_BIND_ADDRESS"], "0.0.0.0")
+        self.assertEqual(environment["DEV_STACK_HTTP_PORT"], "80")
+        self.assertEqual(environment["DEV_STACK_HTTPS_PORT"], "443")
+        self.assertEqual(environment["DEV_STACK_TLS"], "letsencrypt")
+
+    def test_endpoint_parser_accepts_ipv4_and_ipv6_compose_output(self):
+        self.assertEqual(self.dev_stack.parse_published_port("127.0.0.1:49152"), 49152)
+        self.assertEqual(self.dev_stack.parse_published_port("[::1]:49153"), 49153)
+
+    def test_volume_removal_requires_explicit_confirmation(self):
+        with self.assertRaisesRegex(ValueError, "--yes"):
+            self.dev_stack.validate_down_options(remove_volumes=True, confirmed=False)
+
+        self.dev_stack.validate_down_options(remove_volumes=True, confirmed=True)
+
+    def test_bootstrap_includes_every_full_harness_submodule(self):
+        self.assertEqual(
+            self.dev_stack.required_submodules(),
+            (
+                "dataexport",
+                "plugins",
+                "tools/analyzer-mock-server",
+                "tools/openelis-analyzer-bridge",
+            ),
+        )
+
+    def test_frontend_build_override_is_deterministic(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        self.assertTrue(
+            self.dev_stack.frontend_dependencies_changed(
+                context, {"DEV_STACK_BUILD_FRONTEND": "true"}
+            )
+        )
+        self.assertFalse(
+            self.dev_stack.frontend_dependencies_changed(
+                context, {"DEV_STACK_BUILD_FRONTEND": "false"}
+            )
+        )
+
+    def test_full_harness_scenarios_cover_each_transport_without_ids(self):
+        scenarios = self.dev_stack.ANALYZER_SCENARIOS
+
+        self.assertEqual(len(scenarios), 9)
+        self.assertEqual({scenario[2] for scenario in scenarios}, {"generic-astm", "generic-hl7", "generic-file"})
+        self.assertTrue(all(scenario[3] for scenario in scenarios))
+        self.assertFalse(any(isinstance(value, int) for scenario in scenarios for value in scenario[:4]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -1,8 +1,13 @@
 import importlib.machinery
 import importlib.util
+import os
 import pathlib
+import re
+import subprocess
+import tempfile
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -48,6 +53,19 @@ class DevStackContractTest(unittest.TestCase):
             context.compose_files,
         )
 
+    def test_fhir_waits_for_a_healthy_database(self):
+        compose = (
+            REPO_ROOT
+            / "projects"
+            / "analyzer-harness"
+            / "docker-compose.dev.yml"
+        ).read_text()
+
+        fhir = compose.split("  fhir.openelis.org:", 1)[1].split(
+            "  frontend.openelis.org:", 1
+        )[0]
+        self.assertIn("db.openelis.org:\n        condition: service_healthy", fhir)
+
     def test_compose_commands_are_scoped_to_the_worktree_project(self):
         context = self.dev_stack.make_context(REPO_ROOT)
 
@@ -65,6 +83,18 @@ class DevStackContractTest(unittest.TestCase):
         self.assertEqual(environment["ANALYZER_NETWORK_NAMESPACE"], context.project)
         self.assertRegex(environment["ANALYZER_SUBNET_PREFIX"], r"^10\.(?:[6-9][0-9]|1[0-9]{2}|2[01][0-9]|22[0-3])$")
         self.assertEqual(environment["OE_UAT_SCENARIOS_ENABLED"], "true")
+
+    def test_explicit_uat_scenario_setting_overrides_isolated_default(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        with patch.dict(
+            self.dev_stack.os.environ,
+            {"OE_UAT_SCENARIOS_ENABLED": "false"},
+            clear=True,
+        ):
+            environment = self.dev_stack.build_environment(context)
+
+        self.assertEqual(environment["OE_UAT_SCENARIOS_ENABLED"], "false")
 
     def test_localhost_uses_random_loopback_ingress_and_self_signed_tls(self):
         context = self.dev_stack.make_context(REPO_ROOT)
@@ -100,6 +130,30 @@ class DevStackContractTest(unittest.TestCase):
         self.assertEqual(environment["DEV_STACK_HTTPS_PORT"], "443")
         self.assertEqual(environment["DEV_STACK_TLS"], "letsencrypt")
 
+    def test_json_requests_verify_https_certificates_by_default(self):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.status = 200
+        response.read.return_value = b"{}"
+
+        with patch.object(self.dev_stack, "urlopen", return_value=response) as open_url:
+            self.dev_stack.request_json("https://dev.example.org/status")
+
+        self.assertIsNone(open_url.call_args.kwargs["context"])
+
+    def test_json_requests_disable_verification_only_when_explicit(self):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.status = 200
+        response.read.return_value = b"{}"
+
+        with patch.object(self.dev_stack, "urlopen", return_value=response) as open_url:
+            self.dev_stack.request_json(
+                "https://localhost/status", verify_tls=False
+            )
+
+        self.assertEqual(open_url.call_args.kwargs["context"].verify_mode, 0)
+
     def test_endpoint_parser_accepts_ipv4_and_ipv6_compose_output(self):
         self.assertEqual(self.dev_stack.parse_published_port("127.0.0.1:49152"), 49152)
         self.assertEqual(self.dev_stack.parse_published_port("[::1]:49153"), 49153)
@@ -130,6 +184,48 @@ class DevStackContractTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "local changes"):
             repair_mode("expected", "actual", " M file", True)
 
+    def test_submodule_initialization_forces_only_an_empty_failed_checkout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "plugins").mkdir()
+            (root / "plugins" / ".git").write_text("gitdir: missing\n")
+            context = SimpleNamespace(repo_root=root)
+            failed = subprocess.CalledProcessError(128, ["git", "submodule"])
+
+            with patch.object(
+                self.dev_stack, "run", side_effect=[failed, None]
+            ) as run:
+                self.dev_stack.initialize_submodule(context, {}, "plugins")
+
+            self.assertEqual(run.call_count, 2)
+            self.assertEqual(
+                run.call_args_list[1].args[0],
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                    "--checkout",
+                    "--force",
+                    "plugins",
+                ],
+            )
+
+    def test_submodule_initialization_never_forces_a_populated_failed_checkout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "plugins").mkdir()
+            (root / "plugins" / "local-change.txt").write_text("keep me\n")
+            context = SimpleNamespace(repo_root=root)
+            failed = subprocess.CalledProcessError(128, ["git", "submodule"])
+
+            with patch.object(self.dev_stack, "run", side_effect=failed) as run:
+                with self.assertRaisesRegex(RuntimeError, "populated checkout"):
+                    self.dev_stack.initialize_submodule(context, {}, "plugins")
+
+            run.assert_called_once()
+
     def test_frontend_build_override_is_deterministic(self):
         context = self.dev_stack.make_context(REPO_ROOT)
 
@@ -142,6 +238,246 @@ class DevStackContractTest(unittest.TestCase):
             self.dev_stack.frontend_dependencies_changed(
                 context, {"DEV_STACK_BUILD_FRONTEND": "false"}
             )
+        )
+
+    def test_frontend_build_detects_non_mounted_runtime_inputs(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+
+        with patch.object(
+            self.dev_stack.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0),
+        ) as run:
+            self.dev_stack.frontend_dependencies_changed(context, {})
+
+        command = run.call_args.args[0]
+        self.assertIn("frontend/vite.config.ts", command)
+        self.assertIn("frontend/index.html", command)
+        self.assertIn("frontend/tsconfig.json", command)
+        self.assertIn("frontend/.npmrc", command)
+
+    def test_run_java21_honors_selected_java_21_home(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            java_home = root / "selected-java"
+            java_bin = java_home / "bin"
+            java_bin.mkdir(parents=True)
+            java = java_bin / "java"
+            java.write_text(
+                "#!/bin/sh\n"
+                "echo '    java.specification.version = 21' >&2\n",
+                encoding="utf-8",
+            )
+            java.chmod(0o755)
+            environment = os.environ.copy()
+            environment["JAVA_HOME"] = str(java_home)
+            environment["SDKMAN_DIR"] = str(root / "missing-sdkman")
+            environment.pop("JAVA_HOME_21", None)
+
+            result = subprocess.run(
+                [
+                    str(REPO_ROOT / "scripts" / "run-java21"),
+                    "sh",
+                    "-c",
+                    'printf "%s" "$JAVA_HOME"',
+                ],
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, str(java_home))
+
+    def test_playwright_defaults_to_core_app_and_preserves_test_selection(self):
+        command = self.dev_stack.playwright_command(
+            ["playwright/tests/foundational/core/example.spec.ts"]
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "npm",
+                "run",
+                "pw:test",
+                "--",
+                "--project=core-app",
+                "playwright/tests/foundational/core/example.spec.ts",
+            ],
+        )
+
+    def test_playwright_preserves_explicit_project_and_options(self):
+        command = self.dev_stack.playwright_command(
+            ["--project=setup", "--headed"]
+        )
+
+        self.assertEqual(
+            command,
+            ["npm", "run", "pw:test", "--", "--project=setup", "--headed"],
+        )
+
+    def test_playwright_parser_forwards_native_options_without_separator(self):
+        arguments = self.dev_stack.parse_args(
+            [
+                "playwright",
+                "--project=core-app",
+                "playwright/tests/foundational/core/example.spec.ts",
+                "--headed",
+            ]
+        )
+
+        self.assertEqual(
+            arguments.playwright_args,
+            [
+                "--project=core-app",
+                "playwright/tests/foundational/core/example.spec.ts",
+                "--headed",
+            ],
+        )
+
+    def test_playwright_uses_explicit_remote_url_without_stack_discovery(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = {"BASE_URL": "https://amr.openelis-global.org"}
+
+        with patch.object(self.dev_stack, "endpoint_environment") as endpoints:
+            base_url = self.dev_stack.playwright_base_url(context, environment)
+
+        self.assertEqual(base_url, "https://amr.openelis-global.org")
+        endpoints.assert_not_called()
+
+    def test_playwright_discovers_current_worktree_url_when_not_explicit(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = {}
+
+        with patch.object(
+            self.dev_stack,
+            "endpoint_environment",
+            return_value={"BASE_URL": "https://localhost:49152"},
+        ):
+            base_url = self.dev_stack.playwright_base_url(context, environment)
+
+        self.assertEqual(base_url, "https://localhost:49152")
+
+    def test_proxy_resolves_replaceable_services_through_docker_dns(self):
+        for config_name in ("nginx.conf.template", "nginx.conf"):
+            with self.subTest(config_name=config_name):
+                proxy = (REPO_ROOT / "volume" / "nginx" / config_name).read_text()
+
+                self.assertIn("resolver 127.0.0.11", proxy)
+                self.assertEqual(proxy.count('set $frontend_upstream "frontend.openelis.org";'), 2)
+                self.assertEqual(len(re.findall(r"proxy_pass\s+http://\$frontend_upstream;", proxy)), 2)
+                self.assertEqual(proxy.count('set $oe_upstream "oe.openelis.org";'), 4)
+                self.assertEqual(len(re.findall(r"proxy_pass\s+https://\$oe_upstream:8443;", proxy)), 4)
+                if config_name == "nginx.conf.template":
+                    self.assertIn('set $bridge_upstream "bridge.openelis.org";', proxy)
+                    self.assertIn("proxy_pass https://$bridge_upstream:8443;", proxy)
+
+    def test_proxy_configuration_is_validated_and_reloaded(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = self.dev_stack.build_environment(context)
+
+        with patch.object(self.dev_stack, "run") as run:
+            self.dev_stack.reload_proxy(context, environment)
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(commands[0][-5:], ["exec", "-T", "proxy", "nginx", "-t"])
+        self.assertEqual(
+            commands[1][-6:], ["exec", "-T", "proxy", "nginx", "-s", "reload"]
+        )
+
+    def test_backend_running_probe_is_scoped_to_the_worktree(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = self.dev_stack.build_environment(context)
+
+        with patch.object(
+            self.dev_stack,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0, stdout="container-id\n"),
+        ) as run:
+            running = self.dev_stack.service_is_running(
+                context, environment, "oe.openelis.org"
+            )
+
+        self.assertTrue(running)
+        self.assertEqual(
+            run.call_args.args[0][-5:],
+            ["ps", "--status", "running", "-q", "oe.openelis.org"],
+        )
+
+    def test_start_services_recreates_only_a_previously_running_backend(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = self.dev_stack.build_environment(context)
+
+        with patch.object(self.dev_stack, "run") as run:
+            self.dev_stack.start_services(
+                context, environment, refresh_running_backend=True
+            )
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(commands[0][-3:], ["up", "-d", "--remove-orphans"])
+        self.assertEqual(
+            commands[1][-5:],
+            ["up", "-d", "--no-deps", "--force-recreate", "oe.openelis.org"],
+        )
+
+    def test_start_services_does_not_recreate_backend_on_initial_start(self):
+        context = self.dev_stack.make_context(REPO_ROOT)
+        environment = self.dev_stack.build_environment(context)
+
+        with patch.object(self.dev_stack, "run") as run:
+            self.dev_stack.start_services(
+                context, environment, refresh_running_backend=False
+            )
+
+        self.assertEqual(len(run.call_args_list), 1)
+        self.assertIn(
+            "../../target/OpenELIS-Global.war:/usr/local/tomcat/webapps/OpenELIS-Global.war",
+            (
+                REPO_ROOT
+                / "projects"
+                / "analyzer-harness"
+                / "docker-compose.dev.yml"
+            ).read_text(),
+        )
+
+    def test_up_recreates_a_running_backend_exactly_once_after_build(self):
+        with (
+            patch.object(self.dev_stack, "ensure_local_env"),
+            patch.object(self.dev_stack, "ensure_submodules"),
+            patch.object(self.dev_stack, "bootstrap_analyzer_harness"),
+            patch.object(self.dev_stack, "service_is_running", return_value=True),
+            patch.object(self.dev_stack, "heal_war_mount"),
+            patch.object(self.dev_stack, "build_application"),
+            patch.object(self.dev_stack, "stage_analyzer_plugins"),
+            patch.object(self.dev_stack, "build_images"),
+            patch.object(self.dev_stack, "reload_proxy"),
+            patch.object(self.dev_stack, "configure_tls"),
+            patch.object(self.dev_stack, "print_endpoints"),
+            patch.object(self.dev_stack, "run") as run,
+        ):
+            self.dev_stack.main(["up", "--no-wait", "--no-scenarios"])
+
+        recreates = [
+            call.args[0]
+            for call in run.call_args_list
+            if "--force-recreate" in call.args[0]
+        ]
+        self.assertEqual(len(recreates), 1)
+        self.assertEqual(
+            recreates[0][-5:],
+            ["up", "-d", "--no-deps", "--force-recreate", "oe.openelis.org"],
+        )
+
+    def test_harness_refreshes_repository_owned_menu_configuration(self):
+        bootstrap = (
+            REPO_ROOT / "projects" / "analyzer-harness" / "bootstrap.sh"
+        ).read_text()
+
+        self.assertIn(
+            'cp "$ROOT_VOLUME/menu/menu_config.json" '
+            '"$HARNESS_VOLUME/menu/menu_config.json"',
+            bootstrap,
         )
 
     def test_full_harness_scenarios_cover_each_transport_without_ids(self):

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -144,6 +144,57 @@ class DevStackContractTest(unittest.TestCase):
             )
         )
 
+    def test_test_only_frontend_changes_reuse_runtime_image(self):
+        base = {
+            "dependencies": {"react": "17"},
+            "devDependencies": {"@playwright/test": "1", "vite": "8"},
+            "scripts": {"start": "vite", "pw:test": "playwright test"},
+        }
+        current = {
+            "dependencies": {"react": "17"},
+            "devDependencies": {
+                "@axe-core/playwright": "4",
+                "@playwright/test": "1",
+                "vite": "8",
+            },
+            "scripts": {
+                "start": "vite",
+                "pw:test": "playwright test",
+                "pw:test:a11y": "playwright test --project=a11y",
+            },
+        }
+
+        self.assertFalse(
+            self.dev_stack.frontend_image_inputs_changed(
+                base,
+                current,
+                lockfile_changed=True,
+                dockerfile_changed=False,
+            )
+        )
+
+    def test_runtime_frontend_changes_build_a_worktree_image(self):
+        base = {
+            "dependencies": {"react": "17"},
+            "devDependencies": {"vite": "8"},
+            "scripts": {"start": "vite"},
+        }
+
+        for current, lock_changed, dockerfile_changed in (
+            ({**base, "dependencies": {"react": "18"}}, True, False),
+            ({**base, "devDependencies": {"vite": "9"}}, True, False),
+            (base, True, False),
+            (base, False, True),
+        ):
+            self.assertTrue(
+                self.dev_stack.frontend_image_inputs_changed(
+                    base,
+                    current,
+                    lockfile_changed=lock_changed,
+                    dockerfile_changed=dockerfile_changed,
+                )
+            )
+
     def test_full_harness_scenarios_cover_each_transport_without_ids(self):
         scenarios = self.dev_stack.ANALYZER_SCENARIOS
 

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -144,57 +144,6 @@ class DevStackContractTest(unittest.TestCase):
             )
         )
 
-    def test_test_only_frontend_changes_reuse_runtime_image(self):
-        base = {
-            "dependencies": {"react": "17"},
-            "devDependencies": {"@playwright/test": "1", "vite": "8"},
-            "scripts": {"start": "vite", "pw:test": "playwright test"},
-        }
-        current = {
-            "dependencies": {"react": "17"},
-            "devDependencies": {
-                "@axe-core/playwright": "4",
-                "@playwright/test": "1",
-                "vite": "8",
-            },
-            "scripts": {
-                "start": "vite",
-                "pw:test": "playwright test",
-                "pw:test:a11y": "playwright test --project=a11y",
-            },
-        }
-
-        self.assertFalse(
-            self.dev_stack.frontend_image_inputs_changed(
-                base,
-                current,
-                lockfile_changed=True,
-                dockerfile_changed=False,
-            )
-        )
-
-    def test_runtime_frontend_changes_build_a_worktree_image(self):
-        base = {
-            "dependencies": {"react": "17"},
-            "devDependencies": {"vite": "8"},
-            "scripts": {"start": "vite"},
-        }
-
-        for current, lock_changed, dockerfile_changed in (
-            ({**base, "dependencies": {"react": "18"}}, True, False),
-            ({**base, "devDependencies": {"vite": "9"}}, True, False),
-            (base, True, False),
-            (base, False, True),
-        ):
-            self.assertTrue(
-                self.dev_stack.frontend_image_inputs_changed(
-                    base,
-                    current,
-                    lockfile_changed=lock_changed,
-                    dockerfile_changed=dockerfile_changed,
-                )
-            )
-
     def test_full_harness_scenarios_cover_each_transport_without_ids(self):
         scenarios = self.dev_stack.ANALYZER_SCENARIOS
 

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -121,6 +121,15 @@ class DevStackContractTest(unittest.TestCase):
             ),
         )
 
+    def test_submodule_bootstrap_repairs_empty_checkouts_without_forcing_dirty_ones(self):
+        repair_mode = self.dev_stack.submodule_repair_mode
+
+        self.assertEqual(repair_mode("expected", "actual", " D file", False), "force")
+        self.assertEqual(repair_mode("expected", "actual", "", True), "checkout")
+        self.assertIsNone(repair_mode("expected", "expected", "", True))
+        with self.assertRaisesRegex(RuntimeError, "local changes"):
+            repair_mode("expected", "actual", " M file", True)
+
     def test_frontend_build_override_is_deterministic(self):
         context = self.dev_stack.make_context(REPO_ROOT)
 

--- a/volume/nginx/nginx.conf
+++ b/volume/nginx/nginx.conf
@@ -2,6 +2,10 @@ worker_processes 1;
 
 events { worker_connections 1024; }
 http {
+    # Docker service containers can be replaced independently in development.
+    # Resolve their aliases per request so nginx never retains a stale container IP.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # Allows the frontend location blocks below to pass through the Vite dev
     # server's WebSocket-based HMR connection (Upgrade: websocket) alongside
     # normal HTTP requests on the same proxy_pass.
@@ -55,7 +59,8 @@ http {
             # hop between proxy and frontend is plain HTTP (standard edge-
             # termination pattern). Not a security regression — the Docker
             # bridge is private.
-            proxy_pass http://frontend.openelis.org;
+            set $frontend_upstream "frontend.openelis.org";
+            proxy_pass http://$frontend_upstream;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -64,7 +69,8 @@ http {
         }
 
         location /api/ {
-            proxy_pass https://oe.openelis.org:8443/api/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -75,7 +81,8 @@ http {
         }
 
         location /rest/ {
-            proxy_pass https://oe.openelis.org:8443/rest/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -110,7 +117,8 @@ http {
                 #In docker
             # See the storage.openelis-global.org server block above for
             # rationale on HTTP-internal + edge-termination.
-            proxy_pass http://frontend.openelis.org;
+            set $frontend_upstream "frontend.openelis.org";
+            proxy_pass http://$frontend_upstream;
             proxy_redirect     off;
             proxy_http_version 1.1;
             proxy_set_header   Host $host;
@@ -125,7 +133,8 @@ http {
                  #On Mac
             #proxy_pass         https://host.docker.internal:8443/api/;
                 #In docker
-            proxy_pass         https://oe.openelis.org:8443/api/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass         https://$oe_upstream:8443;
             proxy_redirect     off;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
@@ -134,7 +143,8 @@ http {
         }
 
         location /rest/ {
-            proxy_pass         https://oe.openelis.org:8443/rest/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass         https://$oe_upstream:8443;
             proxy_redirect     off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;

--- a/volume/nginx/nginx.conf.template
+++ b/volume/nginx/nginx.conf.template
@@ -15,6 +15,10 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
+    # Docker service containers can be replaced independently in development.
+    # Resolve their aliases per request so nginx never retains a stale container IP.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # HTTP server — handles ACME challenges and redirects to HTTPS for both
     # the primary domain and the bridge subdomain. Certbot writes challenge
     # tokens into /var/www/certbot on ANY domain being validated, so both
@@ -67,14 +71,16 @@ http {
         # (server.allowedHosts, strict since Vite 5) accepts forwarded requests
         # regardless of the public hostname — keeps nginx hostname-agnostic.
         location / {
-            proxy_pass http://frontend.openelis.org;
+            set $frontend_upstream "frontend.openelis.org";
+            proxy_pass http://$frontend_upstream;
             proxy_redirect off;
             proxy_set_header Host localhost;
         }
 
         # Backend API
         location /api/ {
-            proxy_pass https://oe.openelis.org:8443/api/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -86,7 +92,8 @@ http {
 
         # REST API
         location /rest/ {
-            proxy_pass https://oe.openelis.org:8443/rest/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -136,7 +143,8 @@ http {
         }
 
         location / {
-            proxy_pass https://bridge.openelis.org:8443;
+            set $bridge_upstream "bridge.openelis.org";
+            proxy_pass https://$bridge_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -168,14 +176,16 @@ http {
 
         # Frontend — same Vite host-rewrite rationale as the named-host block.
         location / {
-            proxy_pass http://frontend.openelis.org;
+            set $frontend_upstream "frontend.openelis.org";
+            proxy_pass http://$frontend_upstream;
             proxy_redirect off;
             proxy_set_header Host localhost;
         }
 
         # Backend API
         location /api/ {
-            proxy_pass https://oe.openelis.org:8443/api/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;
@@ -187,7 +197,8 @@ http {
 
         # REST API
         location /rest/ {
-            proxy_pass https://oe.openelis.org:8443/rest/;
+            set $oe_upstream "oe.openelis.org";
+            proxy_pass https://$oe_upstream:8443;
             proxy_redirect off;
             proxy_ssl_verify off;
             proxy_ssl_server_name on;


### PR DESCRIPTION
## Contract

From any clone or worktree, one command starts the complete development environment:

`scripts/dev-stack up`

It includes core OpenELIS, frontend, FHIR, PostgreSQL, analyzer Bridge, mock analyzers, and virtual serial support. Local mode uses random loopback ports and self-signed TLS. A real `LETSENCRYPT_DOMAIN` uses the same command with public 80/443 and the existing certificate flow.

## Isolation

- deterministic Compose project per worktree
- project-scoped containers, volumes, images, and base networks
- namespaced dynamic analyzer networks and a worktree-specific private subnet prefix
- `scripts/dev-stack env` exports exact URLs/IPs for Playwright
- explicit `down --volumes --yes` guard for destructive reset

## Scenario setup

The nine analyzer harness scenarios are created idempotently through authenticated OpenELIS services. The development startup path does not execute SQL fixtures, bypass DAOs, or assign primary keys.

## Validation

- dev-stack contract: 11/11
- analyzer network manager: 18/18
- authenticated core Playwright navbar smoke: 6/6
- dynamic HL7 simulator/mapping Playwright journey: 2/2
- repeated startup leaves exactly one record for each of nine analyzers
- concurrent live stacks verified: existing OGC-782, existing OGC-1054 harness, and this isolated stack
- repeat startup measured at 14.8 seconds on this workstation
- localhost and domain Compose renders validated

Depends on DIGI-UW/analyzer-mock-server#39.

## Existing signals observed

The passing browser runs still report pre-existing duplicate sidenav-key warnings, a pending-codes HTTP 500, and Carbon transactional-modal warnings. They are not introduced or masked by this tooling PR.