### PR TITLE
feat(eqa-v2): tiered EQA score to NCE adapter and Follow-Up Queue triage (OGC-611)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAFollowupRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAFollowupRestController.java
@@ -1,0 +1,87 @@
+package org.openelisglobal.eqa.controller.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQAParticipantFollowupService;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.qaevent.service.EqaScoreNceService;
+import org.openelisglobal.qaevent.valueholder.NcEvent;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Follow-Up Queue triage API (OGC-611, FR-V2.3-02): the queue this lab owes a
+ * corrective review on, plus its escalate and dismiss actions.
+ */
+@RestController
+@RequestMapping("/rest/eqa")
+@PreAuthorize(EQAGuards.READ)
+public class EQAFollowupRestController extends BaseRestController {
+
+    private final EQAParticipantFollowupService followupService;
+    private final EqaScoreNceService eqaScoreNceService;
+
+    public EQAFollowupRestController(EQAParticipantFollowupService followupService,
+            EqaScoreNceService eqaScoreNceService) {
+        this.followupService = followupService;
+        this.eqaScoreNceService = eqaScoreNceService;
+    }
+
+    @GetMapping(value = "/followups", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> queue() {
+        return followupService.getQueueRows();
+    }
+
+    @PostMapping(value = "/followups/{followupId}/escalate", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public ResponseEntity<Map<String, Object>> escalate(HttpServletRequest request, @PathVariable Long followupId) {
+        NcEvent nce = eqaScoreNceService.escalateFollowup(followupId, getSysUserId(request));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(Map.of("followupId", followupId, "nceId", nce.getId(), "nceNumber", nce.getNceNumber()));
+    }
+
+    @PostMapping(value = "/followups/{followupId}/dismiss", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public Map<String, Object> dismiss(HttpServletRequest request, @PathVariable Long followupId,
+            @RequestBody Map<String, Object> body) {
+        Object rawCategory = body.get("category");
+        if (rawCategory == null) {
+            throw new IllegalArgumentException("A dismissal needs a category");
+        }
+        EQADismissalCategory category;
+        try {
+            category = EQADismissalCategory.valueOf(String.valueOf(rawCategory).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown dismissal category " + rawCategory);
+        }
+        String notes = body.get("notes") == null ? null : String.valueOf(body.get("notes"));
+        EQAParticipantFollowup dismissed = followupService.dismiss(followupId, category, notes, getSysUserId(request));
+        return Map.of("followupId", dismissed.getId(), "followupStatus", dismissed.getFollowupStatus().name(),
+                "dismissalCategory", category.name());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> onBadRequest(IllegalArgumentException e) {
+        return Map.of("error", e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> onConflict(IllegalStateException e) {
+        return Map.of("error", e.getMessage());
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyService.java
@@ -1,0 +1,30 @@
+package org.openelisglobal.eqa.service;
+
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+
+/**
+ * The single writer for analyst competency events (FR-V2.1-22). Scoring, missed
+ * deadlines, NCE escalation and triage dismissal all record through here so the
+ * "no analyst, no event" rule and the ISO 15189 §6.2.3 evidence trail have one
+ * implementation.
+ */
+public interface EQAAnalystCompetencyService {
+
+    /**
+     * Records an event against the result's assigned analyst.
+     *
+     * @param nceId    the NCE this event attributes to, or null
+     * @param category the triage dismissal category, or null
+     * @return the persisted event, or null when the result has no assigned analyst
+     *         — {@code eqa_analyst_competency_event.analyst_id} is NOT NULL by
+     *         design, because competency is an analyst log
+     */
+    EQAAnalystCompetencyEvent record(EQAParticipantResult result, EQACompetencyEventType type, Integer nceId,
+            EQADismissalCategory category, String notes, String sysUserId);
+
+    /** Stamps the NCE onto the event already written for a scored result. */
+    void attachNce(Long participantResultId, Integer nceId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
@@ -1,0 +1,55 @@
+package org.openelisglobal.eqa.service;
+
+import java.sql.Date;
+import java.util.List;
+import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
+import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyService {
+
+    @Autowired
+    private EQAAnalystCompetencyEventDAO competencyEventDAO;
+
+    @Override
+    public EQAAnalystCompetencyEvent record(EQAParticipantResult result, EQACompetencyEventType type, Integer nceId,
+            EQADismissalCategory category, String notes, String sysUserId) {
+        if (result.getAssignedAnalystId() == null) {
+            return null;
+        }
+        EQAAnalystCompetencyEvent event = new EQAAnalystCompetencyEvent();
+        event.setAnalystId(result.getAssignedAnalystId());
+        event.setEventType(type);
+        event.setEventDate(new Date(System.currentTimeMillis()));
+        event.setScheme(result.getCycle() == null ? null : result.getCycle().getScheme());
+        event.setCycleId(result.getCycle() == null ? null : result.getCycle().getId());
+        event.setParticipantResultId(result.getId());
+        event.setAnalyteId(result.getAnalyteId());
+        event.setNceId(nceId);
+        event.setDismissalCategory(category);
+        event.setNotes(notes);
+        event.setSysUserId(sysUserId);
+        event.setId(competencyEventDAO.insert(event));
+        return event;
+    }
+
+    @Override
+    public void attachNce(Long participantResultId, Integer nceId) {
+        List<EQAAnalystCompetencyEvent> events = competencyEventDAO.getAllMatching("participantResultId",
+                participantResultId);
+        for (EQAAnalystCompetencyEvent event : events) {
+            if (event.getNceId() == null && (event.getEventType() == EQACompetencyEventType.UNACCEPTABLE_SCORE
+                    || event.getEventType() == EQACompetencyEventType.QUESTIONABLE_SCORE)) {
+                event.setNceId(nceId);
+                competencyEventDAO.update(event);
+            }
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -1,7 +1,5 @@
 package org.openelisglobal.eqa.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -14,7 +12,6 @@ import java.util.UUID;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
-import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.IStatusService;
 import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.common.services.StatusService.OrderStatus;
@@ -23,16 +20,13 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
-import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
-import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
-import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
 import org.openelisglobal.eqa.valueholder.EQARound;
@@ -41,8 +35,6 @@ import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
-import org.openelisglobal.organization.service.OrganizationService;
-import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.patient.service.PatientService;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.person.service.PersonService;
@@ -77,7 +69,6 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     private static final String IN_HOUSE_PROVIDER = "In-house";
     /** sample.accession_number is VARCHAR(25); blind_code allows 50. */
     private static final int ACCESSION_NUMBER_MAX = 25;
-    private static final ObjectMapper JSON = new ObjectMapper();
 
     @Autowired
     private EQAPanelService panelService;
@@ -91,8 +82,6 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     private EQASchemeAnalystDAO schemeAnalystDAO;
     @Autowired
     private EQAParticipantResultService participantResultService;
-    @Autowired
-    private EQAParticipantFollowupDAO followupDAO;
     @Autowired
     private EQAParticipantResultDAO participantResultDAO;
     @Autowired
@@ -117,8 +106,6 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     private TestService testService;
     @Autowired
     private TypeOfSampleService typeOfSampleService;
-    @Autowired
-    private OrganizationService organizationService;
     @Autowired
     private IStatusService statusService;
 
@@ -185,18 +172,13 @@ public class EQABlindingServiceImpl implements EQABlindingService {
             samplesById.put(sample.getId(), sample);
         }
 
-        List<Map<String, Object>> unacceptable = new ArrayList<>();
         for (EQAParticipantResult result : participantResultService.getAllMatching("cycle.id",
                 panel.getCycle().getId())) {
             EQAPanelSample target = samplesById.get(result.getPanelSampleId());
             if (target == null) {
                 continue; // belongs to another panel in this cycle, or to external PT
             }
-            resolveResult(result, target, sysUserId, unacceptable);
-        }
-
-        if (!unacceptable.isEmpty()) {
-            openInHouseFollowup(panel, unacceptable, sysUserId);
+            resolveResult(result, target, sysUserId);
         }
 
         panel.setStatus(EQAPanelStatus.SCORED);
@@ -422,8 +404,7 @@ public class EQABlindingServiceImpl implements EQABlindingService {
 
     // ---- unblind helpers ----
 
-    private void resolveResult(EQAParticipantResult result, EQAPanelSample target, String sysUserId,
-            List<Map<String, Object>> unacceptable) {
+    private void resolveResult(EQAParticipantResult result, EQAPanelSample target, String sysUserId) {
         if (result.getSubmissionStatus() == EQASubmissionStatus.SCORED
                 || result.getSubmissionStatus() == EQASubmissionStatus.MISSED_DEADLINE) {
             return; // already resolved — keeps re-runs from double-scoring
@@ -448,7 +429,7 @@ public class EQABlindingServiceImpl implements EQABlindingService {
         if (result.getSubmissionStatus() != EQASubmissionStatus.SUBMITTED) {
             promoteToSubmitted(result, sysUserId);
         }
-        score(result, target, sysUserId, unacceptable);
+        score(result, target, sysUserId);
     }
 
     /**
@@ -484,20 +465,15 @@ public class EQABlindingServiceImpl implements EQABlindingService {
         participantResultService.transitionStatus(result.getId(), EQASubmissionStatus.SUBMITTED, sysUserId);
     }
 
-    private void score(EQAParticipantResult result, EQAPanelSample target, String sysUserId,
-            List<Map<String, Object>> unacceptable) {
-        EQAPerformanceStatus verdict = verdictFor(target, result.getResultValue());
-
-        participantResultService.recordScore(result.getId(), verdict, null, sysUserId);
-        if (verdict == EQAPerformanceStatus.UNACCEPTABLE) {
-            Map<String, Object> row = new LinkedHashMap<>();
-            row.put("participantResultId", result.getId());
-            row.put("analyteId", result.getAnalyteId());
-            row.put("reported", result.getResultValue());
-            row.put("target", target.getTargetValue());
-            row.put("analystId", result.getAssignedAnalystId());
-            unacceptable.add(row);
-        }
+    /**
+     * In-house has no Z by construction (FR-V2.4-07), so the verdict is the whole
+     * score. Routing an unacceptable one to the Follow-Up Queue (FR-V2.4-08) is the
+     * tiered adapter's job, fired by recordScore — this method deliberately does
+     * not enqueue, or the failure would be registered twice.
+     */
+    private void score(EQAParticipantResult result, EQAPanelSample target, String sysUserId) {
+        participantResultService.recordScore(result.getId(), verdictFor(target, result.getResultValue()), null,
+                sysUserId);
     }
 
     /**
@@ -543,79 +519,4 @@ public class EQABlindingServiceImpl implements EQABlindingService {
         }
     }
 
-    /**
-     * One register row per cycle (schema: unique on cycle+org). The
-     * participant_org_id FK demands a real organization; for in-house the
-     * "participant" is the lab itself, materialized once from the configured site
-     * name.
-     */
-    private void openInHouseFollowup(EQAPanel panel, List<Map<String, Object>> unacceptable, String sysUserId) {
-        Organization selfOrg = selfOrganization(sysUserId);
-        Long orgId = Long.parseLong(selfOrg.getId());
-        for (EQAParticipantFollowup existing : followupDAO.getAllMatching("cycle.id", panel.getCycle().getId())) {
-            if (orgId.equals(existing.getParticipantOrgId())) {
-                // A cycle can hold several panels and the register is unique on
-                // cycle + org, so merge rather than return: dropping the second
-                // panel's failures would lose them silently.
-                existing.setParticipantResultSummaryJson(
-                        mergeSummary(existing.getParticipantResultSummaryJson(), unacceptable));
-                existing.setSysUserId(sysUserId);
-                followupDAO.update(existing);
-                return;
-            }
-        }
-        EQAParticipantFollowup followup = new EQAParticipantFollowup();
-        followup.setScheme(panel.getScheme());
-        followup.setCycle(panel.getCycle());
-        followup.setParticipantOrgId(orgId);
-        followup.setFollowupStatus(EQAFollowupStatus.NOTIFIED);
-        followup.setNotifiedAt(DateUtil.getNowAsTimestamp());
-        followup.setParticipantResultSummaryJson(mergeSummary(null, unacceptable));
-        followup.setSysUserId(sysUserId);
-        followupDAO.insert(followup);
-    }
-
-    private String mergeSummary(String existingJson, List<Map<String, Object>> unacceptable) {
-        List<Object> rows = new ArrayList<>();
-        if (!GenericValidator.isBlankOrNull(existingJson)) {
-            try {
-                JsonNode parsed = JSON.readTree(existingJson).get("unacceptable");
-                if (parsed != null && parsed.isArray()) {
-                    for (JsonNode node : parsed) {
-                        rows.add(JSON.convertValue(node, Map.class));
-                    }
-                }
-            } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-                LogEvent.logError(e);
-            }
-        }
-        rows.addAll(unacceptable);
-        try {
-            return JSON.writeValueAsString(Map.of("source", "In-house", "unacceptable", rows));
-        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            LogEvent.logError(e);
-            return existingJson;
-        }
-    }
-
-    private Organization selfOrganization(String sysUserId) {
-        String siteName = ConfigurationProperties.getInstance()
-                .getPropertyValue(ConfigurationProperties.Property.SiteName);
-        if (GenericValidator.isBlankOrNull(siteName)) {
-            siteName = "This laboratory";
-        }
-        Organization lookup = new Organization();
-        lookup.setOrganizationName(siteName);
-        Organization existing = organizationService.getOrganizationByName(lookup, true);
-        if (existing != null) {
-            return existing;
-        }
-        Organization self = new Organization();
-        self.setOrganizationName(siteName);
-        self.setIsActive("Y");
-        self.setMlsSentinelLabFlag("N");
-        self.setSysUserId(sysUserId);
-        organizationService.insert(self);
-        return self;
-    }
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupService.java
@@ -1,0 +1,54 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.service.BaseObjectService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+
+/**
+ * The Follow-Up Queue register (FR-V2.3-02, FR-V2.1-13). One row per cycle and
+ * participant organization — the schema is unique on that pair — carrying a
+ * JSON snapshot of the results that put the participant in the queue.
+ *
+ * <p>
+ * Both enqueue paths land here: in-house unacceptable results routed by the
+ * blinding unblind pass (FR-V2.4-08) and external questionable scores routed by
+ * the tiered NCE rules (FR-V2.3-01).
+ */
+public interface EQAParticipantFollowupService extends BaseObjectService<EQAParticipantFollowup, Long> {
+
+    /**
+     * Open or extend this lab's queue row for a cycle. Merges into an existing row
+     * rather than failing the unique constraint, because a cycle can hold several
+     * panels and several scored analytes.
+     *
+     * @param rows one map per failing result; {@code participantResultId} anchors
+     *             triage back to the result, the rest is display detail
+     */
+    EQAParticipantFollowup enqueueForThisLab(EQAProgram scheme, EQACycle cycle, List<Map<String, Object>> rows,
+            String sysUserId);
+
+    /** Queue rows for the Follow-Up Queue table, newest first. */
+    List<Map<String, Object>> getQueueRows();
+
+    /** Marks a row escalated once its NCE exists (FR-V2.3-02). */
+    EQAParticipantFollowup markEscalated(Long followupId, String sysUserId);
+
+    /**
+     * Closes a row with a required category and free-text notes, writing the
+     * category-specific competency event for every result the row covers
+     * (FR-V2.3-02 mapping table).
+     */
+    EQAParticipantFollowup dismiss(Long followupId, EQADismissalCategory category, String notes, String sysUserId);
+
+    /** The participant-result ids a queue row covers, from its JSON snapshot. */
+    List<Long> resultIdsFor(EQAParticipantFollowup followup);
+
+    /**
+     * Display label for the queue's Source column, derived from the scheme type.
+     */
+    String sourceLabel(EQAProgram scheme);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupServiceImpl.java
@@ -1,0 +1,291 @@
+package org.openelisglobal.eqa.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.common.util.ConfigurationProperties;
+import org.openelisglobal.common.util.DateUtil;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class EQAParticipantFollowupServiceImpl extends BaseObjectServiceImpl<EQAParticipantFollowup, Long>
+        implements EQAParticipantFollowupService {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final String SUMMARY_ROWS = "unacceptable";
+    private static final String SUMMARY_SOURCE = "source";
+    private static final String ROW_RESULT_ID = "participantResultId";
+
+    @Autowired
+    private EQAParticipantFollowupDAO followupDAO;
+
+    @Autowired
+    private EQAParticipantResultDAO participantResultDAO;
+
+    @Autowired
+    private EQAAnalystCompetencyService competencyService;
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    public EQAParticipantFollowupServiceImpl() {
+        super(EQAParticipantFollowup.class);
+    }
+
+    @Override
+    protected EQAParticipantFollowupDAO getBaseObjectDAO() {
+        return followupDAO;
+    }
+
+    @Override
+    public EQAParticipantFollowup enqueueForThisLab(EQAProgram scheme, EQACycle cycle, List<Map<String, Object>> rows,
+            String sysUserId) {
+        if (rows == null || rows.isEmpty()) {
+            return null;
+        }
+        Long orgId = Long.parseLong(selfOrganization(sysUserId).getId());
+        String source = sourceLabel(scheme);
+
+        for (EQAParticipantFollowup existing : followupDAO.getAllMatching("cycle.id", cycle.getId())) {
+            if (orgId.equals(existing.getParticipantOrgId())) {
+                // The register is unique on cycle + org, and one cycle can score
+                // several panels and analytes. Merge rather than return, or the
+                // later failures would be dropped silently.
+                existing.setParticipantResultSummaryJson(
+                        mergeSummary(existing.getParticipantResultSummaryJson(), rows, source));
+                existing.setSysUserId(sysUserId);
+                return followupDAO.update(existing);
+            }
+        }
+
+        EQAParticipantFollowup followup = new EQAParticipantFollowup();
+        followup.setScheme(scheme);
+        followup.setCycle(cycle);
+        followup.setParticipantOrgId(orgId);
+        followup.setFollowupStatus(EQAFollowupStatus.NOTIFIED);
+        followup.setNotifiedAt(DateUtil.getNowAsTimestamp());
+        followup.setParticipantResultSummaryJson(mergeSummary(null, rows, source));
+        followup.setSysUserId(sysUserId);
+        followup.setId(followupDAO.insert(followup));
+        return followup;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getQueueRows() {
+        List<EQAParticipantFollowup> open = new ArrayList<>();
+        for (EQAParticipantFollowup followup : followupDAO.getAll()) {
+            EQAFollowupStatus status = followup.getFollowupStatus();
+            if (status != EQAFollowupStatus.ESCALATED && status != EQAFollowupStatus.RESOLVED) {
+                open.add(followup);
+            }
+        }
+        open.sort(Comparator.comparing(EQAParticipantFollowup::getNotifiedAt,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAParticipantFollowup followup : open) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", followup.getId());
+            dto.put("schemeId", followup.getScheme() == null ? null : followup.getScheme().getId());
+            dto.put("schemeName", followup.getScheme() == null ? null : followup.getScheme().getName());
+            dto.put("cycleId", followup.getCycle() == null ? null : followup.getCycle().getId());
+            dto.put("cycleNumber", followup.getCycle() == null ? null : followup.getCycle().getCycleNumber());
+            dto.put("cycleName", followup.getCycle() == null ? null : followup.getCycle().getCycleName());
+            dto.put("source", sourceLabel(followup.getScheme()));
+            dto.put("followupStatus",
+                    followup.getFollowupStatus() == null ? null : followup.getFollowupStatus().name());
+            dto.put("notifiedAt", followup.getNotifiedAt() == null ? null : followup.getNotifiedAt().toString());
+            dto.put("persistentFailureFlag", followup.getPersistentFailureFlag());
+            dto.put("results", summaryRows(followup));
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    @Override
+    public EQAParticipantFollowup markEscalated(Long followupId, String sysUserId) {
+        EQAParticipantFollowup followup = get(followupId);
+        followup.setFollowupStatus(EQAFollowupStatus.ESCALATED);
+        followup.setResponseReceivedAt(DateUtil.getNowAsTimestamp());
+        followup.setSysUserId(sysUserId);
+        return followupDAO.update(followup);
+    }
+
+    @Override
+    public EQAParticipantFollowup dismiss(Long followupId, EQADismissalCategory category, String notes,
+            String sysUserId) {
+        if (category == null) {
+            throw new IllegalArgumentException("A dismissal needs a category");
+        }
+        EQAParticipantFollowup followup = get(followupId);
+        if (followup.getFollowupStatus() == EQAFollowupStatus.ESCALATED
+                || followup.getFollowupStatus() == EQAFollowupStatus.RESOLVED) {
+            throw new IllegalStateException(
+                    "This follow-up is already " + followup.getFollowupStatus() + " and cannot be dismissed");
+        }
+
+        EQACompetencyEventType eventType = competencyEventTypeFor(category);
+        for (Long resultId : resultIdsFor(followup)) {
+            participantResultDAO.get(resultId)
+                    .ifPresent(result -> competencyService.record(result, eventType, null, category, notes, sysUserId));
+        }
+
+        followup.setFollowupStatus(EQAFollowupStatus.RESOLVED);
+        followup.setResponseReceivedAt(DateUtil.getNowAsTimestamp());
+        followup.setResolutionNotes(notes);
+        followup.setSysUserId(sysUserId);
+        return followupDAO.update(followup);
+    }
+
+    @Override
+    public List<Long> resultIdsFor(EQAParticipantFollowup followup) {
+        List<Long> ids = new ArrayList<>();
+        for (Map<String, Object> row : summaryRows(followup)) {
+            Object id = row.get(ROW_RESULT_ID);
+            if (id != null) {
+                Long parsed = Long.valueOf(String.valueOf(id));
+                if (!ids.contains(parsed)) {
+                    ids.add(parsed);
+                }
+            }
+        }
+        return ids;
+    }
+
+    @Override
+    public String sourceLabel(EQAProgram scheme) {
+        EQASchemeType type = scheme == null ? null : scheme.getSchemeType();
+        if (type == EQASchemeType.IN_HOUSE) {
+            return "In-house";
+        }
+        if (type == EQASchemeType.INTER_LAB_SPLIT) {
+            return "Inter-lab split";
+        }
+        return "External provider";
+    }
+
+    /**
+     * FR-V2.3-02 maps five triage categories onto four competency event types; the
+     * "counts against the analyst" split lives in the FR-V2.3-06 rollup, not here.
+     */
+    private EQACompetencyEventType competencyEventTypeFor(EQADismissalCategory category) {
+        switch (category) {
+        case KNOWN_EQUIPMENT_ISSUE:
+        case PENDING_RE_TEST:
+            return EQACompetencyEventType.DISMISSED_EQUIPMENT;
+        case TRANSCRIPTION_ERROR:
+            return EQACompetencyEventType.DISMISSED_TRANSCRIPTION;
+        case ACCEPTABLE_ON_REVIEW:
+            return EQACompetencyEventType.DISMISSED_ACCEPTABLE_ON_REVIEW;
+        default:
+            return EQACompetencyEventType.DISMISSED_OTHER;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> summaryRows(EQAParticipantFollowup followup) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        String json = followup.getParticipantResultSummaryJson();
+        if (GenericValidator.isBlankOrNull(json)) {
+            return rows;
+        }
+        try {
+            JsonNode parsed = JSON.readTree(json).get(SUMMARY_ROWS);
+            if (parsed != null && parsed.isArray()) {
+                for (JsonNode node : parsed) {
+                    rows.add(JSON.convertValue(node, Map.class));
+                }
+            }
+        } catch (JsonProcessingException e) {
+            LogEvent.logError(e);
+        }
+        return rows;
+    }
+
+    private String mergeSummary(String existingJson, List<Map<String, Object>> rows, String source) {
+        List<Object> merged = new ArrayList<>();
+        if (!GenericValidator.isBlankOrNull(existingJson)) {
+            try {
+                JsonNode parsed = JSON.readTree(existingJson).get(SUMMARY_ROWS);
+                if (parsed != null && parsed.isArray()) {
+                    for (JsonNode node : parsed) {
+                        merged.add(JSON.convertValue(node, Map.class));
+                    }
+                }
+            } catch (JsonProcessingException e) {
+                LogEvent.logError(e);
+            }
+        }
+        merged.addAll(rows);
+        try {
+            return JSON.writeValueAsString(Map.of(SUMMARY_SOURCE, source, SUMMARY_ROWS, merged));
+        } catch (JsonProcessingException e) {
+            LogEvent.logError(e);
+            return existingJson;
+        }
+    }
+
+    /**
+     * The participant_org_id FK demands a real organization. For this lab's own
+     * queue rows the "participant" is the lab itself, materialized once from the
+     * configured site name.
+     */
+    private Organization selfOrganization(String sysUserId) {
+        String siteName = ConfigurationProperties.getInstance()
+                .getPropertyValue(ConfigurationProperties.Property.SiteName);
+        if (GenericValidator.isBlankOrNull(siteName)) {
+            siteName = "This laboratory";
+        }
+        Organization lookup = new Organization();
+        lookup.setOrganizationName(siteName);
+        Organization existing = organizationService.getOrganizationByName(lookup, true);
+        if (existing != null) {
+            return existing;
+        }
+        Organization self = new Organization();
+        self.setOrganizationName(siteName);
+        self.setIsActive("Y");
+        self.setMlsSentinelLabFlag("N");
+        self.setSysUserId(sysUserId);
+        organizationService.insert(self);
+        return self;
+    }
+
+    /** Row builder shared by both enqueue paths (FR-V2.3-01, FR-V2.4-08). */
+    public static Map<String, Object> summaryRow(EQAParticipantResult result, String targetValue) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put(ROW_RESULT_ID, result.getId());
+        row.put("analyteId", result.getAnalyteId());
+        row.put("reported", result.getResultValue());
+        row.put("target", targetValue);
+        row.put("analystId", result.getAssignedAnalystId());
+        row.put("zScore", result.getZScore());
+        row.put("performanceStatus",
+                result.getPerformanceStatus() == null ? null : result.getPerformanceStatus().name());
+        return row;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.eqa.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectService;
@@ -33,6 +34,15 @@ public interface EQAParticipantResultService extends BaseObjectService<EQAPartic
      */
     EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, Long eqaResultId,
             String sysUserId);
+
+    /**
+     * The same transition carrying the provider's Z-score, which the FR-V2.3-01
+     * tiers read to choose between a non-conformity and the Follow-Up Queue.
+     * In-house scoring has no Z by construction (FR-V2.4-07) and uses the overload
+     * above.
+     */
+    EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, BigDecimal zScore,
+            Long eqaResultId, String sysUserId);
 
     /**
      * DRAFT/VALIDATED_PARTIAL → MISSED_DEADLINE (timer terminal). Writes the

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
@@ -1,21 +1,20 @@
 package org.openelisglobal.eqa.service;
 
-import java.sql.Date;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
-import org.openelisglobal.eqa.dao.EQAAnalystCompetencyEventDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
-import org.openelisglobal.eqa.valueholder.EQAAnalystCompetencyEvent;
 import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.qaevent.service.EqaScoreNceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +32,10 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
     private EQAParticipantResultDAO eqaParticipantResultDAO;
 
     @Autowired
-    private EQAAnalystCompetencyEventDAO eqaAnalystCompetencyEventDAO;
+    private EQAAnalystCompetencyService competencyService;
+
+    @Autowired
+    private EqaScoreNceService eqaScoreNceService;
 
     @Autowired
     private EQARoundDAO eqaRoundDAO;
@@ -104,6 +106,12 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
     @Override
     public EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, Long eqaResultId,
             String sysUserId) {
+        return recordScore(resultId, performance, null, eqaResultId, sysUserId);
+    }
+
+    @Override
+    public EQAParticipantResult recordScore(Long resultId, EQAPerformanceStatus performance, BigDecimal zScore,
+            Long eqaResultId, String sysUserId) {
         EQAParticipantResult result = get(resultId);
         if (result.getSubmissionStatus() != EQASubmissionStatus.SUBMITTED) {
             throw new IllegalStateException(
@@ -115,16 +123,19 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
 
         result.setSubmissionStatus(EQASubmissionStatus.SCORED);
         result.setPerformanceStatus(performance);
+        if (zScore != null) {
+            result.setZScore(zScore);
+        }
         result.setScoreReceivedAt(now());
         result.setEqaResultId(eqaResultId);
         result.setSysUserId(sysUserId);
         EQAParticipantResult scored = eqaParticipantResultDAO.update(result);
 
         if (performance != EQAPerformanceStatus.ACCEPTABLE) {
-            recordCompetencyEvent(scored,
+            competencyService.record(scored,
                     performance == EQAPerformanceStatus.UNACCEPTABLE ? EQACompetencyEventType.UNACCEPTABLE_SCORE
                             : EQACompetencyEventType.QUESTIONABLE_SCORE,
-                    sysUserId);
+                    null, null, null, sysUserId);
         }
 
         onResultScored(scored, performance);
@@ -145,39 +156,20 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
 
         boolean inHouse = missed.getCycle() != null && missed.getCycle().getScheme() != null
                 && missed.getCycle().getScheme().getSchemeType() == EQASchemeType.IN_HOUSE;
-        recordCompetencyEvent(missed, inHouse ? EQACompetencyEventType.IN_HOUSE_MISSED_DEADLINE
-                : EQACompetencyEventType.EXTERNAL_MISSED_DEADLINE, sysUserId);
+        competencyService.record(missed, inHouse ? EQACompetencyEventType.IN_HOUSE_MISSED_DEADLINE
+                : EQACompetencyEventType.EXTERNAL_MISSED_DEADLINE, null, null, null, sysUserId);
 
         return missed;
     }
 
     /**
-     * eqa_analyst_competency_event.analyst_id is NOT NULL by design — competency is
-     * an analyst log, so a result with nobody assigned produces no event.
+     * Applies the tiered EQA to NCE rules (OGC-611, FR-V2.3-01) to a freshly scored
+     * result: non-conformity, Follow-Up Queue entry, or nothing. Fired after the
+     * score and any competency event are written to the session, inside the same
+     * transaction, because the adapter stamps the NCE onto that competency event.
      */
-    private void recordCompetencyEvent(EQAParticipantResult result, EQACompetencyEventType type, String sysUserId) {
-        if (result.getAssignedAnalystId() == null) {
-            return;
-        }
-        EQAAnalystCompetencyEvent event = new EQAAnalystCompetencyEvent();
-        event.setAnalystId(result.getAssignedAnalystId());
-        event.setEventType(type);
-        event.setEventDate(new Date(System.currentTimeMillis()));
-        event.setScheme(result.getCycle() == null ? null : result.getCycle().getScheme());
-        event.setCycleId(result.getCycle() == null ? null : result.getCycle().getId());
-        event.setParticipantResultId(result.getId());
-        event.setAnalyteId(result.getAnalyteId());
-        event.setSysUserId(sysUserId);
-        eqaAnalystCompetencyEventDAO.insert(event);
-    }
-
-    /**
-     * Hook for the tiered EQA→NCE trigger adapter (OGC-609): the adapter replaces
-     * this body. Fired after the score and any competency event are committed to
-     * the session, inside the same transaction.
-     */
-    protected void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance) {
-        // Intentionally empty until the NCE adapter is wired (OGC-609).
+    private void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance) {
+        eqaScoreNceService.onResultScored(result, performance);
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/qaevent/service/EqaScoreNceService.java
+++ b/src/main/java/org/openelisglobal/qaevent/service/EqaScoreNceService.java
@@ -1,0 +1,42 @@
+package org.openelisglobal.qaevent.service;
+
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.qaevent.valueholder.NcEvent;
+
+/**
+ * Tiered EQA score to NCE adapter (OGC-611, FR-V2.3-01). The counterpart of
+ * {@link QcViolationNceService} for proficiency testing: it decides whether a
+ * scored participant result becomes a non-conformity, a Follow-Up Queue entry,
+ * or nothing at all.
+ *
+ * <p>
+ * Scoping: only participant-role results reach this adapter.
+ * {@code eqa_participant_result.lab_enrollment_id} is a FK to
+ * {@code eqa_lab_program_enrollment} — this lab's own enrollments — so a remote
+ * participant in a scheme this lab runs cannot produce a row here at all. That
+ * makes AC-V2.5-10 (a provider-role result never creates a local NCE) a
+ * structural property rather than a runtime branch; provider-side
+ * underperformance is tracked by the V2.5 participant follow-up register
+ * instead.
+ */
+public interface EqaScoreNceService {
+
+    /** Trigger source for an auto-created NCE, anchored on the scored result. */
+    String TRIGGER_SOURCE_EQA_UNACCEPTABLE = "EQA_UNACCEPTABLE";
+
+    /** Trigger source for a supervisor escalation, anchored on the queue row. */
+    String TRIGGER_SOURCE_EQA_FOLLOWUP = "EQA_FOLLOWUP_ESCALATION";
+
+    /**
+     * Applies the FR-V2.3-01 tiers to a freshly scored result. Called from
+     * participant-result scoring, inside that transaction.
+     */
+    void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance);
+
+    /**
+     * Escalates a Follow-Up Queue row to a non-conformity (FR-V2.3-02): creates the
+     * NCE, closes the row, and records the competency events.
+     */
+    NcEvent escalateFollowup(Long followupId, String sysUserId);
+}

--- a/src/main/java/org/openelisglobal/qaevent/service/EqaScoreNceServiceImpl.java
+++ b/src/main/java/org/openelisglobal/qaevent/service/EqaScoreNceServiceImpl.java
@@ -1,0 +1,310 @@
+package org.openelisglobal.qaevent.service;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
+import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.service.EQAAnalystCompetencyService;
+import org.openelisglobal.eqa.service.EQAParticipantFollowupService;
+import org.openelisglobal.eqa.service.EQAParticipantFollowupServiceImpl;
+import org.openelisglobal.eqa.valueholder.EQACompetencyEventType;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.qaevent.valueholder.NcEvent;
+import org.openelisglobal.qaevent.valueholder.NceCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class EqaScoreNceServiceImpl implements EqaScoreNceService {
+
+    /** |Z| above which an unacceptable external score is a non-conformity. */
+    private static final BigDecimal NCE_THRESHOLD = new BigDecimal("3");
+
+    /** |Z| above which a score needs a supervisor's eyes. */
+    private static final BigDecimal QUEUE_THRESHOLD = new BigDecimal("2");
+
+    private static final String NCE_SEVERITY_CRITICAL = "CRITICAL";
+    private static final String NCE_STATUS_PENDING = "Pending";
+    private static final String NCE_CATEGORY_ANALYSIS = "Analysis";
+
+    @Autowired
+    private NCEventService ncEventService;
+    @Autowired
+    private NceNumberGeneratorService nceNumberGeneratorService;
+    @Autowired
+    private NceCategoryService nceCategoryService;
+    @Autowired
+    private NceHistoryService nceHistoryService;
+    @Autowired
+    private EQAParticipantFollowupService followupService;
+    @Autowired
+    private EQAAnalystCompetencyService competencyService;
+    @Autowired
+    private EQAParticipantResultDAO participantResultDAO;
+    @Autowired
+    private EQAPanelSampleDAO panelSampleDAO;
+    @Autowired
+    private AnalyteService analyteService;
+
+    @Override
+    public void onResultScored(EQAParticipantResult result, EQAPerformanceStatus performance) {
+        EQACycle cycle = result.getCycle();
+        EQAProgram scheme = cycle == null ? null : cycle.getScheme();
+        if (scheme == null) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "onResultScored",
+                    "Scored result " + result.getId() + " has no scheme; no NCE or follow-up routing possible");
+            return;
+        }
+
+        switch (tierFor(result, performance, scheme)) {
+        case NCE:
+            createNceForResult(result, scheme, cycle);
+            break;
+        case QUEUE:
+            followupService.enqueueForThisLab(scheme, cycle,
+                    List.of(EQAParticipantFollowupServiceImpl.summaryRow(result, sealedTarget(result))),
+                    result.getSysUserId());
+            break;
+        default:
+            break;
+        }
+    }
+
+    /**
+     * FR-V2.3-01. Z governs whenever the provider returned one; the categorical
+     * path exists because HIV qualitative, TB smear grading and blood-film ID have
+     * no Z by construction, and an external provider calling such a result
+     * unacceptable warrants the same non-conformity as a numeric |Z| &gt; 3.
+     *
+     * <p>
+     * Two readings are pinned down here. In-house unacceptable never auto-creates
+     * an NCE (FR-V2.4-08: in-house is exploratory, so it is triaged first). And an
+     * external unacceptable with |Z| &le; 2 is contradictory data rather than a
+     * clean pass, so it is queued for a human instead of taking the FR's literal
+     * "no action" branch — dropping an explicit unacceptable verdict would lose it.
+     */
+    private Tier tierFor(EQAParticipantResult result, EQAPerformanceStatus performance, EQAProgram scheme) {
+        boolean external = scheme.getSchemeType() != EQASchemeType.IN_HOUSE;
+        BigDecimal absZ = result.getZScore() == null ? null : result.getZScore().abs();
+
+        if (performance == EQAPerformanceStatus.UNACCEPTABLE) {
+            if (!external) {
+                return Tier.QUEUE;
+            }
+            return absZ == null || absZ.compareTo(NCE_THRESHOLD) > 0 ? Tier.NCE : Tier.QUEUE;
+        }
+        if (performance == EQAPerformanceStatus.QUESTIONABLE) {
+            return Tier.QUEUE;
+        }
+        return absZ != null && absZ.compareTo(QUEUE_THRESHOLD) > 0 ? Tier.QUEUE : Tier.NONE;
+    }
+
+    /**
+     * Runs in the scoring transaction, unlike {@link QcViolationNceServiceImpl}'s
+     * REQUIRES_NEW: this adapter stamps the NCE onto the competency event that
+     * scoring wrote moments earlier, and a suspended transaction could not see that
+     * uncommitted row. The trade-off is explicit — an NCE failure rolls the score
+     * back with it, rather than leaving an orphan NCE behind.
+     */
+    private NcEvent createNceForResult(EQAParticipantResult result, EQAProgram scheme, EQACycle cycle) {
+        String triggerId = String.valueOf(result.getId());
+        NcEvent existing = ncEventService.findByTriggerSource(TRIGGER_SOURCE_EQA_UNACCEPTABLE, triggerId);
+        if (existing != null) {
+            return existing;
+        }
+
+        String analyte = analyteName(result.getAnalyteId());
+        String sysUserId = result.getSysUserId();
+        BigDecimal z = result.getZScore();
+        String title = z == null
+                ? "Unacceptable EQA score: " + analyte + " (reported " + result.getResultValue() + ") in "
+                        + scheme.getName() + " cycle " + cycle.getCycleNumber()
+                : "Unacceptable EQA score: " + analyte + " Z=" + z.stripTrailingZeros().toPlainString() + " in "
+                        + scheme.getName() + " cycle " + cycle.getCycleNumber();
+
+        NcEvent nce = new NcEvent();
+        nce.setSysUserId(sysUserId);
+        nce.setNceNumber(nceNumberGeneratorService.generateNceNumber());
+        nce.setSeverity(NCE_SEVERITY_CRITICAL);
+        nce.setStatus(NCE_STATUS_PENDING);
+        nce.setAutoGenerated(Boolean.TRUE);
+        nce.setTriggerSourceType(TRIGGER_SOURCE_EQA_UNACCEPTABLE);
+        nce.setTriggerSourceId(triggerId);
+        nce.setTitle(truncate(title, 200));
+        nce.setDescription(describe(result, scheme, cycle, analyte));
+        nce.setImmediateAction("Investigate the analytical process for this analyte before reporting patient results");
+        nce.setNameOfReporter("System (EQA scoring)");
+        nce.setReportDate(new Date(System.currentTimeMillis()));
+        nce.setDateOfEvent(new Date(result.getScoreReceivedAt() == null ? System.currentTimeMillis()
+                : result.getScoreReceivedAt().getTime()));
+        resolveCategory(nce);
+
+        nce = ncEventService.save(nce);
+        competencyService.attachNce(result.getId(), nce.getId());
+        logCreation(nce, "participant result " + result.getId(), sysUserId);
+        return nce;
+    }
+
+    @Override
+    public NcEvent escalateFollowup(Long followupId, String sysUserId) {
+        EQAParticipantFollowup followup = followupService.get(followupId);
+        List<Long> resultIds = followupService.resultIdsFor(followup);
+        String triggerId = String.valueOf(followupId);
+
+        NcEvent nce = ncEventService.findByTriggerSource(TRIGGER_SOURCE_EQA_FOLLOWUP, triggerId);
+        if (followup.getFollowupStatus() == EQAFollowupStatus.ESCALATED && nce != null) {
+            // Already escalated — a repeated click returns the same NCE rather than
+            // duplicating its competency events.
+            return nce;
+        }
+        if (nce == null) {
+            EQAProgram scheme = followup.getScheme();
+            EQACycle cycle = followup.getCycle();
+            List<String> analytes = new ArrayList<>();
+            for (Long resultId : resultIds) {
+                participantResultDAO.get(resultId)
+                        .ifPresent(result -> analytes.add(analyteName(result.getAnalyteId())));
+            }
+
+            nce = new NcEvent();
+            nce.setSysUserId(sysUserId);
+            nce.setNceNumber(nceNumberGeneratorService.generateNceNumber());
+            nce.setSeverity(NCE_SEVERITY_CRITICAL);
+            nce.setStatus(NCE_STATUS_PENDING);
+            nce.setAutoGenerated(Boolean.FALSE);
+            nce.setTriggerSourceType(TRIGGER_SOURCE_EQA_FOLLOWUP);
+            nce.setTriggerSourceId(triggerId);
+            nce.setTitle(truncate("Escalated EQA follow-up: " + String.join(", ", analytes) + " in "
+                    + (scheme == null ? "unknown scheme" : scheme.getName()) + " cycle "
+                    + (cycle == null ? "?" : cycle.getCycleNumber()), 200));
+            nce.setDescription("Escalated from the EQA Follow-Up Queue (FR-V2.3-02). Covers participant result(s) "
+                    + resultIds + ". Queue snapshot: " + followup.getParticipantResultSummaryJson());
+            nce.setImmediateAction("Investigate the flagged analytes and record corrective action");
+            nce.setNameOfReporter("EQA Follow-Up Queue");
+            nce.setReportDate(new Date(System.currentTimeMillis()));
+            nce.setDateOfEvent(new Date(followup.getNotifiedAt() == null ? System.currentTimeMillis()
+                    : followup.getNotifiedAt().getTime()));
+            resolveCategory(nce);
+
+            nce = ncEventService.save(nce);
+            logCreation(nce, "EQA follow-up " + followupId, sysUserId);
+        }
+
+        for (Long resultId : resultIds) {
+            Integer nceId = nce.getId();
+            participantResultDAO.get(resultId).ifPresent(result -> competencyService.record(result,
+                    EQACompetencyEventType.ESCALATED_TO_NCE, nceId, null, null, sysUserId));
+        }
+        followupService.markEscalated(followupId, sysUserId);
+        return nce;
+    }
+
+    private String describe(EQAParticipantResult result, EQAProgram scheme, EQACycle cycle, String analyte) {
+        StringBuilder text = new StringBuilder("Auto-created from an unacceptable EQA score (FR-V2.3-01).");
+        text.append(" Scheme: ").append(scheme.getName()).append(" (").append(scheme.getSchemeType()).append(").");
+        text.append(" Cycle: ").append(cycle.getCycleNumber());
+        if (cycle.getCycleName() != null) {
+            text.append(" — ").append(cycle.getCycleName());
+        }
+        text.append(". Round: ").append(result.getRound() == null ? "n/a" : result.getRound().getId());
+        text.append(". Analyte: ").append(analyte).append(" (id ").append(result.getAnalyteId()).append(").");
+        text.append(" Reported: ").append(result.getResultValue());
+        if (result.getResultUnit() != null) {
+            text.append(" ").append(result.getResultUnit());
+        }
+        text.append(".");
+        if (result.getZScore() != null) {
+            text.append(" Z-score: ").append(result.getZScore().stripTrailingZeros().toPlainString()).append(".");
+        } else {
+            text.append(" No Z-score returned (categorical scheme).");
+        }
+        if (result.getAssignedAnalystId() != null) {
+            text.append(" Assigned analyst id: ").append(result.getAssignedAnalystId()).append(".");
+        }
+        if (result.getAnalysisId() != null) {
+            text.append(" Analysis id: ").append(result.getAnalysisId()).append(".");
+        }
+        return text.toString();
+    }
+
+    /**
+     * Category "Analysis" is seeded by the nce-categories CSV config handler and
+     * ids are sequence-assigned, so it is resolved by name. Optional context — a
+     * missing seed never blocks NCE creation.
+     */
+    private void resolveCategory(NcEvent nce) {
+        try {
+            NceCategory category = nceCategoryService.getAllNceCategories().stream()
+                    .filter(cat -> NCE_CATEGORY_ANALYSIS.equals(cat.getName())).findFirst().orElse(null);
+            if (category != null) {
+                nce.setNceCategoryId(category.getId());
+            }
+        } catch (RuntimeException e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "resolveCategory",
+                    "Could not resolve NCE category: " + e.getMessage());
+        }
+    }
+
+    private void logCreation(NcEvent nce, String source, String sysUserId) {
+        Integer userId = 1;
+        try {
+            userId = Integer.valueOf(sysUserId);
+        } catch (NumberFormatException e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "logCreation",
+                    "Non-numeric sys_user_id " + sysUserId + "; history attributed to the system user");
+        }
+        nceHistoryService.logActivity(nce.getId(), "AUTO_CREATED", "Created from " + source, null, null, userId);
+        LogEvent.logInfo(this.getClass().getSimpleName(), "logCreation",
+                "Created " + nce.getNceNumber() + " from " + source);
+    }
+
+    /**
+     * The target an in-house result was scored against, for the register row. It is
+     * already revealed by the time scoring runs — the unblind pass compared against
+     * it — and external PT keeps its targets at the provider, so this is null
+     * there.
+     */
+    private String sealedTarget(EQAParticipantResult result) {
+        if (result.getPanelSampleId() == null) {
+            return null;
+        }
+        return panelSampleDAO.get(result.getPanelSampleId()).map(EQAPanelSample::getTargetValue).orElse(null);
+    }
+
+    private String analyteName(Long analyteId) {
+        if (analyteId != null) {
+            try {
+                Analyte analyte = analyteService.get(String.valueOf(analyteId));
+                if (analyte != null && analyte.getAnalyteName() != null) {
+                    return analyte.getAnalyteName();
+                }
+            } catch (RuntimeException e) {
+                LogEvent.logWarn(this.getClass().getSimpleName(), "analyteName",
+                        "Could not resolve analyte name for id " + analyteId);
+            }
+        }
+        return "analyte " + analyteId;
+    }
+
+    private static String truncate(String text, int max) {
+        return text.length() <= max ? text : text.substring(0, max);
+    }
+
+    private enum Tier {
+        NCE, QUEUE, NONE
+    }
+}

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -286,6 +286,14 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
                     + "is_active, is_employee, lastupdated) "
                     + "SELECT nextval('system_user_seq'), 'TEST_ADMIN', 'admin', 'Doe', 'John', 'JD', 'Y', 'Y', now() "
                     + "WHERE NOT EXISTS (SELECT 1 FROM system_user WHERE login_name = 'admin')");
+            // A fixture that declares system_user without lastupdated leaves the
+            // Hibernate version null, and an entity with a null version reads as
+            // transient — so stamping a loaded SystemUser onto another entity's
+            // not-null association throws TransientPropertyValueException even
+            // though the row exists. Only ever seen in full-suite runs, because
+            // the DB-init rows all carry a version. Repairing the version changes
+            // no row count and no field a test asserts on.
+            stmt.execute("UPDATE system_user SET lastupdated = now() WHERE lastupdated IS NULL");
         }
     }
 

--- a/src/test/java/org/openelisglobal/eqa/EQAScoreTriageIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAScoreTriageIntegrationTest.java
@@ -1,0 +1,350 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQAParticipantFollowupService;
+import org.openelisglobal.eqa.service.EQAParticipantResultService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQADismissalCategory;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.qaevent.service.EqaScoreNceService;
+import org.openelisglobal.qaevent.valueholder.NcEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-611 (FR-V2.3-01/02) — the tiered EQA to NCE adapter against the real
+ * schema: which scored results become non-conformities, which land in the
+ * Follow-Up Queue, and what escalate and dismiss write.
+ */
+public class EQAScoreTriageIntegrationTest extends EQASpineTestBase {
+
+    private static final long ANALYTE = 9810L;
+    private static final String ANALYTE_NAME = "EQA Triage Analyte";
+    private static final long SECOND_ANALYTE = 9811L;
+    private static final long ENROLLMENT = 9910L;
+    private static final long ANALYST = ADMIN_USER_ID;
+
+    @Autowired
+    private EQAParticipantResultService participantResultService;
+    @Autowired
+    private EQAParticipantFollowupService followupService;
+    @Autowired
+    private EqaScoreNceService eqaScoreNceService;
+
+    @Before
+    public void seedCatalogAndEnrollment() {
+        // Self-ensured seeds: other fixtures truncate the shared catalog in
+        // full-suite runs, so everything this class reads is re-inserted
+        // idempotently.
+        seedAnalyte(ANALYTE, ANALYTE_NAME);
+        seedAnalyte(SECOND_ANALYTE, "EQA Triage Analyte 2");
+        seedEnrollment(ENROLLMENT, "EQA Triage Programme");
+        clearNceTables();
+    }
+
+    /**
+     * A subclass @After runs before the base class's, so everything holding an FK
+     * into nc_event or organization is cleared here rather than left to
+     * {@code cleanEqaTables()}.
+     */
+    @After
+    public void cleanUpTriageTables() {
+        jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
+        jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
+        clearNceTables();
+        jdbc.update("DELETE FROM clinlims.organization WHERE name = 'This laboratory'");
+    }
+
+    private void seedAnalyte(long id, String name) {
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated)"
+                + " SELECT ?, ?, 'Y', now() WHERE NOT EXISTS" + " (SELECT 1 FROM clinlims.analyte WHERE id = ?)", id,
+                name, id);
+    }
+
+    private void clearNceTables() {
+        jdbc.update("DELETE FROM clinlims.nce_history WHERE nce_id IN"
+                + " (SELECT id FROM clinlims.nc_event WHERE trigger_source_type LIKE 'EQA%')");
+        jdbc.update("DELETE FROM clinlims.nc_event WHERE trigger_source_type LIKE 'EQA%'");
+    }
+
+    // ---- tiers ----
+
+    @Test
+    public void numericUnacceptableBeyondThreeSigmaCreatesOneNce() {
+        Scored scored = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.UNACCEPTABLE, new BigDecimal("3.5"),
+                "120");
+
+        List<Map<String, Object>> nces = eqaNces();
+        assertEquals("|Z|>3 unacceptable creates exactly one NCE", 1, nces.size());
+        Map<String, Object> nce = nces.get(0);
+        assertEquals(EqaScoreNceService.TRIGGER_SOURCE_EQA_UNACCEPTABLE, nce.get("trigger_source_type"));
+        assertEquals(String.valueOf(scored.resultId), nce.get("trigger_source_id"));
+        assertEquals("CRITICAL", nce.get("severity"));
+        assertEquals("Pending", nce.get("status"));
+        assertEquals(Boolean.TRUE, nce.get("auto_generated"));
+        assertEquals("Unacceptable EQA score: " + ANALYTE_NAME + " Z=3.5 in " + scored.schemeName + " cycle 1",
+                nce.get("title"));
+        assertTrue("description carries the reported value",
+                String.valueOf(nce.get("description")).contains("Reported: 120"));
+
+        assertEquals("an NCE tier never also queues", 0, followupService.getQueueRows().size());
+        assertEquals("the scoring competency event is stamped with the NCE", nce.get("id"),
+                competencyNceId(scored.resultId));
+    }
+
+    @Test
+    public void categoricalUnacceptableWithoutZScoreAlsoCreatesNce() {
+        Scored scored = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.UNACCEPTABLE, null, "Reactive");
+
+        List<Map<String, Object>> nces = eqaNces();
+        assertEquals("an external provider's unacceptable verdict stands in for a Z-score", 1, nces.size());
+        String title = String.valueOf(nces.get(0).get("title"));
+        assertEquals(
+                "Unacceptable EQA score: " + ANALYTE_NAME + " (reported Reactive) in " + scored.schemeName + " cycle 1",
+                title);
+        assertFalse("a categorical NCE carries no Z token", title.contains("Z="));
+        assertEquals(0, followupService.getQueueRows().size());
+    }
+
+    @Test
+    public void questionableBandQueuesAndNeverCreatesAnNce() {
+        Scored scored = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.UNACCEPTABLE, new BigDecimal("2.4"),
+                "108");
+
+        assertEquals("2<|Z|<=3 is a triage case, not a non-conformity", 0, eqaNces().size());
+        List<Map<String, Object>> queue = followupService.getQueueRows();
+        assertEquals(1, queue.size());
+        assertEquals("External provider", queue.get(0).get("source"));
+        assertEquals("NOTIFIED", queue.get(0).get("followupStatus"));
+        assertEquals(scored.schemeName, queue.get(0).get("schemeName"));
+
+        List<Map<String, Object>> rows = queueResults(queue.get(0));
+        assertEquals(1, rows.size());
+        assertEquals(scored.resultId.intValue(), ((Number) rows.get(0).get("participantResultId")).intValue());
+        assertEquals(2.4d, ((Number) rows.get(0).get("zScore")).doubleValue(), 0.0001d);
+        assertEquals("UNACCEPTABLE", rows.get(0).get("performanceStatus"));
+        assertEquals("108", rows.get(0).get("reported"));
+    }
+
+    @Test
+    public void questionableVerdictQueues() {
+        score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.1"), "104");
+
+        assertEquals(0, eqaNces().size());
+        assertEquals(1, followupService.getQueueRows().size());
+    }
+
+    @Test
+    public void inHouseUnacceptableQueuesAndNeverCreatesAnNce() {
+        score(EQASchemeType.IN_HOUSE, EQAPerformanceStatus.UNACCEPTABLE, null, "Negative");
+
+        assertEquals("in-house scoring is exploratory: triage first, never auto-NCE", 0, eqaNces().size());
+        List<Map<String, Object>> queue = followupService.getQueueRows();
+        assertEquals(1, queue.size());
+        assertEquals("In-house", queue.get(0).get("source"));
+    }
+
+    @Test
+    public void acceptableWithinTwoSigmaDoesNothing() {
+        score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.ACCEPTABLE, new BigDecimal("0.5"), "100");
+
+        assertEquals(0, eqaNces().size());
+        assertEquals(0, followupService.getQueueRows().size());
+        assertEquals("no competency event for a clean score", 0, competencyEventCount());
+    }
+
+    @Test
+    public void acceptableVerdictOutsideTwoSigmaStillQueues() {
+        score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.ACCEPTABLE, new BigDecimal("2.6"), "106");
+
+        assertEquals(0, eqaNces().size());
+        assertEquals("a Z past two sigma needs a human even when the verdict says acceptable", 1,
+                followupService.getQueueRows().size());
+    }
+
+    // ---- triage actions ----
+
+    @Test
+    public void escalateCreatesAnNceClosesTheRowAndIsIdempotent() {
+        Scored scored = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.2"),
+                "105");
+        Long followupId = Long.valueOf(String.valueOf(followupService.getQueueRows().get(0).get("id")));
+
+        NcEvent nce = eqaScoreNceService.escalateFollowup(followupId, USER);
+
+        assertNotNull(nce.getId());
+        assertEquals(EqaScoreNceService.TRIGGER_SOURCE_EQA_FOLLOWUP, nce.getTriggerSourceType());
+        assertEquals(String.valueOf(followupId), nce.getTriggerSourceId());
+        assertEquals("CRITICAL", nce.getSeverity());
+        assertEquals(Boolean.FALSE, nce.getAutoGenerated());
+        assertTrue("the escalated NCE names the analyte", nce.getTitle().contains(ANALYTE_NAME));
+
+        assertEquals("ESCALATED",
+                jdbc.queryForObject("SELECT followup_status FROM clinlims.eqa_participant_followup WHERE id = ?",
+                        String.class, followupId));
+        assertEquals("escalation leaves the queue", 0, followupService.getQueueRows().size());
+        assertEquals(1,
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.eqa_analyst_competency_event"
+                                + " WHERE participant_result_id = ? AND event_type = 'ESCALATED_TO_NCE' AND nce_id = ?",
+                        Integer.class, scored.resultId, nce.getId()).intValue());
+
+        NcEvent again = eqaScoreNceService.escalateFollowup(followupId, USER);
+        assertEquals("a repeated escalation returns the same NCE", nce.getId(), again.getId());
+        assertEquals("and writes no second competency event", 1,
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.eqa_analyst_competency_event"
+                                + " WHERE participant_result_id = ? AND event_type = 'ESCALATED_TO_NCE'",
+                        Integer.class, scored.resultId).intValue());
+    }
+
+    @Test
+    public void dismissMapsEveryCategoryToItsCompetencyEvent() {
+        Map<EQADismissalCategory, String> expected = Map.of(EQADismissalCategory.KNOWN_EQUIPMENT_ISSUE,
+                "DISMISSED_EQUIPMENT", EQADismissalCategory.PENDING_RE_TEST, "DISMISSED_EQUIPMENT",
+                EQADismissalCategory.TRANSCRIPTION_ERROR, "DISMISSED_TRANSCRIPTION",
+                EQADismissalCategory.ACCEPTABLE_ON_REVIEW, "DISMISSED_ACCEPTABLE_ON_REVIEW", EQADismissalCategory.OTHER,
+                "DISMISSED_OTHER");
+
+        int cycleNumber = 1;
+        for (Map.Entry<EQADismissalCategory, String> entry : expected.entrySet()) {
+            Scored scored = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.QUESTIONABLE,
+                    new BigDecimal("2.3"), "103", cycleNumber++);
+            Long followupId = openFollowupFor(scored.cycleId);
+
+            followupService.dismiss(followupId, entry.getKey(), "triaged by " + entry.getKey(), USER);
+
+            assertEquals("RESOLVED",
+                    jdbc.queryForObject("SELECT followup_status FROM clinlims.eqa_participant_followup WHERE id = ?",
+                            String.class, followupId));
+            assertEquals(entry.getKey() + " maps to " + entry.getValue(), entry.getValue(),
+                    jdbc.queryForObject(
+                            "SELECT event_type FROM clinlims.eqa_analyst_competency_event"
+                                    + " WHERE participant_result_id = ? AND dismissal_category = ?",
+                            String.class, scored.resultId, entry.getKey().name()));
+        }
+        assertEquals("dismissal never creates a non-conformity", 0, eqaNces().size());
+        assertEquals("every dismissed row leaves the queue", 0, followupService.getQueueRows().size());
+    }
+
+    @Test
+    public void dismissRefusesAnAlreadyEscalatedRow() {
+        score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.2"), "105");
+        Long followupId = Long.valueOf(String.valueOf(followupService.getQueueRows().get(0).get("id")));
+        eqaScoreNceService.escalateFollowup(followupId, USER);
+
+        try {
+            followupService.dismiss(followupId, EQADismissalCategory.OTHER, "too late", USER);
+            org.junit.Assert.fail("expected an escalated row to refuse dismissal");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("ESCALATED"));
+        }
+    }
+
+    @Test
+    public void severalFailingAnalytesShareOneQueueRowForTheCycle() {
+        Scored first = score(EQASchemeType.INTERNATIONAL_PT, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.2"),
+                "105");
+        EQACycle cycle = readBack(first.cycleId);
+        EQARound round = eqaRoundDAO.get(first.roundId).orElseThrow(AssertionError::new);
+        Long secondResultId = insertParticipantResult(cycle, round, ENROLLMENT, SECOND_ANALYTE,
+                EQASubmissionStatus.SUBMITTED, "107");
+        participantResultService.recordScore(secondResultId, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.7"),
+                null, USER);
+
+        List<Map<String, Object>> queue = followupService.getQueueRows();
+        assertEquals("the register is unique on cycle and organization", 1, queue.size());
+        List<Map<String, Object>> rows = queueResults(queue.get(0));
+        assertEquals("both failures survive the merge", 2, rows.size());
+        assertEquals(first.resultId.intValue(), ((Number) rows.get(0).get("participantResultId")).intValue());
+        assertEquals(secondResultId.intValue(), ((Number) rows.get(1).get("participantResultId")).intValue());
+    }
+
+    @Test
+    public void aResultWithNoAnalystStillReachesTheQueue() {
+        EQAProgram scheme = insertScheme("Unstaffed Scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQARound round = eqaRoundDAO.get(insertRound(cycle, 1, "OPEN")).orElseThrow(AssertionError::new);
+        Long resultId = insertParticipantResult(cycle, round, ENROLLMENT, ANALYTE, EQASubmissionStatus.SUBMITTED,
+                "109");
+
+        participantResultService.recordScore(resultId, EQAPerformanceStatus.QUESTIONABLE, new BigDecimal("2.5"), null,
+                USER);
+
+        assertEquals("triage does not depend on analyst attribution", 1, followupService.getQueueRows().size());
+        assertEquals("but competency stays an analyst log", 0, competencyEventCount());
+    }
+
+    // ---- helpers ----
+
+    private record Scored(Long resultId, Long cycleId, Long roundId, String schemeName) {
+    }
+
+    private Scored score(EQASchemeType type, EQAPerformanceStatus performance, BigDecimal zScore, String value) {
+        return score(type, performance, zScore, value, 1);
+    }
+
+    private Scored score(EQASchemeType type, EQAPerformanceStatus performance, BigDecimal zScore, String value,
+            int cycleNumber) {
+        String schemeName = "Triage Scheme " + type + " " + cycleNumber;
+        EQAProgram scheme = insertScheme(schemeName, type, type == EQASchemeType.IN_HOUSE ? null : "NHLS");
+        Long cycleId = insertCycle(scheme, cycleNumber);
+        EQACycle cycle = readBack(cycleId);
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQARound round = eqaRoundDAO.get(roundId).orElseThrow(AssertionError::new);
+
+        Long resultId = insertParticipantResult(cycle, round, ENROLLMENT, ANALYTE, EQASubmissionStatus.SUBMITTED,
+                value);
+        EQAParticipantResult result = eqaParticipantResultDAO.get(resultId).orElseThrow(AssertionError::new);
+        result.setAssignedAnalystId(ANALYST);
+        result.setSysUserId(USER);
+        eqaParticipantResultDAO.update(result);
+
+        participantResultService.recordScore(resultId, performance, zScore, null, USER);
+        return new Scored(resultId, cycleId, roundId, schemeName);
+    }
+
+    private Long openFollowupFor(Long cycleId) {
+        for (Map<String, Object> row : followupService.getQueueRows()) {
+            if (String.valueOf(cycleId).equals(String.valueOf(row.get("cycleId")))) {
+                return Long.valueOf(String.valueOf(row.get("id")));
+            }
+        }
+        throw new AssertionError("no open follow-up row for cycle " + cycleId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> queueResults(Map<String, Object> queueRow) {
+        return (List<Map<String, Object>>) queueRow.get("results");
+    }
+
+    private List<Map<String, Object>> eqaNces() {
+        return jdbc.queryForList("SELECT id, title, description, severity, status, auto_generated,"
+                + " trigger_source_type, trigger_source_id FROM clinlims.nc_event"
+                + " WHERE trigger_source_type LIKE 'EQA%' ORDER BY id");
+    }
+
+    private Object competencyNceId(Long resultId) {
+        return jdbc.queryForObject("SELECT nce_id FROM clinlims.eqa_analyst_competency_event"
+                + " WHERE participant_result_id = ? AND event_type IN ('UNACCEPTABLE_SCORE', 'QUESTIONABLE_SCORE')",
+                Integer.class, resultId);
+    }
+
+    private int competencyEventCount() {
+        return jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_analyst_competency_event", Integer.class);
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
@@ -73,8 +73,30 @@ public abstract class EQASpineTestBase extends BaseWebContextSensitiveTest {
     public void setUp() throws Exception {
         super.setUp();
         jdbc = new JdbcTemplate(dataSource);
+        ensureSystemUserOne();
         executeDataSetWithStateManagement("testdata/eqa-cycle-spine.xml");
         cleanEqaTables();
+    }
+
+    /**
+     * {@link #ADMIN_USER_ID} has to resolve to a usable entity, not just to a
+     * number: {@code eqa_cycle.created_by} and
+     * {@code eqa_analyst_competency_event.analyst_id} both reference
+     * {@code system_user}.
+     *
+     * <p>
+     * Other suites truncate {@code system_user}, and the web base restores its
+     * admin row from the sequence rather than at id 1, so in a full-suite run the
+     * row can be missing entirely. The related null-version trap is repaired in the
+     * web base, which every suite shares.
+     */
+    private void ensureSystemUserOne() {
+        jdbc.update(
+                "INSERT INTO clinlims.system_user (id, external_id, login_name, last_name, first_name,"
+                        + " initials, is_active, is_employee, lastupdated)"
+                        + " SELECT ?, 'EQA_TEST_SEED', 'eqa_test_seed', 'Seed', 'EQA', 'ES', 'Y', 'Y', now()"
+                        + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.system_user WHERE id = ?)",
+                ADMIN_USER_ID, ADMIN_USER_ID);
     }
 
     @After

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -69,6 +69,8 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQAAlertRestController#acknowledgeAlert", EQAGuards.LAB_WIDE_ALERTS);
         // Cycle lifecycle
         WRITE_GUARDS.put("EQACycleRestController#transition", EQAGuards.MANAGE);
+        WRITE_GUARDS.put("EQAFollowupRestController#escalate", EQAGuards.MANAGE);
+        WRITE_GUARDS.put("EQAFollowupRestController#dismiss", EQAGuards.MANAGE);
         // Provider-round management
         WRITE_GUARDS.put("EQADistributionRestController#createDistribution", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQADistributionRestController#updateDistribution", EQAGuards.PROVIDER);


### PR DESCRIPTION
Implements FR-V2.3-01 and the FR-V2.3-02 triage actions.

## Why this is not additive

`EQAParticipantResultServiceImpl.onResultScored` shipped as an empty method carrying the comment *"the adapter replaces this body"*, and the in-house auto-score from OGC-612 already calls it. So every blinded panel that scored an unacceptable result raised nothing and queued nothing. That is the hole this closes.

## The tiers

| Scored result | Outcome |
|---|---|
| External, unacceptable, \|Z\| > 3 | NCE |
| External, unacceptable, no Z returned | NCE |
| External, unacceptable, \|Z\| ≤ 3 | Follow-Up Queue |
| Questionable, or 2 < \|Z\| ≤ 3 | Follow-Up Queue |
| In-house, unacceptable | Follow-Up Queue, never an NCE |
| \|Z\| ≤ 2 and not flagged | nothing |

Two readings are worth calling out, because the OGC-611 summary and FR-V2.3-01's body disagree:

- **Categorical / null-Z external unacceptable raises an NCE.** The ticket summary says it should queue instead, but the FR body says it takes "the same NCE auto-create path as numeric unacceptable", and gives the reason: HIV qualitative, TB smear grading and blood-film ID have no Z by construction, so an external provider calling the result unacceptable *is* the judgement. The never-auto-NCE rule is the in-house rule (FR-V2.4-08).
- **An external unacceptable inside two sigma is queued, not ignored.** FR-V2.3-01's last tier reads "no action" for |Z| ≤ 2, but a provider verdict that contradicts its own Z is a triage case; dropping it would lose an explicit unacceptable.

**AC-V2.5-10 holds structurally.** `eqa_participant_result.lab_enrollment_id` references `eqa_lab_program_enrollment` — this lab's own enrollments — so a remote participant's result cannot reach the adapter at all. Provider-side underperformance stays with the V2.5 register.

## Consolidation rather than new parallel code

- The in-house enqueue, its JSON merge and the site-name-derived organization lookup move out of `EQABlindingServiceImpl` into a new `EQAParticipantFollowupService`, so both tiers register through one path. **Blinding no longer enqueues** — that is what stops a failure being registered twice — and the Source label now follows `scheme_type` instead of always reading "In-house". Blinding is 123 lines shorter.
- Competency events get one writer, `EQAAnalystCompetencyService`. The "no analyst, no event" rule and NCE attribution live in a single place.
- `recordScore` takes the provider's Z-score. External score intake should call this rather than writing `z_score` behind the service.

## Triage API

`GET /rest/eqa/followups` under the read umbrella; `POST /rest/eqa/followups/{id}/escalate` and `/dismiss` under the manage tier, both registered in `EQARestGuardMatrixTest`. Queue rows carry cycle, scheme, Source and the per-result JSON that the Analyte and Z-score columns need. Escalation creates one NCE per queue row and returns the same NCE on a repeated click; dismissal maps the five FR-V2.3-02 categories onto their four competency event types.

Both trigger sources are `EQA_`-prefixed (`EQA_UNACCEPTABLE`, `EQA_FOLLOWUP_ESCALATION`) for the `?source=eqa` deep-link contract.

## No changeset

The card reserved a liquibase slot for a dismissal-category mapping table. `EQADismissalCategory`, `EQACompetencyEventType` and the `followup_status` CHECK already ship every value FR-V2.3-02 needs, so the 5→4 mapping is a switch. Seeded + admin-editable mapping is deferred until a lab needs to re-map a category.

## Tests

`EQAScoreTriageIntegrationTest` — 12 tests: all tiers, both trigger sources, escalate idempotency, all five dismissal mappings, the multi-analyte merge into one cycle row, and a failing result with no assigned analyst reaching the queue while writing no competency row.

The second commit fixes a suite-order fault that predates this branch: 56 EQA tests errored in a full-suite run while passing in isolation, because a fixture elsewhere leaves `system_user` id 1 with a null `lastupdated`, and that column is the Hibernate version — a null version makes a loaded entity read as transient. Repaired in the web base. `mvn test` over `org.openelisglobal.eqa.**` + `org.openelisglobal.qaevent.**` goes from 68 errors to **621/621 passing**; a 424-test slice over the `system_user`-heavy suites (systemuser, audittrail, role, login, qc) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)