### PR TITLE
ci: let the merge-conflict labeller stay advisory

### DIFF
--- a/.github/workflows/label-merge-conflict.yml
+++ b/.github/workflows/label-merge-conflict.yml
@@ -16,7 +16,16 @@ jobs:
     if: github.repository == 'DIGI-UW/OpenELIS-Global-2'
     runs-on: ubuntu-latest
     steps:
+      # Advisory only: this labels and comments on conflicting PRs, it gates
+      # nothing. A push to develop makes GitHub recompute mergeability for every
+      # open PR against it, and with enough of them open some are still
+      # unresolved when the retries run out — the action then errors with
+      # "Could not determine mergeable status for: #x, #y". That turned develop
+      # red on every merge while saying nothing about the merge itself, so the
+      # step is allowed to fail: the next push or PR update labels whatever it
+      # could not reach this time.
       - uses: prince-chrismc/label-merge-conflicts-action@v2
+        continue-on-error: true
         with:
           conflict_label_name: "merge conflict"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Makes the merge-conflict labeller's step `continue-on-error: true`.

## Why

`Automation / Merge Conflicts` labels and comments on PRs that conflict with `develop`. It **gates nothing** — but it was failing the workflow and turning `develop` red on every merge, while saying nothing about the merge itself.

The failure mode: a push to `develop` makes GitHub recompute mergeability for *every* open PR against it. With enough PRs open, some are still unresolved when the action's retries (`max_retries: 5`, `wait_ms: 15000`) run out, and it errors:

```
##[error]Could not determine mergeable status for: #3986, #3990, #3992
```

That is GitHub being slow to compute mergeability, not a problem with the pushed commit. It has hit **5 of the last 60 runs**, and every one of those was a `push` to `develop` — i.e. it fires precisely on merges, which is where a red mark is most misleading.

## Effect

The run now reports what the job actually is: advisory. Labelling still happens for every PR the action *could* resolve; the ones it couldn't reach get picked up by the next push or when they're next updated, since the workflow also runs on `pull_request_target`.

## Not changed

- **Retry budget.** Raising `max_retries` / `wait_ms` would make it succeed more often, but it lengthens the job for everyone on every push and never removes the race — the number of open PRs sets the pace, not the timeout. Worth doing separately if the missed labels turn out to matter in practice.
- **Action version.** The run logs a Node 20 deprecation warning (`prince-chrismc/label-merge-conflicts-action@v2` forced onto Node 24). That's a warning, not the failure, and bumping a third-party action belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
