### PR TITLE
feat(eqa-v2): panel, participant-result and receipt services with sealed-target access rules (OGC-609)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
@@ -1,0 +1,131 @@
+package org.openelisglobal.eqa.controller.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hibernate.ObjectNotFoundException;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQAPanelReceiptService;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Panel-receipt intake (T-11, FR-V2.1-20). Reception records receipts, so the
+ * class-level roles are the real gate here, not a placeholder.
+ */
+@RestController
+@RequestMapping("/rest/eqa")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS')")
+public class EQAPanelReceiptRestController extends BaseRestController {
+
+    private final EQAPanelReceiptService receiptService;
+
+    public EQAPanelReceiptRestController(EQAPanelReceiptService receiptService) {
+        this.receiptService = receiptService;
+    }
+
+    /** Idempotent: 201 on first record, 200 with the existing row afterwards. */
+    @PostMapping(value = "/cycles/{cycleId}/receipt", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> recordReceipt(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestBody Map<String, Object> body) {
+        Long labEnrollmentId = longField(body, "labEnrollmentId");
+        if (labEnrollmentId == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "labEnrollmentId is required"));
+        }
+
+        String sysUserId = getSysUserId(request);
+        Long receivedBy = longField(body, "receivedBy");
+        if (receivedBy == null) {
+            try {
+                receivedBy = Long.valueOf(sysUserId);
+            } catch (NumberFormatException e) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Cannot resolve the receiving user"));
+            }
+        }
+
+        Integer shipmentId = null;
+        Object rawShipment = body.get("shipmentId");
+        if (rawShipment != null && !String.valueOf(rawShipment).isBlank()) {
+            shipmentId = Integer.valueOf(String.valueOf(rawShipment));
+        }
+
+        BigDecimal receivedTempC = null;
+        Object rawTemp = body.get("receivedTempC");
+        if (rawTemp != null && !String.valueOf(rawTemp).isBlank()) {
+            receivedTempC = new BigDecimal(String.valueOf(rawTemp));
+        }
+
+        Boolean integrityOk = body.get("integrityOk") == null ? null
+                : Boolean.valueOf(String.valueOf(body.get("integrityOk")));
+
+        boolean existedBefore = !receiptService
+                .getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId)).isEmpty();
+
+        EQAPanelReceipt receipt = receiptService.recordReceipt(cycleId, labEnrollmentId, shipmentId, receivedTempC,
+                integrityOk, stringField(body, "integrityNotes"), receivedBy, sysUserId);
+
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("id", receipt.getId());
+        dto.put("cycleId", cycleId);
+        dto.put("labEnrollmentId", receipt.getLabEnrollmentId());
+        dto.put("shipmentId", receipt.getShipmentId());
+        dto.put("receivedDate", receipt.getReceivedDate() == null ? null : receipt.getReceivedDate().toString());
+        dto.put("integrityOk", receipt.getIntegrityOk());
+
+        return ResponseEntity.status(existedBefore ? HttpStatus.OK : HttpStatus.CREATED).body(dto);
+    }
+
+    private String stringField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private Long longField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (value == null || String.valueOf(value).isBlank()) {
+            return null;
+        }
+        return Long.valueOf(String.valueOf(value));
+    }
+
+    @ExceptionHandler(ObjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNotFound(ObjectNotFoundException e) {
+        return Map.of("error", "EQA cycle not found");
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, String> handleBadInput(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    @ExceptionHandler(NumberFormatException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> handleBadNumber(NumberFormatException e) {
+        return Map.of("error", "A numeric field could not be parsed");
+    }
+
+    /**
+     * labEnrollmentId is a raw FK column — surface a bad reference as a conflict,
+     * not a 500 (UAT finding, 2026-08-18). Narrowed to constraint violations so a
+     * real DB failure still reads as a 500.
+     */
+    @ExceptionHandler(org.hibernate.exception.ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> handleConstraintViolation(org.hibernate.exception.ConstraintViolationException e) {
+        return Map.of("error", "The receipt conflicts with existing data: a referenced record does not exist,"
+                + " or a receipt for this cycle and enrollment already exists");
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
@@ -21,8 +21,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Panel-receipt intake (T-11, FR-V2.1-20). Reception records receipts, so the
- * class-level roles are the real gate here, not a placeholder.
+ * Panel-receipt intake (OGC-609, FR-V2.1-20). Reception records receipts, so
+ * the class-level roles are the real gate here, not a placeholder.
  */
 @RestController
 @RequestMapping("/rest/eqa")

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
@@ -1,0 +1,117 @@
+package org.openelisglobal.eqa.controller.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import org.hibernate.ObjectNotFoundException;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQAPanelService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Panel lifecycle + sealed-sample reads (T-11). The sealed-target rule is
+ * enforced in the service's DTO mapping; this controller only decides whether
+ * the caller holds the unblind privilege.
+ *
+ * <p>
+ * Class-level roles are the V1 placeholder (T-05/T-12 tighten them); the
+ * lifecycle writes and the unblind privilege are gated on {@code qa.manage.eqa}
+ * now because sealing integrity cannot wait.
+ */
+@RestController
+@RequestMapping("/rest/eqa")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS')")
+public class EQAPanelRestController extends BaseRestController {
+
+    private final EQAPanelService panelService;
+
+    public EQAPanelRestController(EQAPanelService panelService) {
+        this.panelService = panelService;
+    }
+
+    @GetMapping(value = "/panels", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> panelsByCycle(@RequestParam Long cycleId) {
+        return panelService.getPanelDtos(cycleId);
+    }
+
+    @GetMapping(value = "/panels/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> getPanel(@PathVariable Long id) {
+        return panelService.toPanelDto(panelService.get(id));
+    }
+
+    /** Sample DTOs carry null targets unless revealed — see EQAPanelService. */
+    @GetMapping(value = "/panels/{id}/samples", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> getSamples(@PathVariable Long id) {
+        return panelService.getSampleDtos(id, callerCanUnblind());
+    }
+
+    @PostMapping(value = "/panels/{id}/seal", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
+    public Map<String, Object> seal(HttpServletRequest request, @PathVariable Long id) {
+        return panelService.toPanelDto(panelService.seal(id, getSysUserId(request)));
+    }
+
+    @PostMapping(value = "/panels/{id}/distribute", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
+    public Map<String, Object> distribute(HttpServletRequest request, @PathVariable Long id) {
+        return panelService.toPanelDto(panelService.distribute(id, getSysUserId(request)));
+    }
+
+    @PostMapping(value = "/panels/{id}/unblind", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
+    public Map<String, Object> unblind(HttpServletRequest request, @PathVariable Long id) {
+        return panelService.toPanelDto(panelService.unblind(id, getSysUserId(request)));
+    }
+
+    /**
+     * The unblind privilege, evaluated per call: the cycle-transition grant
+     * (qa.manage.eqa, from T-10) doubles as the sealed-target read grant until
+     * T-12's dedicated tiers land.
+     */
+    private boolean callerCanUnblind() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) {
+            return false;
+        }
+        for (GrantedAuthority authority : auth.getAuthorities()) {
+            if ("qa.manage.eqa".equals(authority.getAuthority())
+                    || "ROLE_GLOBAL_ADMIN".equals(authority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @ExceptionHandler(ObjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNotFound(ObjectNotFoundException e) {
+        return Map.of("error", "EQA panel not found");
+    }
+
+    /** An illegal lifecycle move is a conflict with current state. */
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> handleIllegalMove(IllegalStateException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    /** A failed seal precondition is unprocessable input, not a conflict. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, String> handleBadInput(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Panel lifecycle + sealed-sample reads (T-11). The sealed-target rule is
+ * Panel lifecycle + sealed-sample reads (OGC-609). The sealed-target rule is
  * enforced in the service's DTO mapping; this controller only decides whether
  * the caller holds the unblind privilege.
  *
  * <p>
- * Class-level roles are the V1 placeholder (T-05/T-12 tighten them); the
- * lifecycle writes and the unblind privilege are gated on {@code qa.manage.eqa}
- * now because sealing integrity cannot wait.
+ * Class-level roles are the V1 placeholder (dedicated tiers tighten them under
+ * OGC-609); the lifecycle writes and the unblind privilege are gated on
+ * {@code qa.manage.eqa} now because sealing integrity cannot wait.
  */
 @RestController
 @RequestMapping("/rest/eqa")
@@ -78,8 +78,8 @@ public class EQAPanelRestController extends BaseRestController {
 
     /**
      * The unblind privilege, evaluated per call: the cycle-transition grant
-     * (qa.manage.eqa, from T-10) doubles as the sealed-target read grant until
-     * T-12's dedicated tiers land.
+     * (qa.manage.eqa) doubles as the sealed-target read grant until the dedicated
+     * permission tiers land (OGC-609).
      */
     private boolean callerCanUnblind() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
@@ -27,8 +27,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Participant-result lifecycle API (T-11, FR-V2.1-05). Paths follow the T-10
- * frozen contract style under /rest/eqa.
+ * Participant-result lifecycle API (OGC-609, FR-V2.1-05). Paths follow the
+ * established /rest/eqa contract style.
  */
 @RestController
 @RequestMapping("/rest/eqa")

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
@@ -1,0 +1,179 @@
+package org.openelisglobal.eqa.controller.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import org.hibernate.ObjectNotFoundException;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQAParticipantResultService;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Participant-result lifecycle API (T-11, FR-V2.1-05). Paths follow the T-10
+ * frozen contract style under /rest/eqa.
+ */
+@RestController
+@RequestMapping("/rest/eqa")
+@PreAuthorize("hasAnyRole('RECEPTION', 'RESULTS')")
+public class EQAParticipantResultRestController extends BaseRestController {
+
+    private final EQAParticipantResultService resultService;
+    private final EQACycleService cycleService;
+
+    public EQAParticipantResultRestController(EQAParticipantResultService resultService, EQACycleService cycleService) {
+        this.resultService = resultService;
+        this.cycleService = cycleService;
+    }
+
+    @GetMapping(value = "/cycles/{cycleId}/participant-results", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> resultsForCycle(@PathVariable Long cycleId,
+            @RequestParam(required = false) Long labEnrollmentId) {
+        return resultService.getResultDtos(cycleId, labEnrollmentId);
+    }
+
+    @PostMapping(value = "/participant-results", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> createDraft(HttpServletRequest request,
+            @RequestBody Map<String, Object> body) {
+        Long cycleId = longField(body, "cycleId");
+        Long roundId = longField(body, "roundId");
+        Long labEnrollmentId = longField(body, "labEnrollmentId");
+        Long analyteId = longField(body, "analyteId");
+        if (cycleId == null || roundId == null || labEnrollmentId == null || analyteId == null) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "cycleId, roundId, labEnrollmentId and analyteId are required"));
+        }
+
+        EQAParticipantResult draft = new EQAParticipantResult();
+        draft.setCycle(cycleService.get(cycleId));
+        EQARound round = new EQARound();
+        round.setId(roundId);
+        draft.setRound(round);
+        draft.setLabEnrollmentId(labEnrollmentId);
+        draft.setAnalyteId(analyteId);
+        draft.setAnalysisId(longField(body, "analysisId"));
+        draft.setAssignedAnalystId(longField(body, "assignedAnalystId"));
+        draft.setResultValue(stringField(body, "resultValue"));
+        draft.setResultUnit(stringField(body, "resultUnit"));
+        draft.setEnteredBy(longOrNull(getSysUserId(request)));
+        draft.setSysUserId(getSysUserId(request));
+
+        EQAParticipantResult saved = resultService.saveDraft(draft);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("id", saved.getId(), "submissionStatus", saved.getSubmissionStatus().name()));
+    }
+
+    @PatchMapping(value = "/participant-results/{id}/status", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> transition(HttpServletRequest request, @PathVariable Long id,
+            @RequestBody Map<String, Object> body) {
+        String target = stringField(body, "target");
+        if (target == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "target is required"));
+        }
+        EQASubmissionStatus targetStatus;
+        try {
+            targetStatus = EQASubmissionStatus.valueOf(target.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown submission status"));
+        }
+
+        EQAParticipantResult updated = resultService.transitionStatus(id, targetStatus, getSysUserId(request));
+        return ResponseEntity
+                .ok(Map.of("id", updated.getId(), "submissionStatus", updated.getSubmissionStatus().name()));
+    }
+
+    /** Score intake is a provider/officer act, so it takes the manage grant. */
+    @PatchMapping(value = "/participant-results/{id}/score", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('qa.manage.eqa') or hasRole('GLOBAL_ADMIN')")
+    public ResponseEntity<Map<String, Object>> score(HttpServletRequest request, @PathVariable Long id,
+            @RequestBody Map<String, Object> body) {
+        String performance = stringField(body, "performance");
+        if (performance == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "performance is required"));
+        }
+        EQAPerformanceStatus verdict;
+        try {
+            verdict = EQAPerformanceStatus.valueOf(performance.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Unknown performance status"));
+        }
+
+        EQAParticipantResult scored = resultService.recordScore(id, verdict, longField(body, "eqaResultId"),
+                getSysUserId(request));
+        return ResponseEntity.ok(Map.of("id", scored.getId(), "submissionStatus", scored.getSubmissionStatus().name()));
+    }
+
+    private String stringField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private Long longField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (value == null || String.valueOf(value).isBlank()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(key + " must be a number");
+        }
+    }
+
+    private Long longOrNull(String value) {
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @ExceptionHandler(ObjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNotFound(ObjectNotFoundException e) {
+        return Map.of("error", "EQA participant result or cycle not found");
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> handleIllegalMove(IllegalStateException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, String> handleBadInput(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    /**
+     * analyteId / labEnrollmentId / analysisId are raw FK columns (unlike cycle and
+     * round, which are pre-resolved), and (round, enrollment, analyte) is unique —
+     * surface those DB refusals as a conflict instead of a bare 500 (UAT finding,
+     * 2026-08-18). Narrowed to constraint violations so a real DB failure still
+     * reads as a 500.
+     */
+    @ExceptionHandler(org.hibernate.exception.ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> handleConstraintViolation(org.hibernate.exception.ConstraintViolationException e) {
+        return Map.of("error", "The result conflicts with existing data: a referenced record (analyte, enrollment,"
+                + " analysis) does not exist, or a result for this round, enrollment and analyte already exists");
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptService.java
@@ -1,0 +1,21 @@
+package org.openelisglobal.eqa.service;
+
+import java.math.BigDecimal;
+import org.openelisglobal.common.service.BaseObjectService;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+
+public interface EQAPanelReceiptService extends BaseObjectService<EQAPanelReceipt, Long> {
+
+    /**
+     * Record that this lab received its panel for a cycle (FR-V2.1-20), atomically
+     * with its side-effects: the matched shipment gets its actual delivery date and
+     * DELIVERED status, and a PLANNED cycle advances to PANEL_RECEIVED on the
+     * participant machine. Either all three rows change or none do.
+     *
+     * <p>
+     * Idempotent per (cycle, lab enrollment): a second call returns the existing
+     * receipt unchanged and performs no side-effects.
+     */
+    EQAPanelReceipt recordReceipt(Long cycleId, Long labEnrollmentId, Integer shipmentId, BigDecimal receivedTempC,
+            Boolean integrityOk, String integrityNotes, Long receivedBy, String sysUserId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
@@ -21,7 +21,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Panel receipt intake and its transactional side-effects (T-11, FR-V2.1-20).
+ * Panel receipt intake and its transactional side-effects (OGC-609,
+ * FR-V2.1-20).
  */
 @Service
 @Transactional

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
@@ -1,0 +1,105 @@
+package org.openelisglobal.eqa.service;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.openelisglobal.shipment.service.ShipmentService;
+import org.openelisglobal.shipment.valueholder.Shipment;
+import org.openelisglobal.shipment.valueholder.ShipmentStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Panel receipt intake and its transactional side-effects (T-11, FR-V2.1-20).
+ */
+@Service
+@Transactional
+public class EQAPanelReceiptServiceImpl extends BaseObjectServiceImpl<EQAPanelReceipt, Long>
+        implements EQAPanelReceiptService {
+
+    @Autowired
+    private EQAPanelReceiptDAO eqaPanelReceiptDAO;
+
+    @Autowired
+    private EQACycleService eqaCycleService;
+
+    @Autowired
+    private ShipmentService shipmentService;
+
+    public EQAPanelReceiptServiceImpl() {
+        super(EQAPanelReceipt.class);
+    }
+
+    @Override
+    protected EQAPanelReceiptDAO getBaseObjectDAO() {
+        return eqaPanelReceiptDAO;
+    }
+
+    @Override
+    public EQAPanelReceipt recordReceipt(Long cycleId, Long labEnrollmentId, Integer shipmentId,
+            BigDecimal receivedTempC, Boolean integrityOk, String integrityNotes, Long receivedBy, String sysUserId) {
+        if (receivedBy == null) {
+            throw new IllegalArgumentException("A receipt requires the receiving user");
+        }
+
+        // Idempotency: the DB unique constraint is the backstop; this read is what
+        // makes the double-call read-only instead of a constraint error.
+        List<EQAPanelReceipt> existing = eqaPanelReceiptDAO
+                .getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId));
+        if (!existing.isEmpty()) {
+            return existing.get(0);
+        }
+
+        // Resolve everything the receipt references before writing anything, so a
+        // bad reference is a clean 4xx instead of a flush-time constraint error
+        // (the FK to shipment stays as the backstop).
+        EQACycle cycle = eqaCycleService.get(cycleId);
+        Shipment shipment = null;
+        if (shipmentId != null) {
+            shipment = shipmentService.getShipmentById(shipmentId);
+            if (shipment == null) {
+                throw new IllegalArgumentException("Receipt names shipment " + shipmentId + ", which does not exist");
+            }
+        }
+
+        EQAPanelReceipt receipt = new EQAPanelReceipt();
+        receipt.setCycle(cycle);
+        receipt.setLabEnrollmentId(labEnrollmentId);
+        receipt.setShipmentId(shipmentId);
+        receipt.setReceivedDate(new Date(System.currentTimeMillis()));
+        receipt.setReceivedBy(receivedBy);
+        receipt.setReceivedTempC(receivedTempC);
+        receipt.setIntegrityOk(integrityOk == null || integrityOk);
+        receipt.setIntegrityNotes(integrityNotes);
+        receipt.setSysUserId(sysUserId);
+        receipt.setId(eqaPanelReceiptDAO.insert(receipt));
+
+        if (shipment != null) {
+            shipment.setActualDeliveryDate(new Timestamp(System.currentTimeMillis()));
+            shipment.setStatus(ShipmentStatus.DELIVERED);
+            shipment.setSysUserId(sysUserId);
+            shipmentService.updateShipment(shipment);
+        }
+
+        // Receipt is the participant machine's planned -> panel_received trigger.
+        // A cycle already past PLANNED keeps its state — the receipt is late
+        // paperwork then, not a regression.
+        if (cycle.getStatus() == EQACycleStatus.PLANNED) {
+            eqaCycleService.transition(cycleId, EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                    EQATriggerType.AUTO, EQATriggerEvent.PANEL_RECEIPT, null, "Panel receipt recorded", sysUserId);
+        }
+
+        return receipt;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
@@ -1,0 +1,39 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.service.BaseObjectService;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+
+public interface EQAPanelService extends BaseObjectService<EQAPanel, Long> {
+
+    /**
+     * PREPARING → SEALED (FR-V2.1-11). Refuses a panel with no samples, any sample
+     * with a blank target (the encryption converter passes blanks through
+     * unencrypted, so blanks must never reach the column), and an in-house panel
+     * without an unblind date (FR-V2.1-16).
+     *
+     * @throws IllegalStateException    when the panel is not in PREPARING
+     * @throws IllegalArgumentException when a seal precondition fails
+     */
+    EQAPanel seal(Long panelId, String sysUserId);
+
+    /** SEALED → DISTRIBUTED. */
+    EQAPanel distribute(Long panelId, String sysUserId);
+
+    /** DISTRIBUTED → UNBLINDED (AC-V2.4-03's reveal point). */
+    EQAPanel unblind(Long panelId, String sysUserId);
+
+    /** Panels bound to a cycle, without samples. */
+    List<Map<String, Object>> getPanelDtos(Long cycleId);
+
+    Map<String, Object> toPanelDto(EQAPanel panel);
+
+    /**
+     * The panel's samples as DTOs. Sealed-target rule (FR-V2.1-16 / AC-V2.4-03):
+     * target value, unit and acceptance range are null unless the panel has reached
+     * UNBLINDED/SCORED/CLOSED or the caller holds the unblind permission — the
+     * blinding guarantee is enforced here, in the mapping, not in the UI.
+     */
+    List<Map<String, Object>> getSampleDtos(Long panelId, boolean callerCanUnblind);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -1,0 +1,167 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Panel lifecycle + sealed-target read rule (T-11). SCORED/CLOSED moves belong
+ * to scoring (T-22/T-26), not here.
+ */
+@Service
+@Transactional
+public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> implements EQAPanelService {
+
+    /** FR-V2.1-11's forward edges for the moves this service owns. */
+    private static final Map<EQAPanelStatus, Set<EQAPanelStatus>> EDGES = new EnumMap<>(EQAPanelStatus.class);
+
+    /** Targets stay hidden until one of these states (FR-V2.1-16). */
+    private static final Set<EQAPanelStatus> TARGETS_REVEALED = EnumSet.of(EQAPanelStatus.UNBLINDED,
+            EQAPanelStatus.SCORED, EQAPanelStatus.CLOSED);
+
+    static {
+        EDGES.put(EQAPanelStatus.PREPARING, EnumSet.of(EQAPanelStatus.SEALED));
+        EDGES.put(EQAPanelStatus.SEALED, EnumSet.of(EQAPanelStatus.DISTRIBUTED));
+        EDGES.put(EQAPanelStatus.DISTRIBUTED, EnumSet.of(EQAPanelStatus.UNBLINDED));
+    }
+
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    public EQAPanelServiceImpl() {
+        super(EQAPanel.class);
+    }
+
+    @Override
+    protected EQAPanelDAO getBaseObjectDAO() {
+        return eqaPanelDAO;
+    }
+
+    @Override
+    public EQAPanel seal(Long panelId, String sysUserId) {
+        EQAPanel panel = get(panelId);
+        requireEdge(panel, EQAPanelStatus.SEALED);
+
+        List<EQAPanelSample> samples = samplesOf(panelId);
+        if (samples.isEmpty()) {
+            throw new IllegalArgumentException("Cannot seal a panel with no samples");
+        }
+        // EncryptionConverter passes blank values through unencrypted, so the seal is
+        // the last gate that can keep plaintext-blank targets out of the column.
+        if (samples.stream().anyMatch(s -> GenericValidator.isBlankOrNull(s.getTargetValue()))) {
+            throw new IllegalArgumentException("Cannot seal a panel while a sample has no target value");
+        }
+        if (panel.getScheme() != null && panel.getScheme().getSchemeType() == EQASchemeType.IN_HOUSE
+                && panel.getUnblindDate() == null) {
+            throw new IllegalArgumentException("An in-house panel requires an unblind date before sealing");
+        }
+
+        return move(panel, EQAPanelStatus.SEALED, sysUserId);
+    }
+
+    @Override
+    public EQAPanel distribute(Long panelId, String sysUserId) {
+        EQAPanel panel = get(panelId);
+        requireEdge(panel, EQAPanelStatus.DISTRIBUTED);
+        return move(panel, EQAPanelStatus.DISTRIBUTED, sysUserId);
+    }
+
+    @Override
+    public EQAPanel unblind(Long panelId, String sysUserId) {
+        EQAPanel panel = get(panelId);
+        requireEdge(panel, EQAPanelStatus.UNBLINDED);
+        return move(panel, EQAPanelStatus.UNBLINDED, sysUserId);
+    }
+
+    private void requireEdge(EQAPanel panel, EQAPanelStatus target) {
+        Set<EQAPanelStatus> legal = EDGES.getOrDefault(panel.getStatus(), EnumSet.noneOf(EQAPanelStatus.class));
+        if (!legal.contains(target)) {
+            throw new IllegalStateException("Cannot move a panel from " + panel.getStatus() + " to " + target);
+        }
+    }
+
+    private EQAPanel move(EQAPanel panel, EQAPanelStatus target, String sysUserId) {
+        panel.setStatus(target);
+        panel.setSysUserId(sysUserId);
+        return eqaPanelDAO.update(panel);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getPanelDtos(Long cycleId) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycleId)) {
+            rows.add(toPanelDto(panel));
+        }
+        return rows;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> toPanelDto(EQAPanel panel) {
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("id", panel.getId());
+        dto.put("panelName", panel.getPanelName());
+        dto.put("panelType", panel.getPanelType());
+        dto.put("status", panel.getStatus() == null ? null : panel.getStatus().name());
+        dto.put("schemeId", panel.getScheme() == null ? null : panel.getScheme().getId());
+        dto.put("cycleId", panel.getCycle() == null ? null : panel.getCycle().getId());
+        dto.put("sourceType", panel.getSourceType() == null ? null : panel.getSourceType().name());
+        dto.put("lotNumber", panel.getLotNumber());
+        dto.put("unblindDate", panel.getUnblindDate() == null ? null : panel.getUnblindDate().toString());
+        dto.put("aliquotsProduced", panel.getAliquotsProduced());
+        dto.put("aliquotsReserved", panel.getAliquotsReserved());
+        dto.put("aliquotsShipped", panel.getAliquotsShipped());
+        dto.put("homogeneityQcPassed", panel.getHomogeneityQcPassed());
+        dto.put("expirationDate", panel.getExpirationDate() == null ? null : panel.getExpirationDate().toString());
+        return dto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getSampleDtos(Long panelId, boolean callerCanUnblind) {
+        EQAPanel panel = get(panelId);
+        boolean revealTargets = TARGETS_REVEALED.contains(panel.getStatus()) || callerCanUnblind;
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAPanelSample sample : samplesOf(panelId)) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", sample.getId());
+            dto.put("panelId", panelId);
+            dto.put("sampleCode", sample.getSampleCode());
+            dto.put("blindCode", sample.getBlindCode());
+            dto.put("analyteId", sample.getAnalyteId());
+            // The blinding guarantee: nulls, not omissions, so the shape is stable and a
+            // client cannot infer anything from missing keys.
+            dto.put("targetValue", revealTargets ? sample.getTargetValue() : null);
+            dto.put("targetUnit", revealTargets ? sample.getTargetUnit() : null);
+            dto.put("acceptanceRangeLow", revealTargets ? sample.getAcceptanceRangeLow() : null);
+            dto.put("acceptanceRangeHigh", revealTargets ? sample.getAcceptanceRangeHigh() : null);
+            dto.put("targetsRevealed", revealTargets);
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    private List<EQAPanelSample> samplesOf(Long panelId) {
+        return eqaPanelSampleDAO.getAllMatchingOrdered("panel.id", panelId, "sampleCode", false);
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -20,8 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Panel lifecycle + sealed-target read rule (T-11). SCORED/CLOSED moves belong
- * to scoring (T-22/T-26), not here.
+ * Panel lifecycle + sealed-target read rule (OGC-609). SCORED/CLOSED moves
+ * belong to the scoring flows, not here.
  */
 @Service
 @Transactional

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
@@ -1,0 +1,45 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.service.BaseObjectService;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+
+public interface EQAParticipantResultService extends BaseObjectService<EQAParticipantResult, Long> {
+
+    /**
+     * Insert a new DRAFT, or update the editable fields of an existing DRAFT.
+     * Anything past DRAFT is immutable through this path (FR-V2.1-05).
+     */
+    EQAParticipantResult saveDraft(EQAParticipantResult result);
+
+    /**
+     * DRAFT → VALIDATED_PARTIAL → SUBMITTED (FR-V2.1-05); SUBMITTED stamps
+     * {@code submittedAt}. SCORED and MISSED_DEADLINE are refused here — they carry
+     * side-effects and go through {@link #recordScore} /
+     * {@link #markMissedDeadline}.
+     *
+     * @throws IllegalStateException when the edge is not in the lifecycle
+     */
+    EQAParticipantResult transitionStatus(Long resultId, EQASubmissionStatus target, String sysUserId);
+
+    /**
+     * SUBMITTED → SCORED with the provider's verdict. A QUESTIONABLE or
+     * UNACCEPTABLE score on a result with an assigned analyst writes the
+     * corresponding competency event (FR-V2.1-22).
+     */
+    EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, Long eqaResultId,
+            String sysUserId);
+
+    /**
+     * DRAFT/VALIDATED_PARTIAL → MISSED_DEADLINE (timer terminal). Writes the
+     * scheme-type-appropriate missed-deadline competency event when an analyst is
+     * assigned (FR-V2.1-22). Called by the deadline scheduler (T-16) and manually.
+     */
+    EQAParticipantResult markMissedDeadline(Long resultId, String sysUserId);
+
+    /** Results for one cycle, optionally narrowed to one lab enrollment. */
+    List<Map<String, Object>> getResultDtos(Long cycleId, Long labEnrollmentId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
@@ -36,7 +36,7 @@ public interface EQAParticipantResultService extends BaseObjectService<EQAPartic
     /**
      * DRAFT/VALIDATED_PARTIAL → MISSED_DEADLINE (timer terminal). Writes the
      * scheme-type-appropriate missed-deadline competency event when an analyst is
-     * assigned (FR-V2.1-22). Called by the deadline scheduler (T-16) and manually.
+     * assigned (FR-V2.1-22). Called by the deadline scheduler and manually.
      */
     EQAParticipantResult markMissedDeadline(Long resultId, String sysUserId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
@@ -1,0 +1,216 @@
+package org.openelisglobal.eqa.service;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Participant-result lifecycle enforcement + competency events (T-11,
+ * FR-V2.1-05 / FR-V2.1-22).
+ */
+@Service
+@Transactional
+public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAParticipantResult, Long>
+        implements EQAParticipantResultService {
+
+    @Autowired
+    private EQAParticipantResultDAO eqaParticipantResultDAO;
+
+    @Autowired
+    private EQAAnalystCompetencyEventDAO eqaAnalystCompetencyEventDAO;
+
+    @Autowired
+    private EQARoundDAO eqaRoundDAO;
+
+    public EQAParticipantResultServiceImpl() {
+        super(EQAParticipantResult.class);
+    }
+
+    @Override
+    protected EQAParticipantResultDAO getBaseObjectDAO() {
+        return eqaParticipantResultDAO;
+    }
+
+    @Override
+    public EQAParticipantResult saveDraft(EQAParticipantResult result) {
+        if (result.getId() == null) {
+            // eqa_participant_result.round_id is NOT NULL: every result lives in a
+            // round. Resolve it here so a bad id is a 4xx, not a flush error.
+            if (result.getRound() == null || result.getRound().getId() == null) {
+                throw new IllegalArgumentException("A participant result requires its round");
+            }
+            result.setRound(eqaRoundDAO.get(result.getRound().getId())
+                    .orElseThrow(() -> new IllegalArgumentException("Unknown round " + result.getRound().getId())));
+            result.setSubmissionStatus(EQASubmissionStatus.DRAFT);
+            if (result.getEnteredAt() == null) {
+                result.setEnteredAt(now());
+            }
+            result.setId(eqaParticipantResultDAO.insert(result));
+            return result;
+        }
+
+        EQAParticipantResult existing = get(result.getId());
+        if (existing.getSubmissionStatus() != EQASubmissionStatus.DRAFT) {
+            throw new IllegalStateException(
+                    "Only a DRAFT result can be edited; this one is " + existing.getSubmissionStatus());
+        }
+        existing.setResultValue(result.getResultValue());
+        existing.setResultUnit(result.getResultUnit());
+        existing.setAssignedAnalystId(result.getAssignedAnalystId());
+        existing.setAnalysisId(result.getAnalysisId());
+        existing.setEnteredBy(result.getEnteredBy());
+        existing.setSysUserId(result.getSysUserId());
+        return eqaParticipantResultDAO.update(existing);
+    }
+
+    @Override
+    public EQAParticipantResult transitionStatus(Long resultId, EQASubmissionStatus target, String sysUserId) {
+        if (target == EQASubmissionStatus.SCORED || target == EQASubmissionStatus.MISSED_DEADLINE) {
+            throw new IllegalStateException(target + " carries side-effects; use its dedicated operation");
+        }
+
+        EQAParticipantResult result = get(resultId);
+        EQASubmissionStatus from = result.getSubmissionStatus();
+        boolean legal = (from == EQASubmissionStatus.DRAFT && target == EQASubmissionStatus.VALIDATED_PARTIAL)
+                || (from == EQASubmissionStatus.VALIDATED_PARTIAL && target == EQASubmissionStatus.SUBMITTED);
+        if (!legal) {
+            throw new IllegalStateException("Cannot move a participant result from " + from + " to " + target);
+        }
+
+        if (target == EQASubmissionStatus.SUBMITTED) {
+            result.setSubmittedAt(now());
+        }
+        result.setSubmissionStatus(target);
+        result.setSysUserId(sysUserId);
+        return eqaParticipantResultDAO.update(result);
+    }
+
+    @Override
+    public EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, Long eqaResultId,
+            String sysUserId) {
+        EQAParticipantResult result = get(resultId);
+        if (result.getSubmissionStatus() != EQASubmissionStatus.SUBMITTED) {
+            throw new IllegalStateException(
+                    "Only a SUBMITTED result can be scored; this one is " + result.getSubmissionStatus());
+        }
+        if (performance == null) {
+            throw new IllegalArgumentException("A score needs a performance verdict");
+        }
+
+        result.setSubmissionStatus(EQASubmissionStatus.SCORED);
+        result.setScoreReceivedAt(now());
+        result.setEqaResultId(eqaResultId);
+        result.setSysUserId(sysUserId);
+        EQAParticipantResult scored = eqaParticipantResultDAO.update(result);
+
+        if (performance != EQAPerformanceStatus.ACCEPTABLE) {
+            recordCompetencyEvent(scored,
+                    performance == EQAPerformanceStatus.UNACCEPTABLE ? EQACompetencyEventType.UNACCEPTABLE_SCORE
+                            : EQACompetencyEventType.QUESTIONABLE_SCORE,
+                    sysUserId);
+        }
+
+        onResultScored(scored, performance);
+        return scored;
+    }
+
+    @Override
+    public EQAParticipantResult markMissedDeadline(Long resultId, String sysUserId) {
+        EQAParticipantResult result = get(resultId);
+        EQASubmissionStatus from = result.getSubmissionStatus();
+        if (from != EQASubmissionStatus.DRAFT && from != EQASubmissionStatus.VALIDATED_PARTIAL) {
+            throw new IllegalStateException("Cannot mark a " + from + " result as missed");
+        }
+
+        result.setSubmissionStatus(EQASubmissionStatus.MISSED_DEADLINE);
+        result.setSysUserId(sysUserId);
+        EQAParticipantResult missed = eqaParticipantResultDAO.update(result);
+
+        boolean inHouse = missed.getCycle() != null && missed.getCycle().getScheme() != null
+                && missed.getCycle().getScheme().getSchemeType() == EQASchemeType.IN_HOUSE;
+        recordCompetencyEvent(missed, inHouse ? EQACompetencyEventType.IN_HOUSE_MISSED_DEADLINE
+                : EQACompetencyEventType.EXTERNAL_MISSED_DEADLINE, sysUserId);
+
+        return missed;
+    }
+
+    /**
+     * eqa_analyst_competency_event.analyst_id is NOT NULL by design — competency is
+     * an analyst log, so a result with nobody assigned produces no event.
+     */
+    private void recordCompetencyEvent(EQAParticipantResult result, EQACompetencyEventType type, String sysUserId) {
+        if (result.getAssignedAnalystId() == null) {
+            return;
+        }
+        EQAAnalystCompetencyEvent event = new EQAAnalystCompetencyEvent();
+        event.setAnalystId(result.getAssignedAnalystId());
+        event.setEventType(type);
+        event.setEventDate(new Date(System.currentTimeMillis()));
+        event.setScheme(result.getCycle() == null ? null : result.getCycle().getScheme());
+        event.setCycleId(result.getCycle() == null ? null : result.getCycle().getId());
+        event.setParticipantResultId(result.getId());
+        event.setAnalyteId(result.getAnalyteId());
+        event.setSysUserId(sysUserId);
+        eqaAnalystCompetencyEventDAO.insert(event);
+    }
+
+    /**
+     * T-17 hook (tiered EQA→NCE trigger adapter): the adapter replaces this body.
+     * Fired after the score and any competency event are committed to the session,
+     * inside the same transaction.
+     */
+    protected void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance) {
+        // Intentionally empty until T-17 wires the NCE adapter.
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getResultDtos(Long cycleId, Long labEnrollmentId) {
+        List<EQAParticipantResult> results = labEnrollmentId == null
+                ? eqaParticipantResultDAO.getAllMatching("cycle.id", cycleId)
+                : eqaParticipantResultDAO
+                        .getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId));
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAParticipantResult result : results) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", result.getId());
+            dto.put("cycleId", cycleId);
+            dto.put("roundId", result.getRound() == null ? null : result.getRound().getId());
+            dto.put("labEnrollmentId", result.getLabEnrollmentId());
+            dto.put("analyteId", result.getAnalyteId());
+            dto.put("analysisId", result.getAnalysisId());
+            dto.put("resultValue", result.getResultValue());
+            dto.put("resultUnit", result.getResultUnit());
+            dto.put("assignedAnalystId", result.getAssignedAnalystId());
+            dto.put("submissionStatus",
+                    result.getSubmissionStatus() == null ? null : result.getSubmissionStatus().name());
+            dto.put("submittedAt", result.getSubmittedAt() == null ? null : result.getSubmittedAt().toString());
+            dto.put("scoreReceivedAt",
+                    result.getScoreReceivedAt() == null ? null : result.getScoreReceivedAt().toString());
+            dto.put("eqaResultId", result.getEqaResultId());
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    private static Timestamp now() {
+        return new Timestamp(System.currentTimeMillis());
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Participant-result lifecycle enforcement + competency events (T-11,
+ * Participant-result lifecycle enforcement + competency events (OGC-609,
  * FR-V2.1-05 / FR-V2.1-22).
  */
 @Service
@@ -171,12 +171,12 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
     }
 
     /**
-     * T-17 hook (tiered EQA→NCE trigger adapter): the adapter replaces this body.
-     * Fired after the score and any competency event are committed to the session,
-     * inside the same transaction.
+     * Hook for the tiered EQA→NCE trigger adapter (OGC-609): the adapter replaces
+     * this body. Fired after the score and any competency event are committed to
+     * the session, inside the same transaction.
      */
     protected void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance) {
-        // Intentionally empty until T-17 wires the NCE adapter.
+        // Intentionally empty until the NCE adapter is wired (OGC-609).
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQATriggerEvent.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQATriggerEvent.java
@@ -1,9 +1,10 @@
 package org.openelisglobal.eqa.valueholder;
 
 /**
- * What caused a cycle state transition (FR-V2.1-21). PANEL_RECEIPT is a T-11
- * addition (qa/024 extends the DB CHECK): the receipt insert's automatic
- * planned → panel_received move on the participant machine (FR-V2.1-20).
+ * What caused a cycle state transition (FR-V2.1-21). PANEL_RECEIPT (added with
+ * liquibase qa/024, which extends the DB CHECK) is the receipt insert's
+ * automatic planned → panel_received move on the participant machine
+ * (FR-V2.1-20).
  */
 public enum EQATriggerEvent {
     LAST_VALIDATED_RESULT, FHIR_SUBMIT_SUCCESS, FHIR_SUBMIT_FAILURE_RETRY, SCORE_INTAKE, DEADLINE_TIMER,

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQATriggerEvent.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQATriggerEvent.java
@@ -1,8 +1,12 @@
 package org.openelisglobal.eqa.valueholder;
 
-/** What caused a cycle state transition (FR-V2.1-21). */
+/**
+ * What caused a cycle state transition (FR-V2.1-21). PANEL_RECEIPT is a T-11
+ * addition (qa/024 extends the DB CHECK): the receipt insert's automatic
+ * planned → panel_received move on the participant machine (FR-V2.1-20).
+ */
 public enum EQATriggerEvent {
     LAST_VALIDATED_RESULT, FHIR_SUBMIT_SUCCESS, FHIR_SUBMIT_FAILURE_RETRY, SCORE_INTAKE, DEADLINE_TIMER,
     ALL_SHIPMENTS_DELIVERED, ALL_SUBMISSIONS_RECEIVED, PANEL_SEAL, PANEL_UNBLIND, HOMOGENEITY_QC_PASSED,
-    MANUAL_OVERRIDE, SCHEDULED_JOB
+    MANUAL_OVERRIDE, SCHEDULED_JOB, PANEL_RECEIPT
 }

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -82,4 +82,7 @@
 
   <!-- EQA V2.1 T-10 — OGC-609: write permission for cycle state changes -->
   <include file="liquibase/qa/023-add-eqa-manage-permission.xml" />
+
+  <!-- EQA V2.1 T-11 — OGC-609: PANEL_RECEIPT trigger event for receipt-driven transitions -->
+  <include file="liquibase/qa/024-extend-eqa-trigger-event-check.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -83,6 +83,6 @@
   <!-- EQA V2.1 T-10 — OGC-609: write permission for cycle state changes -->
   <include file="liquibase/qa/023-add-eqa-manage-permission.xml" />
 
-  <!-- EQA V2.1 T-11 — OGC-609: PANEL_RECEIPT trigger event for receipt-driven transitions -->
+  <!-- EQA V2.1 — OGC-609: PANEL_RECEIPT trigger event for receipt-driven transitions -->
   <include file="liquibase/qa/024-extend-eqa-trigger-event-check.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
+++ b/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.1 T-11 (OGC-609): the panel-receipt insert fires the participant
+    machine's planned -> panel_received transition automatically (FR-V2.1-20),
+    which needs a trigger_event value of its own. Extends the CHECK from qa/015
+    with PANEL_RECEIPT.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-037-add-panel-receipt-trigger-event">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM pg_constraint
+                WHERE conname = 'eqa_cycle_state_transition_trigger_event_chk'
+            </sqlCheck>
+        </preConditions>
+        <comment>Allow PANEL_RECEIPT as a cycle-transition trigger event</comment>
+        <sql>
+            ALTER TABLE clinlims.eqa_cycle_state_transition
+            DROP CONSTRAINT eqa_cycle_state_transition_trigger_event_chk;
+
+            ALTER TABLE clinlims.eqa_cycle_state_transition
+            ADD CONSTRAINT eqa_cycle_state_transition_trigger_event_chk
+            CHECK (trigger_event IN ('LAST_VALIDATED_RESULT', 'FHIR_SUBMIT_SUCCESS', 'FHIR_SUBMIT_FAILURE_RETRY',
+                'SCORE_INTAKE', 'DEADLINE_TIMER', 'ALL_SHIPMENTS_DELIVERED', 'ALL_SUBMISSIONS_RECEIVED',
+                'PANEL_SEAL', 'PANEL_UNBLIND', 'HOMOGENEITY_QC_PASSED', 'MANUAL_OVERRIDE', 'SCHEDULED_JOB',
+                'PANEL_RECEIPT'))
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE clinlims.eqa_cycle_state_transition
+                DROP CONSTRAINT eqa_cycle_state_transition_trigger_event_chk;
+
+                ALTER TABLE clinlims.eqa_cycle_state_transition
+                ADD CONSTRAINT eqa_cycle_state_transition_trigger_event_chk
+                CHECK (trigger_event IN ('LAST_VALIDATED_RESULT', 'FHIR_SUBMIT_SUCCESS', 'FHIR_SUBMIT_FAILURE_RETRY',
+                    'SCORE_INTAKE', 'DEADLINE_TIMER', 'ALL_SHIPMENTS_DELIVERED', 'ALL_SUBMISSIONS_RECEIVED',
+                    'PANEL_SEAL', 'PANEL_UNBLIND', 'HOMOGENEITY_QC_PASSED', 'MANUAL_OVERRIDE', 'SCHEDULED_JOB'))
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
+++ b/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    EQA V2.1 T-11 (OGC-609): the panel-receipt insert fires the participant
+    EQA V2.1 (OGC-609): the panel-receipt insert fires the participant
     machine's planned -> panel_received transition automatically (FR-V2.1-20),
     which needs a trigger_event value of its own. Extends the CHECK from qa/015
     with PANEL_RECEIPT.

--- a/src/test/java/org/openelisglobal/eqa/EQACycleMappingValidationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleMappingValidationTest.java
@@ -90,10 +90,10 @@ public class EQACycleMappingValidationTest {
     public void auditVocabulariesMatchTheCheckConstraints() {
         assertEquals(Arrays.asList("PARTICIPANT", "PROVIDER"), names(EQAStateMachine.values()));
         assertEquals(Arrays.asList("AUTO", "MANUAL"), names(EQATriggerType.values()));
-        assertEquals(
-                Arrays.asList("LAST_VALIDATED_RESULT", "FHIR_SUBMIT_SUCCESS", "FHIR_SUBMIT_FAILURE_RETRY",
-                        "SCORE_INTAKE", "DEADLINE_TIMER", "ALL_SHIPMENTS_DELIVERED", "ALL_SUBMISSIONS_RECEIVED",
-                        "PANEL_SEAL", "PANEL_UNBLIND", "HOMOGENEITY_QC_PASSED", "MANUAL_OVERRIDE", "SCHEDULED_JOB"),
+        // PANEL_RECEIPT joined in T-11 (qa/024 extends the DB CHECK in step).
+        assertEquals(Arrays.asList("LAST_VALIDATED_RESULT", "FHIR_SUBMIT_SUCCESS", "FHIR_SUBMIT_FAILURE_RETRY",
+                "SCORE_INTAKE", "DEADLINE_TIMER", "ALL_SHIPMENTS_DELIVERED", "ALL_SUBMISSIONS_RECEIVED", "PANEL_SEAL",
+                "PANEL_UNBLIND", "HOMOGENEITY_QC_PASSED", "MANUAL_OVERRIDE", "SCHEDULED_JOB", "PANEL_RECEIPT"),
                 names(EQATriggerEvent.values()));
     }
 

--- a/src/test/java/org/openelisglobal/eqa/EQACycleMappingValidationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleMappingValidationTest.java
@@ -90,7 +90,8 @@ public class EQACycleMappingValidationTest {
     public void auditVocabulariesMatchTheCheckConstraints() {
         assertEquals(Arrays.asList("PARTICIPANT", "PROVIDER"), names(EQAStateMachine.values()));
         assertEquals(Arrays.asList("AUTO", "MANUAL"), names(EQATriggerType.values()));
-        // PANEL_RECEIPT joined in T-11 (qa/024 extends the DB CHECK in step).
+        // PANEL_RECEIPT joined with liquibase qa/024, which extends the DB CHECK in
+        // step.
         assertEquals(Arrays.asList("LAST_VALIDATED_RESULT", "FHIR_SUBMIT_SUCCESS", "FHIR_SUBMIT_FAILURE_RETRY",
                 "SCORE_INTAKE", "DEADLINE_TIMER", "ALL_SHIPMENTS_DELIVERED", "ALL_SUBMISSIONS_RECEIVED", "PANEL_SEAL",
                 "PANEL_UNBLIND", "HOMOGENEITY_QC_PASSED", "MANUAL_OVERRIDE", "SCHEDULED_JOB", "PANEL_RECEIPT"),

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
@@ -1,0 +1,187 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.service.EQAPanelService;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-609 [EQA V2.1 / T-11] — panel lifecycle guards and the sealed-target read
+ * rule (FR-V2.1-11 / FR-V2.1-16 / AC-V2.4-03). Runs against the
+ * liquibase-provisioned schema, so the encryption converter and constraints are
+ * live.
+ */
+public class EQAPanelLifecycleIntegrationTest extends EQASpineTestBase {
+
+    private static final long ANALYTE = 9801L;
+
+    @Autowired
+    private EQAPanelService panelService;
+
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    private EQAPanelSample insertSample(EQAPanel panel, String code, String target) {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode(code);
+        sample.setBlindCode("BLIND-" + code);
+        sample.setAnalyteId(ANALYTE);
+        sample.setTargetValue(target);
+        sample.setTargetUnit("log10 c/mL");
+        sample.setAcceptanceRangeLow(new BigDecimal("4.00000"));
+        sample.setAcceptanceRangeHigh(new BigDecimal("5.00000"));
+        sample.setSysUserId(USER);
+        sample.setId(eqaPanelSampleDAO.insert(sample));
+        return sample;
+    }
+
+    @Test
+    public void seal_movesPreparingPanelToSealed() {
+        EQAProgram scheme = insertScheme("Seal happy", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("P1"));
+        insertSample(panel, "A01", "4.52");
+
+        EQAPanel sealed = panelService.seal(panel.getId(), USER);
+
+        assertEquals(EQAPanelStatus.SEALED, sealed.getStatus());
+        assertEquals(EQAPanelStatus.SEALED,
+                eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+    }
+
+    @Test
+    public void seal_refusesPanelWithNoSamples() {
+        EQAProgram scheme = insertScheme("Seal empty", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("Empty"));
+
+        try {
+            panelService.seal(panel.getId(), USER);
+            fail("a panel with no samples must not seal");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(EQAPanelStatus.PREPARING,
+                    eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+        }
+    }
+
+    @Test
+    public void seal_refusesBlankTargetValue() {
+        EQAProgram scheme = insertScheme("Seal blank", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("Blank target"));
+        insertSample(panel, "A01", "  ");
+
+        try {
+            panelService.seal(panel.getId(), USER);
+            fail("a blank target must not seal (the converter passes blanks through unencrypted)");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(EQAPanelStatus.PREPARING,
+                    eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+        }
+    }
+
+    @Test
+    public void seal_refusesInHousePanelWithoutUnblindDate() {
+        EQAProgram scheme = insertScheme("Seal in-house", EQASchemeType.IN_HOUSE, null);
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("No unblind date"));
+        insertSample(panel, "A01", "4.52");
+
+        try {
+            panelService.seal(panel.getId(), USER);
+            fail("an in-house panel without an unblind date must not seal");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(EQAPanelStatus.PREPARING,
+                    eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+        }
+    }
+
+    @Test
+    public void seal_acceptsInHousePanelWithUnblindDate() {
+        EQAProgram scheme = insertScheme("Seal in-house ok", EQASchemeType.IN_HOUSE, null);
+        EQAPanel panel = insertPanel(scheme, p -> {
+            p.setPanelName("Dated");
+            p.setUnblindDate(Date.valueOf("2026-12-01"));
+        });
+        insertSample(panel, "A01", "4.52");
+
+        assertEquals(EQAPanelStatus.SEALED, panelService.seal(panel.getId(), USER).getStatus());
+    }
+
+    @Test
+    public void lifecycle_illegalJumpIsRefused() {
+        EQAProgram scheme = insertScheme("Bad jump", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("Jump"));
+
+        try {
+            panelService.unblind(panel.getId(), USER);
+            fail("PREPARING cannot jump straight to UNBLINDED");
+        } catch (IllegalStateException expected) {
+            assertEquals(EQAPanelStatus.PREPARING,
+                    eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+        }
+    }
+
+    @Test
+    public void sealedTargets_hiddenFromUnprivilegedCaller() {
+        EQAProgram scheme = insertScheme("Sealed read", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("Sealed"));
+        insertSample(panel, "A01", "4.52");
+        panelService.seal(panel.getId(), USER);
+
+        List<Map<String, Object>> dtos = panelService.getSampleDtos(panel.getId(), false);
+
+        assertEquals(1, dtos.size());
+        Map<String, Object> dto = dtos.get(0);
+        assertEquals("A01", dto.get("sampleCode"));
+        assertEquals("BLIND-A01", dto.get("blindCode"));
+        assertNull("sealed target must not appear in the DTO", dto.get("targetValue"));
+        assertNull("sealed unit must not appear in the DTO", dto.get("targetUnit"));
+        assertNull("sealed range low must not appear in the DTO", dto.get("acceptanceRangeLow"));
+        assertNull("sealed range high must not appear in the DTO", dto.get("acceptanceRangeHigh"));
+        assertEquals(Boolean.FALSE, dto.get("targetsRevealed"));
+    }
+
+    @Test
+    public void sealedTargets_visibleToPrivilegedCaller() {
+        EQAProgram scheme = insertScheme("Privileged read", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQAPanel panel = insertPanel(scheme, p -> p.setPanelName("Sealed priv"));
+        insertSample(panel, "A01", "4.52");
+        panelService.seal(panel.getId(), USER);
+
+        Map<String, Object> dto = panelService.getSampleDtos(panel.getId(), true).get(0);
+
+        assertEquals("4.52", dto.get("targetValue"));
+        assertEquals("log10 c/mL", dto.get("targetUnit"));
+        assertEquals(0, new BigDecimal("4.00000").compareTo((BigDecimal) dto.get("acceptanceRangeLow")));
+        assertEquals(Boolean.TRUE, dto.get("targetsRevealed"));
+    }
+
+    @Test
+    public void unblindedTargets_visibleToEveryone() {
+        EQAProgram scheme = insertScheme("Unblinded read", EQASchemeType.IN_HOUSE, null);
+        EQAPanel panel = insertPanel(scheme, p -> {
+            p.setPanelName("Unblinded");
+            p.setUnblindDate(Date.valueOf("2026-12-01"));
+        });
+        insertSample(panel, "A01", "4.52");
+        panelService.seal(panel.getId(), USER);
+        panelService.distribute(panel.getId(), USER);
+        panelService.unblind(panel.getId(), USER);
+
+        Map<String, Object> dto = panelService.getSampleDtos(panel.getId(), false).get(0);
+
+        assertEquals("4.52", dto.get("targetValue"));
+        assertEquals(Boolean.TRUE, dto.get("targetsRevealed"));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
@@ -19,8 +19,8 @@ import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * OGC-609 [EQA V2.1 / T-11] — panel lifecycle guards and the sealed-target read
- * rule (FR-V2.1-11 / FR-V2.1-16 / AC-V2.4-03). Runs against the
+ * OGC-609 [EQA V2.1] — panel lifecycle guards and the sealed-target read rule
+ * (FR-V2.1-11 / FR-V2.1-16 / AC-V2.4-03). Runs against the
  * liquibase-provisioned schema, so the encryption converter and constraints are
  * live.
  */

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
@@ -1,0 +1,132 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQAPanelReceiptService;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-609 [EQA V2.1 / T-11] — receipt intake side-effects are one transaction
+ * (FR-V2.1-20): receipt row + shipment delivery + cycle transition, and a
+ * double receipt is a read, not a write.
+ */
+public class EQAPanelReceiptIntegrationTest extends EQASpineTestBase {
+
+    private static final long ENROLLMENT = 9901L;
+
+    @Autowired
+    private EQAPanelReceiptService receiptService;
+
+    @Override
+    protected void cleanEqaTables() {
+        // Receipts reference shipments, so the EQA tables go first.
+        super.cleanEqaTables();
+        jdbc.update("DELETE FROM clinlims.shipment WHERE id BETWEEN 9950 AND 9959");
+        jdbc.update("DELETE FROM clinlims.shipping_box WHERE id BETWEEN 9950 AND 9959");
+        jdbc.update("DELETE FROM clinlims.organization WHERE id = '9950'");
+    }
+
+    private Integer seedShipment(int id) {
+        jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                + " VALUES ('9950', 'Receipt Test Lab', 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING");
+        jdbc.update(
+                "INSERT INTO clinlims.shipping_box (id, box_id, fhir_uuid, destination_facility_id, state,"
+                        + " created_date, archived, sys_user_id, lastupdated)"
+                        + " VALUES (?, 'BOX-' || ?, gen_random_uuid(), 9950, 'IN_TRANSIT', now(), false, ?, now())",
+                id, id, Integer.parseInt(USER));
+        jdbc.update(
+                "INSERT INTO clinlims.shipment (id, shipping_box_id, courier, tracking_number, status,"
+                        + " shipped_date, sys_user_id, lastupdated)"
+                        + " VALUES (?, ?, 'DHL', 'TRK-' || ?, 'IN_TRANSIT', now(), ?, now())",
+                id, id, id, Integer.parseInt(USER));
+        return id;
+    }
+
+    @Test
+    public void receipt_flipsShipmentAndCycleAtomically() {
+        seedEnrollment(ENROLLMENT, "Receipt program");
+        EQAProgram scheme = insertScheme("Receipt scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+        Integer shipmentId = seedShipment(9951);
+
+        EQAPanelReceipt receipt = receiptService.recordReceipt(cycleId, ENROLLMENT, shipmentId, new BigDecimal("4.50"),
+                true, null, ADMIN_USER_ID, USER);
+
+        // All three rows changed: receipt, shipment, cycle (+ its audit row).
+        assertEquals(Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_panel_receipt WHERE id = ?", Integer.class, receipt.getId()));
+        assertEquals("DELIVERED",
+                jdbc.queryForObject("SELECT status FROM clinlims.shipment WHERE id = ?", String.class, shipmentId));
+        Timestamp delivered = jdbc.queryForObject("SELECT actual_delivery_date FROM clinlims.shipment WHERE id = ?",
+                Timestamp.class, shipmentId);
+        assertEquals("actual_delivery_date must be stamped", false, delivered == null);
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, readBack(cycleId).getStatus());
+        assertEquals("PANEL_RECEIPT",
+                jdbc.queryForObject("SELECT trigger_event FROM clinlims.eqa_cycle_state_transition"
+                        + " WHERE cycle_id = ? ORDER BY id DESC LIMIT 1", String.class, cycleId));
+        assertEquals("AUTO", jdbc.queryForObject("SELECT trigger_type FROM clinlims.eqa_cycle_state_transition"
+                + " WHERE cycle_id = ? ORDER BY id DESC LIMIT 1", String.class, cycleId));
+    }
+
+    @Test
+    public void doubleReceipt_isIdempotentAndReadOnly() {
+        seedEnrollment(ENROLLMENT, "Double receipt");
+        EQAProgram scheme = insertScheme("Double scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+
+        EQAPanelReceipt first = receiptService.recordReceipt(cycleId, ENROLLMENT, null, null, true, null, ADMIN_USER_ID,
+                USER);
+        int transitionsAfterFirst = jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ?", Integer.class, cycleId);
+
+        EQAPanelReceipt second = receiptService.recordReceipt(cycleId, ENROLLMENT, seedShipment(9952),
+                new BigDecimal("9.99"), false, "should be ignored", ADMIN_USER_ID, USER);
+
+        assertEquals("second call returns the existing receipt", first.getId(), second.getId());
+        assertEquals(Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_panel_receipt WHERE cycle_id = ?", Integer.class, cycleId));
+        assertEquals("no second transition fires", Integer.valueOf(transitionsAfterFirst), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ?", Integer.class, cycleId));
+        assertEquals("the ignored shipment stays untouched", "IN_TRANSIT",
+                jdbc.queryForObject("SELECT status FROM clinlims.shipment WHERE id = 9952", String.class));
+    }
+
+    @Test
+    public void receiptWithoutShipment_stillAdvancesTheCycle() {
+        seedEnrollment(ENROLLMENT, "No shipment");
+        EQAProgram scheme = insertScheme("No-shipment scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+
+        EQAPanelReceipt receipt = receiptService.recordReceipt(cycleId, ENROLLMENT, null, null, null, null,
+                ADMIN_USER_ID, USER);
+
+        assertNull(receipt.getShipmentId());
+        assertEquals(Boolean.TRUE, receipt.getIntegrityOk());
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, readBack(cycleId).getStatus());
+    }
+
+    @Test
+    public void unknownShipment_rollsBackTheWholeReceipt() {
+        seedEnrollment(ENROLLMENT, "Rollback");
+        EQAProgram scheme = insertScheme("Rollback scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+
+        try {
+            receiptService.recordReceipt(cycleId, ENROLLMENT, 424242, null, true, null, ADMIN_USER_ID, USER);
+        } catch (IllegalArgumentException expected) {
+            // the receipt insert that preceded the failure must not survive
+        }
+
+        assertEquals("nothing may persist when a side-effect fails", Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_panel_receipt WHERE cycle_id = ?", Integer.class, cycleId));
+        assertEquals(EQACycleStatus.PLANNED, readBack(cycleId).getStatus());
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
@@ -14,7 +14,7 @@ import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * OGC-609 [EQA V2.1 / T-11] — receipt intake side-effects are one transaction
+ * OGC-609 [EQA V2.1] — receipt intake side-effects are one transaction
  * (FR-V2.1-20): receipt row + shipment delivery + cycle transition, and a
  * double receipt is a read, not a write.
  */

--- a/src/test/java/org/openelisglobal/eqa/EQAParticipantResultLifecycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAParticipantResultLifecycleIntegrationTest.java
@@ -19,8 +19,8 @@ import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * OGC-609 [EQA V2.1 / T-11] — participant-result lifecycle enforcement
- * (FR-V2.1-05) and the competency events it emits (FR-V2.1-22).
+ * OGC-609 [EQA V2.1] — participant-result lifecycle enforcement (FR-V2.1-05)
+ * and the competency events it emits (FR-V2.1-22).
  */
 public class EQAParticipantResultLifecycleIntegrationTest extends EQASpineTestBase {
 

--- a/src/test/java/org/openelisglobal/eqa/EQAParticipantResultLifecycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAParticipantResultLifecycleIntegrationTest.java
@@ -1,0 +1,213 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQAParticipantResultService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-609 [EQA V2.1 / T-11] — participant-result lifecycle enforcement
+ * (FR-V2.1-05) and the competency events it emits (FR-V2.1-22).
+ */
+public class EQAParticipantResultLifecycleIntegrationTest extends EQASpineTestBase {
+
+    private static final long ENROLLMENT = 9901L;
+    private static final long ANALYTE = 9801L;
+    private static final long ANALYST = 1L;
+
+    @Autowired
+    private EQAParticipantResultService resultService;
+
+    private EQACycle cycle;
+
+    private Long draft(Long analystId) {
+        return draftFor(insertScheme("Lifecycle scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS"), analystId);
+    }
+
+    private Long draftInHouse(Long analystId) {
+        return draftFor(insertScheme("In-house lifecycle", EQASchemeType.IN_HOUSE, null), analystId);
+    }
+
+    private Long draftFor(EQAProgram scheme, Long analystId) {
+        seedEnrollment(ENROLLMENT, "Lifecycle program");
+        cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+
+        EQAParticipantResult result = new EQAParticipantResult();
+        result.setCycle(cycle);
+        EQARound round = new EQARound();
+        round.setId(roundId);
+        result.setRound(round);
+        result.setLabEnrollmentId(ENROLLMENT);
+        result.setAnalyteId(ANALYTE);
+        result.setResultValue("4.7");
+        result.setResultUnit("log10 c/mL");
+        result.setAssignedAnalystId(analystId);
+        result.setSysUserId(USER);
+        return resultService.saveDraft(result).getId();
+    }
+
+    private String statusInDb(Long id) {
+        return jdbc.queryForObject("SELECT submission_status FROM clinlims.eqa_participant_result WHERE id = ?",
+                String.class, id);
+    }
+
+    @Test
+    public void happyPath_draftToValidatedToSubmittedToScored() {
+        Long id = draft(null);
+        assertEquals("DRAFT", statusInDb(id));
+
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+        assertEquals("VALIDATED_PARTIAL", statusInDb(id));
+
+        resultService.transitionStatus(id, EQASubmissionStatus.SUBMITTED, USER);
+        assertEquals("SUBMITTED", statusInDb(id));
+        assertNotNull("submittedAt stamps on submit", jdbc.queryForObject(
+                "SELECT submitted_at FROM clinlims.eqa_participant_result WHERE id = ?", java.sql.Timestamp.class, id));
+
+        resultService.recordScore(id, EQAPerformanceStatus.ACCEPTABLE, null, USER);
+        assertEquals("SCORED", statusInDb(id));
+        assertNotNull(jdbc.queryForObject("SELECT score_received_at FROM clinlims.eqa_participant_result WHERE id = ?",
+                java.sql.Timestamp.class, id));
+    }
+
+    @Test
+    public void illegalJump_draftStraightToSubmitted_isRefused() {
+        Long id = draft(null);
+        try {
+            resultService.transitionStatus(id, EQASubmissionStatus.SUBMITTED, USER);
+            fail("DRAFT cannot jump straight to SUBMITTED");
+        } catch (IllegalStateException expected) {
+            assertEquals("DRAFT", statusInDb(id));
+        }
+    }
+
+    @Test
+    public void scoredAndMissedDeadline_areRefusedOnTheGenericPath() {
+        Long id = draft(null);
+        try {
+            resultService.transitionStatus(id, EQASubmissionStatus.SCORED, USER);
+            fail("SCORED must go through recordScore");
+        } catch (IllegalStateException expected) {
+        }
+        try {
+            resultService.transitionStatus(id, EQASubmissionStatus.MISSED_DEADLINE, USER);
+            fail("MISSED_DEADLINE must go through markMissedDeadline");
+        } catch (IllegalStateException expected) {
+        }
+        assertEquals("DRAFT", statusInDb(id));
+    }
+
+    @Test
+    public void editingPastDraft_isRefused() {
+        Long id = draft(null);
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+
+        EQAParticipantResult edit = new EQAParticipantResult();
+        edit.setId(id);
+        edit.setResultValue("9.9");
+        edit.setSysUserId(USER);
+        try {
+            resultService.saveDraft(edit);
+            fail("a VALIDATED_PARTIAL result must not be editable as a draft");
+        } catch (IllegalStateException expected) {
+            assertEquals("4.7", jdbc.queryForObject(
+                    "SELECT result_value FROM clinlims.eqa_participant_result WHERE id = ?", String.class, id));
+        }
+    }
+
+    @Test
+    public void unacceptableScore_writesCompetencyEventForAssignedAnalyst() {
+        Long id = draft(ANALYST);
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+        resultService.transitionStatus(id, EQASubmissionStatus.SUBMITTED, USER);
+
+        resultService.recordScore(id, EQAPerformanceStatus.UNACCEPTABLE, null, USER);
+
+        Map<String, Object> event = jdbc
+                .queryForMap("SELECT analyst_id, event_type, cycle_id, participant_result_id, analyte_id"
+                        + " FROM clinlims.eqa_analyst_competency_event WHERE participant_result_id = ?", id);
+        assertEquals(ANALYST, ((Number) event.get("analyst_id")).longValue());
+        assertEquals("UNACCEPTABLE_SCORE", event.get("event_type"));
+        assertEquals(cycle.getId().longValue(), ((Number) event.get("cycle_id")).longValue());
+        assertEquals(ANALYTE, ((Number) event.get("analyte_id")).longValue());
+    }
+
+    @Test
+    public void acceptableScore_writesNoCompetencyEvent() {
+        Long id = draft(ANALYST);
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+        resultService.transitionStatus(id, EQASubmissionStatus.SUBMITTED, USER);
+
+        resultService.recordScore(id, EQAPerformanceStatus.ACCEPTABLE, null, USER);
+
+        assertEquals(Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                Integer.class, id));
+    }
+
+    @Test
+    public void questionableScoreWithNoAnalyst_writesNoCompetencyEvent() {
+        Long id = draft(null);
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+        resultService.transitionStatus(id, EQASubmissionStatus.SUBMITTED, USER);
+
+        resultService.recordScore(id, EQAPerformanceStatus.QUESTIONABLE, null, USER);
+
+        assertEquals("SCORED", statusInDb(id));
+        assertEquals(Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                Integer.class, id));
+    }
+
+    @Test
+    public void missedDeadline_externalScheme_writesExternalEvent() {
+        Long id = draft(ANALYST);
+
+        resultService.markMissedDeadline(id, USER);
+
+        assertEquals("MISSED_DEADLINE", statusInDb(id));
+        assertEquals("EXTERNAL_MISSED_DEADLINE", jdbc.queryForObject(
+                "SELECT event_type FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                String.class, id));
+    }
+
+    @Test
+    public void missedDeadline_inHouseScheme_writesInHouseEvent() {
+        Long id = draftInHouse(ANALYST);
+
+        resultService.markMissedDeadline(id, USER);
+
+        assertEquals("IN_HOUSE_MISSED_DEADLINE", jdbc.queryForObject(
+                "SELECT event_type FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                String.class, id));
+    }
+
+    @Test
+    public void resultDtos_narrowByEnrollmentAndExposeLifecycleFields() {
+        Long id = draft(ANALYST);
+        resultService.transitionStatus(id, EQASubmissionStatus.VALIDATED_PARTIAL, USER);
+
+        List<Map<String, Object>> mine = resultService.getResultDtos(cycle.getId(), ENROLLMENT);
+        assertEquals(1, mine.size());
+        assertEquals(id, mine.get(0).get("id"));
+        assertEquals("VALIDATED_PARTIAL", mine.get(0).get("submissionStatus"));
+        assertEquals("4.7", mine.get(0).get("resultValue"));
+        assertNull(mine.get(0).get("submittedAt"));
+
+        assertEquals(0, resultService.getResultDtos(cycle.getId(), 424242L).size());
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
@@ -17,10 +17,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
- * OGC-609 [EQA V2.1 / T-11] — the unblind privilege the controller hands the
- * DTO mapper comes from the caller's authorities, nothing else. The mapping
- * itself (null targets vs values) is covered by
- * EQAPanelLifecycleIntegrationTest against the real converter.
+ * OGC-609 [EQA V2.1] — the unblind privilege the controller hands the DTO
+ * mapper comes from the caller's authorities, nothing else. The mapping itself
+ * (null targets vs values) is covered by EQAPanelLifecycleIntegrationTest
+ * against the real converter.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EQAPanelRestControllerTest {

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
@@ -1,0 +1,79 @@
+package org.openelisglobal.eqa.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.eqa.controller.rest.EQAPanelRestController;
+import org.openelisglobal.eqa.service.EQAPanelService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * OGC-609 [EQA V2.1 / T-11] — the unblind privilege the controller hands the
+ * DTO mapper comes from the caller's authorities, nothing else. The mapping
+ * itself (null targets vs values) is covered by
+ * EQAPanelLifecycleIntegrationTest against the real converter.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EQAPanelRestControllerTest {
+
+    @Mock
+    private EQAPanelService panelService;
+
+    @InjectMocks
+    private EQAPanelRestController controller;
+
+    @After
+    public void clearAuth() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateWith(String... authorities) {
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken("tester", "n/a",
+                List.of(authorities).stream().map(SimpleGrantedAuthority::new).toList()));
+    }
+
+    @Test
+    public void unprivilegedCaller_readsSamplesBlinded() {
+        authenticateWith("ROLE_RESULTS");
+
+        controller.getSamples(5L);
+
+        verify(panelService).getSampleDtos(eq(5L), eq(false));
+    }
+
+    @Test
+    public void manageGrant_unlocksTargets() {
+        authenticateWith("ROLE_RESULTS", "qa.manage.eqa");
+
+        controller.getSamples(5L);
+
+        verify(panelService).getSampleDtos(eq(5L), eq(true));
+    }
+
+    @Test
+    public void globalAdmin_unlocksTargets() {
+        authenticateWith("ROLE_GLOBAL_ADMIN");
+
+        controller.getSamples(5L);
+
+        verify(panelService).getSampleDtos(eq(5L), eq(true));
+    }
+
+    @Test
+    public void noAuthentication_readsBlinded() {
+        SecurityContextHolder.clearContext();
+
+        controller.getSamples(5L);
+
+        verify(panelService).getSampleDtos(eq(5L), eq(false));
+    }
+}


### PR DESCRIPTION
## Summary
The EQA V2 service layer over the schema spine (OGC-609), on three fronts.

### Panel lifecycle + sealed-target rule (FR-V2.1-11 / FR-V2.1-16 / AC-V2.4-03)
- `EQAPanelService`: `seal` (PREPARING→SEALED), `distribute`, `unblind`, with seal preconditions — ≥1 sample, no blank target (the `EncryptionConverter` passes blanks through unencrypted, so the seal is the last gate), in-house panels need an unblind date.
- **Sealed-target guarantee lives in the DTO mapping, not the UI:** sample DTOs carry `null` target value/unit/acceptance range unless the panel reached UNBLINDED/SCORED/CLOSED **or** the caller holds the unblind grant (`qa.manage.eqa` / GLOBAL_ADMIN — the cycle-transition grant doubles as the reveal grant until the dedicated permission tiers land). Nulls, not omitted keys, so the shape is stable.

### Participant-result lifecycle + competency events (FR-V2.1-05 / FR-V2.1-22)
- DRAFT→VALIDATED_PARTIAL→SUBMITTED→SCORED enforced; SCORED and MISSED_DEADLINE are refused on the generic path and go through `recordScore` / `markMissedDeadline`, which write analyst competency events (UNACCEPTABLE_SCORE / QUESTIONABLE_SCORE / EXTERNAL- vs IN_HOUSE_MISSED_DEADLINE by scheme type; skipped when no analyst is assigned — `analyst_id` is NOT NULL by design).
- `onResultScored(result, performance)` hook left in place for the upcoming EQA→NCE trigger adapter.

### Receipt intake with atomic side-effects (FR-V2.1-20)
- `recordReceipt` in one transaction: receipt insert + matched shipment gets `actual_delivery_date` and DELIVERED + a PLANNED cycle advances PLANNED→PANEL_RECEIVED on the participant machine (**new `PANEL_RECEIPT` trigger event; `qa/024` extends the CHECK**). Idempotent per (cycle, enrollment): a second call is a read (HTTP 200 vs 201).
- References resolved before any write so a bad shipment/cycle is a clean 4xx; the FK stays as backstop.

### REST
`/rest/eqa/panels*` (reads + lifecycle writes, writes manage-gated), `/rest/eqa/cycles/{id}/receipt`, `/rest/eqa/cycles/{id}/participant-results` + `/rest/eqa/participant-results*` (score manage-gated). 404/409/422 semantics per endpoint; constraint violations map to 409 (live-UAT finding, narrowed to `ConstraintViolationException` so real DB failures stay 500).

## Tests (44 green on this branch)
- `EQAPanelLifecycleIntegrationTest` (9): seal guards incl. blank-target and in-house-date, illegal jumps, and the sealed-target rule asserted against the real encryption converter — hidden for unprivileged, visible for privileged, visible post-unblind.
- `EQAPanelReceiptIntegrationTest` (4): three-row atomic flip asserted in DB (receipt + shipment DELIVERED/stamped + cycle transition AUTO/PANEL_RECEIPT), idempotent double receipt (no second transition, ignored shipment untouched), no-shipment path, unknown-shipment full rollback.
- `EQAParticipantResultLifecycleIntegrationTest` (10): full lifecycle with exact DB status assertions, illegal jumps, draft-immutability past DRAFT, competency-event rows asserted (type/analyst/cycle/analyte), scheme-type-aware missed-deadline events, DTO narrowing.
- `EQAPanelRestControllerTest` (4): the unblind privilege handed to the DTO mapper comes from authorities only.
- `EQACycleMappingValidationTest` (17-suite neighbour) re-run green with the PANEL_RECEIPT vocabulary addition pinned.

## Live UAT (dev stack, 2026-08-18)
Seeded scheme/cycle/round/enrollment/shipment via psql, drove the REST API through an authenticated browser session: seal-empty→422, unblind-from-PREPARING→409, unknown panel→404, receipt→201 with all three DB side-effects verified by SQL, double receipt→200 same id and no extra rows, full result lifecycle 201/200/409/200/200/409 with the UNACCEPTABLE competency event row asserted in DB. UAT also caught the bare-500-on-FK-violation, fixed here. Stack restored afterwards (original war redeployed, seed rows removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
