### PR TITLE
feat(eqa-v2/T-16): 7/3/1-day cycle deadline digest in the existing scheduler (OGC-610)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/dao/EQARoundDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQARoundDAO.java
@@ -1,7 +1,16 @@
 package org.openelisglobal.eqa.dao;
 
+import java.sql.Timestamp;
+import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQARound;
 
 public interface EQARoundDAO extends BaseDAO<EQARound, Long> {
+
+    /**
+     * Rounds whose submission deadline falls in [from, to), with the owning cycle
+     * fetch-joined — callers include the scheduler, which runs outside a
+     * transaction, so a lazy cycle proxy would blow up on first touch.
+     */
+    List<EQARound> findWithSubmissionDeadlineBetween(Timestamp from, Timestamp to);
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQARoundDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQARoundDAOImpl.java
@@ -1,8 +1,15 @@
 package org.openelisglobal.eqa.daoimpl;
 
+import java.sql.Timestamp;
+import java.util.List;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
+import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.valueholder.EQARound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,7 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class EQARoundDAOImpl extends BaseDAOImpl<EQARound, Long> implements EQARoundDAO {
 
+    private static final Logger logger = LoggerFactory.getLogger(EQARoundDAOImpl.class);
+
     public EQARoundDAOImpl() {
         super(EQARound.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQARound> findWithSubmissionDeadlineBetween(Timestamp from, Timestamp to) {
+        try {
+            String hql = "FROM EQARound r JOIN FETCH r.cycle JOIN FETCH r.cycle.scheme"
+                    + " WHERE r.submissionDeadline >= :from AND r.submissionDeadline < :to";
+            Query<EQARound> query = entityManager.unwrap(Session.class).createQuery(hql, EQARound.class);
+            query.setParameter("from", from);
+            query.setParameter("to", to);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error retrieving rounds with deadline between {} and {}", from, to, e);
+            throw new LIMSRuntimeException("Error retrieving rounds by deadline window", e);
+        }
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
+++ b/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
@@ -1,16 +1,27 @@
 package org.openelisglobal.eqa.scheduler;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.openelisglobal.alert.service.AlertService;
 import org.openelisglobal.alert.valueholder.Alert;
 import org.openelisglobal.alert.valueholder.AlertSeverity;
 import org.openelisglobal.alert.valueholder.AlertStatus;
 import org.openelisglobal.alert.valueholder.AlertType;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.dao.SampleEQADAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,16 +34,41 @@ public class EQADeadlineAlertScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(EQADeadlineAlertScheduler.class);
     private static final String ENTITY_TYPE_SAMPLE_EQA = "SampleEQA";
+    private static final String ENTITY_TYPE_EQA_ROUND = "EQARound";
+    private static final ObjectMapper CONTEXT_MAPPER = new ObjectMapper();
     private static final long HOURS_72 = 72;
     private static final long HOURS_24 = 24;
     private static final long HOURS_4 = 4;
     private static final long ESCALATION_HOURS = 4;
+
+    /**
+     * FR-V2.2-14: digest thresholds, in days before a round's submission deadline.
+     */
+    private static final long[] DIGEST_DAYS = { 7, 3, 1 };
+
+    /**
+     * Cycle states in which a submission is still expected — a reminder for a cycle
+     * already submitted, scored or closed is noise.
+     */
+    private static final Set<EQACycleStatus> AWAITING_SUBMISSION = EnumSet.of(EQACycleStatus.PLANNED,
+            EQACycleStatus.PANEL_RECEIVED, EQACycleStatus.TESTING, EQACycleStatus.READY_TO_SUBMIT,
+            EQACycleStatus.PREP_IN_PROGRESS, EQACycleStatus.READY_TO_SHIP, EQACycleStatus.SHIPPED,
+            EQACycleStatus.DELIVERED, EQACycleStatus.SUBMISSIONS_OPEN);
+
+    /**
+     * Only the digest reads this; the older jobs keep their inline Instant.now().
+     * Package-private setter exists for tests to pin the day the digest sees.
+     */
+    private Clock clock = Clock.systemDefaultZone();
 
     @Autowired
     private AlertService alertService;
 
     @Autowired
     private SampleEQADAO sampleEQADAO;
+
+    @Autowired
+    private EQARoundDAO eqaRoundDAO;
 
     @Scheduled(fixedDelay = 300000)
     public void checkEQADeadlines() {
@@ -107,6 +143,80 @@ public class EQADeadlineAlertScheduler {
                     "Critical alert unacknowledged for " + ESCALATION_HOURS + "+ hours: " + alert.getMessage(),
                     "{\"originalAlertId\":" + alert.getId() + "}");
         }
+    }
+
+    /**
+     * FR-V2.2-14: 7/3/1-day submission-deadline digest. Alert rows are keyed to the
+     * ROUND, not the cycle: createAlert dedupes blindly on (type, entityType,
+     * entityId) within 30 minutes, so cycle-keyed rows would fold two different
+     * thresholds fired in one tick — a cycle whose round 1 is due tomorrow and
+     * round 2 in three days would permanently lose the second reminder. The
+     * business dedupe the FRS asks for — one alert per (cycle, threshold), ever —
+     * is the explicit alreadyAlerted check, which also outlives createAlert's
+     * 30-minute window across 5-minute reschedules.
+     */
+    @Scheduled(fixedDelay = 300000)
+    public void sendCycleDeadlineDigest() {
+        logger.debug("Running EQA cycle deadline digest...");
+        LocalDate today = LocalDate.now(clock);
+        Timestamp from = Timestamp.valueOf(today.atStartOfDay());
+        Timestamp to = Timestamp.valueOf(today.plusDays(DIGEST_DAYS[0] + 1).atStartOfDay());
+
+        for (EQARound round : eqaRoundDAO.findWithSubmissionDeadlineBetween(from, to)) {
+            EQACycle cycle = round.getCycle();
+            if (!AWAITING_SUBMISSION.contains(cycle.getStatus())) {
+                continue;
+            }
+            long daysOut = ChronoUnit.DAYS.between(today,
+                    round.getSubmissionDeadline().toLocalDateTime().toLocalDate());
+            if (!isDigestThreshold(daysOut) || alreadyAlerted(cycle.getId(), daysOut)) {
+                continue;
+            }
+            String schemeName = cycle.getScheme() != null ? cycle.getScheme().getName() : "?";
+            String message = "EQA cycle '" + schemeName + "' #" + cycle.getCycleNumber() + " round "
+                    + round.getRoundNumber() + ": submission deadline in " + daysOut + " day(s)";
+            String contextJson = String.format(
+                    "{\"cycleId\":%d,\"roundId\":%d,\"thresholdDays\":%d,\"submissionDeadline\":\"%s\"}", cycle.getId(),
+                    round.getId(), daysOut, round.getSubmissionDeadline());
+            alertService.createAlert(AlertType.EQA_DEADLINE, ENTITY_TYPE_EQA_ROUND, round.getId(),
+                    daysOut <= 1 ? AlertSeverity.CRITICAL : AlertSeverity.WARNING, message, contextJson);
+        }
+    }
+
+    private boolean isDigestThreshold(long daysOut) {
+        for (long d : DIGEST_DAYS) {
+            if (daysOut == d) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A threshold fires once per cycle (rows are round-keyed). The context is
+     * PARSED, never substring-matched: context_data is jsonb, and Postgres
+     * canonicalizes it on storage — "thresholdDays":7 comes back as
+     * "thresholdDays": 7, so a marker string that includes the exact punctuation
+     * silently never matches and the dedupe evaporates.
+     */
+    private boolean alreadyAlerted(Long cycleId, long daysOut) {
+        return alertService
+                .getAllMatching(Map.of("alertType", AlertType.EQA_DEADLINE, "alertEntityType", ENTITY_TYPE_EQA_ROUND))
+                .stream().anyMatch(a -> {
+                    if (a.getContextData() == null) {
+                        return false;
+                    }
+                    try {
+                        JsonNode ctx = CONTEXT_MAPPER.readTree(a.getContextData());
+                        return ctx.path("cycleId").asLong() == cycleId && ctx.path("thresholdDays").asLong() == daysOut;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+    }
+
+    void setClock(Clock clock) {
+        this.clock = clock;
     }
 
     private void generateDeadlineAlert(SampleEQA sample, AlertSeverity severity, String message) {

--- a/src/test/java/org/openelisglobal/eqa/scheduler/EQACycleDeadlineDigestIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/scheduler/EQACycleDeadlineDigestIntegrationTest.java
@@ -1,0 +1,154 @@
+package org.openelisglobal.eqa.scheduler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.alert.service.AlertService;
+import org.openelisglobal.alert.valueholder.Alert;
+import org.openelisglobal.alert.valueholder.AlertSeverity;
+import org.openelisglobal.alert.valueholder.AlertType;
+import org.openelisglobal.eqa.EQASpineTestBase;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * OGC-610 [EQA V2.2 / T-16] — the 7/3/1-day cycle deadline digest (FR-V2.2-14),
+ * against a real DB with a pinned clock.
+ *
+ * <p>
+ * The clock is pinned so "7 days out" is a fact of the fixture, not of when CI
+ * happens to run. The digest's own dedupe (one alert per cycle+threshold, ever)
+ * is what these tests exercise — createAlert's built-in 30-minute window would
+ * mask a missing guard by folding duplicates into duplicate_count, so the rerun
+ * test asserts BOTH the row count and duplicate_count stay flat.
+ */
+public class EQACycleDeadlineDigestIntegrationTest extends EQASpineTestBase {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 9, 1);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    private AlertService alertService;
+
+    /**
+     * Built by hand: AppTestConfig excludes eqa.scheduler.* from scanning so
+     * that @Scheduled jobs cannot fire mid-test. The collaborators are still the
+     * context's transactional proxies, so the digest runs here exactly as it does
+     * in production — a non-transactional caller of transactional beans.
+     */
+    private EQADeadlineAlertScheduler scheduler;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        scheduler = new EQADeadlineAlertScheduler();
+        ReflectionTestUtils.setField(scheduler, "alertService", alertService);
+        ReflectionTestUtils.setField(scheduler, "eqaRoundDAO", eqaRoundDAO);
+        scheduler.setClock(Clock.fixed(Instant.parse("2026-09-01T08:00:00Z"), ZoneId.of("UTC")));
+        cleanAlerts();
+    }
+
+    @After
+    public void tearDownDigest() {
+        cleanAlerts();
+    }
+
+    private void cleanAlerts() {
+        jdbc.update("DELETE FROM clinlims.alert WHERE alert_entity_type = 'EQARound'");
+    }
+
+    private long deadlineDaysOut(EQACycle cycle, int roundNumber, int daysOut) {
+        Long roundId = insertRound(readBack(cycle.getId()), roundNumber, "OPEN");
+        jdbc.update("UPDATE clinlims.eqa_round SET submission_deadline = ? WHERE id = ?",
+                Timestamp.valueOf(TODAY.plusDays(daysOut).atStartOfDay().plusHours(17)), roundId);
+        return roundId;
+    }
+
+    private long thresholdOf(Alert a) {
+        try {
+            return MAPPER.readTree(a.getContextData()).path("thresholdDays").asLong();
+        } catch (Exception e) {
+            return -999;
+        }
+    }
+
+    private List<Alert> digestAlerts() {
+        return alertService.getAllMatching(Map.of("alertType", AlertType.EQA_DEADLINE, "alertEntityType", "EQARound"));
+    }
+
+    @Test
+    public void firesExactlyOncePerThresholdAndNeverAgain() {
+        EQAProgram scheme = insertScheme("Digest scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        deadlineDaysOut(cycle, 1, 7);
+        deadlineDaysOut(cycle, 2, 3);
+        deadlineDaysOut(cycle, 3, 1);
+        deadlineDaysOut(cycle, 4, 5); // not a threshold — must stay silent
+        deadlineDaysOut(cycle, 5, -1); // already past — the digest is not an overdue alarm
+
+        scheduler.sendCycleDeadlineDigest();
+
+        List<Alert> alerts = digestAlerts();
+        assertEquals("one alert per threshold, nothing for day 5 or the past", 3, alerts.size());
+        for (long d : new long[] { 7, 3, 1 }) {
+            assertEquals("exactly one alert carries thresholdDays " + d, 1,
+                    alerts.stream().filter(a -> thresholdOf(a) == d).count());
+        }
+        Alert dayOne = alerts.stream().filter(a -> thresholdOf(a) == 1).findFirst().orElseThrow(AssertionError::new);
+        assertEquals("the last-day reminder escalates", AlertSeverity.CRITICAL, dayOne.getSeverity());
+        assertEquals("earlier reminders warn", 2,
+                alerts.stream().filter(a -> a.getSeverity() == AlertSeverity.WARNING).count());
+        assertTrue("message names the scheme and round",
+                dayOne.getMessage().contains("Digest scheme") && dayOne.getMessage().contains("round 3"));
+
+        // Rerun the tick: the digest's own dedupe must skip BEFORE createAlert, so
+        // neither new rows nor duplicate_count may move.
+        scheduler.sendCycleDeadlineDigest();
+        List<Alert> after = digestAlerts();
+        assertEquals("rerun creates nothing", 3, after.size());
+        assertEquals("rerun does not even count a duplicate", 0,
+                after.stream().mapToInt(Alert::getDuplicateCount).sum());
+    }
+
+    @Test
+    public void cyclesNoLongerAwaitingSubmissionAreSilent() {
+        EQAProgram scheme = insertScheme("Submitted scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        deadlineDaysOut(cycle, 1, 7);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMITTED' WHERE id = ?", cycle.getId());
+
+        scheduler.sendCycleDeadlineDigest();
+
+        assertEquals("a submitted cycle needs no reminder", 0, digestAlerts().size());
+    }
+
+    @Test
+    public void eachCycleDedupesIndependently() {
+        EQAProgram scheme = insertScheme("Two-cycle scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQACycle first = readBack(insertCycle(scheme, 1));
+        EQACycle second = readBack(insertCycle(scheme, 2));
+        deadlineDaysOut(first, 1, 3);
+        deadlineDaysOut(second, 1, 3);
+
+        scheduler.sendCycleDeadlineDigest();
+
+        List<Alert> alerts = digestAlerts();
+        assertEquals("same threshold on two cycles is two alerts", 2, alerts.size());
+        assertEquals(2, alerts.stream().map(Alert::getAlertEntityId).distinct().count());
+    }
+}


### PR DESCRIPTION
## What

FR-V2.2-14 as a fourth pass in `EQADeadlineAlertScheduler` — no second scheduler, per the plan's standing correction of the FRS. Rounds whose submission deadline is exactly 7, 3, or 1 days out produce one alert each (WARNING at 7/3, CRITICAL at 1) for cycles still awaiting submission. +144 lines, three files, one new test class.

One card correction folded in: the FRS says "cycle deadlines", but cycles carry no deadline column — the real source is `eqa_round.submission_deadline`, fetch-joined because the scheduler runs outside a transaction and a lazy cycle proxy would throw on first touch.

## Two design bugs the tests caught before first commit

**Same-tick threshold collapse.** Alerts were initially cycle-keyed; `createAlert` dedupes blindly on (type, entityType, entityId) within 30 minutes, so a cycle with round 1 due tomorrow and round 2 due in three days would *permanently* lose the second reminder — folded into `duplicate_count` and re-refreshed by every 5-minute tick. Alert rows are now **round-keyed** so the built-in dedupe cannot collide; the business rule the FRS asks for — one alert per (cycle, threshold), ever — is an explicit guard.

**jsonb canonicalization.** The guard first substring-matched `"thresholdDays":7`, but `context_data` is jsonb and Postgres reads it back as `"thresholdDays": 7` — the marker never matches and the dedupe silently evaporates, re-firing duplicates daily. The guard now parses the context JSON.

## Verification

- 3 integration tests on a pinned `Clock` via `EQASpineTestBase`: exactly one alert per threshold, silence for non-threshold days, past deadlines, and cycles no longer awaiting submission; a rerun moves neither row count nor `duplicate_count`; two cycles at the same threshold dedupe independently.
- Inversion-verified: deleting the dedupe guard fails the rerun test at `duplicate_count` 3.
- 259 EQA tests green.
- Live UAT on the dev stack, with the deployed `.class` checked for the new method *before* trusting results: a seeded round 3 days out fired exactly one WARNING on the real 5-minute tick with correct message and jsonb context; the following tick created nothing and left `duplicate_count` at 0; UAT rows cleaned up.

## Notes for the reviewer

- Reuses `AlertType.EQA_DEADLINE` with entity type `EQARound` — a new enum value would need a liquibase change to `chk_alert_type` for zero consumer benefit today.
- The digest reads an injectable `Clock` (package-private setter); the three pre-existing jobs keep their inline `Instant.now()` — refactoring them was out of scope.
- Does **not** write `MISSED_DEADLINE`: this is the reminder digest only. The standing warning holds — whichever task first writes that status must add its derivation rule in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)