### PR TITLE
fix: resolve acting user properly in storage module controllers

### DIFF
--- a/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/LabelManagementRestController.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.common.util.UserContextHolder;
 import org.openelisglobal.storage.dao.StorageDeviceDAO;
 import org.openelisglobal.storage.dao.StorageRackDAO;
 import org.openelisglobal.storage.dao.StorageShelfDAO;
@@ -43,6 +44,9 @@ public class LabelManagementRestController extends BaseRestController {
     @Autowired
     private StorageRackDAO storageRackDAO;
 
+    @Autowired
+    private UserContextHolder userContextHolder;
+
     /**
      * Generate and return PDF label POST /rest/storage/{type}/{id}/print-label
      * Validates code exists before printing, returns error if missing
@@ -79,9 +83,19 @@ public class LabelManagementRestController extends BaseRestController {
                 return;
             }
 
+            String userId;
+            try {
+                userId = getCurrentUserId();
+            } catch (org.openelisglobal.common.exception.LIMSRuntimeException e) {
+                logger.error("Could not resolve acting user for label print", e);
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                response.getWriter().write("{\"error\":\"Authentication required to print label\"}");
+                return;
+            }
+
             // Generate label (uses code from entity)
             ByteArrayOutputStream pdfStream;
-            String userId = getCurrentUserId(); // Get from security context
 
             if (location instanceof StorageDevice) {
                 pdfStream = labelManagementService.generateLabel((StorageDevice) location);
@@ -198,12 +212,9 @@ public class LabelManagementRestController extends BaseRestController {
     }
 
     /**
-     * Get current user ID from security context TODO: Implement proper security
-     * context retrieval
+     * Get current user ID from security context
      */
     private String getCurrentUserId() {
-        // Placeholder: should get from Spring Security context
-        // For now, return default system user
-        return "1";
+        return userContextHolder.requireSysUserId();
     }
 }

