### PR TITLE
test(microbiology): prove supported order save integration

### DIFF
--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -150,10 +150,10 @@ capability is available; it does not own macro authoring or administration.
   only if this evidence exposes a real defect; do not deploy test-only changes.
 - [ ] **Accept the current stack** - Complete human UAT in Grist, remediate real
    findings in manageable slices, and merge the stack bottom-up.
-- [ ] **Supported order-save integration proof** - Add the missing direct
+- [x] **Supported order-save integration proof** - Add the missing direct
    integration test around the complete supported save path without SQL,
    fixed primary keys, or DAO bypass.
-- [ ] **Clinical and NFR qualification** - Finish representative-volume worklist
+- [*] **Clinical and NFR qualification** - Finish representative-volume worklist
    and case measurements, keyboard/screen-reader review, and a clear decision
    on shared offline/conflict behavior. Do not build a microbiology-only offline
    queue.

--- a/src/test/java/org/openelisglobal/microbiology/MicrobiologyOrderSaveIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/MicrobiologyOrderSaveIntegrationTest.java
@@ -1,0 +1,181 @@
+package org.openelisglobal.microbiology;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.services.SampleAddService;
+import org.openelisglobal.microbiology.fixture.MicrobiologyTestFixtures;
+import org.openelisglobal.microbiology.form.MicroCaseOrderDetailRequestForm;
+import org.openelisglobal.microbiology.service.MicroCaseAnalysisService;
+import org.openelisglobal.microbiology.service.MicroCaseOrderDetailService;
+import org.openelisglobal.microbiology.service.MicroCaseService;
+import org.openelisglobal.microbiology.valueholder.MicroCase;
+import org.openelisglobal.microbiology.valueholder.MicroCaseOrderDetail;
+import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.patient.action.bean.PatientManagementInfo;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
+import org.openelisglobal.sample.form.SamplePatientEntryForm;
+import org.openelisglobal.sample.service.PatientManagementUpdate;
+import org.openelisglobal.sample.service.SamplePatientEntryService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class MicrobiologyOrderSaveIntegrationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private MicrobiologyTestFixtures fixtures;
+
+    @Autowired
+    private SamplePatientEntryService samplePatientEntryService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private MicroCaseService caseService;
+
+    @Autowired
+    private MicroCaseAnalysisService caseAnalysisService;
+
+    @Autowired
+    private MicroCaseOrderDetailService orderDetailService;
+
+    private String userId;
+    private org.openelisglobal.test.valueholder.Test cultureTest;
+    private Patient patient;
+    private TypeOfSample sampleType;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        userId = fixtures.defaultUserId();
+        String methodId = fixtures.createMethodId();
+        fixtures.createReferenceData(methodId);
+        cultureTest = fixtures.createCatalogCultureTest(methodId, MicroWorkflowType.BACTERIOLOGY);
+        patient = fixtures.createPatient("OGC782M4");
+        sampleType = fixtures.firstActiveSampleType();
+    }
+
+    /**
+     * Covers the real transactional save orchestration; the supported browser
+     * interaction remains covered by the registered M-03 Playwright journey.
+     */
+    @Test
+    public void supportedOrderSaveCreatesOneCaseAndRemainsIdempotent() {
+        Sample sample = newSample();
+        MicroCaseOrderDetailRequestForm orderDetail = orderDetail();
+
+        SamplePatientUpdateData firstSave = orderUpdate(sample, null);
+        persist(firstSave, orderDetail);
+
+        SampleItem savedItem = firstSave.getSampleItemsTests().getFirst().item;
+        Analysis savedAnalysis = analysisService.getAnalysisBySampleItemAndTest(savedItem.getId(), cultureTest.getId());
+        List<MicroCase> firstCases = caseService.getSiblingCases(savedItem.getId());
+
+        assertNotNull(sample.getId());
+        assertNotNull(savedItem.getId());
+        assertNotNull(savedAnalysis);
+        assertEquals(1, firstCases.size());
+        assertOrderDetail(firstCases.getFirst(), orderDetail);
+        assertCaseAnalysisLink(firstCases.getFirst(), savedAnalysis);
+
+        SamplePatientUpdateData repeatedSave = orderUpdate(sample, savedItem.getId());
+        persist(repeatedSave, orderDetail);
+
+        SampleItem repeatedItem = repeatedSave.getSampleItemsTests().getFirst().item;
+        Analysis repeatedAnalysis = analysisService.getAnalysisBySampleItemAndTest(repeatedItem.getId(),
+                cultureTest.getId());
+        List<MicroCase> repeatedCases = caseService.getSiblingCases(repeatedItem.getId());
+
+        assertEquals(savedItem.getId(), repeatedItem.getId());
+        assertEquals(savedAnalysis.getId(), repeatedAnalysis.getId());
+        assertEquals(1, repeatedCases.size());
+        assertEquals(firstCases.getFirst().getId(), repeatedCases.getFirst().getId());
+        assertOrderDetail(repeatedCases.getFirst(), orderDetail);
+        assertCaseAnalysisLink(repeatedCases.getFirst(), repeatedAnalysis);
+    }
+
+    private Sample newSample() {
+        Sample sample = new Sample();
+        sample.setAccessionNumber("M4" + UUID.randomUUID().toString().replace("-", "").substring(0, 10));
+        sample.setEnteredDate(new Date(System.currentTimeMillis()));
+        sample.setReceivedTimestamp(Timestamp.from(Instant.now()));
+        sample.setStatusId(fixtures.ensureSampleEnteredStatus());
+        sample.setSysUserId(userId);
+        return sample;
+    }
+
+    private SamplePatientUpdateData orderUpdate(Sample sample, String existingSampleItemId) {
+        String itemIdAttribute = existingSampleItemId == null ? "" : " sampleItemId='" + existingSampleItemId + "'";
+        String sampleXml = "<samples><sample sampleID='" + sampleType.getId() + "' tests='" + cultureTest.getId()
+                + "' testSectionMap='' testSampleTypeMap='' panels='' date='' time='' initialConditionIds=''"
+                + itemIdAttribute + "/></samples>";
+        SampleAddService sampleAddService = new SampleAddService(sampleXml, userId, sample, "");
+
+        SamplePatientUpdateData updateData = new SamplePatientUpdateData(userId);
+        updateData.setSample(sample);
+        updateData.setSampleAddService(sampleAddService);
+        updateData.setSampleItemsTests(sampleAddService.createSampleTestCollection());
+        return updateData;
+    }
+
+    private void persist(SamplePatientUpdateData updateData, MicroCaseOrderDetailRequestForm orderDetail) {
+        PatientManagementInfo patientInfo = new PatientManagementInfo();
+        patientInfo.setPatientPK(patient.getId());
+        SamplePatientEntryForm form = new SamplePatientEntryForm();
+        form.setPatientProperties(patientInfo);
+        form.setMicrobiologyOrderDetail(orderDetail);
+
+        PatientManagementUpdate patientUpdate = SpringContext.getBean(PatientManagementUpdate.class);
+        samplePatientEntryService.persistData(updateData, patientUpdate, patientInfo, form,
+                new MockHttpServletRequest());
+    }
+
+    private MicroCaseOrderDetailRequestForm orderDetail() {
+        MicroCaseOrderDetailRequestForm detail = new MicroCaseOrderDetailRequestForm();
+        detail.cultureMethodId = cultureTest.getMethod().getId();
+        detail.patientOrigin = "INPATIENT";
+        detail.admissionDate = "2026-08-17";
+        detail.numberOfSets = 2;
+        detail.clinicalHistory = "Persistent fever after antibiotics";
+        detail.antibioticExposure = true;
+        return detail;
+    }
+
+    private void assertOrderDetail(MicroCase microCase, MicroCaseOrderDetailRequestForm expected) {
+        MicroCaseOrderDetail actual = orderDetailService.getOrderDetail(microCase.getId());
+        assertNotNull(actual);
+        assertEquals(expected.cultureMethodId, actual.getCultureMethodId());
+        assertEquals(expected.patientOrigin, actual.getPatientOrigin());
+        assertEquals(LocalDate.parse(expected.admissionDate), actual.getAdmissionDate());
+        assertEquals(expected.numberOfSets, actual.getNumberOfSets());
+        assertEquals(expected.clinicalHistory, actual.getClinicalHistory());
+        assertEquals(expected.antibioticExposure, actual.getAntibioticExposure());
+    }
+
+    private void assertCaseAnalysisLink(MicroCase microCase, Analysis analysis) {
+        var links = caseAnalysisService.getCaseAnalyses(microCase.getId());
+        assertEquals(1, links.size());
+        assertEquals(microCase.getId(), links.getFirst().getCaseId());
+        assertEquals(analysis.getId(), links.getFirst().getAnalysisId());
+    }
+}

