### PR TITLE
feat(eqa-v2/T-15): panel receipt on Add Order + EQA order cleanup (OGC-610)

### DIFF
--- a/frontend/src/components/eqa/EQAOrderForm.jsx
+++ b/frontend/src/components/eqa/EQAOrderForm.jsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Column, Grid, Select, SelectItem, TextInput } from "@carbon/react";
+import {
+  Checkbox,
+  Column,
+  Grid,
+  Select,
+  SelectItem,
+  TextInput,
+} from "@carbon/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../utils/Utils";
 import CustomDatePicker from "../common/CustomDatePicker";
@@ -9,8 +16,12 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
   const componentMounted = useRef(false);
 
   const [myPrograms, setMyPrograms] = useState([]);
+  const [cycles, setCycles] = useState([]);
+  const [existingReceipt, setExistingReceipt] = useState(null);
 
   const sampleOrder = orderFormValues?.sampleOrderItems || {};
+  const cycleId = sampleOrder.eqaCycleId || "";
+  const enrollmentId = sampleOrder.eqaProgramId || "";
 
   useEffect(() => {
     componentMounted.current = true;
@@ -22,10 +33,38 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
       }
     });
 
+    getFromOpenElisServer("/rest/eqa/cycles/mine", (response) => {
+      if (componentMounted.current && Array.isArray(response)) {
+        setCycles(response);
+      }
+    });
+
     return () => {
       componentMounted.current = false;
     };
   }, []);