--- a/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
+++ b/src/main/java/org/openelisglobal/storage/controller/StorageLocationRestController.java
@@ -1,7 +1,6 @@
 package org.openelisglobal.storage.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -75,13 +74,12 @@ public class StorageLocationRestController extends BaseRestController {
     /**
      * Helper method to check admin status with graceful error handling
      *
-     * @param request HTTP request containing session information
      * @return true if user is admin, false otherwise (defaults to false if session
      *         unavailable)
      */
-    private boolean checkAdminStatus(HttpServletRequest request) {
+    private boolean checkAdminStatus() {
         try {
-            String sysUserId = getSysUserId(request);
+            String sysUserId = getSysUserId();
             if (sysUserId == null) {
                 return false;
             }
@@ -95,7 +93,7 @@ public class StorageLocationRestController extends BaseRestController {
     // ========== Room Endpoints ==========
 
     @PostMapping("/rooms")
-    public ResponseEntity<?> createRoom(@Valid @RequestBody StorageRoomForm form, HttpServletRequest request) {
+    public ResponseEntity<?> createRoom(@Valid @RequestBody StorageRoomForm form) {
         try {
             if (!storageLocationService.isNameUniqueWithinParent(form.getName(), null, "room", null)) {
                 Map<String, Object> error = new HashMap<>();
@@ -228,7 +226,7 @@ public class StorageLocationRestController extends BaseRestController {
      * OGC-75: Check if a room can be deleted (pre-flight check for frontend)
      */
     @GetMapping("/rooms/{id}/can-delete")
-    public ResponseEntity<Map<String, Object>> canDeleteRoom(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> canDeleteRoom(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageRoom room = storageLocationService.getRoom(idInt);
@@ -236,7 +234,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
 
             Map<String, Object> response = new HashMap<>();
             response.put("isAdmin", isAdmin);
@@ -280,7 +278,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @DeleteMapping("/rooms/{id}")
-    public ResponseEntity<?> deleteRoom(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<?> deleteRoom(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageRoom room = storageLocationService.getRoom(idInt);
@@ -288,7 +286,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             if (!isAdmin) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
@@ -327,7 +325,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @PostMapping("/devices")
-    public ResponseEntity<?> createDevice(@Valid @RequestBody StorageDeviceForm form, HttpServletRequest request) {
+    public ResponseEntity<?> createDevice(@Valid @RequestBody StorageDeviceForm form) {
         try {
             // Set parent room first (needed for code generation)
             Integer parentRoomId = form.getParentRoomId() != null ? Integer.parseInt(form.getParentRoomId()) : null;
@@ -524,7 +522,7 @@ public class StorageLocationRestController extends BaseRestController {
      * OGC-75: Check if a device can be deleted (pre-flight check for frontend)
      */
     @GetMapping("/devices/{id}/can-delete")
-    public ResponseEntity<Map<String, Object>> canDeleteDevice(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> canDeleteDevice(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageDevice device = (StorageDevice) storageLocationService.get(idInt, StorageDevice.class);
@@ -532,7 +530,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             Map<String, Object> response = new HashMap<>();
             response.put("isAdmin", isAdmin);
 
@@ -596,7 +594,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @DeleteMapping("/devices/{id}")
-    public ResponseEntity<?> deleteDevice(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<?> deleteDevice(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageDevice device = (StorageDevice) storageLocationService.get(idInt, StorageDevice.class);
@@ -604,7 +602,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             if (!isAdmin) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
@@ -633,7 +631,7 @@ public class StorageLocationRestController extends BaseRestController {
     // ========== Shelf Endpoints ==========
 
     @PostMapping("/shelves")
-    public ResponseEntity<?> createShelf(@Valid @RequestBody StorageShelfForm form, HttpServletRequest request) {
+    public ResponseEntity<?> createShelf(@Valid @RequestBody StorageShelfForm form) {
         try {
             StorageShelf shelf = new StorageShelf();
             shelf.setLabel(form.getLabel());
@@ -810,7 +808,7 @@ public class StorageLocationRestController extends BaseRestController {
      * OGC-75: Check if a shelf can be deleted (pre-flight check for frontend)
      */
     @GetMapping("/shelves/{id}/can-delete")
-    public ResponseEntity<Map<String, Object>> canDeleteShelf(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> canDeleteShelf(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageShelf shelf = (StorageShelf) storageLocationService.get(idInt, StorageShelf.class);
@@ -818,7 +816,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             Map<String, Object> response = new HashMap<>();
             response.put("isAdmin", isAdmin);
 
@@ -859,7 +857,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @DeleteMapping("/shelves/{id}")
-    public ResponseEntity<?> deleteShelf(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<?> deleteShelf(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageShelf shelf = (StorageShelf) storageLocationService.get(idInt, StorageShelf.class);
@@ -867,7 +865,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             if (!isAdmin) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
@@ -896,7 +894,7 @@ public class StorageLocationRestController extends BaseRestController {
     // ========== Rack Endpoints ==========
 
     @PostMapping("/racks")
-    public ResponseEntity<?> createRack(@Valid @RequestBody StorageRackForm form, HttpServletRequest request) {
+    public ResponseEntity<?> createRack(@Valid @RequestBody StorageRackForm form) {
         try {
             StorageRack rack = new StorageRack();
             rack.setLabel(form.getLabel());
@@ -1076,7 +1074,7 @@ public class StorageLocationRestController extends BaseRestController {
      * OGC-75: Check if a rack can be deleted (pre-flight check for frontend)
      */
     @GetMapping("/racks/{id}/can-delete")
-    public ResponseEntity<Map<String, Object>> canDeleteRack(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> canDeleteRack(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageRack rack = (StorageRack) storageLocationService.get(idInt, StorageRack.class);
@@ -1084,7 +1082,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
 
             Map<String, Object> response = new HashMap<>();
             response.put("isAdmin", isAdmin);
@@ -1126,7 +1124,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @DeleteMapping("/racks/{id}")
-    public ResponseEntity<?> deleteRack(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<?> deleteRack(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageRack rack = (StorageRack) storageLocationService.get(idInt, StorageRack.class);
@@ -1134,7 +1132,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             if (!isAdmin) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
@@ -1178,7 +1176,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @PostMapping("/boxes")
-    public ResponseEntity<?> createBox(@Valid @RequestBody StorageBoxForm form, HttpServletRequest request) {
+    public ResponseEntity<?> createBox(@Valid @RequestBody StorageBoxForm form) {
         try {
             StorageBox box = new StorageBox();
             box.setLabel(form.getLabel());
@@ -1310,7 +1308,7 @@ public class StorageLocationRestController extends BaseRestController {
      * OGC-75: Check if a box can be deleted (pre-flight check for frontend)
      */
     @GetMapping("/boxes/{id}/can-delete")
-    public ResponseEntity<Map<String, Object>> canDeleteBox(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> canDeleteBox(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageBox box = (StorageBox) storageLocationService.get(idInt, StorageBox.class);
@@ -1318,7 +1316,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
 
             Map<String, Object> response = new HashMap<>();
             response.put("isAdmin", isAdmin);
@@ -1340,7 +1338,7 @@ public class StorageLocationRestController extends BaseRestController {
     }
 
     @DeleteMapping("/boxes/{id}")
-    public ResponseEntity<?> deleteBox(@PathVariable String id, HttpServletRequest request) {
+    public ResponseEntity<?> deleteBox(@PathVariable String id) {
         try {
             Integer idInt = Integer.parseInt(id);
             StorageBox box = (StorageBox) storageLocationService.get(idInt, StorageBox.class);
@@ -1348,7 +1346,7 @@ public class StorageLocationRestController extends BaseRestController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             }
 
-            boolean isAdmin = checkAdminStatus(request);
+            boolean isAdmin = checkAdminStatus();
             if (!isAdmin) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
Closes #4082

`LabelManagementRestController.getCurrentUserId()` was a stub that always returned `"1"`, so every label print got recorded in print history under the system user instead of whoever actually printed it. It now resolves the real user through `UserContextHolder`, and the print endpoint returns 401 if there's no auth context instead of silently writing a bad value.

`StorageLocationRestController` wasn't hardcoded, but it was still on the old `getSysUserId(request)` pattern that #3356 replaced everywhere else — 15 methods carrying an `HttpServletRequest` around just to feed `checkAdminStatus(request)`. Switched it over to the no-arg `getSysUserId()` like the rest of the module, and dropped the now-unused `HttpServletRequest` param from all 15 signatures.

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue
Fixes #4082

## Other

[Add any additional information or notes here]