--- a/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixtures.java
+++ b/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixtures.java
@@ -28,6 +28,10 @@ import org.openelisglobal.microbiology.valueholder.MicroBreakpointStandard;
 import org.openelisglobal.microbiology.valueholder.MicroCultureSetup;
 import org.openelisglobal.microbiology.valueholder.MicroOrganism;
 import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
+import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.person.service.PersonService;
+import org.openelisglobal.person.valueholder.Person;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.sampleitem.service.SampleItemService;
@@ -64,13 +68,16 @@ public class MicrobiologyTestFixtures {
     private final StatusOfSampleService statusOfSampleService;
     private final SystemUserService systemUserService;
     private final MicrobiologyConfigurationService configurationService;
+    private final PersonService personService;
+    private final PatientService patientService;
 
     public MicrobiologyTestFixtures(MethodService methodService, SampleService sampleService,
             SampleItemService sampleItemService, AnalysisService analysisService, TestService testService,
             TypeOfSampleService typeOfSampleService, LocalizationService localizationService,
             TestMethodService testMethodService, IStatusService statusService,
             StatusOfSampleService statusOfSampleService, SystemUserService systemUserService,
-            MicrobiologyConfigurationService configurationService) {
+            MicrobiologyConfigurationService configurationService, PersonService personService,
+            PatientService patientService) {
         this.methodService = methodService;
         this.sampleService = sampleService;
         this.sampleItemService = sampleItemService;
@@ -83,6 +90,8 @@ public class MicrobiologyTestFixtures {
         this.statusOfSampleService = statusOfSampleService;
         this.systemUserService = systemUserService;
         this.configurationService = configurationService;
+        this.personService = personService;
+        this.patientService = patientService;
     }
 
     public String defaultUserId() {
@@ -145,6 +154,30 @@ public class MicrobiologyTestFixtures {
         sampleItem.setSysUserId(defaultUserId());
         sampleItemService.insert(sampleItem);
         return sampleItem;
+    }
+
+    public Patient createPatient(String externalIdPrefix) {
+        String userId = defaultUserId();
+        String suffix = uniqueSuffix();
+        Person person = new Person();
+        person.setFirstName("Microbiology");
+        person.setLastName("Order " + suffix);
+        person.setSysUserId(userId);
+        personService.insert(person);
+
+        Patient patient = new Patient();
+        patient.setPerson(person);
+        patient.setExternalId(uniqueValue(externalIdPrefix, 30));
+        patient.setNationalId("NID" + suffix);
+        patient.setSysUserId(userId);
+        patientService.insert(patient);
+        return patient;
+    }
+
+    public TypeOfSample firstActiveSampleType() {
+        return typeOfSampleService.getAllTypeOfSamples().stream().filter(TypeOfSample::getIsActive)
+                .sorted(Comparator.comparing(TypeOfSample::getId)).findFirst()
+                .orElseThrow(() -> new IllegalStateException("No active specimen type is available for tests"));
     }
 
     public ReferenceData createReferenceData(String methodId) {

--- a/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixturesTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/fixture/MicrobiologyTestFixturesTest.java
@@ -24,6 +24,8 @@ import org.openelisglobal.localization.valueholder.Localization;
 import org.openelisglobal.method.service.MethodService;
 import org.openelisglobal.method.valueholder.Method;
 import org.openelisglobal.microbiology.service.MicrobiologyConfigurationService;
+import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.statusofsample.service.StatusOfSampleService;
@@ -62,6 +64,10 @@ public class MicrobiologyTestFixturesTest {
     private SystemUserService systemUserService;
     @Mock
     private MicrobiologyConfigurationService configurationService;
+    @Mock
+    private PersonService personService;
+    @Mock
+    private PatientService patientService;
 
     private MicrobiologyTestFixtures fixtures;
 
@@ -70,7 +76,7 @@ public class MicrobiologyTestFixturesTest {
         when(systemUserService.getAllSystemUsers()).thenReturn(List.of(systemUser("7")));
         fixtures = new MicrobiologyTestFixtures(methodService, sampleService, sampleItemService, analysisService,
                 testService, typeOfSampleService, localizationService, testMethodService, statusService,
-                statusOfSampleService, systemUserService, configurationService);
+                statusOfSampleService, systemUserService, configurationService, personService, patientService);
     }
 
     @Test


### PR DESCRIPTION
## Stack

- Base: #4074 (R3 separate no-growth review and release)
- Slice: R4 supported order-save integration proof

## Behavior proved

- The supported `SamplePatientEntryService.persistData` save path creates the sample item and analysis.
- A configured bacteriology test routes to exactly one microbiology case and retains the submitted culture-order details.
- Repeating the supported save with the existing sample item remains idempotent: no duplicate analysis or case is created.
- Test data is created through services only; there is no SQL fixture, fixed primary key, or DAO bypass.

## Validation

- Focused Java validation: 13/13 passing across the new save-path integration test, routing integration tests, and fixture unit tests.
- Inversion check: removing the production routing call made the new test fail at the expected one-case assertion; restoring it returned the test to green.
- Narrow Spotless formatting/check for the touched Java source passes. Full-repository `spotless:check` still reports inherited formatting in `README.md` and `projects/analyzer-harness/README.md`; this PR deliberately carries no unrelated README churn.
- `DIGI-UW/code-qa`: aligned with the documented M-03 gap, meaningful real-database coverage at the transaction boundary, and no unnecessary runtime abstraction.
- The registered M-03 Playwright journey remains the user-visible browser proof. This slice changes no runtime behavior or UI, so it requires no deployment, screenshot, or Grist checklist update.

## Roadmap

- Supported order-save integration proof: `[x]`
- Clinical and NFR qualification: `[*]`
