### PR TITLE
feat(eqa-v2): shipment.repeat_of_shipment_id for EQA reprovisioning (OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/shipment/valueholder/Shipment.java
+++ b/src/main/java/org/openelisglobal/shipment/valueholder/Shipment.java
@@ -59,6 +59,13 @@ public class Shipment extends BaseObject<Integer> {
     @Column(name = "status", nullable = false, length = 50)
     private ShipmentStatus status;
 
+    /**
+     * The shipment this one replaces (EQA reprovisioning, FR-V2.5-15). Plain id
+     * rather than a self-reference: readers only ever display or join it.
+     */
+    @Column(name = "repeat_of_shipment_id")
+    private Integer repeatOfShipmentId;
+
     public Shipment() {
         this.status = ShipmentStatus.PENDING;
     }
@@ -143,5 +150,13 @@ public class Shipment extends BaseObject<Integer> {
 
     public void setStatus(ShipmentStatus status) {
         this.status = status;
+    }
+
+    public Integer getRepeatOfShipmentId() {
+        return repeatOfShipmentId;
+    }
+
+    public void setRepeatOfShipmentId(Integer repeatOfShipmentId) {
+        this.repeatOfShipmentId = repeatOfShipmentId;
     }
 }

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -80,7 +80,7 @@
   <!-- EQA V2.1 T-09 — OGC-609: follow-ups, panel receipts, competency events -->
   <include file="liquibase/qa/018-create-eqa-followup-receipt-competency.xml" />
 
-  <!-- EQA V2.5 T-23 — OGC-613: shipment.repeat_of_shipment_id for reprovisioning -->
+  <!-- EQA V2.5 — OGC-613: shipment.repeat_of_shipment_id for reprovisioning -->
   <include file="liquibase/qa/020-add-shipment-repeat-of.xml" />
 
   <!-- EQA V2.1 T-10 — OGC-609: write permission for cycle state changes -->

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -80,6 +80,9 @@
   <!-- EQA V2.1 T-09 — OGC-609: follow-ups, panel receipts, competency events -->
   <include file="liquibase/qa/018-create-eqa-followup-receipt-competency.xml" />
 
+  <!-- EQA V2.5 T-23 — OGC-613: shipment.repeat_of_shipment_id for reprovisioning -->
+  <include file="liquibase/qa/020-add-shipment-repeat-of.xml" />
+
   <!-- EQA V2.1 T-10 — OGC-609: write permission for cycle state changes -->
   <include file="liquibase/qa/023-add-eqa-manage-permission.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/020-add-shipment-repeat-of.xml
+++ b/src/main/resources/liquibase/qa/020-add-shipment-repeat-of.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.5 T-23 (OGC-613): FR-V2.5-15 reprovisioning sends a repeat panel as a
+    new shipment that records which shipment it replaces. Nullable self-FK; the
+    only schema change the shared shipment module needs for EQA.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-038-add-shipment-repeat-of">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="shipment" schemaName="clinlims" />
+            <not>
+                <columnExists tableName="shipment" columnName="repeat_of_shipment_id" schemaName="clinlims" />
+            </not>
+        </preConditions>
+        <comment>Track which shipment a repeat shipment replaces (FR-V2.5-15)</comment>
+        <addColumn tableName="shipment" schemaName="clinlims">
+            <column name="repeat_of_shipment_id" type="INTEGER">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <!-- RESTRICT, not CASCADE: deleting an original that a repeat points at
+             would silently erase the reprovisioning trail the register reads. -->
+        <addForeignKeyConstraint constraintName="fk_shipment_repeat_of"
+            baseTableSchemaName="clinlims" baseTableName="shipment" baseColumnNames="repeat_of_shipment_id"
+            referencedTableSchemaName="clinlims" referencedTableName="shipment" referencedColumnNames="id"
+            onDelete="RESTRICT" />
+        <rollback>
+            <dropForeignKeyConstraint baseTableSchemaName="clinlims" baseTableName="shipment"
+                constraintName="fk_shipment_repeat_of" />
+            <dropColumn tableName="shipment" columnName="repeat_of_shipment_id" schemaName="clinlims" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/qa/020-add-shipment-repeat-of.xml
+++ b/src/main/resources/liquibase/qa/020-add-shipment-repeat-of.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    EQA V2.5 T-23 (OGC-613): FR-V2.5-15 reprovisioning sends a repeat panel as a
+    EQA V2.5 (OGC-613): FR-V2.5-15 reprovisioning sends a repeat panel as a
     new shipment that records which shipment it replaces. Nullable self-FK; the
     only schema change the shared shipment module needs for EQA.
 -->

--- a/src/test/java/org/openelisglobal/shipment/ShipmentRepeatOfIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/shipment/ShipmentRepeatOfIntegrationTest.java
@@ -14,7 +14,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * OGC-613 [EQA V2.5 / T-23] — shipment.repeat_of_shipment_id (FR-V2.5-15): the
+ * OGC-613 [EQA V2.5] — shipment.repeat_of_shipment_id (FR-V2.5-15): the
  * reprovisioning trail persists, and deleting an original that a repeat still
  * points at is refused (RESTRICT), so the register cannot lose its history.
  */

--- a/src/test/java/org/openelisglobal/shipment/ShipmentRepeatOfIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/shipment/ShipmentRepeatOfIntegrationTest.java
@@ -1,0 +1,98 @@
+package org.openelisglobal.shipment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import javax.sql.DataSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * OGC-613 [EQA V2.5 / T-23] — shipment.repeat_of_shipment_id (FR-V2.5-15): the
+ * reprovisioning trail persists, and deleting an original that a repeat still
+ * points at is refused (RESTRICT), so the register cannot lose its history.
+ */
+public class ShipmentRepeatOfIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final int ORIGINAL = 9950;
+    private static final int REPEAT = 9951;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private JdbcTemplate jdbc;
+
+    @Before
+    public void seed() {
+        jdbc = new JdbcTemplate(dataSource);
+        cleanRows();
+        jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                + " VALUES ('9950', 'Repeat Test Lab', 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING");
+        for (int id : new int[] { ORIGINAL, REPEAT }) {
+            jdbc.update(
+                    "INSERT INTO clinlims.shipping_box (id, box_id, fhir_uuid, destination_facility_id, state,"
+                            + " created_date, archived, sys_user_id, lastupdated)"
+                            + " VALUES (?, 'BOX-' || ?, gen_random_uuid(), 9950, 'IN_TRANSIT', now(), false, 1, now())",
+                    id, id);
+            jdbc.update(
+                    "INSERT INTO clinlims.shipment (id, shipping_box_id, courier, tracking_number, status,"
+                            + " sys_user_id, lastupdated) VALUES (?, ?, 'DHL', 'TRK-' || ?, 'PENDING', 1, now())",
+                    id, id, id);
+        }
+    }
+
+    @After
+    public void cleanRows() {
+        if (jdbc == null) {
+            return;
+        }
+        jdbc.update("DELETE FROM clinlims.shipment WHERE id IN (9950, 9951)");
+        jdbc.update("DELETE FROM clinlims.shipping_box WHERE id IN (9950, 9951)");
+        jdbc.update("DELETE FROM clinlims.organization WHERE id = '9950'");
+    }
+
+    @Test
+    public void repeatOf_persistsAndReadsBack() {
+        jdbc.update("UPDATE clinlims.shipment SET repeat_of_shipment_id = ? WHERE id = ?", ORIGINAL, REPEAT);
+
+        assertEquals(Integer.valueOf(ORIGINAL), jdbc.queryForObject(
+                "SELECT repeat_of_shipment_id FROM clinlims.shipment WHERE id = ?", Integer.class, REPEAT));
+        assertNull("the original carries no repeat pointer", jdbc.queryForObject(
+                "SELECT repeat_of_shipment_id FROM clinlims.shipment WHERE id = ?", Integer.class, ORIGINAL));
+    }
+
+    @Test
+    public void unknownRepeatTarget_isRefusedByTheFk() {
+        try {
+            jdbc.update("UPDATE clinlims.shipment SET repeat_of_shipment_id = 424242 WHERE id = ?", REPEAT);
+            fail("fk_shipment_repeat_of must refuse a repeat pointer at a shipment that does not exist");
+        } catch (DataIntegrityViolationException expected) {
+            assertNull(jdbc.queryForObject("SELECT repeat_of_shipment_id FROM clinlims.shipment WHERE id = ?",
+                    Integer.class, REPEAT));
+        }
+    }
+
+    @Test
+    public void deletingAReferencedOriginal_isRefused() {
+        jdbc.update("UPDATE clinlims.shipment SET repeat_of_shipment_id = ? WHERE id = ?", ORIGINAL, REPEAT);
+
+        try {
+            jdbc.update("DELETE FROM clinlims.shipment WHERE id = ?", ORIGINAL);
+            fail("deleting an original a repeat points at must be refused (RESTRICT keeps the trail)");
+        } catch (DataIntegrityViolationException expected) {
+            assertEquals("the original must survive the refused delete", Integer.valueOf(1), jdbc
+                    .queryForObject("SELECT count(*) FROM clinlims.shipment WHERE id = ?", Integer.class, ORIGINAL));
+        }
+        // Clearing the pointer makes the delete legal again — the rollback path.
+        jdbc.update("UPDATE clinlims.shipment SET repeat_of_shipment_id = NULL WHERE id = ?", REPEAT);
+        jdbc.update("DELETE FROM clinlims.shipment WHERE id = ?", ORIGINAL);
+        assertEquals(Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.shipment WHERE id = ?", Integer.class, ORIGINAL));
+    }
+}


### PR DESCRIPTION
## Summary
The one schema change the shared shipment module needs for EQA reprovisioning (OGC-613, FR-V2.5-15) — everything else glues via services in the upcoming provider prep/receipt work.

- `qa/020`: nullable self-FK `shipment.repeat_of_shipment_id` → `shipment(id)`, **RESTRICT on delete** — deleting an original that a repeat still points at would erase the reprovisioning trail the follow-up register reads.
- Matching `Shipment` entity field (plain id, not a self-reference — readers only display or join it).
- Confirmed: `ShipmentStatus` already covers the workbench states (PENDING/IN_TRANSIT/DELIVERED/RETURNED/LOST/CANCELLED); no EQA-specific states added to the shared enum.
- A cycle-level shipment lookup is deliberately deferred: `eqa_panel_receipt.shipment_id` now carries the cycle→shipment link, so the lookup lands with its consumer (the provider prep/receipt workbenches) instead of shipping speculative API.

## Tests
`ShipmentRepeatOfIntegrationTest` (3, real schema via the liquibase-provisioned test DB — which also proves the changeset): trail persists and reads back, unknown target refused by the FK, delete-of-referenced-original refused with the original surviving, then legal again once the pointer clears (rollback smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
