### PR TITLE
fix(eqa): derive order status from the analysis pipeline + result-entry EQA badge (OGC-609)

### DIFF
--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1179,7 +1179,7 @@ export function SearchResults(props) {
                 : row.accessionNumber) +
                 "-" +
                 row.sequenceNumber}
-              {row.isEqaSample && <EQABadge priority={row.eqaPriority} />}
+              {row.eqaSample && <EQABadge priority={row.eqaPriority} />}
               <br></br>
               {row.patientName} <br></br>
               {row.patientInfo}

--- a/frontend/src/components/workplan/Workplan.jsx
+++ b/frontend/src/components/workplan/Workplan.jsx
@@ -335,7 +335,7 @@ export default function Workplan(props) {
                                         )}
                                       </u>
                                     </Link>
-                                    {row.isEqaSample && (
+                                    {row.eqaSample && (
                                       <EQABadge priority={row.eqaPriority} />
                                     )}
                                   </>

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAOrdersRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAOrdersRestController.java
@@ -79,12 +79,11 @@ public class EQAOrdersRestController extends ControllerUtills {
                     .collect(Collectors.toList());
         }
 
-        if (status != null && !status.isBlank()) {
-            samples = samples.stream().filter(s -> status.equalsIgnoreCase(deriveStatus(s)))
-                    .collect(Collectors.toList());
-        }
-
-        List<Map<String, Object>> dtos = samples.stream().map(this::toOrderDto).collect(Collectors.toList());
+        // Status is derived per sample inside toOrderDto; filter on the DTO so each
+        // sample's analyses are only queried once.
+        List<Map<String, Object>> dtos = samples.stream().map(this::toOrderDto).filter(
+                dto -> status == null || status.isBlank() || status.equalsIgnoreCase((String) dto.get("status")))
+                .collect(Collectors.toList());
 
         return ResponseEntity.ok(dtos);
     }
@@ -93,14 +92,26 @@ public class EQAOrdersRestController extends ControllerUtills {
     public ResponseEntity<Map<String, Object>> getSummary() {
         List<SampleEQA> samples = sampleEQAService.findEqaSamples();
 
-        long pending = samples.stream().filter(s -> "PENDING".equals(deriveStatus(s))).count();
-        long inProgress = samples.stream().filter(s -> "IN_PROGRESS".equals(deriveStatus(s))).count();
-        long overdue = samples.stream().filter(s -> "OVERDUE".equals(deriveStatus(s))).count();
-
         LocalDateTime startOfMonth = LocalDate.now().withDayOfMonth(1).atStartOfDay();
         Timestamp monthStart = Timestamp.valueOf(startOfMonth);
-        long completedThisMonth = samples.stream().filter(s -> "COMPLETED".equals(deriveStatus(s)))
-                .filter(s -> s.getLastupdated() != null && !s.getLastupdated().before(monthStart)).count();
+
+        long pending = 0;
+        long inProgress = 0;
+        long overdue = 0;
+        long completedThisMonth = 0;
+        for (SampleEQA sample : samples) {
+            String derived = sampleEQAService.deriveOrderStatus(sample);
+            if ("PENDING".equals(derived)) {
+                pending++;
+            } else if ("IN_PROGRESS".equals(derived)) {
+                inProgress++;
+            } else if ("OVERDUE".equals(derived)) {
+                overdue++;
+            } else if ("COMPLETED".equals(derived) && sample.getLastupdated() != null
+                    && !sample.getLastupdated().before(monthStart)) {
+                completedThisMonth++;
+            }
+        }
 
         Map<String, Object> summary = new HashMap<>();
         summary.put("pending", pending);
@@ -109,14 +120,6 @@ public class EQAOrdersRestController extends ControllerUtills {
         summary.put("completedThisMonth", completedThisMonth);
 
         return ResponseEntity.ok(summary);
-    }
-
-    private String deriveStatus(SampleEQA sample) {
-        if (sample.getEqaDeadline() != null
-                && sample.getEqaDeadline().before(new Timestamp(System.currentTimeMillis()))) {
-            return "OVERDUE";
-        }
-        return "PENDING";
     }
 
     private Map<String, Object> toOrderDto(SampleEQA sample) {
@@ -135,7 +138,7 @@ public class EQAOrdersRestController extends ControllerUtills {
                 dto.put("providerName", enrollment.getProvider());
             }
         }
-        dto.put("status", deriveStatus(sample));
+        dto.put("status", sampleEQAService.deriveOrderStatus(sample));
         dto.put("deadline", sample.getEqaDeadline());
         dto.put("priority", sample.getEqaPriority() != null ? sample.getEqaPriority().name() : null);
         dto.put("dateEntered", sample.getLastupdated());

--- a/src/main/java/org/openelisglobal/eqa/service/SampleEQAService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/SampleEQAService.java
@@ -17,10 +17,11 @@ public interface SampleEQAService extends BaseObjectService<SampleEQA, Long> {
     List<SampleEQA> findEqaSamples();
 
     /**
-     * Order status derived live from the linked order's analyses (D-LIVE-2):
+     * Order status derived live from the linked order's analyses (OGC-609):
      * COMPLETED when every non-cancelled analysis is finalized, else OVERDUE once
      * the deadline has passed, IN_PROGRESS once any analysis has left NotStarted,
-     * else PENDING. Read-side only — V2 cycle state (T-10) supersedes this.
+     * else PENDING. Read-side only — no column stores this; the EQA cycle state
+     * model replaces it once orders are cycle-linked.
      */
     String deriveOrderStatus(SampleEQA sampleEQA);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/SampleEQAService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/SampleEQAService.java
@@ -15,4 +15,12 @@ public interface SampleEQAService extends BaseObjectService<SampleEQA, Long> {
     List<SampleEQA> findByProgramId(Long programId);
 
     List<SampleEQA> findEqaSamples();
+
+    /**
+     * Order status derived live from the linked order's analyses (D-LIVE-2):
+     * COMPLETED when every non-cancelled analysis is finalized, else OVERDUE once
+     * the deadline has passed, IN_PROGRESS once any analysis has left NotStarted,
+     * else PENDING. Read-side only — V2 cycle state (T-10) supersedes this.
+     */
+    String deriveOrderStatus(SampleEQA sampleEQA);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/SampleEQAServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/SampleEQAServiceImpl.java
@@ -3,7 +3,12 @@ package org.openelisglobal.eqa.service;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.eqa.dao.SampleEQADAO;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +21,12 @@ public class SampleEQAServiceImpl extends BaseObjectServiceImpl<SampleEQA, Long>
 
     @Autowired
     private SampleEQADAO sampleEQADAO;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private IStatusService statusService;
 
     public SampleEQAServiceImpl() {
         super(SampleEQA.class);
@@ -48,5 +59,33 @@ public class SampleEQAServiceImpl extends BaseObjectServiceImpl<SampleEQA, Long>
     @Transactional(readOnly = true)
     public List<SampleEQA> findEqaSamples() {
         return sampleEQADAO.findByIsEqaSample(true);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String deriveOrderStatus(SampleEQA sampleEQA) {
+        boolean completed = false;
+        boolean started = false;
+        if (sampleEQA.getSampleId() != null) {
+            // ponytail: one analysis query per order — fine at EQA volumes (tens); batch if
+            // that ever changes
+            List<Analysis> analyses = analysisService.getAnalysesBySampleIdExcludedByStatusId(
+                    String.valueOf(sampleEQA.getSampleId()),
+                    Set.of(statusService.getStatusID(AnalysisStatus.Canceled)));
+            if (!analyses.isEmpty()) {
+                String finalizedId = statusService.getStatusID(AnalysisStatus.Finalized);
+                String notStartedId = statusService.getStatusID(AnalysisStatus.NotStarted);
+                completed = analyses.stream().allMatch(a -> finalizedId.equals(a.getStatusId()));
+                started = analyses.stream().anyMatch(a -> !notStartedId.equals(a.getStatusId()));
+            }
+        }
+        if (completed) {
+            return "COMPLETED";
+        }
+        if (sampleEQA.getEqaDeadline() != null
+                && sampleEQA.getEqaDeadline().before(new Timestamp(System.currentTimeMillis()))) {
+            return "OVERDUE";
+        }
+        return started ? "IN_PROGRESS" : "PENDING";
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/service/SampleEQAServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/SampleEQAServiceImpl.java
@@ -67,8 +67,8 @@ public class SampleEQAServiceImpl extends BaseObjectServiceImpl<SampleEQA, Long>
         boolean completed = false;
         boolean started = false;
         if (sampleEQA.getSampleId() != null) {
-            // ponytail: one analysis query per order — fine at EQA volumes (tens); batch if
-            // that ever changes
+            // One analysis query per order — fine at EQA volumes (tens); batch if
+            // that ever changes.
             List<Analysis> analyses = analysisService.getAnalysesBySampleIdExcludedByStatusId(
                     String.valueOf(sampleEQA.getSampleId()),
                     Set.of(statusService.getStatusID(AnalysisStatus.Canceled)));

--- a/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * D-LIVE-2 (T-02): EQA order status must follow the order's analyses through
- * the result pipeline instead of sitting on PENDING until the deadline passes.
- * Runs against the real schema: fixture analyses are moved through real
+ * OGC-609: EQA order status must follow the order's analyses through the result
+ * pipeline instead of sitting on PENDING until the deadline passes. Runs
+ * against the real schema: fixture analyses are moved through real
  * {@code status_of_sample} ids resolved via {@link IStatusService}.
  */
 public class SampleEQAOrderStatusIntegrationTest extends BaseWebContextSensitiveTest {

--- a/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
@@ -16,6 +16,7 @@ import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.eqa.service.SampleEQAService;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * D-LIVE-2 (T-02): EQA order status must follow the order's analyses through
@@ -41,9 +42,38 @@ public class SampleEQAOrderStatusIntegrationTest extends BaseWebContextSensitive
     @Autowired
     private IStatusService statusService;
 
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
     @Before
     public void initData() throws Exception {
+        ensureStatusRows();
         executeDataSetWithStateManagement("testdata/eqa-order-status.xml");
+    }
+
+    /**
+     * Other fixtures (e.g. testdata/analysis.xml) truncate status_of_sample and a
+     * later cache refresh rebuilds StatusService's maps from those dummy rows, so
+     * in a full-suite run every AnalysisStatus lookup can return "-1" by the time
+     * this class runs. Restore the canonical ANALYSIS rows by the exact names
+     * StatusService maps (plus sentinel id 1 for the dataset's sample_item rows),
+     * then refresh the cache so the ids this class writes and compares are real
+     * again — under any suite order.
+     */
+    private void ensureStatusRows() {
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                + " VALUES (1, 1, 'ANALYSIS', 'Fixture sentinel', 'restored by SampleEQAOrderStatusIntegrationTest')"
+                + " ON CONFLICT (id) DO NOTHING");
+        String[][] canonical = { { "9604", "Not Tested" }, { "9615", "Technical Acceptance" },
+                { "9616", "Technical Rejected" }, { "9606", "Finalized" }, { "9614", "Test Canceled" } };
+        for (String[] row : canonical) {
+            jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                    + " SELECT ?::numeric, 1, 'ANALYSIS', ?, 'restored by SampleEQAOrderStatusIntegrationTest'"
+                    + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.status_of_sample"
+                    + "   WHERE name = ? AND status_type = 'ANALYSIS')", row[0], row[1], row[1]);
+        }
+        statusService.refreshCache();
     }
 
     private SampleEQA eqaOrder(Long sampleId, Timestamp deadline) {

--- a/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/SampleEQAOrderStatusIntegrationTest.java
@@ -1,0 +1,150 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.eqa.service.SampleEQAService;
+import org.openelisglobal.eqa.valueholder.SampleEQA;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * D-LIVE-2 (T-02): EQA order status must follow the order's analyses through
+ * the result pipeline instead of sitting on PENDING until the deadline passes.
+ * Runs against the real schema: fixture analyses are moved through real
+ * {@code status_of_sample} ids resolved via {@link IStatusService}.
+ */
+public class SampleEQAOrderStatusIntegrationTest extends BaseWebContextSensitiveTest {
+
+    /** Fixture sample carrying analyses 1 and 2. */
+    private static final Long SAMPLE_WITH_TWO_ANALYSES = 1L;
+    /** Fixture sample carrying analysis 3 only. */
+    private static final Long SAMPLE_WITH_ONE_ANALYSIS = 2L;
+    /** Fixture sample with no analyses at all. */
+    private static final Long SAMPLE_WITHOUT_ANALYSES = 3L;
+
+    @Autowired
+    private SampleEQAService sampleEQAService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private IStatusService statusService;
+
+    @Before
+    public void initData() throws Exception {
+        executeDataSetWithStateManagement("testdata/eqa-order-status.xml");
+    }
+
+    private SampleEQA eqaOrder(Long sampleId, Timestamp deadline) {
+        SampleEQA eqa = new SampleEQA();
+        eqa.setSampleId(sampleId);
+        eqa.setIsEqaSample(true);
+        eqa.setEqaDeadline(deadline);
+        eqa.setSysUserId(TEST_SYS_USER_ID);
+        sampleEQAService.insert(eqa);
+        return eqa;
+    }
+
+    /** Sets the sample's analyses (ordered by id) to the given real statuses. */
+    private void setAnalysisStatuses(Long sampleId, AnalysisStatus... statuses) {
+        List<Analysis> analyses = analysisService.getAnalysesBySampleId(String.valueOf(sampleId));
+        analyses.sort(Comparator.comparing(a -> Long.valueOf(a.getId())));
+        assertEquals("fixture analysis count for sample " + sampleId, statuses.length, analyses.size());
+        for (int i = 0; i < statuses.length; i++) {
+            Analysis analysis = analyses.get(i);
+            analysis.setStatusId(statusService.getStatusID(statuses[i]));
+            analysis.setSysUserId(TEST_SYS_USER_ID);
+            analysisService.update(analysis);
+        }
+    }
+
+    private static Timestamp inDays(int days) {
+        return Timestamp.valueOf(LocalDate.now().plusDays(days).atStartOfDay());
+    }
+
+    @Test
+    public void deriveOrderStatus_allAnalysesNotStarted_isPending() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.NotStarted, AnalysisStatus.NotStarted);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(7));
+        assertEquals("PENDING", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_anyAnalysisEntered_isInProgress() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.TechnicalAcceptance, AnalysisStatus.NotStarted);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(7));
+        assertEquals("IN_PROGRESS", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_allAnalysesFinalized_isCompleted() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.Finalized, AnalysisStatus.Finalized);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(7));
+        assertEquals("COMPLETED", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_partiallyFinalized_isInProgressNotCompleted() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.Finalized, AnalysisStatus.NotStarted);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(7));
+        assertEquals("IN_PROGRESS", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_pastDeadlineNotCompleted_isOverdue() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.TechnicalAcceptance, AnalysisStatus.NotStarted);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(-3));
+        assertEquals("OVERDUE", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_pastDeadlineAllFinalized_staysCompleted() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.Finalized, AnalysisStatus.Finalized);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(-3));
+        assertEquals("COMPLETED", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_cancelledAnalysisExcludedFromCompletion() {
+        setAnalysisStatuses(SAMPLE_WITH_TWO_ANALYSES, AnalysisStatus.Finalized, AnalysisStatus.Canceled);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_TWO_ANALYSES, inDays(7));
+        assertEquals("COMPLETED", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_onlyCancelledAnalyses_isPending() {
+        setAnalysisStatuses(SAMPLE_WITH_ONE_ANALYSIS, AnalysisStatus.Canceled);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_ONE_ANALYSIS, inDays(7));
+        assertEquals("PENDING", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_rejectedResult_countsAsInProgress() {
+        setAnalysisStatuses(SAMPLE_WITH_ONE_ANALYSIS, AnalysisStatus.TechnicalRejected);
+        SampleEQA order = eqaOrder(SAMPLE_WITH_ONE_ANALYSIS, inDays(7));
+        assertEquals("IN_PROGRESS", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_noAnalyses_isPending() {
+        SampleEQA order = eqaOrder(SAMPLE_WITHOUT_ANALYSES, inDays(7));
+        assertEquals("PENDING", sampleEQAService.deriveOrderStatus(order));
+    }
+
+    @Test
+    public void deriveOrderStatus_noAnalysesPastDeadline_isOverdue() {
+        SampleEQA order = eqaOrder(SAMPLE_WITHOUT_ANALYSES, inDays(-3));
+        assertEquals("OVERDUE", sampleEQAService.deriveOrderStatus(order));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAOrdersRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAOrdersRestControllerTest.java
@@ -91,6 +91,11 @@ public class EQAOrdersRestControllerTest {
         overdueSample.setEqaPriority(EQAPriority.STANDARD);
         overdueSample.setEqaDeadline(Timestamp.valueOf(LocalDate.now().minusDays(3).atStartOfDay()));
         overdueSample.setSysUserId("1");
+
+        // Status derivation lives in the service (T-02); the controller only routes it.
+        when(sampleEQAService.deriveOrderStatus(sample1)).thenReturn("PENDING");
+        when(sampleEQAService.deriveOrderStatus(sample2)).thenReturn("PENDING");
+        when(sampleEQAService.deriveOrderStatus(overdueSample)).thenReturn("OVERDUE");
     }
 
     @Test
@@ -208,11 +213,28 @@ public class EQAOrdersRestControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         Map<String, Object> summary = response.getBody();
-        assertNotNull(summary.get("pending"));
-        assertNotNull(summary.get("inProgress"));
-        assertNotNull(summary.get("overdue"));
-        assertNotNull(summary.get("completedThisMonth"));
+        assertEquals(2L, summary.get("pending"));
+        assertEquals(0L, summary.get("inProgress"));
         assertEquals(1L, summary.get("overdue"));
+        assertEquals(0L, summary.get("completedThisMonth"));
+    }
+
+    @Test
+    public void testGetSummary_CompletedCountsOnlyThisMonth() {
+        sample1.setLastupdated(new Timestamp(System.currentTimeMillis()));
+        sample2.setLastupdated(Timestamp.valueOf(LocalDate.now().minusMonths(2).atStartOfDay()));
+        when(sampleEQAService.deriveOrderStatus(sample1)).thenReturn("COMPLETED");
+        when(sampleEQAService.deriveOrderStatus(sample2)).thenReturn("COMPLETED");
+        when(sampleEQAService.findEqaSamples()).thenReturn(List.of(sample1, sample2));
+
+        ResponseEntity<Map<String, Object>> response = controller.getSummary();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Map<String, Object> summary = response.getBody();
+        assertEquals(1L, summary.get("completedThisMonth"));
+        assertEquals(0L, summary.get("pending"));
+        assertEquals(0L, summary.get("inProgress"));
+        assertEquals(0L, summary.get("overdue"));
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAOrdersRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAOrdersRestControllerTest.java
@@ -92,7 +92,7 @@ public class EQAOrdersRestControllerTest {
         overdueSample.setEqaDeadline(Timestamp.valueOf(LocalDate.now().minusDays(3).atStartOfDay()));
         overdueSample.setSysUserId("1");
 
-        // Status derivation lives in the service (T-02); the controller only routes it.
+        // Status derivation lives in the service; the controller only routes it.
         when(sampleEQAService.deriveOrderStatus(sample1)).thenReturn("PENDING");
         when(sampleEQAService.deriveOrderStatus(sample2)).thenReturn("PENDING");
         when(sampleEQAService.deriveOrderStatus(overdueSample)).thenReturn("OVERDUE");

--- a/src/test/resources/testdata/eqa-order-status.xml
+++ b/src/test/resources/testdata/eqa-order-status.xml
@@ -78,24 +78,28 @@
     <type_of_sample id="1" description="Blood Sample"
         domain="H" name_localization_id="1" lastupdated="2023-12-01 12:00:00" />
 
-    <!-- sample -->
-    <sample id="1" accession_number="EQAT02001" status_id="1"
+    <!-- sample: status_id is nullable and irrelevant to the derivation, so
+        it is omitted rather than pinned to a row another fixture may have wiped
+        (status_of_sample is truncated by e.g. testdata/analysis.xml, so suite order
+        must not matter here). -->
+    <sample id="1" accession_number="EQAT02001"
         received_date="2024-06-03 00:00:00.0"
         entered_date="2024-06-03 00:00:00.0"
         collection_date="2024-06-03 00:00:00.0"
         lastupdated="2023-11-01 12:00:00" />
-    <sample id="2" accession_number="EQAT02002" status_id="1"
+    <sample id="2" accession_number="EQAT02002"
         received_date="2024-06-03 00:00:00.0"
         entered_date="2024-06-03 00:00:00.0"
         collection_date="2024-06-03 00:00:00.0"
         lastupdated="2023-11-01 12:00:00" />
-    <sample id="3" accession_number="EQAT02003" status_id="1"
+    <sample id="3" accession_number="EQAT02003"
         received_date="2024-06-03 00:00:00.0"
         entered_date="2024-06-03 00:00:00.0"
         collection_date="2024-06-03 00:00:00.0"
         lastupdated="2023-11-01 12:00:00" />
 
-    <!-- sample_item -->
+    <!-- sample_item.status_id is NOT NULL; id 1 is the sentinel status row
+        the test guarantees in @Before (ensureStatusRows) before this loads. -->
     <sample_item id="1" sort_order="1" status_id="1"
         samp_id="1" typeosamp_id="1" collection_date="2023-11-15 10:00:00"
         lastupdated="2023-12-01 12:00:00" />
@@ -106,17 +110,19 @@
         samp_id="3" typeosamp_id="1" collection_date="2023-11-15 10:00:00"
         lastupdated="2023-12-01 12:00:00" />
 
-    <!-- analysis: two on sample 1, one on sample 2, none on sample 3 -->
+    <!-- analysis: two on sample 1, one on sample 2, none on sample 3. status_id
+        is nullable and every test sets real ids via IStatusService before asserting,
+        so no static status literal is baked in. -->
     <analysis id="1" sampitem_id="1" test_sect_id="1" test_id="1"
-        revision="1" status_id="1" analysis_type="ROUTINE"
-        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        revision="1" analysis_type="ROUTINE" entry_date="2023-11-15 12:00:00"
+        lastupdated="2023-12-01 12:00:00"
         fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01" />
     <analysis id="2" sampitem_id="1" test_sect_id="1" test_id="1"
-        revision="1" status_id="1" analysis_type="ROUTINE"
-        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        revision="1" analysis_type="ROUTINE" entry_date="2023-11-15 12:00:00"
+        lastupdated="2023-12-01 12:00:00"
         fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02" />
     <analysis id="3" sampitem_id="2" test_sect_id="1" test_id="1"
-        revision="1" status_id="1" analysis_type="ROUTINE"
-        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        revision="1" analysis_type="ROUTINE" entry_date="2023-11-15 12:00:00"
+        lastupdated="2023-12-01 12:00:00"
         fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b03" />
 </dataset>

--- a/src/test/resources/testdata/eqa-order-status.xml
+++ b/src/test/resources/testdata/eqa-order-status.xml
@@ -1,0 +1,122 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Fixture for SampleEQAOrderStatusIntegrationTest. Deliberately does NOT
+    seed status_of_sample: analysis.status_id has an FK to it, and the tests
+    set real status ids resolved through IStatusService (built from the liquibase
+    seed at context boot). Truncating/replacing that table here would break both
+    the FK writes and the cached lookups. Sample 1 carries two analyses (1, 2),
+    sample 2 one analysis (3), sample 3 none. sample_eqa is declared empty so
+    rows inserted by one test are truncated before the next. -->
+<dataset>
+    <sample_eqa />
+
+    <!-- localization -->
+    <localization id="1" description="Test Description 1" />
+    <localization id="2" description="Test Description 2" />
+    <localization_value id="1" localization_id="1"
+        locale="en" value="Test Localization 1" />
+    <localization_value id="3" localization_id="2"
+        locale="en" value="Test Localization 2" />
+    <supported_locale id="1" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+
+    <!-- unit_of_measure -->
+    <unit_of_measure id="1" name="mg/dL"
+        description="Milligrams per deciliter" />
+    <unit_of_measure id="2" name="g/L"
+        description="Grams per liter" />
+
+    <!-- test_trailer -->
+    <test_trailer id="1" name="Trailer Name 1"
+        description="Description 1" text="Sample Text 1"
+        lastupdated="2025-03-13 12:00:00" />
+
+    <!-- scriptlet -->
+    <scriptlet id="1" name="Scriptlet 1" code_type="T"
+        code_source="Source1" lastupdated="2025-03-13 12:00:00" />
+
+    <!-- label -->
+    <label id="1" name="Patient Label"
+        description="Label for patient samples" printer_type="T"
+        scriptlet_id="1" lastupdated="2025-03-20 12:00:00" />
+
+    <!-- method -->
+    <method id="1" name="therapy" description="using therapy"
+        name_localization_id="1" reporting_description=""
+        active_begin="2012-11-01" lastupdated="2023-10-01 12:00:00" />
+
+    <!-- organization -->
+    <organization id="3" lastupdated="2024-06-03 12:00:00.0"
+        name="Global Health Org" city="New York" zip_code="10001"
+        short_name="GHG" multiple_unit="NYC Unit"
+        street_address="123 Health St" state="NY"
+        internet_address="www.globalhealth.org" clia_num="CLIA12345"
+        pws_id="PWS123" local_abbrev="1" code="GHG001" />
+
+    <!-- test_section -->
+    <test_section id="1" name="TB"
+        description="SectionDescription1" org_id="3" is_external="N"
+        lastupdated="2025-03-20 12:00:00.0" sort_order="2147483647"
+        name_localization_id="1" display_key="TestKey1" />
+
+    <!-- test_formats -->
+    <test_formats id="1" lastupdated="2025-03-21 12:00:00" />
+
+    <!-- test -->
+    <test id="1" method_id="1" uom_id="1" description="Blood Test"
+        loinc="123456" reporting_description="Complete Blood Count"
+        active_begin="2025-01-01 12:00:00" active_end="2025-12-31 12:00:00"
+        time_holding="30" time_wait="15" time_ta_average="60"
+        time_ta_warning="90" time_ta_max="120" label_qty="1"
+        lastupdated="2025-03-20 12:00:00" label_id="1" test_trailer_id="1"
+        test_section_id="1" scriptlet_id="1" test_format_id="1"
+        local_code="CBC" sort_order="2147483646" name="Complete Blood Count"
+        orderable="true" guid="abc-123" name_localization_id="1"
+        antimicrobial_resistance="true" />
+
+    <!-- type_of_sample -->
+    <type_of_sample id="1" description="Blood Sample"
+        domain="H" name_localization_id="1" lastupdated="2023-12-01 12:00:00" />
+
+    <!-- sample -->
+    <sample id="1" accession_number="EQAT02001" status_id="1"
+        received_date="2024-06-03 00:00:00.0"
+        entered_date="2024-06-03 00:00:00.0"
+        collection_date="2024-06-03 00:00:00.0"
+        lastupdated="2023-11-01 12:00:00" />
+    <sample id="2" accession_number="EQAT02002" status_id="1"
+        received_date="2024-06-03 00:00:00.0"
+        entered_date="2024-06-03 00:00:00.0"
+        collection_date="2024-06-03 00:00:00.0"
+        lastupdated="2023-11-01 12:00:00" />
+    <sample id="3" accession_number="EQAT02003" status_id="1"
+        received_date="2024-06-03 00:00:00.0"
+        entered_date="2024-06-03 00:00:00.0"
+        collection_date="2024-06-03 00:00:00.0"
+        lastupdated="2023-11-01 12:00:00" />
+
+    <!-- sample_item -->
+    <sample_item id="1" sort_order="1" status_id="1"
+        samp_id="1" typeosamp_id="1" collection_date="2023-11-15 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+    <sample_item id="2" sort_order="1" status_id="1"
+        samp_id="2" typeosamp_id="1" collection_date="2023-11-15 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+    <sample_item id="3" sort_order="1" status_id="1"
+        samp_id="3" typeosamp_id="1" collection_date="2023-11-15 10:00:00"
+        lastupdated="2023-12-01 12:00:00" />
+
+    <!-- analysis: two on sample 1, one on sample 2, none on sample 3 -->
+    <analysis id="1" sampitem_id="1" test_sect_id="1" test_id="1"
+        revision="1" status_id="1" analysis_type="ROUTINE"
+        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01" />
+    <analysis id="2" sampitem_id="1" test_sect_id="1" test_id="1"
+        revision="1" status_id="1" analysis_type="ROUTINE"
+        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02" />
+    <analysis id="3" sampitem_id="2" test_sect_id="1" test_id="1"
+        revision="1" status_id="1" analysis_type="ROUTINE"
+        entry_date="2023-11-15 12:00:00" lastupdated="2023-12-01 12:00:00"
+        fhir_uuid="e1b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b03" />
+</dataset>


### PR DESCRIPTION
## Summary
Two live EQA defects fixed (OGC-609 hardening):

- **Order status frozen at "Pending":** the orders endpoint's status derivation only ever returned `OVERDUE`/`PENDING` — it never consulted the order's analyses, so `IN_PROGRESS`/`COMPLETED` were unreachable even though the UI already renders those tags. Status now derives from the analysis pipeline in `SampleEQAServiceImpl.deriveOrderStatus` — all non-cancelled analyses finalized → `COMPLETED`, past deadline & not completed → `OVERDUE`, any analysis past NotStarted → `IN_PROGRESS`, else `PENDING`. One rule shared by the list and `/summary` endpoints; the list's status filter runs on the DTO so each order's analyses are queried once. Read-side only (no schema change).
- **No EQA badge at result entry:** Jackson serialises `TestResultItem.isEqaSample()` as `eqaSample`, but `SearchResultForm.jsx` and `Workplan.jsx` read `row.isEqaSample` — always `undefined`. Backend population (`ResultsLoadUtility`) was already correct; both reads fixed to `row.eqaSample`.

## Tests
- `SampleEQAOrderStatusIntegrationTest` — 11 real-DB integration tests: exact-status assertions for pending/in-progress/partial-finalize/completed, completed-beats-overdue precedence both ways, cancelled-analysis exclusion, no-analysis and past-deadline cases. Fixture is suite-order-proof (restores the canonical analysis status rows and refreshes the status cache before loading, since other fixtures truncate `status_of_sample`).
- `EQAOrdersRestControllerTest` — updated for service-derived status + exact 4-bucket summary assertions incl. the completed-this-month window.
- Neighbouring EQA suites re-run green on the rebased branch.

## Live UAT (dev stack)
Order `DEV01260000000000014`: **Pending** → entered result 1500 + e-signature → **In Progress** (KPI tiles Pending 1→0, In Progress 0→1) → analysis finalized → **Completed**. EQA badge renders on the result-entry row.

Noted out of scope: EQA orders never appear on the Validation page even at Technical Acceptance (likely the NULL-patient sample) — pre-existing, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