+
+  // A receipt already on file makes this a read-only view: saving again is a
+  // no-op server-side, so re-offering the fields would only mislead.
+  useEffect(() => {
+    if (!cycleId || !enrollmentId) {
+      return;
+    }
+    getFromOpenElisServer(
+      `/rest/eqa/cycles/${cycleId}/receipt?labEnrollmentId=${enrollmentId}`,
+      (response) => {
+        if (componentMounted.current) {
+          setExistingReceipt(response?.id ? response : null);
+        }
+      },
+    );
+  }, [cycleId, enrollmentId]);
+
+  // Ignore a receipt still held from a previously picked cycle.
+  const receiptOnFile =
+    existingReceipt && String(existingReceipt.cycleId) === String(cycleId)
+      ? existingReceipt
+      : null;
 
   const updateField = (field, value) => {
     setOrderFormValues((prev) => ({
@@ -108,7 +147,82 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
                 <SelectItem value="CRITICAL" text="Critical" />
               </Select>
             </Column>
+
+            {/* Cycle — optional; uncycled orders stay visible in My Cycles */}
+            <Column lg={8} md={4} sm={4}>
+              <Select
+                id="eqa-cycle"
+                labelText={intl.formatMessage({ id: "eqa.order.cycle" })}
+                value={cycleId}
+                onChange={(e) => updateField("eqaCycleId", e.target.value)}
+              >
+                <SelectItem value="" text="" />
+                {cycles.map((cycle) => (
+                  <SelectItem
+                    key={cycle.id}
+                    value={String(cycle.id)}
+                    text={cycle.cycleName || `#${cycle.cycleNumber}`}
+                  />
+                ))}
+              </Select>
+            </Column>
           </Grid>
+
+          {cycleId && enrollmentId && (
+            <>
+              <h4>
+                <FormattedMessage id="eqa.order.receipt.title" />
+              </h4>
+              {receiptOnFile ? (
+                <p>
+                  <FormattedMessage
+                    id="eqa.order.receipt.recorded"
+                    values={{ date: receiptOnFile.receivedDate }}
+                  />
+                </p>
+              ) : (
+                <Grid>
+                  <Column lg={8} md={4} sm={4}>
+                    <TextInput
+                      id="eqa-received-temp"
+                      type="number"
+                      labelText={intl.formatMessage({
+                        id: "eqa.order.receipt.tempC",
+                      })}
+                      value={sampleOrder.eqaReceivedTempC || ""}
+                      onChange={(e) =>
+                        updateField("eqaReceivedTempC", e.target.value)
+                      }
+                    />
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <Checkbox
+                      id="eqa-integrity-ok"
+                      labelText={intl.formatMessage({
+                        id: "eqa.order.receipt.integrityOk",
+                      })}
+                      checked={sampleOrder.eqaIntegrityOk !== false}
+                      onChange={(e, { checked }) =>
+                        updateField("eqaIntegrityOk", checked)
+                      }
+                    />
+                  </Column>
+                  <Column lg={16} md={8} sm={4}>
+                    <TextInput
+                      id="eqa-integrity-notes"
+                      labelText={intl.formatMessage({
+                        id: "eqa.order.receipt.notes",
+                      })}
+                      value={sampleOrder.eqaIntegrityNotes || ""}
+                      onChange={(e) =>
+                        updateField("eqaIntegrityNotes", e.target.value)
+                      }
+                    />
+                  </Column>
+                </Grid>
+              )}
+            </>
+          )}
         </div>
       </Column>
     </Grid>

--- a/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.js
+++ b/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.js
@@ -6,11 +6,18 @@ export const createOrderEntryValidationSchema = (
 ) => {
   const requesterRequired =
     configurationProperties.REQUESTER_REQUIRED === "true";
+  // A blind PT sample has no referring site and no requester — demanding the
+  // clinical ceremony on an EQA order blocks a save that is otherwise complete.
+  const requiredUnlessEQA = (message) =>
+    Yup.string().when("isEQASample", {
+      is: true,
+      otherwise: (schema) => schema.required(message),
+    });
   const providerFirstNameSchema = requesterRequired
-    ? Yup.string().required("Requester First Name is required")
+    ? requiredUnlessEQA("Requester First Name is required")
     : Yup.string();
   const providerLastNameSchema = requesterRequired
-    ? Yup.string().required("Requester Last Name is required")
+    ? requiredUnlessEQA("Requester Last Name is required")
     : Yup.string();
 
   return Yup.object().shape({
@@ -29,8 +36,9 @@ export const createOrderEntryValidationSchema = (
         "referringSiteName",
         "Referring Site is required",
         function (value) {
-          const { referringSiteName, referringSiteId } = value || {};
-          return !!referringSiteName || !!referringSiteId;
+          const { referringSiteName, referringSiteId, isEQASample } =
+            value || {};
+          return !!isEQASample || !!referringSiteName || !!referringSiteId;
         },
       ),
   });

--- a/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.test.js
+++ b/frontend/src/components/formModel/validationSchema/OrderEntryValidationSchema.test.js
@@ -150,4 +150,25 @@ describe("createOrderEntryValidationSchema", () => {
 
     await expect(schema.isValid(valuesWithoutRequester)).resolves.toBe(false);
   });
+
+  test("accepts an EQA order with neither referring site nor requester", async () => {
+    const schema = createOrderEntryValidationSchema({
+      PATIENT_NATIONAL_ID_REQUIRED: "false",
+      REQUESTER_REQUIRED: "true",
+    });
+
+    const eqaOrder = {
+      ...minimalOrderValues,
+      sampleOrderItems: {
+        ...minimalOrderValues.sampleOrderItems,
+        isEQASample: true,
+        referringSiteName: "",
+        referringSiteId: "",
+        providerFirstName: "",
+        providerLastName: "",
+      },
+    };
+
+    await expect(schema.isValid(eqaOrder)).resolves.toBe(true);
+  });
 });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8152,5 +8152,11 @@
   "eqa.review.auditFootnote": "Every value above was validated in the standard pipeline, which captured the validating user in the audit trail. Submitting records the acknowledgement only — no separate sign-off.",
   "eqa.sample.analyte": "Analyte",
   "eqa.sample.reportedValue": "Reported value",
-  "eqa.sample.validatedAt": "Validated"
+  "eqa.sample.validatedAt": "Validated",
+  "eqa.order.cycle": "EQA Cycle",
+  "eqa.order.receipt.title": "Panel Receipt",
+  "eqa.order.receipt.tempC": "Temperature on arrival (°C)",
+  "eqa.order.receipt.integrityOk": "Panel arrived intact",
+  "eqa.order.receipt.notes": "Integrity notes",
+  "eqa.order.receipt.recorded": "Panel receipt already recorded on {date}."
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
@@ -13,10 +13,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -75,15 +77,32 @@ public class EQAPanelReceiptRestController extends BaseRestController {
         EQAPanelReceipt receipt = receiptService.recordReceipt(cycleId, labEnrollmentId, shipmentId, receivedTempC,
                 integrityOk, stringField(body, "integrityNotes"), receivedBy, sysUserId);
 
+        return ResponseEntity.status(existedBefore ? HttpStatus.OK : HttpStatus.CREATED).body(toDto(cycleId, receipt));
+    }
+
+    /**
+     * The already-recorded receipt for this cycle and enrollment, so order entry
+     * can render it read-only instead of re-offering the fields. 404 when none.
+     */
+    @GetMapping(value = "/cycles/{cycleId}/receipt", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> getReceipt(@PathVariable Long cycleId,
+            @RequestParam Long labEnrollmentId) {
+        return receiptService.getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId)).stream()
+                .findFirst().map(receipt -> ResponseEntity.ok(toDto(cycleId, receipt)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    private Map<String, Object> toDto(Long cycleId, EQAPanelReceipt receipt) {
         Map<String, Object> dto = new LinkedHashMap<>();
         dto.put("id", receipt.getId());
         dto.put("cycleId", cycleId);
         dto.put("labEnrollmentId", receipt.getLabEnrollmentId());
         dto.put("shipmentId", receipt.getShipmentId());
         dto.put("receivedDate", receipt.getReceivedDate() == null ? null : receipt.getReceivedDate().toString());
+        dto.put("receivedTempC", receipt.getReceivedTempC());
         dto.put("integrityOk", receipt.getIntegrityOk());
-
-        return ResponseEntity.status(existedBefore ? HttpStatus.OK : HttpStatus.CREATED).body(dto);
+        dto.put("integrityNotes", receipt.getIntegrityNotes());
+        return dto;
     }
 
     private String stringField(Map<String, Object> body, String key) {

--- a/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
+++ b/src/main/java/org/openelisglobal/sample/action/util/SamplePatientUpdateData.java
@@ -109,6 +109,10 @@ public class SamplePatientUpdateData {
     private String eqaParticipantId;
     private String eqaDeadline;
     private String eqaPriority;
+    private String eqaCycleId;
+    private String eqaReceivedTempC;
+    private Boolean eqaIntegrityOk;
+    private String eqaIntegrityNotes;
 
     private boolean customNotificationLogic;
     private List<String> patientEmailNotificationTestIds;
@@ -936,6 +940,38 @@ public class SamplePatientUpdateData {
 
     public void setEqaPriority(String eqaPriority) {
         this.eqaPriority = eqaPriority;
+    }
+
+    public String getEqaCycleId() {
+        return eqaCycleId;
+    }
+
+    public void setEqaCycleId(String eqaCycleId) {
+        this.eqaCycleId = eqaCycleId;
+    }
+
+    public String getEqaReceivedTempC() {
+        return eqaReceivedTempC;
+    }
+
+    public void setEqaReceivedTempC(String eqaReceivedTempC) {
+        this.eqaReceivedTempC = eqaReceivedTempC;
+    }
+
+    public Boolean getEqaIntegrityOk() {
+        return eqaIntegrityOk;
+    }
+
+    public void setEqaIntegrityOk(Boolean eqaIntegrityOk) {
+        this.eqaIntegrityOk = eqaIntegrityOk;
+    }
+
+    public String getEqaIntegrityNotes() {
+        return eqaIntegrityNotes;
+    }
+
+    public void setEqaIntegrityNotes(String eqaIntegrityNotes) {
+        this.eqaIntegrityNotes = eqaIntegrityNotes;
     }
 
     /**

--- a/src/main/java/org/openelisglobal/sample/bean/SampleOrderItem.java
+++ b/src/main/java/org/openelisglobal/sample/bean/SampleOrderItem.java
@@ -240,6 +240,12 @@ public class SampleOrderItem implements Serializable {
     private String eqaDeadline;
     private String eqaPriority;
 
+    // Panel receipt captured on the order form (FR-V2.1-20)
+    private String eqaCycleId;
+    private String eqaReceivedTempC;
+    private Boolean eqaIntegrityOk;
+    private String eqaIntegrityNotes;
+
     // Informed consent fields
     private Boolean consentGiven;
 
@@ -709,6 +715,38 @@ public class SampleOrderItem implements Serializable {
 
     public void setEqaPriority(String eqaPriority) {
         this.eqaPriority = eqaPriority;
+    }
+
+    public String getEqaCycleId() {
+        return eqaCycleId;
+    }
+
+    public void setEqaCycleId(String eqaCycleId) {
+        this.eqaCycleId = eqaCycleId;
+    }
+
+    public String getEqaReceivedTempC() {
+        return eqaReceivedTempC;
+    }
+
+    public void setEqaReceivedTempC(String eqaReceivedTempC) {
+        this.eqaReceivedTempC = eqaReceivedTempC;
+    }
+
+    public Boolean getEqaIntegrityOk() {
+        return eqaIntegrityOk;
+    }
+
+    public void setEqaIntegrityOk(Boolean eqaIntegrityOk) {
+        this.eqaIntegrityOk = eqaIntegrityOk;
+    }
+
+    public String getEqaIntegrityNotes() {
+        return eqaIntegrityNotes;
+    }
+
+    public void setEqaIntegrityNotes(String eqaIntegrityNotes) {
+        this.eqaIntegrityNotes = eqaIntegrityNotes;
     }
 
     public Map<String, Object> getEnvironmentalFields() {

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SamplePatientEntryRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SamplePatientEntryRestController.java
@@ -353,6 +353,10 @@ public class SamplePatientEntryRestController extends BaseSampleEntryController 
             updateData.setEqaProviderSampleId(sampleOrder.getEqaProviderSampleId());
             updateData.setEqaDeadline(sampleOrder.getEqaDeadline());
             updateData.setEqaPriority(sampleOrder.getEqaPriority());
+            updateData.setEqaCycleId(sampleOrder.getEqaCycleId());
+            updateData.setEqaReceivedTempC(sampleOrder.getEqaReceivedTempC());
+            updateData.setEqaIntegrityOk(sampleOrder.getEqaIntegrityOk());
+            updateData.setEqaIntegrityNotes(sampleOrder.getEqaIntegrityNotes());
         }
         if (Boolean.valueOf(ConfigurationProperties.getInstance().getPropertyValue(Property.CONTACT_TRACING))) {
             setContactTracingInfo(updateData, sampleOrder);

--- a/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.sample.service;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -27,6 +28,7 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
 import org.openelisglobal.dataexchange.service.order.ElectronicOrderService;
+import org.openelisglobal.eqa.service.EQAPanelReceiptService;
 import org.openelisglobal.eqa.service.SampleEQAService;
 import org.openelisglobal.eqa.valueholder.EQAPriority;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
@@ -126,6 +128,8 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
     private ProgramSampleService programSampleService;
     @Autowired
     private SampleEQAService sampleEQAService;
+    @Autowired
+    private EQAPanelReceiptService eqaPanelReceiptService;
     @Autowired
     private BarcodeInfoService barcodeInfoService;
     @Autowired
@@ -459,16 +463,28 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
         }
     }
 
-    private void persistSampleEQAData(SamplePatientUpdateData updateData) {
+    // Package-private so the EQA order/receipt wiring can be exercised directly
+    // (same reason as persistOrderSpecimenBarcodeCounts below).
+    void persistSampleEQAData(SamplePatientUpdateData updateData) {
         SampleEQA sampleEQA = new SampleEQA();
         sampleEQA.setSampleId(Long.parseLong(updateData.getSample().getId()));
         sampleEQA.setIsEqaSample(true);
         sampleEQA.setSysUserId(updateData.getCurrentUserId());
 
+        Long enrollmentId = null;
         if (!GenericValidator.isBlankOrNull(updateData.getEqaProgramId())) {
-            sampleEQA.setEqaEnrollmentId(Long.parseLong(updateData.getEqaProgramId()));
+            enrollmentId = Long.parseLong(updateData.getEqaProgramId());
+            sampleEQA.setEqaEnrollmentId(enrollmentId);
         }
         sampleEQA.setEqaProviderSampleId(updateData.getEqaProviderSampleId());
+
+        // The cycle link is optional (FR-V2.1-03): an order without one stays
+        // visible in the uncycled bucket rather than being rejected outright.
+        Long cycleId = null;
+        if (!GenericValidator.isBlankOrNull(updateData.getEqaCycleId())) {
+            cycleId = Long.parseLong(updateData.getEqaCycleId());
+            sampleEQA.setCycleId(cycleId);
+        }
 
         if (!GenericValidator.isBlankOrNull(updateData.getEqaDeadline())) {
             java.sql.Date deadlineDate = DateUtil.convertStringDateToSqlDate(updateData.getEqaDeadline());
@@ -481,6 +497,17 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
         }
 
         sampleEQAService.insert(sampleEQA);
+
+        // FR-V2.1-20: the panel receipt rides this order's transaction on purpose —
+        // a receipt that cannot be recorded must take the whole order down with it.
+        // recordReceipt is idempotent, so re-saving the same cycle is a read.
+        if (cycleId != null && enrollmentId != null) {
+            BigDecimal receivedTempC = GenericValidator.isBlankOrNull(updateData.getEqaReceivedTempC()) ? null
+                    : new BigDecimal(updateData.getEqaReceivedTempC());
+            eqaPanelReceiptService.recordReceipt(cycleId, enrollmentId, null, receivedTempC,
+                    updateData.getEqaIntegrityOk(), updateData.getEqaIntegrityNotes(),
+                    Long.valueOf(updateData.getCurrentUserId()), updateData.getCurrentUserId());
+        }
     }
 
     void persistOrderSpecimenBarcodeCounts(org.openelisglobal.sample.valueholder.Sample sample, Integer numOrderLabels,

--- a/src/test/java/org/openelisglobal/sample/service/SamplePatientEntryEQAReceiptIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/sample/service/SamplePatientEntryEQAReceiptIntegrationTest.java
@@ -1,0 +1,129 @@
+package org.openelisglobal.sample.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.openelisglobal.eqa.EQASpineTestBase;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.sample.action.util.SamplePatientUpdateData;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * OGC-610 [EQA V2.2] — saving an EQA order routes it to a cycle and records the
+ * panel receipt in the same transaction (FR-V2.2-12): the order and its receipt
+ * either both land or neither does.
+ */
+public class SamplePatientEntryEQAReceiptIntegrationTest extends EQASpineTestBase {
+
+    private static final long SAMPLE_ID = 9970L;
+    private static final long ENROLLMENT = 9903L;
+    /** Never seeded — lab_enrollment_id is a real FK on eqa_panel_receipt. */
+    private static final long UNKNOWN_ENROLLMENT = 9989L;
+
+    @Autowired
+    private SamplePatientEntryService samplePatientEntryService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    /**
+     * The receipt wiring is package-private on the impl, and the bean is behind a
+     * transactional proxy, so unwrap to reach it.
+     */
+    private SamplePatientEntryServiceImpl impl() {
+        return AopTestUtils.getTargetObject(samplePatientEntryService);
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        // sample_eqa points at eqa_cycle, so it goes before the spine tables; the
+        // sample itself goes after, being sample_eqa's own parent.
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id = ?", SAMPLE_ID);
+        super.cleanEqaTables();
+        jdbc.update("DELETE FROM clinlims.sample WHERE id = ?", SAMPLE_ID);
+    }
+
+    private void seedSample() {
+        jdbc.update("INSERT INTO clinlims.sample (id, accession_number, entered_date, received_date, lastupdated)"
+                + " VALUES (?, 'EQAT15001', now(), now(), now()) ON CONFLICT (id) DO NOTHING", SAMPLE_ID);
+    }
+
+    private SamplePatientUpdateData eqaOrder(Long cycleId, long enrollmentId) {
+        Sample sample = new Sample();
+        sample.setId(String.valueOf(SAMPLE_ID));
+
+        SamplePatientUpdateData updateData = new SamplePatientUpdateData(USER);
+        updateData.setSample(sample);
+        updateData.setEqaSample(true);
+        updateData.setEqaProgramId(String.valueOf(enrollmentId));
+        updateData.setEqaCycleId(cycleId == null ? null : String.valueOf(cycleId));
+        updateData.setEqaReceivedTempC("4.5");
+        updateData.setEqaIntegrityOk(Boolean.TRUE);
+        updateData.setEqaIntegrityNotes("Cool box intact");
+        return updateData;
+    }
+
+    private Long seedCycle(String schemeName) {
+        seedSample();
+        seedEnrollment(ENROLLMENT, schemeName + " enrollment");
+        EQAProgram scheme = insertScheme(schemeName, EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        return insertCycle(scheme, 1);
+    }
+
+    @Test
+    public void orderSave_linksTheCycleAndRecordsTheReceipt() {
+        Long cycleId = seedCycle("Order receipt");
+
+        impl().persistSampleEQAData(eqaOrder(cycleId, ENROLLMENT));
+
+        assertEquals("the order must carry the cycle link the V2 screens read", cycleId, jdbc
+                .queryForObject("SELECT cycle_id FROM clinlims.sample_eqa WHERE sample_id = ?", Long.class, SAMPLE_ID));
+        assertEquals(Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_panel_receipt WHERE cycle_id = ?", Integer.class, cycleId));
+        assertEquals(0,
+                new java.math.BigDecimal("4.5").compareTo(
+                        jdbc.queryForObject("SELECT received_temp_c FROM clinlims.eqa_panel_receipt WHERE cycle_id = ?",
+                                java.math.BigDecimal.class, cycleId)));
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, readBack(cycleId).getStatus());
+    }
+
+    /** FR-V2.1-03: no cycle picked is a legal order, not a rejected one. */
+    @Test
+    public void orderSaveWithoutACycle_recordsNoReceipt() {
+        seedCycle("Uncycled order");
+
+        impl().persistSampleEQAData(eqaOrder(null, ENROLLMENT));
+
+        assertNull(jdbc.queryForObject("SELECT cycle_id FROM clinlims.sample_eqa WHERE sample_id = ?", Long.class,
+                SAMPLE_ID));
+        assertEquals(Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_panel_receipt", Integer.class));
+    }
+
+    /**
+     * FR-V2.2-12 atomicity: a receipt that cannot be recorded takes the order row
+     * down with it rather than leaving a half-saved EQA order behind.
+     */
+    @Test
+    public void receiptFailure_rollsBackTheWholeOrderSave() {
+        Long cycleId = seedCycle("Rollback order");
+        TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+
+        assertThrows(Exception.class, () -> transaction.execute(status -> {
+            impl().persistSampleEQAData(eqaOrder(cycleId, UNKNOWN_ENROLLMENT));
+            return null;
+        }));
+
+        assertEquals("the sample_eqa row must not survive a failed receipt", Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.sample_eqa WHERE sample_id = ?", Integer.class, SAMPLE_ID));
+        assertEquals(EQACycleStatus.PLANNED, readBack(cycleId).getStatus());
+    }
+}


### PR DESCRIPTION
Saving an EQA-flagged order now routes it to a cycle and records the panel receipt in the same transaction (FR-V2.2-12, FR-V2.1-20), and stops demanding clinical ceremony a blind PT sample cannot supply.

The receipt service shipped with OGC-609 — this wires it into order entry rather than rebuilding it.

## Backend

- Cycle id and the receipt fields (temperature, integrity flag, notes) ride the order-save DTO through `SampleOrderItem` and `SamplePatientUpdateData`.
- `persistSampleEQAData` sets `sample_eqa.cycle_id` and calls `recordReceipt` inline, so it joins `persistData`'s transaction: a receipt that cannot be written takes the whole order down with it. The cycle link stays optional (FR-V2.1-03) — an order without one surfaces in the uncycled bucket.
- New `GET /rest/eqa/cycles/{id}/receipt?labEnrollmentId=` (404 when none) so order entry can render an existing receipt read-only. The POST response builder is now shared with it rather than duplicated.

## Frontend

- `EQAOrderForm` gains a cycle picker fed by `/rest/eqa/cycles/mine` plus the receipt fields, replaced by a read-only line once a receipt is on file.
- Order entry validation no longer requires a referring site or a requester name when the order is flagged EQA. Only the referring-site test and the two requester schemas actually blocked the save; payment status, consent and the notification toggles were never validated, so nothing else needed relaxing.

## Tests

- `SamplePatientEntryEQAReceiptIntegrationTest` — cycle link, receipt write, the no-cycle case, and rollback of the order row when the receipt fails (driven through a real `TransactionTemplate`).
- One `OrderEntryValidationSchema` case asserting an EQA order validates with neither site nor requester.
- 390 backend and 113 frontend tests green on this branch.

## Manual verification

Walked the wizard on a live stack (`/SamplePatientEntry?isEQA=true`):

- Program Selection renders the EQA Cycle picker; choosing a programme and cycle reveals the Panel Receipt fields with the integrity flag defaulted on.
- Submit is enabled with referring site, requester and payment status all empty.
- Saving wrote `sample_eqa.cycle_id`, an `eqa_panel_receipt` row carrying the entered temperature and notes, and moved the cycle `PLANNED -> PANEL_RECEIVED` with one `PARTICIPANT / AUTO / PANEL_RECEIPT` transition row.
- Re-entering on the same cycle and programme shows the recorded receipt read-only; switching to a cycle without one brings the fields back.
- A second order against the same cycle and enrollment left the receipt count and transition count at one, with the original values intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
