### PR TITLE
feat(eqa-v2): in-house blinded panels — seal to orders, unblind, auto-score (OGC-612)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelRestController.java
@@ -1,13 +1,20 @@
 package org.openelisglobal.eqa.controller.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.validator.GenericValidator;
 import org.hibernate.ObjectNotFoundException;
+import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQABlindingService;
+import org.openelisglobal.eqa.service.EQALabelPDFService;
 import org.openelisglobal.eqa.service.EQAPanelService;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,6 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -38,9 +46,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class EQAPanelRestController extends BaseRestController {
 
     private final EQAPanelService panelService;
+    private final EQABlindingService blindingService;
+    private final EQALabelPDFService labelPDFService;
 
-    public EQAPanelRestController(EQAPanelService panelService) {
+    public EQAPanelRestController(EQAPanelService panelService, EQABlindingService blindingService,
+            EQALabelPDFService labelPDFService) {
         this.panelService = panelService;
+        this.blindingService = blindingService;
+        this.labelPDFService = labelPDFService;
     }
 
     @GetMapping(value = "/panels", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -71,10 +84,68 @@ public class EQAPanelRestController extends BaseRestController {
         return panelService.toPanelDto(panelService.distribute(id, getSysUserId(request)));
     }
 
+    /**
+     * FR-V2.4-06 manual unblind: unblinds AND scores — the endpoint's caller
+     * expects the panel to come back resolved, same as the scheduled path.
+     */
     @PostMapping(value = "/panels/{id}/unblind", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.UNBLIND)
     public Map<String, Object> unblind(HttpServletRequest request, @PathVariable Long id) {
-        return panelService.toPanelDto(panelService.unblind(id, getSysUserId(request)));
+        return panelService
+                .toPanelDto(blindingService.unblindAndScore(id, getSysUserId(request), EQAUnblindMethod.MANUAL));
+    }
+
+    /**
+     * FR-V2.4-04 "Seal panel &amp; distribute": body carries one order spec per
+     * panel sample — {@code {"orders":[{"panelSampleId":1,"testId":"7",
+     * "analystId":12}]}} — analystId optional (round-robin fills it). Values are
+     * read via String.valueOf so a numeric-vs-string JSON mismatch cannot 500.
+     */
+    @PostMapping(value = "/panels/{id}/seal-and-distribute", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public Map<String, Object> sealAndDistribute(HttpServletRequest request, @PathVariable Long id,
+            @RequestBody Map<String, Object> body) {
+        List<EQABlindingService.BlindOrderSpec> specs = new ArrayList<>();
+        Object orders = body.get("orders");
+        if (orders instanceof List<?> rows) {
+            for (Object row : rows) {
+                if (row instanceof Map<?, ?> spec) {
+                    specs.add(new EQABlindingService.BlindOrderSpec(longOrNull(spec.get("panelSampleId")),
+                            stringOrNull(spec.get("testId")), longOrNull(spec.get("analystId"))));
+                }
+            }
+        }
+        return blindingService.sealAndDistribute(id, specs, getSysUserId(request));
+    }
+
+    /** FR-V2.4-13: blind-code label sheet, printable any time after sealing. */
+    /**
+     * FR-V2.4-13: reprint is allowed to anyone who can see the panel, so this stays
+     * on the read umbrella rather than the lifecycle grant — the sheet carries
+     * blind codes only, never a target.
+     */
+    @GetMapping(value = "/panels/{id}/labels", produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> labelSheet(HttpServletRequest request, @PathVariable Long id) {
+        byte[] pdf = labelPDFService.generateLabelSheet(id);
+        LogEvent.logInfo(getClass().getSimpleName(), "labelSheet", "EQA label sheet printed: panel=" + id + " user="
+                + getSysUserId(request) + " labelCount=" + labelPDFService.countLabels(id));
+        return ResponseEntity.ok().header("Content-Disposition", "attachment; filename=eqa-panel-" + id + "-labels.pdf")
+                .body(pdf);
+    }
+
+    private static Long longOrNull(Object value) {
+        if (value == null || GenericValidator.isBlankOrNull(String.valueOf(value))) {
+            return null;
+        }
+        try {
+            return Long.valueOf(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Not a numeric id: " + value);
+        }
+    }
+
+    private static String stringOrNull(Object value) {
+        return value == null || GenericValidator.isBlankOrNull(String.valueOf(value)) ? null : String.valueOf(value);
     }
 
     /**

--- a/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
+++ b/src/main/java/org/openelisglobal/eqa/dao/EQAPanelDAO.java
@@ -1,7 +1,11 @@
 package org.openelisglobal.eqa.dao;
 
+import java.util.Optional;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 
 public interface EQAPanelDAO extends BaseDAO<EQAPanel, Long> {
+
+    /** Row-locked read, so a state check and its write cannot interleave. */
+    Optional<EQAPanel> getForUpdate(Long id);
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQAPanelDAOImpl.java
@@ -1,5 +1,7 @@
 package org.openelisglobal.eqa.daoimpl;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
@@ -12,5 +14,10 @@ public class EQAPanelDAOImpl extends BaseDAOImpl<EQAPanel, Long> implements EQAP
 
     public EQAPanelDAOImpl() {
         super(EQAPanel.class);
+    }
+
+    @Override
+    public Optional<EQAPanel> getForUpdate(Long id) {
+        return Optional.ofNullable(entityManager.find(EQAPanel.class, id, LockModeType.PESSIMISTIC_WRITE));
     }
 }

--- a/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
+++ b/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
@@ -17,11 +17,17 @@ import org.openelisglobal.alert.valueholder.Alert;
 import org.openelisglobal.alert.valueholder.AlertSeverity;
 import org.openelisglobal.alert.valueholder.AlertStatus;
 import org.openelisglobal.alert.valueholder.AlertType;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.dao.SampleEQADAO;
+import org.openelisglobal.eqa.service.EQABlindingService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
 import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +42,8 @@ public class EQADeadlineAlertScheduler {
     private static final String ENTITY_TYPE_SAMPLE_EQA = "SampleEQA";
     private static final String ENTITY_TYPE_EQA_ROUND = "EQARound";
     private static final ObjectMapper CONTEXT_MAPPER = new ObjectMapper();
+    /** System actor for scheduler-initiated writes (admin user id). */
+    private static final String SCHEDULER_USER = "1";
     private static final long HOURS_72 = 72;
     private static final long HOURS_24 = 24;
     private static final long HOURS_4 = 4;
@@ -56,8 +64,9 @@ public class EQADeadlineAlertScheduler {
             EQACycleStatus.DELIVERED, EQACycleStatus.SUBMISSIONS_OPEN);
 
     /**
-     * Only the digest reads this; the older jobs keep their inline Instant.now().
-     * Package-private setter exists for tests to pin the day the digest sees.
+     * Read by the digest and the auto-unblind pass; the older jobs keep their
+     * inline Instant.now(). Package-private setter exists for tests to pin the day
+     * the digest sees.
      */
     private Clock clock = Clock.systemDefaultZone();
 
@@ -69,6 +78,12 @@ public class EQADeadlineAlertScheduler {
 
     @Autowired
     private EQARoundDAO eqaRoundDAO;
+
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+
+    @Autowired
+    private EQABlindingService blindingService;
 
     @Scheduled(fixedDelay = 300000)
     public void checkEQADeadlines() {
@@ -213,6 +228,30 @@ public class EQADeadlineAlertScheduler {
                         return false;
                     }
                 });
+    }
+
+    /**
+     * FR-V2.4-06 automatic unblind: any distributed in-house panel whose unblind
+     * date has arrived is unblinded and scored. Idempotent — a scored panel is no
+     * longer DISTRIBUTED, so a re-run finds nothing (AC-V2.4-11); a per-panel
+     * failure is logged and never blocks the other panels.
+     */
+    @Scheduled(fixedDelay = 300000)
+    public void unblindDueInHousePanels() {
+        LocalDate today = LocalDate.now(clock);
+        for (EQAPanel panel : eqaPanelDAO.getAllMatching("status", EQAPanelStatus.DISTRIBUTED)) {
+            if (panel.getUnblindDate() == null || panel.getScheme() == null
+                    || panel.getScheme().getSchemeType() != EQASchemeType.IN_HOUSE
+                    || panel.getUnblindDate().toLocalDate().isAfter(today)) {
+                continue;
+            }
+            try {
+                blindingService.unblindAndScore(panel.getId(), SCHEDULER_USER, EQAUnblindMethod.SCHEDULED);
+                logger.info("Auto-unblinded in-house panel {}", panel.getId());
+            } catch (RuntimeException e) {
+                logger.error("Auto-unblind failed for panel {}", panel.getId(), e);
+            }
+        }
     }
 
     void setClock(Clock clock) {

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingService.java
@@ -1,0 +1,50 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
+
+/**
+ * In-house blinding backend (OGC-612, FR-V2.4-04..08): seal a panel and
+ * distribute it as standard OpenELIS orders keyed by blind code, then unblind
+ * at the deadline and score every participant result against the sealed
+ * targets.
+ */
+public interface EQABlindingService {
+
+    /**
+     * One order to create for one panel sample: which orderable test carries the
+     * analysis, and (optionally) which analyst is assigned. When {@code analystId}
+     * is null the service round-robins over the scheme's analyst roster
+     * (FR-V2.4-03).
+     */
+    record BlindOrderSpec(Long panelSampleId, String testId, Long analystId) {
+    }
+
+    /**
+     * FR-V2.4-04 "Seal panel &amp; distribute": seals the panel (existing
+     * validation: targets present, in-house unblind date), then for every panel
+     * sample creates a standard order — Sample with the blind code as its accession
+     * number (FR-V2.4-15 Workplan handoff), SampleItem, NotStarted Analysis,
+     * sample_eqa row linked to the cycle/round — plus a DRAFT
+     * eqa_participant_result carrying the analyst assignment, and finally moves the
+     * panel to DISTRIBUTED. Every panel sample must appear in {@code specs} exactly
+     * once.
+     *
+     * @return the panel DTO plus the created accession (blind) codes
+     */
+    Map<String, Object> sealAndDistribute(Long panelId, List<BlindOrderSpec> specs, String sysUserId);
+
+    /**
+     * FR-V2.4-06/07: DISTRIBUTED → UNBLINDED (the state machine makes a second call
+     * a no-op conflict, which is the idempotency guard), then every participant
+     * result in the panel's cycle is resolved: submitted results are scored against
+     * the sealed target (numeric acceptance range, else categorical exact match);
+     * unsubmitted results with a value are promoted and scored; empty results are
+     * marked MISSED_DEADLINE (competency event IN_HOUSE_MISSED_DEADLINE,
+     * FR-V2.4-14). Unacceptable verdicts open one Follow-Up Queue row per cycle
+     * (FR-V2.4-08 — never auto-NCE for in-house). The panel ends SCORED.
+     */
+    EQAPanel unblindAndScore(Long panelId, String sysUserId, EQAUnblindMethod method);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -1,0 +1,621 @@
+package org.openelisglobal.eqa.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.common.services.StatusService.OrderStatus;
+import org.openelisglobal.common.services.StatusService.SampleStatus;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.common.util.DateUtil;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
+import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
+import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
+import org.openelisglobal.eqa.valueholder.SampleEQA;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.person.service.PersonService;
+import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.result.service.ResultService;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.OrderPriority;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.test.service.TestService;
+import org.openelisglobal.test.valueholder.Test;
+import org.openelisglobal.typeofsample.service.TypeOfSampleService;
+import org.openelisglobal.typeofsample.valueholder.TypeOfSample;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OGC-612 (FR-V2.4) — the in-house blinding flows. Order creation deliberately
+ * reuses the same service layer the standard order wizard bottoms out in
+ * (SampleService.insertDataWithAccessionNumber + item/analysis services) — the
+ * wizard facade itself is request-bound and unusable from a scheduler.
+ */
+@Service
+@Transactional
+public class EQABlindingServiceImpl implements EQABlindingService {
+
+    private static final String IN_HOUSE_PROVIDER = "In-house";
+    /** sample.accession_number is VARCHAR(25); blind_code allows 50. */
+    private static final int ACCESSION_NUMBER_MAX = 25;
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Autowired
+    private EQAPanelService panelService;
+    @Autowired
+    private EQAPanelDAO panelDAO;
+    @Autowired
+    private EQAPanelSampleDAO panelSampleDAO;
+    @Autowired
+    private EQARoundDAO roundDAO;
+    @Autowired
+    private EQASchemeAnalystDAO schemeAnalystDAO;
+    @Autowired
+    private EQAParticipantResultService participantResultService;
+    @Autowired
+    private EQAParticipantFollowupDAO followupDAO;
+    @Autowired
+    private EQAParticipantResultDAO participantResultDAO;
+    @Autowired
+    private ResultService resultService;
+    @Autowired
+    private EQALabProgramEnrollmentService labEnrollmentService;
+    @Autowired
+    private SampleService sampleService;
+    @Autowired
+    private SampleItemService sampleItemService;
+    @Autowired
+    private AnalysisService analysisService;
+    @Autowired
+    private SampleHumanService sampleHumanService;
+    @Autowired
+    private SampleEQAService sampleEQAService;
+    @Autowired
+    private PatientService patientService;
+    @Autowired
+    private PersonService personService;
+    @Autowired
+    private TestService testService;
+    @Autowired
+    private TypeOfSampleService typeOfSampleService;
+    @Autowired
+    private OrganizationService organizationService;
+    @Autowired
+    private IStatusService statusService;
+
+    @Override
+    public Map<String, Object> sealAndDistribute(Long panelId, List<BlindOrderSpec> specs, String sysUserId) {
+        EQAPanel panel = panelService.get(panelId);
+        if (panel.getScheme() == null || panel.getScheme().getSchemeType() != EQASchemeType.IN_HOUSE) {
+            throw new IllegalArgumentException("Blinded distribution is for in-house schemes only");
+        }
+        if (panel.getCycle() == null) {
+            throw new IllegalArgumentException("The panel needs a cycle before it can be distributed as orders");
+        }
+
+        List<EQAPanelSample> samples = panelSampleDAO.getAllMatchingOrdered("panel.id", panelId, "sampleCode", false);
+        requireFullCoverage(samples, specs);
+        requirePrepEvidence(panel, samples);
+        requireUsableBlindCodes(samples);
+
+        // Existing seal validation: legal edge, targets present, unblind date set.
+        panel = panelService.seal(panelId, sysUserId);
+
+        EQARound round = findOrCreateRound(panel, sysUserId);
+        EQALabProgramEnrollment enrollment = findOrCreateSelfEnrollment(panel, sysUserId);
+        List<Long> roster = analystRoster(panel);
+
+        Patient blindPatient = createBlindPatient(sysUserId);
+        Map<Long, EQAPanelSample> samplesById = new LinkedHashMap<>();
+        for (EQAPanelSample sample : samples) {
+            samplesById.put(sample.getId(), sample);
+        }
+
+        List<String> accessions = new ArrayList<>();
+        int rosterCursor = 0;
+        for (BlindOrderSpec spec : specs) {
+            EQAPanelSample panelSample = samplesById.get(spec.panelSampleId());
+            Long analystId = spec.analystId();
+            if (analystId == null && !roster.isEmpty()) {
+                analystId = roster.get(rosterCursor++ % roster.size());
+            }
+            accessions.add(createBlindOrder(panel, round, enrollment, panelSample, spec.testId(), analystId,
+                    blindPatient, sysUserId));
+        }
+
+        panel = panelService.distribute(panelId, sysUserId);
+
+        Map<String, Object> dto = new LinkedHashMap<>(panelService.toPanelDto(panel));
+        dto.put("orderAccessionNumbers", accessions);
+        return dto;
+    }
+
+    @Override
+    public EQAPanel unblindAndScore(Long panelId, String sysUserId, EQAUnblindMethod method) {
+        // The DISTRIBUTED → UNBLINDED edge is the idempotency guard, taken under
+        // a row lock so a manual and a scheduled unblind cannot both pass the
+        // edge check against the same prior state (the cycle machine hit exactly
+        // this race and fixed it the same way).
+        EQAPanel panel = panelService.unblindForUpdate(panelId, sysUserId, method);
+
+        // One result per aliquot: a panel may carry several samples for the same
+        // analyte (FR-V2.4-02 Mode A splits a pool into N), so results are keyed
+        // by panel sample and each is scored against its own sealed target.
+        Map<Long, EQAPanelSample> samplesById = new LinkedHashMap<>();
+        for (EQAPanelSample sample : panelSampleDAO.getAllMatchingOrdered("panel.id", panelId, "sampleCode", false)) {
+            samplesById.put(sample.getId(), sample);
+        }
+
+        List<Map<String, Object>> unacceptable = new ArrayList<>();
+        for (EQAParticipantResult result : participantResultService.getAllMatching("cycle.id",
+                panel.getCycle().getId())) {
+            EQAPanelSample target = samplesById.get(result.getPanelSampleId());
+            if (target == null) {
+                continue; // belongs to another panel in this cycle, or to external PT
+            }
+            resolveResult(result, target, sysUserId, unacceptable);
+        }
+
+        if (!unacceptable.isEmpty()) {
+            openInHouseFollowup(panel, unacceptable, sysUserId);
+        }
+
+        panel.setStatus(EQAPanelStatus.SCORED);
+        panel.setSysUserId(sysUserId);
+        return panelDAO.update(panel);
+    }
+
+    // ---- seal helpers ----
+
+    /**
+     * AC-V2.4-13: the prep invariants are enforced here, not only in the wizard, so
+     * an API caller cannot distribute a panel the bench never signed off. Failing
+     * homogeneity QC is allowed, but only with the written justification the
+     * standard asks for.
+     */
+    private void requirePrepEvidence(EQAPanel panel, List<EQAPanelSample> samples) {
+        int produced = panel.getAliquotsProduced() == null ? 0 : panel.getAliquotsProduced();
+        if (produced < samples.size()) {
+            throw new IllegalArgumentException(
+                    "Panel has " + samples.size() + " samples but records only " + produced + " aliquots produced");
+        }
+        if (!Boolean.TRUE.equals(panel.getHomogeneityQcPassed())
+                && GenericValidator.isBlankOrNull(panel.getHomogeneityQcNotes())) {
+            throw new IllegalArgumentException(
+                    "Homogeneity QC has not passed, so distributing requires a written justification");
+        }
+    }
+
+    /**
+     * The blind code becomes the order's accession number, which is globally unique
+     * and narrower than the blind_code column. Both facts have to be checked before
+     * any order is written, or a late collision aborts a half-created distribution.
+     */
+    private void requireUsableBlindCodes(List<EQAPanelSample> samples) {
+        Set<String> seen = new HashSet<>();
+        for (EQAPanelSample sample : samples) {
+            String code = sample.getBlindCode();
+            if (GenericValidator.isBlankOrNull(code)) {
+                throw new IllegalArgumentException("Panel sample " + sample.getSampleCode() + " has no blind code");
+            }
+            if (code.length() > ACCESSION_NUMBER_MAX) {
+                throw new IllegalArgumentException("Blind code '" + code + "' exceeds the " + ACCESSION_NUMBER_MAX
+                        + " characters an accession number allows");
+            }
+            if (!seen.add(code)) {
+                throw new IllegalArgumentException("Blind code '" + code + "' is used twice in this panel");
+            }
+            if (sampleService.getSampleByAccessionNumber(code) != null) {
+                throw new IllegalArgumentException("Blind code '" + code + "' is already an order accession number");
+            }
+        }
+    }
+
+    private void requireFullCoverage(List<EQAPanelSample> samples, List<BlindOrderSpec> specs) {
+        if (specs == null || specs.isEmpty()) {
+            throw new IllegalArgumentException("Distribution needs one order spec (testId) per panel sample");
+        }
+        Set<Long> expected = new HashSet<>();
+        for (EQAPanelSample sample : samples) {
+            expected.add(sample.getId());
+        }
+        Set<Long> provided = new HashSet<>();
+        for (BlindOrderSpec spec : specs) {
+            if (spec.panelSampleId() == null || GenericValidator.isBlankOrNull(spec.testId())) {
+                throw new IllegalArgumentException("Every order spec needs a panelSampleId and a testId");
+            }
+            if (!provided.add(spec.panelSampleId())) {
+                throw new IllegalArgumentException("Panel sample " + spec.panelSampleId() + " appears twice");
+            }
+            if (testService.get(spec.testId()) == null) {
+                throw new IllegalArgumentException("Unknown test " + spec.testId());
+            }
+        }
+        if (!provided.equals(expected)) {
+            throw new IllegalArgumentException("Order specs must cover every panel sample exactly once");
+        }
+    }
+
+    private EQARound findOrCreateRound(EQAPanel panel, String sysUserId) {
+        List<EQARound> rounds = roundDAO.getAllMatchingOrdered("cycle.id", panel.getCycle().getId(), "roundNumber",
+                false);
+        if (!rounds.isEmpty()) {
+            return rounds.get(0);
+        }
+        EQARound round = new EQARound();
+        round.setFhirUuid(UUID.randomUUID());
+        round.setCycle(panel.getCycle());
+        round.setRoundNumber(1);
+        round.setDistributionDate(DateUtil.getNowAsTimestamp());
+        if (panel.getUnblindDate() != null) {
+            round.setSubmissionDeadline(new Timestamp(panel.getUnblindDate().getTime()));
+        }
+        round.setSysUserId(sysUserId);
+        round.setId(roundDAO.insert(round));
+        return round;
+    }
+
+    /**
+     * eqa_participant_result.lab_enrollment_id is NOT NULL by schema; for an
+     * in-house scheme the lab participates in its own program, so a self-enrollment
+     * row (provider "In-house", named after the scheme) is created once and reused.
+     */
+    private EQALabProgramEnrollment findOrCreateSelfEnrollment(EQAPanel panel, String sysUserId) {
+        String programName = panel.getScheme().getName();
+        for (EQALabProgramEnrollment enrollment : labEnrollmentService.getAllMatching("programName", programName)) {
+            if (IN_HOUSE_PROVIDER.equals(enrollment.getProvider())) {
+                return enrollment;
+            }
+        }
+        EQALabProgramEnrollment enrollment = new EQALabProgramEnrollment();
+        enrollment.setProgramName(programName);
+        enrollment.setProvider(IN_HOUSE_PROVIDER);
+        enrollment.setDescription("Self-enrollment for in-house blinded PT");
+        enrollment.setIsActive(true);
+        enrollment.setCreatedDate(new java.sql.Date(System.currentTimeMillis()));
+        enrollment.setSysUserId(sysUserId);
+        enrollment.setId(labEnrollmentService.insert(enrollment));
+        return enrollment;
+    }
+
+    private List<Long> analystRoster(EQAPanel panel) {
+        List<Long> roster = new ArrayList<>();
+        for (EQASchemeAnalyst analyst : schemeAnalystDAO.getAllMatchingOrdered("scheme.id", panel.getScheme().getId(),
+                "id", false)) {
+            roster.add(analyst.getSystemUserId());
+        }
+        return roster;
+    }
+
+    /**
+     * The blind patient carries no demographics on purpose — matching the V1 EQA
+     * order convention where PT orders surface as a nameless patient.
+     */
+    private Patient createBlindPatient(String sysUserId) {
+        Person person = new Person();
+        person.setSysUserId(sysUserId);
+        personService.insert(person);
+
+        Patient patient = new Patient();
+        patient.setPerson(person);
+        patient.setSysUserId(sysUserId);
+        patientService.insert(patient);
+        return patient;
+    }
+
+    private String createBlindOrder(EQAPanel panel, EQARound round, EQALabProgramEnrollment enrollment,
+            EQAPanelSample panelSample, String testId, Long analystId, Patient patient, String sysUserId) {
+        Test test = testService.get(testId);
+
+        // FR-V2.4-04/-15: the blind code IS the accession number, so Workplan
+        // and result entry display it with no EQA-specific code path.
+        Sample sample = new Sample();
+        sample.setAccessionNumber(panelSample.getBlindCode());
+        sample.setDomain("H");
+        sample.setEnteredDate(DateUtil.getNowAsSqlDate());
+        sample.setReceivedTimestamp(DateUtil.getNowAsTimestamp());
+        sample.setStatusId(statusService.getStatusID(OrderStatus.Entered));
+        // Result entry dereferences priority unconditionally, so a blinded order
+        // cannot be left with the column null.
+        sample.setPriority(OrderPriority.ROUTINE);
+        sample.setFhirUuid(UUID.randomUUID());
+        sample.setSysUserId(sysUserId);
+        sampleService.insertDataWithAccessionNumber(sample);
+
+        SampleHuman sampleHuman = new SampleHuman();
+        sampleHuman.setSampleId(sample.getId());
+        sampleHuman.setPatientId(patient.getId());
+        sampleHuman.setSysUserId(sysUserId);
+        sampleHumanService.insert(sampleHuman);
+
+        SampleItem sampleItem = new SampleItem();
+        sampleItem.setSample(sample);
+        sampleItem.setSortOrder("1");
+        sampleItem.setStatusId(statusService.getStatusID(SampleStatus.Entered));
+        List<TypeOfSample> types = typeOfSampleService.getTypeOfSampleForTest(test.getId());
+        if (types != null && !types.isEmpty()) {
+            sampleItem.setTypeOfSample(types.get(0));
+        }
+        sampleItem.setFhirUuid(UUID.randomUUID());
+        sampleItem.setSysUserId(sysUserId);
+        sampleItemService.insert(sampleItem);
+
+        Analysis analysis = new Analysis();
+        analysis.setTest(test);
+        analysis.setIsReportable(test.getIsReportable());
+        analysis.setAnalysisType("MANUAL");
+        analysis.setSampleItem(sampleItem);
+        analysis.setRevision(ConfigurationProperties.getInstance().getPropertyValue("analysis.default.revision"));
+        analysis.setStartedDate(DateUtil.getNowAsTimestamp());
+        analysis.setStatusId(statusService.getStatusID(AnalysisStatus.NotStarted));
+        analysis.setTestSection(test.getTestSection());
+        analysis.setFhirUuid(UUID.randomUUID());
+        analysis.setSysUserId(sysUserId);
+        analysisService.insert(analysis);
+
+        SampleEQA sampleEQA = new SampleEQA();
+        sampleEQA.setSampleId(Long.parseLong(sample.getId()));
+        sampleEQA.setIsEqaSample(true);
+        sampleEQA.setEqaEnrollmentId(enrollment.getId());
+        sampleEQA.setEqaProviderSampleId(panelSample.getBlindCode());
+        if (panel.getUnblindDate() != null) {
+            sampleEQA.setEqaDeadline(new Timestamp(panel.getUnblindDate().getTime()));
+        }
+        sampleEQA.setCycleId(panel.getCycle().getId());
+        sampleEQA.setRoundId(round.getId());
+        sampleEQA.setSysUserId(sysUserId);
+        sampleEQAService.insert(sampleEQA);
+
+        EQAParticipantResult draft = new EQAParticipantResult();
+        draft.setFhirUuid(UUID.randomUUID());
+        draft.setCycle(panel.getCycle());
+        draft.setRound(round);
+        draft.setLabEnrollmentId(enrollment.getId());
+        draft.setAnalyteId(panelSample.getAnalyteId());
+        draft.setPanelSampleId(panelSample.getId());
+        draft.setAnalysisId(Long.parseLong(analysis.getId()));
+        draft.setAssignedAnalystId(analystId);
+        draft.setSysUserId(sysUserId);
+        participantResultService.saveDraft(draft);
+
+        return panelSample.getBlindCode();
+    }
+
+    // ---- unblind helpers ----
+
+    private void resolveResult(EQAParticipantResult result, EQAPanelSample target, String sysUserId,
+            List<Map<String, Object>> unacceptable) {
+        if (result.getSubmissionStatus() == EQASubmissionStatus.SCORED
+                || result.getSubmissionStatus() == EQASubmissionStatus.MISSED_DEADLINE) {
+            return; // already resolved — keeps re-runs from double-scoring
+        }
+
+        // The analyst runs a blinded panel through standard result entry, so the
+        // reported value lives on the analysis, not on this row. Read it here
+        // rather than expecting something to have copied it across: nothing
+        // does, and treating a blank column as "no result" marks every analyst
+        // who did the work as having missed the deadline.
+        String reported = reportedValueOf(result);
+        if (GenericValidator.isBlankOrNull(reported)) {
+            participantResultService.markMissedDeadline(result.getId(), sysUserId);
+            return;
+        }
+        if (!reported.equals(result.getResultValue())) {
+            result.setResultValue(reported);
+            result.setSysUserId(sysUserId);
+            participantResultDAO.update(result);
+        }
+
+        if (result.getSubmissionStatus() != EQASubmissionStatus.SUBMITTED) {
+            promoteToSubmitted(result, sysUserId);
+        }
+        score(result, target, sysUserId, unacceptable);
+    }
+
+    /**
+     * The value the analyst actually entered: the row's own column when a client
+     * supplied one, otherwise the linked analysis's result. Dictionary-backed
+     * results store a dictionary id in result.value, so the printable form is what
+     * gets compared against a target a supervisor typed by hand.
+     */
+    private String reportedValueOf(EQAParticipantResult result) {
+        if (!GenericValidator.isBlankOrNull(result.getResultValue())) {
+            return result.getResultValue().trim();
+        }
+        if (result.getAnalysisId() == null) {
+            return null;
+        }
+        Analysis analysis = analysisService.get(String.valueOf(result.getAnalysisId()));
+        if (analysis == null) {
+            return null;
+        }
+        for (Result pipelineResult : resultService.getResultsByAnalysis(analysis)) {
+            String value = resultService.getResultValue(pipelineResult, ",", true, false);
+            if (!GenericValidator.isBlankOrNull(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    private void promoteToSubmitted(EQAParticipantResult result, String sysUserId) {
+        if (result.getSubmissionStatus() == EQASubmissionStatus.DRAFT) {
+            participantResultService.transitionStatus(result.getId(), EQASubmissionStatus.VALIDATED_PARTIAL, sysUserId);
+        }
+        participantResultService.transitionStatus(result.getId(), EQASubmissionStatus.SUBMITTED, sysUserId);
+    }
+
+    private void score(EQAParticipantResult result, EQAPanelSample target, String sysUserId,
+            List<Map<String, Object>> unacceptable) {
+        EQAPerformanceStatus verdict = verdictFor(target, result.getResultValue());
+
+        participantResultService.recordScore(result.getId(), verdict, null, sysUserId);
+        if (verdict == EQAPerformanceStatus.UNACCEPTABLE) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("participantResultId", result.getId());
+            row.put("analyteId", result.getAnalyteId());
+            row.put("reported", result.getResultValue());
+            row.put("target", target.getTargetValue());
+            row.put("analystId", result.getAssignedAnalystId());
+            unacceptable.add(row);
+        }
+    }
+
+    /**
+     * FR-V2.4-07 / AC-V2.4-07/-08: numeric when an acceptance range is sealed
+     * (inside the closed range = acceptable), categorical exact match otherwise. A
+     * non-numeric report against a numeric target is a mismatch, not an error.
+     */
+    private EQAPerformanceStatus verdictFor(EQAPanelSample target, String reported) {
+        String value = reported == null ? "" : reported.trim();
+        if (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null) {
+            BigDecimal numeric;
+            try {
+                numeric = new BigDecimal(value);
+            } catch (NumberFormatException e) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeLow() != null && numeric.compareTo(target.getAcceptanceRangeLow()) < 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeHigh() != null && numeric.compareTo(target.getAcceptanceRangeHigh()) > 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            return EQAPerformanceStatus.ACCEPTABLE;
+        }
+        String targetValue = target.getTargetValue() == null ? "" : target.getTargetValue().trim();
+        // A quantitative target sealed without a range still has to compare as a
+        // number, or "100.0" fails against a target of "100".
+        BigDecimal targetNumber = parseOrNull(targetValue);
+        BigDecimal reportedNumber = parseOrNull(value);
+        if (targetNumber != null && reportedNumber != null) {
+            return targetNumber.compareTo(reportedNumber) == 0 ? EQAPerformanceStatus.ACCEPTABLE
+                    : EQAPerformanceStatus.UNACCEPTABLE;
+        }
+        return targetValue.equalsIgnoreCase(value) ? EQAPerformanceStatus.ACCEPTABLE
+                : EQAPerformanceStatus.UNACCEPTABLE;
+    }
+
+    private static BigDecimal parseOrNull(String value) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * One register row per cycle (schema: unique on cycle+org). The
+     * participant_org_id FK demands a real organization; for in-house the
+     * "participant" is the lab itself, materialized once from the configured site
+     * name.
+     */
+    private void openInHouseFollowup(EQAPanel panel, List<Map<String, Object>> unacceptable, String sysUserId) {
+        Organization selfOrg = selfOrganization(sysUserId);
+        Long orgId = Long.parseLong(selfOrg.getId());
+        for (EQAParticipantFollowup existing : followupDAO.getAllMatching("cycle.id", panel.getCycle().getId())) {
+            if (orgId.equals(existing.getParticipantOrgId())) {
+                // A cycle can hold several panels and the register is unique on
+                // cycle + org, so merge rather than return: dropping the second
+                // panel's failures would lose them silently.
+                existing.setParticipantResultSummaryJson(
+                        mergeSummary(existing.getParticipantResultSummaryJson(), unacceptable));
+                existing.setSysUserId(sysUserId);
+                followupDAO.update(existing);
+                return;
+            }
+        }
+        EQAParticipantFollowup followup = new EQAParticipantFollowup();
+        followup.setScheme(panel.getScheme());
+        followup.setCycle(panel.getCycle());
+        followup.setParticipantOrgId(orgId);
+        followup.setFollowupStatus(EQAFollowupStatus.NOTIFIED);
+        followup.setNotifiedAt(DateUtil.getNowAsTimestamp());
+        followup.setParticipantResultSummaryJson(mergeSummary(null, unacceptable));
+        followup.setSysUserId(sysUserId);
+        followupDAO.insert(followup);
+    }
+
+    private String mergeSummary(String existingJson, List<Map<String, Object>> unacceptable) {
+        List<Object> rows = new ArrayList<>();
+        if (!GenericValidator.isBlankOrNull(existingJson)) {
+            try {
+                JsonNode parsed = JSON.readTree(existingJson).get("unacceptable");
+                if (parsed != null && parsed.isArray()) {
+                    for (JsonNode node : parsed) {
+                        rows.add(JSON.convertValue(node, Map.class));
+                    }
+                }
+            } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+                LogEvent.logError(e);
+            }
+        }
+        rows.addAll(unacceptable);
+        try {
+            return JSON.writeValueAsString(Map.of("source", "In-house", "unacceptable", rows));
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            LogEvent.logError(e);
+            return existingJson;
+        }
+    }
+
+    private Organization selfOrganization(String sysUserId) {
+        String siteName = ConfigurationProperties.getInstance()
+                .getPropertyValue(ConfigurationProperties.Property.SiteName);
+        if (GenericValidator.isBlankOrNull(siteName)) {
+            siteName = "This laboratory";
+        }
+        Organization lookup = new Organization();
+        lookup.setOrganizationName(siteName);
+        Organization existing = organizationService.getOrganizationByName(lookup, true);
+        if (existing != null) {
+            return existing;
+        }
+        Organization self = new Organization();
+        self.setOrganizationName(siteName);
+        self.setIsActive("Y");
+        self.setMlsSentinelLabFlag("N");
+        self.setSysUserId(sysUserId);
+        organizationService.insert(self);
+        return self;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFService.java
@@ -1,0 +1,16 @@
+package org.openelisglobal.eqa.service;
+
+/**
+ * Blind-code label sheets for in-house panels (OGC-612, FR-V2.4-13): Avery
+ * 5160-equivalent stock (30 per letter sheet), each label carrying the blind
+ * code, cycle identifier and analyte name — and nothing else, so a dropped
+ * label cannot leak a target (AC-V2.4-14). Regeneration is byte-identical
+ * (AC-V2.4-15).
+ */
+public interface EQALabelPDFService {
+
+    byte[] generateLabelSheet(Long panelId);
+
+    /** Labels the sheet carries, for the print audit FR-V2.4-13 asks for. */
+    int countLabels(Long panelId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFServiceImpl.java
@@ -1,0 +1,180 @@
+package org.openelisglobal.eqa.service;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.PageSize;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.ColumnText;
+import com.itextpdf.text.pdf.PdfContentByte;
+import com.itextpdf.text.pdf.PdfWriter;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OGC-612 (FR-V2.4-13) — Avery 5160-equivalent label sheets. Layout is plain
+ * text placed on a fixed 3×10 grid; the only data read is the blind code, the
+ * cycle identifier and the analyte name, so a target value can never reach the
+ * text layer (AC-V2.4-14). Output bytes are normalized so regeneration is
+ * byte-identical (AC-V2.4-15).
+ */
+@Service
+@Transactional(readOnly = true)
+public class EQALabelPDFServiceImpl implements EQALabelPDFService {
+
+    // Avery 5160 geometry in points: 3 columns × 10 rows on US Letter.
+    private static final float LABEL_WIDTH = 189f; // 2.625"
+    private static final float LABEL_HEIGHT = 72f; // 1"
+    private static final float LEFT_MARGIN = 13.5f; // 0.1875"
+    private static final float TOP_MARGIN = 36f; // 0.5"
+    private static final float COLUMN_PITCH = 198f; // 2.75"
+    private static final int COLUMNS = 3;
+    private static final int ROWS = 10;
+    private static final float PAD = 8f;
+
+    /** Sealed and distributed only — see generateLabelSheet. */
+    private static final Set<EQAPanelStatus> PRINTABLE_STATES = EnumSet.of(EQAPanelStatus.SEALED,
+            EQAPanelStatus.DISTRIBUTED);
+
+    private static final Font CODE_FONT = new Font(Font.FontFamily.HELVETICA, 16, Font.BOLD);
+    private static final Font META_FONT = new Font(Font.FontFamily.HELVETICA, 8, Font.NORMAL);
+
+    @Autowired
+    private EQAPanelService panelService;
+    @Autowired
+    private EQAPanelSampleDAO panelSampleDAO;
+    @Autowired
+    private AnalyteService analyteService;
+
+    @Override
+    public byte[] generateLabelSheet(Long panelId) {
+        EQAPanel panel = panelService.get(panelId);
+        if (!PRINTABLE_STATES.contains(panel.getStatus())) {
+            // FR-V2.4-13 scopes the sheet to after sealing and before unblinding:
+            // before, the panel is still being built; after, the targets are out
+            // and a blind code is no longer blind.
+            throw new IllegalStateException(
+                    "Labels are printable between sealing and unblinding; this panel is " + panel.getStatus());
+        }
+        List<EQAPanelSample> samples = panelSampleDAO.getAllMatchingOrdered("panel.id", panelId, "sampleCode", false);
+        if (samples.isEmpty()) {
+            throw new IllegalArgumentException("The panel has no samples to label");
+        }
+        // A blank code would render an empty label, which is worse than no sheet:
+        // the tube gets an anonymous sticker and the aliquot becomes untraceable.
+        for (EQAPanelSample sample : samples) {
+            if (GenericValidator.isBlankOrNull(sample.getBlindCode())) {
+                throw new IllegalArgumentException(
+                        "Panel sample " + sample.getSampleCode() + " has no blind code to print");
+            }
+        }
+
+        String cycleIdentifier = panel.getCycle() != null
+                && !GenericValidator.isBlankOrNull(panel.getCycle().getCycleName()) ? panel.getCycle().getCycleName()
+                        : panel.getPanelName();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Document document = new Document(PageSize.LETTER, 0, 0, 0, 0);
+        try {
+            PdfWriter writer = PdfWriter.getInstance(document, out);
+            document.open();
+            PdfContentByte canvas = writer.getDirectContent();
+            int slot = 0;
+            for (EQAPanelSample sample : samples) {
+                if (slot == COLUMNS * ROWS) {
+                    document.newPage();
+                    slot = 0;
+                }
+                drawLabel(canvas, slot, sample, cycleIdentifier);
+                slot++;
+            }
+            document.close();
+        } catch (DocumentException e) {
+            throw new IllegalStateException("Label sheet generation failed", e);
+        }
+        return normalize(out.toByteArray());
+    }
+
+    @Override
+    public int countLabels(Long panelId) {
+        return panelSampleDAO.getAllMatching("panel.id", panelId).size();
+    }
+
+    private void drawLabel(PdfContentByte canvas, int slot, EQAPanelSample sample, String cycleIdentifier) {
+        int column = slot % COLUMNS;
+        int row = slot / COLUMNS;
+        float left = LEFT_MARGIN + column * COLUMN_PITCH + PAD;
+        float top = PageSize.LETTER.getHeight() - TOP_MARGIN - row * LABEL_HEIGHT;
+
+        // Blind code large and first; cycle + analyte small underneath. Target
+        // values and acceptance ranges are deliberately never read here.
+        show(canvas, new Phrase(sample.getBlindCode(), CODE_FONT), left, top - 24);
+        show(canvas, new Phrase(cycleIdentifier, META_FONT), left, top - 42);
+        show(canvas, new Phrase(analyteName(sample.getAnalyteId()), META_FONT), left, top - 54);
+    }
+
+    /**
+     * Clipped to the label box: showTextAligned draws a single unwrapped line, so a
+     * long blind code would otherwise run into the neighbouring label.
+     */
+    private void show(PdfContentByte canvas, Phrase phrase, float x, float y) {
+        ColumnText column = new ColumnText(canvas);
+        column.setSimpleColumn(x, y - 2f, x + LABEL_WIDTH - 2f * PAD, y + phrase.getFont().getSize() + 2f);
+        column.addText(phrase);
+        try {
+            column.go();
+        } catch (DocumentException e) {
+            throw new IllegalStateException("Label text layout failed", e);
+        }
+    }
+
+    /**
+     * Repeated ids cost nothing: the persistence context caches within the read.
+     */
+    private String analyteName(Long analyteId) {
+        Analyte analyte = analyteService.get(String.valueOf(analyteId));
+        return analyte == null || analyte.getAnalyteName() == null ? "" : analyte.getAnalyteName();
+    }
+
+    /**
+     * iText stamps wall-clock metadata (/CreationDate, /ModDate) and a random
+     * trailer /ID on every run. Both are replaced with fixed same-length values —
+     * offsets are untouched, so the document stays valid — making regeneration
+     * byte-identical (AC-V2.4-15).
+     */
+    private byte[] normalize(byte[] pdf) {
+        String raw = new String(pdf, StandardCharsets.ISO_8859_1);
+        raw = replaceSameLength(raw, Pattern.compile("/CreationDate\\(([^)]*)\\)"), 'D');
+        raw = replaceSameLength(raw, Pattern.compile("/ModDate\\(([^)]*)\\)"), 'D');
+        raw = replaceSameLength(raw, Pattern.compile("/ID *\\[<([0-9a-fA-F]+)><([0-9a-fA-F]+)>\\]"), '0');
+        return raw.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    private String replaceSameLength(String raw, Pattern pattern, char filler) {
+        Matcher matcher = pattern.matcher(raw);
+        StringBuilder result = new StringBuilder(raw);
+        while (matcher.find()) {
+            for (int group = 1; group <= matcher.groupCount(); group++) {
+                for (int i = matcher.start(group); i < matcher.end(group); i++) {
+                    result.setCharAt(i, filler);
+                }
+            }
+        }
+        return result.toString();
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 
 public interface EQAPanelService extends BaseObjectService<EQAPanel, Long> {
 
@@ -23,6 +24,14 @@ public interface EQAPanelService extends BaseObjectService<EQAPanel, Long> {
 
     /** DISTRIBUTED → UNBLINDED (AC-V2.4-03's reveal point). */
     EQAPanel unblind(Long panelId, String sysUserId);
+
+    /**
+     * DISTRIBUTED → UNBLINDED taken under a row lock, recording how the panel was
+     * unblinded (FR-V2.4-10). The lock is what makes the edge check a real
+     * idempotency guard: without it a manual and a scheduled unblind can both read
+     * DISTRIBUTED and both proceed to score.
+     */
+    EQAPanel unblindForUpdate(Long panelId, String sysUserId, EQAUnblindMethod method);
 
     /** Panels bound to a cycle, without samples. */
     List<Map<String, Object>> getPanelDtos(Long cycleId);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.eqa.service;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -15,6 +16,7 @@ import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,6 +90,23 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
     public EQAPanel unblind(Long panelId, String sysUserId) {
         EQAPanel panel = get(panelId);
         requireEdge(panel, EQAPanelStatus.UNBLINDED);
+        return move(panel, EQAPanelStatus.UNBLINDED, sysUserId);
+    }
+
+    @Override
+    public EQAPanel unblindForUpdate(Long panelId, String sysUserId, EQAUnblindMethod method) {
+        if (method == null) {
+            throw new IllegalArgumentException("An unblind must record whether it was scheduled or manual");
+        }
+        EQAPanel panel = eqaPanelDAO.getForUpdate(panelId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown panel " + panelId));
+        // The loser of a race re-reads the committed status here and fails the
+        // edge check, rather than both callers passing it against the same
+        // pre-lock read and scoring twice.
+        requireEdge(panel, EQAPanelStatus.UNBLINDED);
+        panel.setUnblindMethod(method);
+        panel.setUnblindedBy(GenericValidator.isBlankOrNull(sysUserId) ? null : Long.valueOf(sysUserId));
+        panel.setUnblindedAt(new Timestamp(System.currentTimeMillis()));
         return move(panel, EQAPanelStatus.UNBLINDED, sysUserId);
     }
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
@@ -26,9 +26,10 @@ public interface EQAParticipantResultService extends BaseObjectService<EQAPartic
     EQAParticipantResult transitionStatus(Long resultId, EQASubmissionStatus target, String sysUserId);
 
     /**
-     * SUBMITTED → SCORED with the provider's verdict. A QUESTIONABLE or
-     * UNACCEPTABLE score on a result with an assigned analyst writes the
-     * corresponding competency event (FR-V2.1-22).
+     * SUBMITTED → SCORED with the provider's verdict, which is persisted on the row
+     * (FR-V2.4-07) so a scored result is distinguishable from an unscored one. A
+     * QUESTIONABLE or UNACCEPTABLE score on a result with an assigned analyst
+     * writes the corresponding competency event (FR-V2.1-22).
      */
     EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, Long eqaResultId,
             String sysUserId);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
@@ -114,6 +114,7 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
         }
 
         result.setSubmissionStatus(EQASubmissionStatus.SCORED);
+        result.setPerformanceStatus(performance);
         result.setScoreReceivedAt(now());
         result.setEqaResultId(eqaResultId);
         result.setSysUserId(sysUserId);
@@ -205,6 +206,10 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
             dto.put("scoreReceivedAt",
                     result.getScoreReceivedAt() == null ? null : result.getScoreReceivedAt().toString());
             dto.put("eqaResultId", result.getEqaResultId());
+            dto.put("panelSampleId", result.getPanelSampleId());
+            dto.put("performanceStatus",
+                    result.getPerformanceStatus() == null ? null : result.getPerformanceStatus().name());
+            dto.put("zScore", result.getZScore());
             rows.add(dto);
         }
         return rows;

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAPanel.java
@@ -73,6 +73,20 @@ public class EQAPanel extends BaseObject<Long> {
     @Column(name = "unblind_date")
     private Date unblindDate;
 
+    /**
+     * How the panel left DISTRIBUTED (FR-V2.4-10). sys_user_id cannot carry this on
+     * its own, because the scheduler also writes a real user id.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "unblind_method", length = 20)
+    private EQAUnblindMethod unblindMethod;
+
+    @Column(name = "unblinded_by")
+    private Long unblindedBy;
+
+    @Column(name = "unblinded_at")
+    private Timestamp unblindedAt;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private EQAPanelStatus status = EQAPanelStatus.PREPARING;

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantResult.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAParticipantResult.java
@@ -15,6 +15,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.UUID;
 import lombok.Getter;
@@ -70,6 +71,14 @@ public class EQAParticipantResult extends BaseObject<Long> {
     @Column(name = "analysis_id")
     private Long analysisId;
 
+    /**
+     * The exact aliquot this result answers, for in-house panels (FR-V2.4-02). Null
+     * for external PT, where the analyte alone identifies the result — the partial
+     * unique indexes in qa/027 enforce one rule per case.
+     */
+    @Column(name = "panel_sample_id")
+    private Long panelSampleId;
+
     @Column(name = "result_value", length = 255)
     private String resultValue;
 
@@ -91,6 +100,15 @@ public class EQAParticipantResult extends BaseObject<Long> {
 
     @Column(name = "submitted_at")
     private Timestamp submittedAt;
+
+    /** The scoring verdict (FR-V2.4-07); null until the result is scored. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "performance_status", length = 20)
+    private EQAPerformanceStatus performanceStatus;
+
+    /** Null for in-house, which has no consensus SD by construction. */
+    @Column(name = "z_score", precision = 10, scale = 5)
+    private BigDecimal zScore;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "submission_channel", length = 10)

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAUnblindMethod.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAUnblindMethod.java
@@ -1,0 +1,10 @@
+package org.openelisglobal.eqa.valueholder;
+
+/**
+ * How an in-house panel was unblinded (FR-V2.4-10). Recorded separately from
+ * the acting user, because the scheduled path also writes a real user id and
+ * the audit has to distinguish the two.
+ */
+public enum EQAUnblindMethod {
+    SCHEDULED, MANUAL
+}

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -97,4 +97,7 @@
 
   <!-- EQA V2.1 — OGC-609: bench roles keep participant-lane writes as a grant -->
   <include file="liquibase/qa/026-grant-eqa-participant-to-bench-roles.xml" />
+
+  <!-- EQA V2.4 — OGC-612: scoring verdict, per-aliquot result grain, unblind provenance -->
+  <include file="liquibase/qa/027-add-eqa-scoring-and-unblind-provenance.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/027-add-eqa-scoring-and-unblind-provenance.xml
+++ b/src/main/resources/liquibase/qa/027-add-eqa-scoring-and-unblind-provenance.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.4 (OGC-612): the three columns in-house scoring cannot work without,
+    plus unblind provenance.
+
+    1. eqa_participant_result.performance_status — FR-V2.4-07 requires the
+       scoring verdict to be persisted. Without it a scored result is
+       indistinguishable from an unscored one and the post-unblind view
+       (FR-V2.4-09) has nothing to render. z_score is nullable and stays null
+       for in-house, which has no consensus SD by construction; it exists so an
+       external scheme's score intake has somewhere to put it.
+
+    2. eqa_participant_result.panel_sample_id — the result grain. FR-V2.4-02
+       Mode A splits one pool into N aliquots, all for the same analyte, so the
+       original unique constraint (round_id, lab_enrollment_id, analyte_id) made
+       the primary in-house panel mode impossible to distribute. The constraint
+       is replaced by two partial unique indexes so external PT keeps exactly
+       its previous per-analyte guarantee while in-house becomes per-aliquot.
+
+    3. eqa_panel.unblind_method / unblinded_by / unblinded_at — FR-V2.4-10
+       requires the audit trail to distinguish a scheduled unblind from a manual
+       one. sys_user_id alone cannot: the scheduler writes a real user id.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-047-add-participant-result-scoring-columns">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eqa_participant_result" schemaName="clinlims"/>
+                <not>
+                    <columnExists tableName="eqa_participant_result" columnName="performance_status"
+                        schemaName="clinlims"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>Persist the scoring verdict and its optional z-score (FR-V2.4-07)</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_participant_result">
+            <column name="performance_status" type="VARCHAR(20)"/>
+            <column name="z_score" type="numeric(10,5)"/>
+        </addColumn>
+        <sql>
+            ALTER TABLE clinlims.eqa_participant_result
+            ADD CONSTRAINT eqa_participant_result_performance_status_chk
+            CHECK (performance_status IS NULL
+                OR performance_status IN ('ACCEPTABLE', 'QUESTIONABLE', 'UNACCEPTABLE'))
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE clinlims.eqa_participant_result
+                DROP CONSTRAINT IF EXISTS eqa_participant_result_performance_status_chk;
+            </sql>
+            <dropColumn schemaName="clinlims" tableName="eqa_participant_result" columnName="z_score"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_participant_result"
+                columnName="performance_status"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-048-add-participant-result-panel-sample">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eqa_panel_sample" schemaName="clinlims"/>
+                <not>
+                    <columnExists tableName="eqa_participant_result" columnName="panel_sample_id"
+                        schemaName="clinlims"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>Per-aliquot result grain for in-house panels (FR-V2.4-02 Mode A)</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_participant_result">
+            <column name="panel_sample_id" type="numeric(10,0)"/>
+        </addColumn>
+        <addForeignKeyConstraint
+            constraintName="fk_eqa_participant_result_panel_sample"
+            baseTableSchemaName="clinlims" baseTableName="eqa_participant_result"
+            baseColumnNames="panel_sample_id"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_panel_sample"
+            referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableSchemaName="clinlims"
+                baseTableName="eqa_participant_result"
+                constraintName="fk_eqa_participant_result_panel_sample"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_participant_result"
+                columnName="panel_sample_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-049-split-participant-result-uniqueness">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM pg_constraint
+                WHERE conname = 'uq_eqa_participant_result_round_lab_analyte'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            External PT keeps one result per analyte per lab per round; in-house gets one
+            result per aliquot. A single nullable-column constraint cannot express both,
+            because Postgres treats every NULL as distinct and would stop enforcing the
+            external rule entirely.
+        </comment>
+        <sql>
+            ALTER TABLE clinlims.eqa_participant_result
+            DROP CONSTRAINT uq_eqa_participant_result_round_lab_analyte;
+
+            CREATE UNIQUE INDEX uq_eqa_participant_result_round_lab_analyte
+            ON clinlims.eqa_participant_result (round_id, lab_enrollment_id, analyte_id)
+            WHERE panel_sample_id IS NULL;
+
+            CREATE UNIQUE INDEX uq_eqa_participant_result_round_lab_sample
+            ON clinlims.eqa_participant_result (round_id, lab_enrollment_id, panel_sample_id)
+            WHERE panel_sample_id IS NOT NULL;
+        </sql>
+        <rollback>
+            <sql>
+                DROP INDEX IF EXISTS clinlims.uq_eqa_participant_result_round_lab_sample;
+                DROP INDEX IF EXISTS clinlims.uq_eqa_participant_result_round_lab_analyte;
+
+                ALTER TABLE clinlims.eqa_participant_result
+                ADD CONSTRAINT uq_eqa_participant_result_round_lab_analyte
+                UNIQUE (round_id, lab_enrollment_id, analyte_id);
+            </sql>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-050-add-panel-unblind-provenance">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eqa_panel" schemaName="clinlims"/>
+                <not>
+                    <columnExists tableName="eqa_panel" columnName="unblind_method" schemaName="clinlims"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>Record how and by whom a panel was unblinded (FR-V2.4-10)</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_panel">
+            <column name="unblind_method" type="VARCHAR(20)"/>
+            <column name="unblinded_by" type="numeric(10,0)"/>
+            <column name="unblinded_at" type="TIMESTAMP WITHOUT TIME ZONE"/>
+        </addColumn>
+        <sql>
+            ALTER TABLE clinlims.eqa_panel
+            ADD CONSTRAINT eqa_panel_unblind_method_chk
+            CHECK (unblind_method IS NULL OR unblind_method IN ('SCHEDULED', 'MANUAL'))
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE clinlims.eqa_panel DROP CONSTRAINT IF EXISTS eqa_panel_unblind_method_chk;
+            </sql>
+            <dropColumn schemaName="clinlims" tableName="eqa_panel" columnName="unblinded_at"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_panel" columnName="unblinded_by"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_panel" columnName="unblind_method"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -1,0 +1,606 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itextpdf.text.pdf.PdfReader;
+import com.itextpdf.text.pdf.parser.PdfTextExtractor;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.scheduler.EQADeadlineAlertScheduler;
+import org.openelisglobal.eqa.service.EQABlindingService;
+import org.openelisglobal.eqa.service.EQABlindingService.BlindOrderSpec;
+import org.openelisglobal.eqa.service.EQALabelPDFService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-612 (FR-V2.4) — the in-house blinding backend against the real schema:
+ * seal-and-distribute creates standard orders keyed by blind code, the unblind
+ * pass scores numeric and categorical results (AC-V2.4-07/-08), flags absent
+ * results as missed deadlines with their competency event (AC-V2.4-16), opens
+ * the follow-up register row (AC-V2.4-09), refuses to double-score
+ * (AC-V2.4-11), and the label sheet leaks no target while regenerating
+ * byte-identically (AC-V2.4-14/-15).
+ */
+public class EQABlindingIntegrationTest extends EQASpineTestBase {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final long NUMERIC_ANALYTE = 9801L;
+    private static final long CATEGORICAL_ANALYTE = 9802L;
+    private static final long LATE_ANALYTE = 9803L;
+    private static final String SEEDED_TEST_ID = "9807";
+
+    @Autowired
+    private EQABlindingService blindingService;
+    @Autowired
+    private EQALabelPDFService labelPDFService;
+    @Autowired
+    private EQAPanelSampleDAO panelSampleDAO;
+    @Autowired
+    private IStatusService statusService;
+
+    /**
+     * The eqa.scheduler package is deliberately excluded from the test component
+     * scan (schedulers must not fire mid-suite), so the scheduler is built by hand
+     * with only what the unblind pass reads.
+     */
+    private EQADeadlineAlertScheduler scheduler;
+
+    @Before
+    public void seedCatalogAndStatuses() {
+        scheduler = new EQADeadlineAlertScheduler();
+        org.springframework.test.util.ReflectionTestUtils.setField(scheduler, "eqaPanelDAO", eqaPanelDAO);
+        org.springframework.test.util.ReflectionTestUtils.setField(scheduler, "blindingService", blindingService);
+
+        // Self-ensured seeds: other fixtures truncate status_of_sample and the
+        // test catalog in full-suite runs, so everything this class relies on
+        // is (re)inserted idempotently and the status cache refreshed.
+        jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                + " SELECT 9604, 1, 'ANALYSIS', 'Not Tested', 'restored by EQABlindingIntegrationTest'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.status_of_sample"
+                + "   WHERE name = 'Not Tested' AND status_type = 'ANALYSIS')");
+        jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                + " SELECT 9801, 1, 'ORDER', 'Test Entered', 'restored by EQABlindingIntegrationTest'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.status_of_sample"
+                + "   WHERE name = 'Test Entered' AND status_type = 'ORDER')");
+        jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                + " SELECT 9802, 1, 'SAMPLE', 'Entered', 'restored by EQABlindingIntegrationTest'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.status_of_sample"
+                + "   WHERE name = 'Entered' AND status_type = 'SAMPLE')");
+        statusService.refreshCache();
+
+        jdbc.update("INSERT INTO clinlims.localization (id, description)" + " SELECT 9807, 'EQA Blinding Test'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.localization WHERE id = 9807)");
+        jdbc.update("INSERT INTO clinlims.test_section (id, name, description, is_external, sort_order,"
+                + " name_localization_id)"
+                + " SELECT 9807, 'EQA Blinding Section', 'EQA Blinding Section', 'N', 9807, 9807"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.test_section WHERE id = 9807)");
+        jdbc.update("INSERT INTO clinlims.test (id, name, description, test_section_id, is_active, orderable,"
+                + " sort_order, lastupdated, name_localization_id, guid)"
+                + " SELECT 9807, 'EQA Blinding Test', 'EQA Blinding Test', 9807, 'Y', true, 9807, now(), 9807,"
+                + " 'eqa-blinding-9807'" + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = 9807)");
+    }
+
+    @After
+    public void cleanUpOrders() {
+        // Results reference analyses (FK), so they go first; the base class
+        // would clear them too, but only after this method has run.
+        jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE eqa_provider_sample_id LIKE 'IHBLIND-%'");
+        jdbc.update("DELETE FROM clinlims.result WHERE analysis_id IN (SELECT a.id FROM clinlims.analysis a"
+                + " JOIN clinlims.sample_item si ON a.sampitem_id = si.id JOIN clinlims.sample s ON si.samp_id = s.id"
+                + " WHERE s.accession_number LIKE 'IHBLIND-%')");
+        jdbc.update("DELETE FROM clinlims.analysis WHERE sampitem_id IN (SELECT si.id FROM clinlims.sample_item si"
+                + " JOIN clinlims.sample s ON si.samp_id = s.id WHERE s.accession_number LIKE 'IHBLIND-%')");
+        jdbc.update("DELETE FROM clinlims.sample_item WHERE samp_id IN"
+                + " (SELECT id FROM clinlims.sample WHERE accession_number LIKE 'IHBLIND-%')");
+        List<Long> patientIds = jdbc.queryForList(
+                "SELECT DISTINCT sh.patient_id FROM clinlims.sample_human sh"
+                        + " JOIN clinlims.sample s ON sh.samp_id = s.id WHERE s.accession_number LIKE 'IHBLIND-%'",
+                Long.class);
+        jdbc.update("DELETE FROM clinlims.sample_human WHERE samp_id IN"
+                + " (SELECT id FROM clinlims.sample WHERE accession_number LIKE 'IHBLIND-%')");
+        jdbc.update("DELETE FROM clinlims.sample WHERE accession_number LIKE 'IHBLIND-%'");
+        for (Long patientId : patientIds) {
+            Long personId = jdbc.queryForObject("SELECT person_id FROM clinlims.patient WHERE id = ?", Long.class,
+                    patientId);
+            jdbc.update("DELETE FROM clinlims.patient WHERE id = ?", patientId);
+            jdbc.update("DELETE FROM clinlims.person WHERE id = ?", personId);
+        }
+        jdbc.update("DELETE FROM clinlims.eqa_lab_program_enrollment WHERE provider = 'In-house'");
+        // The base class also clears this, but its @After runs later and the
+        // organization row is FK-referenced by the follow-up register.
+        jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
+        jdbc.update("DELETE FROM clinlims.organization WHERE name = 'This laboratory'");
+    }
+
+    // ---- fixture builders ----
+
+    private EQAProgram inHouseScheme(String name) {
+        return insertScheme(name, EQASchemeType.IN_HOUSE, null);
+    }
+
+    private EQAPanel panelWith(EQAProgram scheme, EQACycle cycle, EQAPanelStatus status, LocalDate unblindDate) {
+        return insertPanel(scheme, p -> {
+            p.setCycle(cycle);
+            p.setStatus(status);
+            p.setUnblindDate(unblindDate == null ? null : Date.valueOf(unblindDate));
+            // Prep evidence the seal gate now requires (AC-V2.4-13).
+            p.setAliquotsProduced(8);
+            p.setHomogeneityQcPassed(true);
+        });
+    }
+
+    /**
+     * Enters a result the way an analyst does — through the standard pipeline,
+     * against the analysis the blinded order created — rather than writing
+     * eqa_participant_result.result_value directly. Writing that column in a test
+     * is what hid the fact that nothing in production fills it.
+     */
+    private void enterResultViaPipeline(String blindCode, String value) {
+        Long analysisId = jdbc.queryForObject(
+                "SELECT a.id FROM clinlims.analysis a JOIN clinlims.sample_item si ON a.sampitem_id = si.id"
+                        + " JOIN clinlims.sample s ON si.samp_id = s.id WHERE s.accession_number = ?",
+                Long.class, blindCode);
+        jdbc.update(
+                "INSERT INTO clinlims.result (id, analysis_id, result_type, value, sort_order, is_reportable,"
+                        + " lastupdated, fhir_uuid)"
+                        + " VALUES (nextval('clinlims.result_seq'), ?, 'N', ?, 1, 'Y', now(), gen_random_uuid())",
+                analysisId, value);
+    }
+
+    private Map<String, Object> panelRow(Long panelId) {
+        return jdbc.queryForMap(
+                "SELECT status, unblind_method, unblinded_by, unblinded_at FROM clinlims.eqa_panel" + " WHERE id = ?",
+                panelId);
+    }
+
+    private Map<String, Object> resultRow(Long resultId) {
+        return jdbc.queryForMap("SELECT submission_status, performance_status, result_value, panel_sample_id"
+                + " FROM clinlims.eqa_participant_result WHERE id = ?", resultId);
+    }
+
+    private Long insertPanelSample(EQAPanel panel, String sampleCode, String blindCode, long analyteId, String target,
+            String low, String high) {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode(sampleCode);
+        sample.setBlindCode(blindCode);
+        sample.setAnalyteId(analyteId);
+        sample.setTargetValue(target);
+        if (low != null) {
+            sample.setAcceptanceRangeLow(new BigDecimal(low));
+        }
+        if (high != null) {
+            sample.setAcceptanceRangeHigh(new BigDecimal(high));
+        }
+        sample.setSysUserId(USER);
+        return panelSampleDAO.insert(sample);
+    }
+
+    private Long insertResult(EQACycle cycle, Long roundId, long enrollmentId, long analyteId,
+            EQASubmissionStatus status, String value, Long analystId) {
+        return insertResult(cycle, roundId, enrollmentId, analyteId, status, value, analystId, null);
+    }
+
+    private Long insertResult(EQACycle cycle, Long roundId, long enrollmentId, long analyteId,
+            EQASubmissionStatus status, String value, Long analystId, Long panelSampleId) {
+        EQAParticipantResult result = new EQAParticipantResult();
+        result.setCycle(cycle);
+        result.setRound(eqaRoundDAO.get(roundId).orElseThrow(AssertionError::new));
+        result.setLabEnrollmentId(enrollmentId);
+        result.setAnalyteId(analyteId);
+        result.setSubmissionStatus(status);
+        result.setResultValue(value);
+        result.setAssignedAnalystId(analystId);
+        result.setPanelSampleId(panelSampleId);
+        result.setSysUserId(USER);
+        return eqaParticipantResultDAO.insert(result);
+    }
+
+    private String resultStatus(Long resultId) {
+        return jdbc.queryForObject("SELECT submission_status FROM clinlims.eqa_participant_result WHERE id = ?",
+                String.class, resultId);
+    }
+
+    // ---- seal-and-distribute (FR-V2.4-04, AC-V2.4-01/-17) ----
+
+    @Test
+    public void sealAndDistribute_createsBlindOrdersDraftResultsAndDistributes() {
+        EQAProgram scheme = inHouseScheme("IH Seal Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(7));
+        Long sampleA = insertPanelSample(panel, "IH-01", "IHBLIND-A7", NUMERIC_ANALYTE, "100", "95", "105");
+        Long sampleB = insertPanelSample(panel, "IH-02", "IHBLIND-B3", CATEGORICAL_ANALYTE, "Positive", null, null);
+
+        Map<String, Object> dto = blindingService.sealAndDistribute(panel.getId(), List
+                .of(new BlindOrderSpec(sampleA, SEEDED_TEST_ID, 1L), new BlindOrderSpec(sampleB, SEEDED_TEST_ID, 1L)),
+                USER);
+
+        assertEquals("DISTRIBUTED", dto.get("status"));
+        assertEquals(List.of("IHBLIND-A7", "IHBLIND-B3"), dto.get("orderAccessionNumbers"));
+
+        // The blind code IS the accession number of a real order (FR-V2.4-15).
+        Long orderId = jdbc.queryForObject("SELECT id FROM clinlims.sample WHERE accession_number = 'IHBLIND-A7'",
+                Long.class);
+        assertEquals("one NotStarted analysis on the seeded test", Integer.valueOf(1),
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.analysis a JOIN clinlims.sample_item si ON a.sampitem_id = si.id"
+                                + " WHERE si.samp_id = ? AND a.test_id = 9807 AND a.status_id = ?::numeric",
+                        Integer.class, orderId, statusService.getStatusID(AnalysisStatus.NotStarted)));
+        Map<String, Object> eqaRow = jdbc.queryForMap(
+                "SELECT cycle_id, round_id, is_eqa_sample FROM clinlims.sample_eqa WHERE sample_id = ?", orderId);
+        assertEquals(cycle.getId().longValue(), ((Number) eqaRow.get("cycle_id")).longValue());
+        assertNotNull("seal must have created round 1 and linked the order to it", eqaRow.get("round_id"));
+        assertEquals(Boolean.TRUE, eqaRow.get("is_eqa_sample"));
+
+        List<Map<String, Object>> drafts = jdbc.queryForList(
+                "SELECT analyte_id, submission_status, assigned_analyst_id, analysis_id"
+                        + " FROM clinlims.eqa_participant_result WHERE cycle_id = ? ORDER BY analyte_id",
+                cycle.getId());
+        assertEquals(2, drafts.size());
+        assertEquals(NUMERIC_ANALYTE, ((Number) drafts.get(0).get("analyte_id")).longValue());
+        assertEquals("DRAFT", drafts.get(0).get("submission_status"));
+        assertEquals(1L, ((Number) drafts.get(0).get("assigned_analyst_id")).longValue());
+        assertNotNull("draft is linked to the created analysis", drafts.get(0).get("analysis_id"));
+
+        assertEquals("in-house self-enrollment created once", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_lab_program_enrollment"
+                        + " WHERE program_name = 'IH Seal Scheme' AND provider = 'In-house'", Integer.class));
+    }
+
+    @Test
+    public void sealAndDistribute_refusesPartialCoverage() {
+        EQAProgram scheme = inHouseScheme("IH Coverage Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(7));
+        Long sampleA = insertPanelSample(panel, "IH-01", "IHBLIND-C1", NUMERIC_ANALYTE, "100", "95", "105");
+        insertPanelSample(panel, "IH-02", "IHBLIND-C2", CATEGORICAL_ANALYTE, "Positive", null, null);
+
+        try {
+            blindingService.sealAndDistribute(panel.getId(), List.of(new BlindOrderSpec(sampleA, SEEDED_TEST_ID, null)),
+                    USER);
+            fail("a spec list that skips a panel sample must be refused");
+        } catch (IllegalArgumentException expected) {
+        }
+        assertEquals("panel must not have moved", EQAPanelStatus.PREPARING,
+                eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals("no orders were created", Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.sample WHERE accession_number LIKE 'IHBLIND-C%'", Integer.class));
+    }
+
+    // ---- unblind + scoring (FR-V2.4-06/-07/-08/-14) ----
+
+    @Test
+    public void unblind_scoresEveryResultAndRoutesFailures() throws Exception {
+        // One enrollment is enough now: the grain is per aliquot, so several
+        // results for the same lab and analyte coexist legitimately.
+        seedEnrollment(9901, "IH Scoring Scheme");
+        EQAProgram scheme = inHouseScheme("IH Scoring Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long inRangeSample = insertPanelSample(panel, "IH-01", "IHBLIND-N1", NUMERIC_ANALYTE, "100", "95", "105");
+        Long lowSample = insertPanelSample(panel, "IH-02", "IHBLIND-N2", NUMERIC_ANALYTE, "100", "95", "105");
+        Long highSample = insertPanelSample(panel, "IH-03", "IHBLIND-N3", NUMERIC_ANALYTE, "100", "95", "105");
+        Long catSample = insertPanelSample(panel, "IH-04", "IHBLIND-K1", CATEGORICAL_ANALYTE, "Positive", null, null);
+        Long lateSample = insertPanelSample(panel, "IH-05", "IHBLIND-L1", LATE_ANALYTE, "50", "45", "55");
+
+        Long inRange = insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "102", 1L,
+                inRangeSample);
+        Long belowLow = insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "92", 1L,
+                lowSample);
+        Long aboveHigh = insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "140", 1L,
+                highSample);
+        Long catMismatch = insertResult(cycle, roundId, 9901, CATEGORICAL_ANALYTE, EQASubmissionStatus.SUBMITTED,
+                "Negative", 1L, catSample);
+        Long neverEntered = insertResult(cycle, roundId, 9901, LATE_ANALYTE, EQASubmissionStatus.DRAFT, null, 1L,
+                lateSample);
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        assertEquals("panel ends SCORED", EQAPanelStatus.SCORED,
+                eqaPanelDAO.get(panel.getId()).orElseThrow(AssertionError::new).getStatus());
+
+        // AC-V2.4-07/-08: the verdict itself is persisted, not merely implied by
+        // a competency event. Both range bounds are exercised.
+        assertEquals("ACCEPTABLE", resultRow(inRange).get("performance_status"));
+        assertEquals("UNACCEPTABLE", resultRow(belowLow).get("performance_status"));
+        assertEquals("UNACCEPTABLE", resultRow(aboveHigh).get("performance_status"));
+        assertEquals("UNACCEPTABLE", resultRow(catMismatch).get("performance_status"));
+        assertEquals("SCORED", resultRow(inRange).get("submission_status"));
+        assertEquals("an empty draft misses the deadline", "MISSED_DEADLINE",
+                resultRow(neverEntered).get("submission_status"));
+        assertNull("a missed deadline carries no verdict", resultRow(neverEntered).get("performance_status"));
+
+        // FR-V2.4-10: the audit distinguishes this from a scheduled unblind.
+        Map<String, Object> panelRow = panelRow(panel.getId());
+        assertEquals("MANUAL", panelRow.get("unblind_method"));
+        assertEquals(1L, ((Number) panelRow.get("unblinded_by")).longValue());
+        assertNotNull(panelRow.get("unblinded_at"));
+
+        List<Map<String, Object>> events = jdbc
+                .queryForList("SELECT event_type, participant_result_id FROM clinlims.eqa_analyst_competency_event"
+                        + " WHERE cycle_id = ? ORDER BY participant_result_id", cycle.getId());
+        assertEquals(4, events.size());
+        assertEquals("IN_HOUSE_MISSED_DEADLINE",
+                events.stream()
+                        .filter(e -> neverEntered.longValue() == ((Number) e.get("participant_result_id")).longValue())
+                        .findFirst().orElseThrow().get("event_type"));
+
+        // AC-V2.4-09: one register row, tagged In-house, holding every failure.
+        List<Map<String, Object>> followups = jdbc.queryForList(
+                "SELECT followup_status, participant_result_summary_json FROM clinlims.eqa_participant_followup"
+                        + " WHERE cycle_id = ?",
+                cycle.getId());
+        assertEquals(1, followups.size());
+        assertEquals("NOTIFIED", followups.get(0).get("followup_status"));
+        JsonNode summary = JSON.readTree((String) followups.get(0).get("participant_result_summary_json"));
+        assertEquals("In-house", summary.get("source").asText());
+        assertEquals(3, summary.get("unacceptable").size());
+        java.util.Set<String> reported = new java.util.HashSet<>();
+        summary.get("unacceptable").forEach(node -> reported.add(node.get("reported").asText()));
+        assertEquals(java.util.Set.of("92", "140", "Negative"), reported);
+    }
+
+    @Test
+    public void unblind_readsTheAnalystsValueFromTheResultPipeline() {
+        // The defect this covers: an analyst runs a blinded order through standard
+        // result entry, which writes the result table — nothing copies that into
+        // eqa_participant_result. Reading the column alone marked every working
+        // analyst as having missed the deadline.
+        EQAProgram scheme = inHouseScheme("IH Bridge Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(1));
+        Long acceptableSample = insertPanelSample(panel, "IH-01", "IHBLIND-BR1", NUMERIC_ANALYTE, "100", "95", "105");
+        Long failingSample = insertPanelSample(panel, "IH-02", "IHBLIND-BR2", NUMERIC_ANALYTE, "100", "95", "105");
+        Long silentSample = insertPanelSample(panel, "IH-03", "IHBLIND-BR3", LATE_ANALYTE, "50", "45", "55");
+
+        blindingService.sealAndDistribute(panel.getId(),
+                List.of(new BlindOrderSpec(acceptableSample, SEEDED_TEST_ID, 1L),
+                        new BlindOrderSpec(failingSample, SEEDED_TEST_ID, 1L),
+                        new BlindOrderSpec(silentSample, SEEDED_TEST_ID, 1L)),
+                USER);
+
+        // Two analysts enter results the normal way; the third never does.
+        enterResultViaPipeline("IHBLIND-BR1", "101");
+        enterResultViaPipeline("IHBLIND-BR2", "80");
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        Map<Long, Map<String, Object>> bySample = new java.util.HashMap<>();
+        for (Map<String, Object> row : jdbc
+                .queryForList("SELECT panel_sample_id, submission_status, performance_status, result_value"
+                        + " FROM clinlims.eqa_participant_result WHERE cycle_id = ?", cycle.getId())) {
+            bySample.put(((Number) row.get("panel_sample_id")).longValue(), row);
+        }
+        assertEquals("the entered value is picked up from the pipeline", "101",
+                bySample.get(acceptableSample).get("result_value"));
+        assertEquals("ACCEPTABLE", bySample.get(acceptableSample).get("performance_status"));
+        assertEquals("UNACCEPTABLE", bySample.get(failingSample).get("performance_status"));
+        assertEquals("only the analyst who entered nothing misses the deadline", "MISSED_DEADLINE",
+                bySample.get(silentSample).get("submission_status"));
+    }
+
+    @Test
+    public void sealAndDistribute_handlesReplicateAliquotsOfOneAnalyte() {
+        // FR-V2.4-02 Mode A: one pool split into N aliquots, all the same analyte.
+        // The original per-analyte uniqueness made this impossible to distribute.
+        EQAProgram scheme = inHouseScheme("IH Replicate Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(2));
+        Long first = insertPanelSample(panel, "IH-01", "IHBLIND-R1", NUMERIC_ANALYTE, "100", "95", "105");
+        Long second = insertPanelSample(panel, "IH-02", "IHBLIND-R2", NUMERIC_ANALYTE, "60", "55", "65");
+
+        blindingService.sealAndDistribute(panel.getId(),
+                List.of(new BlindOrderSpec(first, SEEDED_TEST_ID, 1L), new BlindOrderSpec(second, SEEDED_TEST_ID, 1L)),
+                USER);
+
+        assertEquals("both aliquots produced a draft", Integer.valueOf(2),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_participant_result WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()));
+
+        // Each replicate scores against its OWN target, not the first one found.
+        enterResultViaPipeline("IHBLIND-R1", "100");
+        enterResultViaPipeline("IHBLIND-R2", "100");
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        assertEquals("ACCEPTABLE",
+                jdbc.queryForObject(
+                        "SELECT performance_status FROM" + " clinlims.eqa_participant_result WHERE panel_sample_id = ?",
+                        String.class, first));
+        assertEquals("100 against a target of 60 is out of range", "UNACCEPTABLE",
+                jdbc.queryForObject(
+                        "SELECT performance_status FROM clinlims.eqa_participant_result WHERE panel_sample_id = ?",
+                        String.class, second));
+    }
+
+    @Test
+    public void verdict_numericTargetWithoutARangeComparesAsANumber() {
+        EQAProgram scheme = inHouseScheme("IH Numeric Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(1));
+        Long sample = insertPanelSample(panel, "IH-01", "IHBLIND-NUM", NUMERIC_ANALYTE, "100", null, null);
+
+        blindingService.sealAndDistribute(panel.getId(), List.of(new BlindOrderSpec(sample, SEEDED_TEST_ID, 1L)), USER);
+        enterResultViaPipeline("IHBLIND-NUM", "100.0");
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        assertEquals("100.0 equals a target of 100", "ACCEPTABLE",
+                jdbc.queryForObject(
+                        "SELECT performance_status FROM clinlims.eqa_participant_result WHERE panel_sample_id = ?",
+                        String.class, sample));
+    }
+
+    @Test
+    public void sealAndDistribute_refusesUnusableBlindCodesAndMissingPrepEvidence() {
+        EQAProgram scheme = inHouseScheme("IH Validation Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+
+        EQAPanel tooLong = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(1));
+        Long longCode = insertPanelSample(tooLong, "IH-01", "IHBLIND-THIS-CODE-IS-FAR-TOO-LONG", NUMERIC_ANALYTE, "100",
+                "95", "105");
+        assertRefused(
+                () -> blindingService.sealAndDistribute(tooLong.getId(),
+                        List.of(new BlindOrderSpec(longCode, SEEDED_TEST_ID, 1L)), USER),
+                "a blind code wider than an accession number");
+
+        EQACycle secondCycle = readBack(insertCycle(scheme, 2));
+        EQAPanel shortOnAliquots = insertPanel(scheme, p -> {
+            p.setCycle(secondCycle);
+            p.setStatus(EQAPanelStatus.PREPARING);
+            p.setUnblindDate(Date.valueOf(LocalDate.now().plusDays(1)));
+            p.setAliquotsProduced(0);
+            p.setHomogeneityQcPassed(true);
+        });
+        Long sample = insertPanelSample(shortOnAliquots, "IH-01", "IHBLIND-V1", NUMERIC_ANALYTE, "100", "95", "105");
+        assertRefused(() -> blindingService.sealAndDistribute(shortOnAliquots.getId(),
+                List.of(new BlindOrderSpec(sample, SEEDED_TEST_ID, 1L)), USER), "fewer aliquots than samples");
+
+        EQACycle thirdCycle = readBack(insertCycle(scheme, 3));
+        EQAPanel failedQc = insertPanel(scheme, p -> {
+            p.setCycle(thirdCycle);
+            p.setStatus(EQAPanelStatus.PREPARING);
+            p.setUnblindDate(Date.valueOf(LocalDate.now().plusDays(1)));
+            p.setAliquotsProduced(4);
+            p.setHomogeneityQcPassed(false);
+        });
+        Long qcSample = insertPanelSample(failedQc, "IH-01", "IHBLIND-V2", NUMERIC_ANALYTE, "100", "95", "105");
+        assertRefused(
+                () -> blindingService.sealAndDistribute(failedQc.getId(),
+                        List.of(new BlindOrderSpec(qcSample, SEEDED_TEST_ID, 1L)), USER),
+                "failed homogeneity QC with no justification");
+
+        assertEquals("no orders were created by any refused seal", Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.sample WHERE accession_number LIKE 'IHBLIND-V%'"
+                        + " OR accession_number LIKE 'IHBLIND-THIS%'", Integer.class));
+    }
+
+    private void assertRefused(Runnable action, String why) {
+        try {
+            action.run();
+            fail("expected refusal: " + why);
+        } catch (IllegalArgumentException | IllegalStateException expected) {
+            // the service refuses before writing anything
+        }
+    }
+
+    @Test
+    public void unblind_secondRunConflictsAndNeverRescores() {
+        seedEnrollment(9902, "IH Idempotency Scheme");
+        EQAProgram scheme = inHouseScheme("IH Idempotency Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long d1 = insertPanelSample(panel, "IH-01", "IHBLIND-D1", NUMERIC_ANALYTE, "100", "95", "105");
+        insertResult(cycle, roundId, 9902, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "80", 1L, d1);
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+        int eventsAfterFirstRun = jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_analyst_competency_event WHERE cycle_id = ?", Integer.class,
+                cycle.getId());
+
+        try {
+            blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+            fail("a SCORED panel must refuse a second unblind (AC-V2.4-11)");
+        } catch (IllegalStateException expected) {
+        }
+        assertEquals("no double-scoring on the re-run", Integer.valueOf(eventsAfterFirstRun),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_analyst_competency_event WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()));
+    }
+
+    // ---- scheduled unblind (FR-V2.4-06 automatic path) ----
+
+    @Test
+    public void scheduler_unblindsOnlyDueInHousePanels() {
+        EQAProgram inHouse = inHouseScheme("IH Scheduler Scheme");
+        EQAProgram external = insertScheme("External Scheduler Scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQACycle dueCycle = readBack(insertCycle(inHouse, 1));
+        EQACycle futureCycle = readBack(insertCycle(inHouse, 2));
+        EQACycle externalCycle = readBack(insertCycle(external, 1));
+
+        EQAPanel due = panelWith(inHouse, dueCycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        EQAPanel notDue = panelWith(inHouse, futureCycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().plusDays(3));
+        EQAPanel externalPanel = panelWith(external, externalCycle, EQAPanelStatus.DISTRIBUTED,
+                LocalDate.now().minusDays(1));
+
+        scheduler.unblindDueInHousePanels();
+
+        assertEquals("due in-house panel is unblinded and scored", EQAPanelStatus.SCORED,
+                eqaPanelDAO.get(due.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals("the audit records that the scheduler did it, not a person", "SCHEDULED",
+                panelRow(due.getId()).get("unblind_method"));
+        assertEquals("future panel untouched", EQAPanelStatus.DISTRIBUTED,
+                eqaPanelDAO.get(notDue.getId()).orElseThrow(AssertionError::new).getStatus());
+        assertEquals("external panels are not the scheduler's to unblind", EQAPanelStatus.DISTRIBUTED,
+                eqaPanelDAO.get(externalPanel.getId()).orElseThrow(AssertionError::new).getStatus());
+    }
+
+    // ---- label sheet (FR-V2.4-13, AC-V2.4-14/-15) ----
+
+    @Test
+    public void labelSheet_showsBlindCodesNeverTargets_andRegeneratesByteIdentically() throws Exception {
+        EQAProgram scheme = inHouseScheme("IH Label Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.SEALED, LocalDate.now().plusDays(7));
+        insertPanelSample(panel, "IH-01", "IHBLIND-P1", NUMERIC_ANALYTE, "43.7", "41.1", "46.3");
+        insertPanelSample(panel, "IH-02", "IHBLIND-P2", CATEGORICAL_ANALYTE, "SecretPositive77", null, null);
+
+        byte[] first = labelPDFService.generateLabelSheet(panel.getId());
+        byte[] second = labelPDFService.generateLabelSheet(panel.getId());
+        assertArrayEquals("regeneration is byte-identical (AC-V2.4-15)", first, second);
+
+        PdfReader reader = new PdfReader(first);
+        StringBuilder text = new StringBuilder();
+        for (int page = 1; page <= reader.getNumberOfPages(); page++) {
+            text.append(PdfTextExtractor.getTextFromPage(reader, page)).append('\n');
+        }
+        reader.close();
+        String extracted = text.toString();
+
+        assertTrue("every blind code prints", extracted.contains("IHBLIND-P1") && extracted.contains("IHBLIND-P2"));
+        assertFalse("numeric target must not leak (AC-V2.4-14)", extracted.contains("43.7"));
+        assertFalse("acceptance range must not leak", extracted.contains("41.1") || extracted.contains("46.3"));
+        assertFalse("categorical target must not leak", extracted.contains("SecretPositive77"));
+    }
+
+    @Test
+    public void labelSheet_refusedOutsideTheSealedWindow() {
+        EQAProgram scheme = inHouseScheme("IH Early Label Scheme");
+        EQAPanel panel = panelWith(scheme, null, EQAPanelStatus.PREPARING, null);
+        insertPanelSample(panel, "IH-01", "IHBLIND-E1", NUMERIC_ANALYTE, "100", "95", "105");
+
+        try {
+            labelPDFService.generateLabelSheet(panel.getId());
+            fail("labels before sealing would leak the panel's existence to the bench");
+        } catch (IllegalStateException expected) {
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAPanelRestControllerTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openelisglobal.eqa.controller.rest.EQAPanelRestController;
+import org.openelisglobal.eqa.service.EQABlindingService;
+import org.openelisglobal.eqa.service.EQALabelPDFService;
 import org.openelisglobal.eqa.service.EQAPanelService;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,6 +30,12 @@ public class EQAPanelRestControllerTest {
 
     @Mock
     private EQAPanelService panelService;
+
+    @Mock
+    private EQABlindingService blindingService;
+
+    @Mock
+    private EQALabelPDFService labelPDFService;
 
     @InjectMocks
     private EQAPanelRestController controller;

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -93,6 +93,7 @@ public class EQARestGuardMatrixTest {
         // Panel lifecycle, and the separate privilege that reveals sealed targets
         WRITE_GUARDS.put("EQAPanelRestController#seal", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQAPanelRestController#distribute", EQAGuards.MANAGE);
+        WRITE_GUARDS.put("EQAPanelRestController#sealAndDistribute", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQAPanelRestController#unblind", EQAGuards.UNBLIND);
         WRITE_GUARDS.put("EQAParticipantResultRestController#score", EQAGuards.MANAGE);
     }

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
@@ -19,7 +19,9 @@ import org.openelisglobal.config.ControllerSetup;
 import org.openelisglobal.eqa.controller.rest.EQAMyProgramsRestController;
 import org.openelisglobal.eqa.controller.rest.EQAPanelRestController;
 import org.openelisglobal.eqa.controller.rest.EQAProgramRestController;
+import org.openelisglobal.eqa.service.EQABlindingService;
 import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
+import org.openelisglobal.eqa.service.EQALabelPDFService;
 import org.openelisglobal.eqa.service.EQAPanelService;
 import org.openelisglobal.eqa.service.EQAProgramEnrollmentService;
 import org.openelisglobal.eqa.service.EQAProgramService;
@@ -231,8 +233,19 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
         }
 
         @Bean
-        EQAPanelRestController panelRestController(EQAPanelService panelService) {
-            return new EQAPanelRestController(panelService);
+        EQABlindingService blindingService() {
+            return Mockito.mock(EQABlindingService.class);
+        }
+
+        @Bean
+        EQALabelPDFService labelPDFService() {
+            return Mockito.mock(EQALabelPDFService.class);
+        }
+
+        @Bean
+        EQAPanelRestController panelRestController(EQAPanelService panelService, EQABlindingService blindingService,
+                EQALabelPDFService labelPDFService) {
+            return new EQAPanelRestController(panelService, blindingService, labelPDFService);
         }
 
         @Bean


### PR DESCRIPTION
> **Stacks on #4090.** Both branches touch `EQAPanelRestController`. Merge #4090 first; this branch then needs a small rebase (the unblind guard here is already aligned to `qa.eqa.inhouse.unblind`, and the two new endpoints must be added to the write-guard map in that PR's test).

## What this does

Implements FRS V2.4 on the backend. A supervisor seals an in-house panel; the system distributes it as ordinary OpenELIS orders identified only by blind code; analysts run them through the standard pipeline; at the unblind date the panel is unblinded and every result is scored against its sealed target.

- **`EQABlindingService`** — `sealAndDistribute` creates, per panel sample, a `Sample` whose accession number *is* the blind code (so Workplan and result entry need no EQA-specific path, FR-V2.4-15), a `SampleItem`, a NotStarted `Analysis`, the `sample_eqa` link to cycle and round, and a DRAFT `eqa_participant_result` carrying the analyst assignment. `unblindAndScore` resolves every result and routes unacceptable ones to the Follow-Up Queue rather than an NCE, because in-house PT is exploratory (FR-V2.4-08).
- **`EQALabelPDFService`** — Avery 5160 sheets carrying blind code, cycle, and analyte, and nothing else. Byte-identical on regeneration. Printable only between sealing and unblinding, readable by anyone who can view the panel, per FR-V2.4-13.
- **Scheduler** — the existing EQA scheduler gains an auto-unblind pass; no second job.

## Schema — qa/025

| Change | Why |
| --- | --- |
| `eqa_participant_result.performance_status`, `z_score` | The computed verdict had nowhere to go, so a scored result was indistinguishable from an unscored one (FR-V2.4-07). |
| `eqa_participant_result.panel_sample_id`; per-analyte unique constraint replaced by two **partial** unique indexes | FR-V2.4-02 Mode A splits one pool into N aliquots of the same analyte, which the old constraint made impossible to distribute. External PT keeps exactly its previous per-analyte guarantee, because a single nullable-column constraint cannot express both (Postgres treats every NULL as distinct). |
| `eqa_panel.unblind_method`, `unblinded_by`, `unblinded_at` | `sys_user_id` cannot distinguish a scheduled unblind from a manual one — the scheduler also writes a real user id (FR-V2.4-10). |

Verified applying to a populated database, not only a fresh one.

## Three defects an adversarial review caught before this shipped

An earlier revision of this work passed its whole suite and a full live walkthrough, and still did not work. All three are fixed here, and each has a test that fails without the fix.

1. **Scoring never saw the analyst's result.** The code read `eqa_participant_result.result_value`, but nothing writes that column from the standard result pipeline — an analyst's entry lands in `result`, keyed to the analysis. Every analyst who did the work would have been marked `MISSED_DEADLINE` with a false competency event. Scoring now reads the value from the analysis, using the printable form because dictionary results store a dictionary id in `result.value`. The earlier walkthrough only passed because the column had been seeded by hand.
2. **The verdict was discarded.** `recordScore` used the performance status to decide a competency event and then dropped it. It is now persisted, and exposed on the result DTO for the post-unblind view.
3. **Replicate panels could not be sealed.** Every draft in one seal shares round and enrollment, so two samples on the same analyte violated the per-analyte unique constraint — exactly Mode A. Results are now keyed per aliquot and each scores against its own target.

## Other fixes from the same review

- Blind codes are validated before any order is written: present, unique within the panel, not already an accession number, and within the 25 characters `accession_number` allows (`blind_code` permits 50, so a long code failed mid-distribution).
- Prep invariants are enforced in the service, not just the wizard (AC-V2.4-13): aliquots produced must cover the samples, and homogeneity QC must have passed or carry a written justification.
- The DISTRIBUTED → UNBLINDED move is taken under a row lock, so a manual and a scheduled unblind cannot both pass the edge check and score twice. This mirrors the fix already applied to the cycle state machine.
- A second panel's failures now merge into the cycle's existing Follow-Up row instead of being dropped.
- A numeric target sealed without a range compares numerically, so `100.0` matches a target of `100`.
- Blinded orders are created with a priority, which result entry dereferences unconditionally.
- Label sheet: blank blind codes are refused rather than printing anonymous stickers, text is clipped to the label box, and the print audit records the label count.

## Tests

11 integration tests against the liquibase-provisioned schema: a replicate panel of one analyte, both acceptance bounds, a categorical mismatch, per-aliquot targets scoring the *same* reported value differently, unblind provenance, and every seal refusal. Results are entered through the result pipeline rather than by writing the EQA column — writing that column is what hid the missing read. 312 EQA tests pass.

Verified live on the dev stack: a replicate panel seals; two analysts who entered results through the pipeline are scored ACCEPTABLE and UNACCEPTABLE *against their own targets from an identical reported value*; only the silent analyst misses the deadline; provenance records MANUAL with actor and timestamp; a second unblind returns 409; a bench user can print the label sheet and it contains no target.

## Not included

No z-score is computed — in-house PT has no consensus SD by construction, so the column stays null and exists for external score intake. Cycle-level state transitions on seal and unblind are left to the cycle owner rather than driven from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)