### PR TITLE
feat(eqa-v2): automatic result submission, fallbacks and score intake (OGC-610)

### DIFF
--- a/frontend/src/components/eqa/InlineEnrollmentForm.jsx
+++ b/frontend/src/components/eqa/InlineEnrollmentForm.jsx
@@ -7,6 +7,8 @@ import {
   Toggle,
   Button,
   FilterableMultiSelect,
+  Select,
+  SelectItem,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../utils/Utils";
@@ -30,17 +32,22 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
   const [selectedLabUnits, setSelectedLabUnits] = useState([]);
   const [selectedTests, setSelectedTests] = useState([]);
   const [selectedPanels, setSelectedPanels] = useState([]);
+  // Which analyte each selected test reports for this scheme, keyed by test id.
+  // Automatic submission cannot name an analyte without this: a result row only
+  // carries one when the test has a test_analyte mapping, which most do not.
+  const [testAnalytes, setTestAnalytes] = useState({});
   const [dataReady, setDataReady] = useState(false);
 
   const [labUnits, setLabUnits] = useState([]);
   const [tests, setTests] = useState([]);
   const [panels, setPanels] = useState([]);
+  const [analytes, setAnalytes] = useState([]);
 
   useEffect(() => {
     let loaded = 0;
     const checkReady = () => {
       loaded++;
-      if (loaded >= 3) setDataReady(true);
+      if (loaded >= 4) setDataReady(true);
     };
 
     getFromOpenElisServer("/rest/displayList/TEST_SECTION_ACTIVE", (data) => {
@@ -71,7 +78,19 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
             .map((t) => items.find((te) => te.id === String(t.id)))
             .filter(Boolean);
           setSelectedTests(selected);
+          const mapped = {};
+          (enrollment.tests || []).forEach((t) => {
+            if (t.analyteId) mapped[String(t.id)] = String(t.analyteId);
+          });
+          setTestAnalytes(mapped);
         }
+      }
+      checkReady();
+    });
+
+    getFromOpenElisServer("/rest/eqa/my-programs/analytes", (data) => {
+      if (data) {
+        setAnalytes(data.map((a) => ({ id: String(a.id), text: a.value })));
       }
       checkReady();
     });
@@ -101,6 +120,11 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
       labUnitIds: selectedLabUnits.map((u) => Number(u.id)),
       testIds: selectedTests.map((t) => Number(t.id)),
       panelIds: selectedPanels.map((p) => Number(p.id)),
+      // Only for tests still selected, so deselecting one drops its analyte too.
+      testAnalytes: selectedTests.reduce((acc, t) => {
+        if (testAnalytes[t.id]) acc[Number(t.id)] = Number(testAnalytes[t.id]);
+        return acc;
+      }, {}),
     };
     onSave(payload);
   };
@@ -209,6 +233,54 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
               })}
             />
           </Column>
+        </Grid>
+      )}
+
+      {dataReady && selectedTests.length > 0 && (
+        <Grid style={{ marginTop: "1rem" }}>
+          <Column lg={16} md={8} sm={4}>
+            <h6 style={{ marginBottom: "0.5rem" }}>
+              {intl.formatMessage({ id: "eqa.enrollment.testAnalytes" })}
+            </h6>
+            <p
+              style={{
+                fontSize: "0.75rem",
+                marginBottom: "0.75rem",
+                color: "#525252",
+              }}
+            >
+              {intl.formatMessage({ id: "eqa.enrollment.testAnalytes.help" })}
+            </p>
+          </Column>
+          {selectedTests.map((test) => (
+            <Column lg={5} md={4} sm={4} key={test.id}>
+              <Select
+                id={`enrollment-analyte-${test.id}`}
+                labelText={test.text}
+                value={testAnalytes[test.id] || ""}
+                onChange={(e) =>
+                  setTestAnalytes({
+                    ...testAnalytes,
+                    [test.id]: e.target.value,
+                  })
+                }
+              >
+                <SelectItem
+                  value=""
+                  text={intl.formatMessage({
+                    id: "eqa.enrollment.selectAnalyte",
+                  })}
+                />
+                {analytes.map((analyte) => (
+                  <SelectItem
+                    key={analyte.id}
+                    value={analyte.id}
+                    text={analyte.text}
+                  />
+                ))}
+              </Select>
+            </Column>
+          ))}
         </Grid>
       )}
 

--- a/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
+++ b/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
@@ -85,6 +85,11 @@ describe("MyProgramsPage", () => {
         ]);
       } else if (url === "/rest/displayList/PANELS") {
         callback([{ id: 200, value: "Basic Metabolic Panel" }]);
+      } else if (url === "/rest/eqa/my-programs/analytes") {
+        callback([
+          { id: 900, value: "Glucose (serum)" },
+          { id: 901, value: "Creatinine (serum)" },
+        ]);
       }
     });
   });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8308,5 +8308,8 @@
   "eqa.inhouse.storageTemp.DRY_ICE": "Dry ice",
   "eqa.inhouse.back": "Back",
   "eqa.inhouse.next": "Next",
-  "eqa.inhouse.cancel": "Cancel"
+  "eqa.inhouse.cancel": "Cancel",
+  "eqa.enrollment.testAnalytes": "Reporting analyte per test",
+  "eqa.enrollment.testAnalytes.help": "Set which analyte each test reports for this scheme. Results are submitted to the provider under this analyte; a test left unset is not submitted automatically.",
+  "eqa.enrollment.selectAnalyte": "Choose an analyte"
 }

--- a/src/main/java/org/openelisglobal/alert/valueholder/AlertType.java
+++ b/src/main/java/org/openelisglobal/alert/valueholder/AlertType.java
@@ -55,5 +55,11 @@ public enum AlertType {
      * A saved result outside its authored critical bounds (OGC-1022 R3); entity is
      * the ANALYSIS carrying the value
      */
-    CRITICAL_RESULT
+    CRITICAL_RESULT,
+
+    /**
+     * Automatic EQA result submission exhausted its retries (FR-V2.2-05); entity is
+     * the EQA CYCLE that could not be submitted
+     */
+    EQA_SUBMISSION_FAILED
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.openelisglobal.analyte.service.AnalyteService;
 import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
 import org.openelisglobal.eqa.valueholder.EQALabEnrollmentTestMap;
@@ -31,6 +32,9 @@ public class EQAMyProgramsRestController extends ControllerUtills {
 
     @Autowired
     private EQALabProgramEnrollmentService enrollmentService;
+
+    @Autowired
+    private AnalyteService analyteService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<Map<String, Object>>> listMyPrograms() {
@@ -75,7 +79,7 @@ public class EQAMyProgramsRestController extends ControllerUtills {
             List<Long> panelIds = toLongList(body.get("panelIds"));
 
             EQALabProgramEnrollment created = enrollmentService.createEnrollment(enrollment, labUnitIds, testIds,
-                    panelIds);
+                    panelIds, toLongMap(body.get("testAnalytes")));
             return ResponseEntity.status(HttpStatus.CREATED).body(toDto(created));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
@@ -109,7 +113,7 @@ public class EQAMyProgramsRestController extends ControllerUtills {
             List<Long> panelIds = toLongList(body.get("panelIds"));
 
             EQALabProgramEnrollment result = enrollmentService.updateEnrollment(id, updated, labUnitIds, testIds,
-                    panelIds);
+                    panelIds, toLongMap(body.get("testAnalytes")));
             return ResponseEntity.ok(toDto(result));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
@@ -127,6 +131,24 @@ public class EQAMyProgramsRestController extends ControllerUtills {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
         }
+    }
+
+    /**
+     * Analytes for the enrollment form's per-test selector, in the {id, value}
+     * shape the Carbon selects already consume. Served here rather than as a new
+     * DisplayListService type: that registry caches and refreshes in three places,
+     * and this list has one consumer.
+     */
+    @GetMapping(value = "/analytes", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<Map<String, Object>>> getAnalytes() {
+        List<Map<String, Object>> analytes = analyteService.getAll().stream().map(a -> {
+            Map<String, Object> m = new HashMap<>();
+            m.put("id", a.getId());
+            m.put("value", a.getAnalyteName());
+            return m;
+        }).sorted((left, right) -> String.valueOf(left.get("value"))
+                .compareToIgnoreCase(String.valueOf(right.get("value")))).collect(Collectors.toList());
+        return ResponseEntity.ok(analytes);
     }
 
     @GetMapping(value = "/providers", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -157,6 +179,7 @@ public class EQAMyProgramsRestController extends ControllerUtills {
             if (tm.getTestId() != null) {
                 Map<String, Object> m = new HashMap<>();
                 m.put("id", tm.getTestId());
+                m.put("analyteId", tm.getAnalyteId());
                 tests.add(m);
             }
             if (tm.getPanelId() != null) {
@@ -169,6 +192,26 @@ public class EQAMyProgramsRestController extends ControllerUtills {
         dto.put("panels", panels);
 
         return dto;
+    }
+
+    /** {"testAnalytes": {"314": 9802}} — JSON object keys arrive as strings. */
+    private Map<Long, Long> toLongMap(Object obj) {
+        if (!(obj instanceof Map)) {
+            return Map.of();
+        }
+        Map<Long, Long> parsed = new HashMap<>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) obj).entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            try {
+                parsed.put(Long.valueOf(String.valueOf(entry.getKey())),
+                        Long.valueOf(String.valueOf(entry.getValue())));
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("testAnalytes must map test ids to analyte ids");
+            }
+        }
+        return parsed;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAParticipantResultRestController.java
@@ -101,7 +101,12 @@ public class EQAParticipantResultRestController extends BaseRestController {
                 .ok(Map.of("id", updated.getId(), "submissionStatus", updated.getSubmissionStatus().name()));
     }
 
-    /** Score intake is a provider/officer act, so it takes the manage grant. */
+    /**
+     * Score intake is a provider/officer act, so it takes the manage grant. An
+     * external scheme's Z-score is passed through to the Z-carrying overload: the
+     * FR-V2.3-01 tiers read z_score, so dropping it here would silently downgrade
+     * every external unacceptable to the no-Z path.
+     */
     @PatchMapping(value = "/participant-results/{id}/score", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.MANAGE)
     public ResponseEntity<Map<String, Object>> score(HttpServletRequest request, @PathVariable Long id,
@@ -117,9 +122,25 @@ public class EQAParticipantResultRestController extends BaseRestController {
             return ResponseEntity.badRequest().body(Map.of("error", "Unknown performance status"));
         }
 
-        EQAParticipantResult scored = resultService.recordScore(id, verdict, longField(body, "eqaResultId"),
-                getSysUserId(request));
+        EQAParticipantResult scored = resultService.recordScore(id, verdict, decimalField(body, "zScore"),
+                longField(body, "eqaResultId"), getSysUserId(request));
         return ResponseEntity.ok(Map.of("id", scored.getId(), "submissionStatus", scored.getSubmissionStatus().name()));
+    }
+
+    /**
+     * No inherited equivalent: BaseRestController hoists the string, long and
+     * integer readers, and a z-score is the first decimal any EQA body carries.
+     */
+    private java.math.BigDecimal decimalField(Map<String, Object> body, String key) {
+        Object value = body.get(key);
+        if (value == null || String.valueOf(value).isBlank()) {
+            return null;
+        }
+        try {
+            return new java.math.BigDecimal(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(key + " must be a number");
+        }
     }
 
     private Long longOrNull(String value) {

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
@@ -1,25 +1,35 @@
 package org.openelisglobal.eqa.controller.rest;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.Map;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQACycleSubmissionService;
 import org.openelisglobal.eqa.service.EQAFhirSubmissionService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/eqa")
 @PreAuthorize(EQAGuards.READ)
-public class EQASubmissionRestController {
+public class EQASubmissionRestController extends BaseRestController {
 
     @Autowired
     private EQAFhirSubmissionService fhirSubmissionService;
+
+    @Autowired
+    private EQACycleSubmissionService cycleSubmissionService;
 
     @PostMapping(value = "/distributions/{distributionId}/submit/{organizationId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PARTICIPANT)
@@ -38,6 +48,53 @@ public class EQASubmissionRestController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "Submission failed: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * FR-V2.2-06 manual fallback. The provider's reference is mandatory: without it
+     * a manual submission is a claim rather than a record.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/submit-manual", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PARTICIPANT)
+    public ResponseEntity<?> submitManually(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestParam(required = false) Long labEnrollmentId, @RequestBody Map<String, String> body) {
+        String reference = body.get("manualSubmissionReference");
+        try {
+            EQACycle cycle = cycleSubmissionService.submitManually(cycleId, labEnrollmentId, reference,
+                    getSysUserId(request));
+            return ResponseEntity.ok(Map.of("cycleId", cycle.getId(), "status", cycle.getStatus().name(), "channel",
+                    "MANUAL", "manualSubmissionReference", reference.trim()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /** FR-V2.2-06 export bundle: what a lab uploads to the provider by hand. */
+    @GetMapping(value = "/cycles/{cycleId}/export-bundle", produces = "text/csv")
+    public ResponseEntity<String> exportBundle(@PathVariable Long cycleId,
+            @RequestParam(required = false) Long labEnrollmentId) {
+        String csv = cycleSubmissionService.exportBundleCsv(cycleId, labEnrollmentId);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"eqa-cycle-" + cycleId + "-results.csv\"")
+                .body(csv);
+    }
+
+    /**
+     * FR-V2.2-08 score intake: the provider's verdicts, with the Z-score the
+     * FR-V2.3-01 tiers read. Provider act, so it takes the manage grant.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/score-intake", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public ResponseEntity<?> intakeScores(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestParam(required = false) Long labEnrollmentId, @RequestBody List<Map<String, Object>> scores) {
+        try {
+            int scored = cycleSubmissionService.intakeScores(cycleId, labEnrollmentId, scores, getSysUserId(request));
+            return ResponseEntity.ok(Map.of("cycleId", cycleId, "scored", scored));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
         }
     }
 

--- a/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
+++ b/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
@@ -21,6 +21,7 @@ import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.dao.SampleEQADAO;
 import org.openelisglobal.eqa.service.EQABlindingService;
+import org.openelisglobal.eqa.service.EQACycleSubmissionService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
@@ -84,6 +85,9 @@ public class EQADeadlineAlertScheduler {
 
     @Autowired
     private EQABlindingService blindingService;
+
+    @Autowired
+    private EQACycleSubmissionService cycleSubmissionService;
 
     @Scheduled(fixedDelay = 300000)
     public void checkEQADeadlines() {
@@ -259,6 +263,27 @@ public class EQADeadlineAlertScheduler {
                 logger.info("Auto-unblinded in-house panel {}", panel.getId());
             } catch (RuntimeException e) {
                 logger.error("Auto-unblind failed for panel {}", panel.getId(), e);
+            }
+        }
+    }
+
+    /**
+     * FR-V2.2-05 automatic submission: bridge each participant cycle's validated
+     * results onto its own rows, advance the participant state machine, and post to
+     * the provider once the review window has elapsed. Per-cycle calls in a
+     * try/catch, like the unblind pass above — one unreachable cycle must not abort
+     * the sweep, and the submission window makes a 5-minute cadence plenty.
+     */
+    @Scheduled(fixedDelay = 300000)
+    public void advanceEQASubmissions() {
+        logger.debug("Running EQA submission sweep...");
+        for (Long cycleId : cycleSubmissionService.findAdvanceCandidates()) {
+            try {
+                if (cycleSubmissionService.advanceCycle(cycleId)) {
+                    logger.info("Advanced EQA cycle {}", cycleId);
+                }
+            } catch (RuntimeException e) {
+                logger.error("EQA submission sweep failed for cycle {}", cycleId, e);
             }
         }
     }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
@@ -1,0 +1,61 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+
+/**
+ * Automatic submission of a participant cycle's results, and the two fallbacks
+ * around it (OGC-610, FR-V2.2-05 / FR-V2.2-06 / FR-V2.2-08).
+ *
+ * <p>
+ * This is also the only production path that bridges the standard result
+ * pipeline into {@code eqa_participant_result} for an external scheme. Before
+ * it, the table had exactly two writers: the participant-result REST controller
+ * and the in-house blinding service — so a lab that ordered an EQA sample,
+ * entered its result and validated it produced no EQA-side row at all, and its
+ * cycle stayed in the state its panel receipt left it in.
+ */
+public interface EQACycleSubmissionService {
+
+    /**
+     * Cycles worth a look this tick: participant-side states in which results can
+     * still arrive or a submission can still be owed.
+     */
+    List<Long> findAdvanceCandidates();
+
+    /**
+     * Bridge this cycle's validated analyses into participant results, advance the
+     * participant state machine as far as the evidence allows, and submit when
+     * FR-V2.2-05's preconditions are met. Idempotent: a re-run over an unchanged
+     * cycle writes nothing.
+     *
+     * @return true when anything changed, for the scheduler's log line
+     */
+    boolean advanceCycle(Long cycleId);
+
+    /**
+     * FR-V2.2-06 manual fallback: record that this lab submitted outside OpenELIS.
+     * The provider's reference is mandatory — an unreferenced manual submission is
+     * indistinguishable from a lab claiming it submitted.
+     *
+     * @throws IllegalArgumentException when the reference is missing
+     */
+    EQACycle submitManually(Long cycleId, Long labEnrollmentId, String reference, String sysUserId);
+
+    /**
+     * FR-V2.2-06 export bundle: this lab's submittable results as CSV, for a
+     * provider portal upload or an email attachment.
+     */
+    String exportBundleCsv(Long cycleId, Long labEnrollmentId);
+
+    /**
+     * FR-V2.2-08 score intake: the provider's verdicts coming back. Each entry
+     * carries {@code resultId} or {@code analyteId}, {@code performance}, and an
+     * optional {@code zScore}. The cycle moves to SCORED once every submitted
+     * result carries a verdict.
+     *
+     * @return how many results were scored
+     */
+    int intakeScores(Long cycleId, Long labEnrollmentId, List<Map<String, Object>> scores, String sysUserId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -1,0 +1,659 @@
+package org.openelisglobal.eqa.service;
+
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.CLOSED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.PANEL_RECEIVED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.PLANNED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.READY_TO_SUBMIT;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SCORED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.SUBMITTED;
+import static org.openelisglobal.eqa.valueholder.EQACycleStatus.TESTING;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.GenericValidator;
+import org.openelisglobal.alert.service.AlertService;
+import org.openelisglobal.alert.valueholder.AlertSeverity;
+import org.openelisglobal.alert.valueholder.AlertType;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyte.valueholder.Analyte;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.eqa.dao.EQALabProgramEnrollmentDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
+import org.openelisglobal.eqa.dao.SampleEQADAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQALabEnrollmentTestMap;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQASubmissionChannel;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.openelisglobal.eqa.valueholder.SampleEQA;
+import org.openelisglobal.result.service.ResultService;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.testanalyte.service.TestAnalyteService;
+import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** See {@link EQACycleSubmissionService}. */
+@Service
+@Transactional
+public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EQACycleSubmissionServiceImpl.class);
+
+    /** FR-V2.2-05. */
+    private static final int MAX_ATTEMPTS = 5;
+
+    private static final String ENTITY_TYPE_EQA_CYCLE = "EQACycle";
+
+    /** System actor for sweep-initiated writes, as in EQADeadlineAlertScheduler. */
+    private static final String SCHEDULER_USER = "1";
+
+    /** The participant machine in order (FR-V2.1-04), walked one edge at a time. */
+    private static final List<EQACycleStatus> PARTICIPANT_PATH = List.of(PLANNED, PANEL_RECEIVED, TESTING,
+            READY_TO_SUBMIT, SUBMITTED, SCORED, CLOSED);
+
+    /** States in which more results can arrive or a submission is still owed. */
+    private static final Set<EQACycleStatus> ADVANCEABLE = EnumSet.of(PLANNED, PANEL_RECEIVED, TESTING,
+            READY_TO_SUBMIT);
+
+    /** A result that counts as this lab's answer for its analyte. */
+    private static final Set<EQASubmissionStatus> ANSWERED = EnumSet.of(EQASubmissionStatus.VALIDATED_PARTIAL,
+            EQASubmissionStatus.SUBMITTED, EQASubmissionStatus.SCORED);
+
+    /** Sent, or awaiting scoring after being sent. */
+    private static final Set<EQASubmissionStatus> SUBMITTABLE = EnumSet.of(EQASubmissionStatus.VALIDATED_PARTIAL,
+            EQASubmissionStatus.SUBMITTED);
+
+    @Value("${org.openelisglobal.eqa.submission.windowHours:1}")
+    private long windowHours;
+
+    @Value("${org.openelisglobal.eqa.submission.retryBaseMinutes:15}")
+    private long retryBaseMinutes;
+
+    @Autowired
+    private EQACycleDAO cycleDAO;
+
+    @Autowired
+    private EQACycleService cycleService;
+
+    @Autowired
+    private EQARoundDAO roundDAO;
+
+    @Autowired
+    private EQAParticipantResultDAO participantResultDAO;
+
+    @Autowired
+    private EQAParticipantResultService participantResultService;
+
+    @Autowired
+    private SampleEQADAO sampleEQADAO;
+
+    @Autowired
+    private EQALabProgramEnrollmentDAO enrollmentDAO;
+
+    @Autowired
+    private TestAnalyteService testAnalyteService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private ResultService resultService;
+
+    @Autowired
+    private IStatusService statusService;
+
+    @Autowired
+    private EQAFhirSubmissionService fhirSubmissionService;
+
+    @Autowired
+    private AlertService alertService;
+
+    @Autowired
+    private FhirConfig fhirConfig;
+
+    /** Package-private setter so tests can pin the submission window. */
+    private Clock clock = Clock.systemDefaultZone();
+
+    void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Long> findAdvanceCandidates() {
+        Set<Long> ids = new LinkedHashSet<>();
+        for (EQACycleStatus status : ADVANCEABLE) {
+            for (EQACycle cycle : cycleDAO.getAllMatching("status", status)) {
+                ids.add(cycle.getId());
+            }
+        }
+        return new ArrayList<>(ids);
+    }
+
+    @Override
+    public boolean advanceCycle(Long cycleId) {
+        EQACycle cycle = cycleDAO.get(cycleId).orElse(null);
+        if (cycle == null || !ADVANCEABLE.contains(cycle.getStatus())) {
+            return false;
+        }
+        EQAProgram scheme = cycle.getScheme();
+        // An in-house cycle is driven by the blinding service, which creates its
+        // results, submits and scores them itself (FR-V2.4-06). Sweeping it here
+        // would race that path and submit blinded answers to nobody.
+        if (scheme == null || scheme.getSchemeType() == EQASchemeType.IN_HOUSE) {
+            return false;
+        }
+
+        Tally tally = bridgeResults(cycle, SCHEDULER_USER);
+        if (tally.answered == 0) {
+            return tally.written > 0;
+        }
+
+        boolean changed = tally.written > 0;
+        EQACycleStatus target = tally.answered >= tally.expected ? READY_TO_SUBMIT : TESTING;
+        changed |= advanceTo(cycle, target, EQATriggerType.AUTO, EQATriggerEvent.LAST_VALIDATED_RESULT, null, null,
+                SCHEDULER_USER);
+
+        if (target == READY_TO_SUBMIT) {
+            changed |= submitIfDue(cycleDAO.get(cycleId).orElseThrow(), scheme);
+        }
+        return changed;
+    }
+
+    // ---- bridge: standard pipeline -> eqa_participant_result ----
+
+    /**
+     * One participant result per analyte the lab actually reported, promoted to
+     * VALIDATED_PARTIAL once its analysis is finalized. The denominator is
+     * analyses, not analytes: a not-yet-finalized analysis has no result rows to
+     * count, so counting analytes would call a half-finished cycle complete.
+     */
+    private Tally bridgeResults(EQACycle cycle, String sysUserId) {
+        Tally tally = new Tally();
+        String finalizedId = statusService.getStatusID(AnalysisStatus.Finalized);
+        String canceledId = statusService.getStatusID(AnalysisStatus.Canceled);
+        List<EQARound> rounds = roundDAO.getAllMatching("cycle.id", cycle.getId());
+
+        for (SampleEQA sample : sampleEQADAO.getAllMatching("cycleId", cycle.getId())) {
+            if (!Boolean.TRUE.equals(sample.getIsEqaSample()) || sample.getSampleId() == null) {
+                continue;
+            }
+            Long enrollmentId = sample.getEqaEnrollmentId();
+            Long roundId = resolveRound(sample, rounds);
+            if (enrollmentId == null || roundId == null) {
+                // Refused rather than guessed: eqa_participant_result.round_id and
+                // lab_enrollment_id are both NOT NULL, and filing a result under the
+                // wrong round misattributes an ISO 15189 record. A multi-round cycle
+                // whose orders do not name their round needs the order to carry it.
+                logger.warn("EQA sample {} skipped: enrollment={} round={} (cycle {})", sample.getSampleId(),
+                        enrollmentId, roundId, cycle.getId());
+                continue;
+            }
+
+            Map<Long, Long> schemeAnalytes = analyteByTest(enrollmentId);
+            for (Analysis analysis : analysisService.getAnalysesBySampleId(String.valueOf(sample.getSampleId()))) {
+                if (canceledId.equals(analysis.getStatusId())) {
+                    continue;
+                }
+                tally.expected++;
+                if (!finalizedId.equals(analysis.getStatusId())) {
+                    continue;
+                }
+                if (bridgeAnalysis(cycle, roundId, enrollmentId, analysis, schemeAnalytes, sysUserId, tally)) {
+                    tally.answered++;
+                }
+            }
+        }
+        return tally;
+    }
+
+    /**
+     * @return true when this analysis now has at least one answered participant
+     *         result
+     */
+    private boolean bridgeAnalysis(EQACycle cycle, Long roundId, Long enrollmentId, Analysis analysis,
+            Map<Long, Long> schemeAnalytes, String sysUserId, Tally tally) {
+        boolean answered = false;
+        for (Result pipelineResult : resultService.getResultsByAnalysis(analysis)) {
+            String value = resultService.getResultValue(pipelineResult, ",", true, false);
+            if (GenericValidator.isBlankOrNull(value)) {
+                continue;
+            }
+            Long analyteId = analyteIdOf(pipelineResult, analysis, schemeAnalytes);
+            if (analyteId == null) {
+                // Logged rather than skipped quietly: the cycle then stays short of
+                // its denominator and never submits, and this line is the only thing
+                // that says why.
+                logger.warn(
+                        "EQA analysis {} (test {}) reports no analyte; map the test to its scheme analyte on the"
+                                + " enrollment before this cycle can be submitted",
+                        analysis.getId(), analysis.getTest() == null ? "?" : analysis.getTest().getId());
+                continue;
+            }
+            if (upsert(cycle, roundId, enrollmentId, analysis, analyteId, value.trim(), sysUserId, tally)) {
+                answered = true;
+            }
+        }
+        return answered;
+    }
+
+    /**
+     * eqa_participant_result.analyte_id is a NOT NULL FK, so a result with no
+     * resolvable analyte cannot be bridged. Three sources, in order of how
+     * specifically each one describes THIS value:
+     *
+     * <ol>
+     * <li>the result's own analyte — the only source with the right grain when one
+     * test reports several analytes. ResultSaveService fills it from test_analyte,
+     * and only when such a row exists.
+     * <li>the enrollment's scheme mapping (qa/030) — what the lab declared this
+     * test reports for this scheme. The normal external-PT case: most test
+     * configurations carry no test_analyte row at all, so source 1 is null.
+     * <li>test_analyte for the analysis's test — covers a result saved before the
+     * catalog mapping was added.
+     * </ol>
+     */
+    private Long analyteIdOf(Result pipelineResult, Analysis analysis, Map<Long, Long> schemeAnalytes) {
+        Analyte reported = pipelineResult.getAnalyte();
+        if (reported != null && reported.getId() != null) {
+            return Long.valueOf(reported.getId());
+        }
+        Long testId = analysis.getTest() == null ? null : Long.valueOf(analysis.getTest().getId());
+        if (testId != null && schemeAnalytes.get(testId) != null) {
+            return schemeAnalytes.get(testId);
+        }
+        if (analysis.getTest() == null) {
+            return null;
+        }
+        for (TestAnalyte testAnalyte : testAnalyteService.getAllTestAnalytesPerTest(analysis.getTest())) {
+            if (testAnalyte.getAnalyte() != null && testAnalyte.getAnalyte().getId() != null) {
+                return Long.valueOf(testAnalyte.getAnalyte().getId());
+            }
+        }
+        return null;
+    }
+
+    /** This enrollment's declared test-to-analyte mapping, empty when unmapped. */
+    private Map<Long, Long> analyteByTest(Long enrollmentId) {
+        return enrollmentDAO.get(enrollmentId).map(enrollment -> {
+            Map<Long, Long> byTest = new java.util.HashMap<>();
+            for (EQALabEnrollmentTestMap testMap : enrollment.getTestMaps()) {
+                if (testMap.getTestId() != null && testMap.getAnalyteId() != null) {
+                    byTest.put(testMap.getTestId(), testMap.getAnalyteId());
+                }
+            }
+            return byTest;
+        }).orElseGet(Map::of);
+    }
+
+    private boolean upsert(EQACycle cycle, Long roundId, Long enrollmentId, Analysis analysis, Long analyteId,
+            String value, String sysUserId, Tally tally) {
+        List<EQAParticipantResult> existing = participantResultDAO
+                .getAllMatching(Map.of("round.id", roundId, "labEnrollmentId", enrollmentId, "analyteId", analyteId));
+        EQAParticipantResult row = existing.isEmpty() ? null : existing.get(0);
+
+        if (row == null) {
+            row = new EQAParticipantResult();
+            row.setCycle(cycle);
+            EQARound roundRef = new EQARound();
+            roundRef.setId(roundId);
+            row.setRound(roundRef);
+            row.setLabEnrollmentId(enrollmentId);
+            row.setAnalyteId(analyteId);
+            row.setAnalysisId(Long.valueOf(analysis.getId()));
+            row.setResultValue(value);
+            row.setSysUserId(sysUserId);
+            row = participantResultService.saveDraft(row);
+            tally.written++;
+        } else if (row.getSubmissionStatus() == EQASubmissionStatus.DRAFT && !value.equals(row.getResultValue())) {
+            // External PT is one result per analyte per round, so a second sample
+            // reporting the same analyte updates this row rather than adding one —
+            // the partial unique index would refuse the insert anyway.
+            row.setResultValue(value);
+            row.setSysUserId(sysUserId);
+            row = participantResultService.saveDraft(row);
+            tally.written++;
+        }
+
+        if (row.getSubmissionStatus() == EQASubmissionStatus.DRAFT) {
+            row = participantResultService.transitionStatus(row.getId(), EQASubmissionStatus.VALIDATED_PARTIAL,
+                    sysUserId);
+            tally.written++;
+        }
+        return ANSWERED.contains(row.getSubmissionStatus());
+    }
+
+    /**
+     * The order's own round when it carries one, otherwise the cycle's single
+     * round. A multi-round cycle is never guessed at.
+     */
+    private Long resolveRound(SampleEQA sample, List<EQARound> rounds) {
+        if (sample.getRoundId() != null) {
+            return sample.getRoundId();
+        }
+        return rounds.size() == 1 ? rounds.get(0).getId() : null;
+    }
+
+    // ---- submission ----
+
+    /**
+     * FR-V2.2-05: submit automatically only when the scheme delegates it, an
+     * endpoint exists, the review window has elapsed and the retry budget allows
+     * another try.
+     */
+    private boolean submitIfDue(EQACycle cycle, EQAProgram scheme) {
+        if (cycle.getStatus() != READY_TO_SUBMIT || Boolean.TRUE.equals(scheme.getRequiresCycleReview())) {
+            return false;
+        }
+        // No FHIR store configured is the manual-fallback deployment (FR-V2.2-06),
+        // not a failure: attempting a post would burn the retry budget on a
+        // submission channel this lab never had.
+        if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
+            return false;
+        }
+
+        Timestamp readyAt = readyToSubmitAt(cycle.getId());
+        Instant now = clock.instant();
+        if (readyAt == null || now.isBefore(readyAt.toInstant().plus(windowHours, ChronoUnit.HOURS))) {
+            return false;
+        }
+
+        int attempts = cycle.getSubmissionAttempts() == null ? 0 : cycle.getSubmissionAttempts();
+        if (attempts >= MAX_ATTEMPTS) {
+            return false;
+        }
+        if (cycle.getLastSubmissionAttemptAt() != null && now.isBefore(
+                cycle.getLastSubmissionAttemptAt().toInstant().plus(backoffMinutes(attempts), ChronoUnit.MINUTES))) {
+            return false;
+        }
+
+        List<Long> enrollments = submittingEnrollments(cycle.getId());
+        if (enrollments.isEmpty()) {
+            return false;
+        }
+
+        boolean allSent = true;
+        for (Long enrollmentId : enrollments) {
+            if (!fhirSubmissionService.submitCycleViaFhir(cycle.getId(), enrollmentId)) {
+                allSent = false;
+            }
+        }
+
+        if (allSent) {
+            for (Long enrollmentId : enrollments) {
+                markSent(cycle.getId(), enrollmentId, EQASubmissionChannel.FHIR, null, SCHEDULER_USER);
+            }
+            advanceTo(cycle, SUBMITTED, EQATriggerType.AUTO, EQATriggerEvent.FHIR_SUBMIT_SUCCESS, null, null,
+                    SCHEDULER_USER);
+            return true;
+        }
+        recordFailedAttempt(cycle, attempts + 1);
+        return true;
+    }
+
+    /** 15, 30, 60, 120 minutes by default — doubling from the first failure. */
+    private long backoffMinutes(int attempts) {
+        return attempts <= 0 ? 0 : retryBaseMinutes << (attempts - 1);
+    }
+
+    private Timestamp readyToSubmitAt(Long cycleId) {
+        Timestamp readyAt = null;
+        for (EQACycleStateTransition transition : cycleService.getTransitions(cycleId)) {
+            if (READY_TO_SUBMIT.name().equals(transition.getNewState())) {
+                readyAt = transition.getOccurredAt();
+            }
+        }
+        return readyAt;
+    }
+
+    private void recordFailedAttempt(EQACycle cycle, int attempts) {
+        cycle.setSubmissionAttempts(attempts);
+        cycle.setLastSubmissionAttemptAt(Timestamp.from(clock.instant()));
+        cycle.setSysUserId(SCHEDULER_USER);
+        cycleDAO.update(cycle);
+
+        // One alert, when the budget is gone. Alerting on every attempt would put
+        // five rows on the lab's dashboard for one unreachable endpoint.
+        if (attempts >= MAX_ATTEMPTS) {
+            alertService.createAlert(AlertType.EQA_SUBMISSION_FAILED, ENTITY_TYPE_EQA_CYCLE, cycle.getId(),
+                    AlertSeverity.CRITICAL,
+                    "Automatic EQA submission failed " + attempts + " times; submit manually before the deadline",
+                    String.format("{\"cycleId\":%d,\"attempts\":%d}", cycle.getId(), attempts));
+        }
+        logger.warn("EQA cycle {} submission attempt {} failed", cycle.getId(), attempts);
+    }
+
+    private List<Long> submittingEnrollments(Long cycleId) {
+        Set<Long> enrollments = new LinkedHashSet<>();
+        for (EQAParticipantResult result : participantResultDAO.getAllMatching("cycle.id", cycleId)) {
+            if (SUBMITTABLE.contains(result.getSubmissionStatus())) {
+                enrollments.add(result.getLabEnrollmentId());
+            }
+        }
+        return new ArrayList<>(enrollments);
+    }
+
+    /** Stamps the channel the transition itself does not carry. */
+    private int markSent(Long cycleId, Long labEnrollmentId, EQASubmissionChannel channel, String reference,
+            String sysUserId) {
+        int sent = 0;
+        for (EQAParticipantResult result : results(cycleId, labEnrollmentId)) {
+            if (result.getSubmissionStatus() != EQASubmissionStatus.VALIDATED_PARTIAL) {
+                continue;
+            }
+            EQAParticipantResult submitted = participantResultService.transitionStatus(result.getId(),
+                    EQASubmissionStatus.SUBMITTED, sysUserId);
+            submitted.setSubmissionChannel(channel);
+            if (reference != null) {
+                submitted.setManualSubmissionReference(reference);
+            }
+            submitted.setSysUserId(sysUserId);
+            participantResultDAO.update(submitted);
+            sent++;
+        }
+        return sent;
+    }
+
+    // ---- fallbacks ----
+
+    @Override
+    public EQACycle submitManually(Long cycleId, Long labEnrollmentId, String reference, String sysUserId) {
+        if (GenericValidator.isBlankOrNull(reference)) {
+            throw new IllegalArgumentException("A manual submission requires the provider's reference");
+        }
+        EQACycle cycle = cycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("Cycle not found: " + cycleId));
+
+        int sent = markSent(cycleId, labEnrollmentId, EQASubmissionChannel.MANUAL, reference.trim(), sysUserId);
+        if (sent == 0) {
+            throw new IllegalArgumentException("No validated result to submit for cycle " + cycleId);
+        }
+        advanceTo(cycle, SUBMITTED, EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, actingUser(sysUserId),
+                "Manual submission, provider reference " + reference.trim(), sysUserId);
+        return cycleDAO.get(cycleId).orElseThrow();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String exportBundleCsv(Long cycleId, Long labEnrollmentId) {
+        StringBuilder csv = new StringBuilder(
+                "cycle_id,cycle_name,round_number,analyte_id,result_value,result_unit,submission_status,entered_at\n");
+        for (EQAParticipantResult result : results(cycleId, labEnrollmentId)) {
+            if (!SUBMITTABLE.contains(result.getSubmissionStatus())) {
+                continue;
+            }
+            EQACycle cycle = result.getCycle();
+            EQARound round = result.getRound();
+            csv.append(cycleId).append(',').append(csvField(cycle == null ? null : cycle.getCycleName())).append(',')
+                    .append(round == null || round.getRoundNumber() == null ? "" : round.getRoundNumber()).append(',')
+                    .append(result.getAnalyteId()).append(',').append(csvField(result.getResultValue())).append(',')
+                    .append(csvField(result.getResultUnit())).append(',').append(result.getSubmissionStatus().name())
+                    .append(',').append(result.getEnteredAt() == null ? "" : result.getEnteredAt()).append('\n');
+        }
+        return csv.toString();
+    }
+
+    /** RFC 4180 quoting: a value carrying a comma, quote or newline is quoted. */
+    private String csvField(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (StringUtils.containsAny(value, ',', '"', '\n', '\r')) {
+            return '"' + value.replace("\"", "\"\"") + '"';
+        }
+        return value;
+    }
+
+    @Override
+    public int intakeScores(Long cycleId, Long labEnrollmentId, List<Map<String, Object>> scores, String sysUserId) {
+        if (scores == null || scores.isEmpty()) {
+            throw new IllegalArgumentException("A score intake needs at least one score");
+        }
+        EQACycle cycle = cycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("Cycle not found: " + cycleId));
+
+        int scored = 0;
+        for (Map<String, Object> entry : scores) {
+            EQAParticipantResult row = resolveScoredRow(cycleId, labEnrollmentId, entry);
+            participantResultService.recordScore(row.getId(), verdictOf(entry), decimalOf(entry, "zScore"),
+                    longOf(entry, "eqaResultId"), sysUserId);
+            scored++;
+        }
+
+        // FR-V2.2-08: the cycle is scored when nothing is still waiting for a
+        // verdict. A missed-deadline result is resolved, not pending.
+        boolean pending = participantResultDAO.getAllMatching("cycle.id", cycleId).stream()
+                .anyMatch(r -> r.getSubmissionStatus() != EQASubmissionStatus.SCORED
+                        && r.getSubmissionStatus() != EQASubmissionStatus.MISSED_DEADLINE);
+        if (!pending) {
+            advanceTo(cycle, SCORED, EQATriggerType.AUTO, EQATriggerEvent.SCORE_INTAKE, null, null, sysUserId);
+        }
+        return scored;
+    }
+
+    private EQAParticipantResult resolveScoredRow(Long cycleId, Long labEnrollmentId, Map<String, Object> entry) {
+        Long resultId = longOf(entry, "resultId");
+        if (resultId == null) {
+            Long analyteId = longOf(entry, "analyteId");
+            if (analyteId == null) {
+                throw new IllegalArgumentException("Each score needs a resultId or an analyteId");
+            }
+            return results(cycleId, labEnrollmentId).stream().filter(
+                    r -> analyteId.equals(r.getAnalyteId()) && r.getSubmissionStatus() == EQASubmissionStatus.SUBMITTED)
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException(
+                            "No submitted result for analyte " + analyteId + " in cycle " + cycleId));
+        }
+        EQAParticipantResult row = participantResultService.get(resultId);
+        if (row.getCycle() == null || !cycleId.equals(row.getCycle().getId())) {
+            throw new IllegalArgumentException("Result " + resultId + " does not belong to cycle " + cycleId);
+        }
+        return row;
+    }
+
+    // ---- shared helpers ----
+
+    private List<EQAParticipantResult> results(Long cycleId, Long labEnrollmentId) {
+        return labEnrollmentId == null ? participantResultDAO.getAllMatching("cycle.id", cycleId)
+                : participantResultDAO.getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId));
+    }
+
+    /**
+     * Walks the participant machine edge by edge so every step keeps its own audit
+     * row. A cycle whose panel receipt was never recorded is walked through
+     * PANEL_RECEIVED too: a validated result is proof the panel arrived, and the
+     * audit row names the real trigger rather than claiming a receipt.
+     */
+    private boolean advanceTo(EQACycle cycle, EQACycleStatus target, EQATriggerType triggerType,
+            EQATriggerEvent triggerEvent, Long triggeredBy, String reason, String sysUserId) {
+        int from = PARTICIPANT_PATH.indexOf(cycle.getStatus());
+        int to = PARTICIPANT_PATH.indexOf(target);
+        if (from < 0 || to <= from) {
+            return false;
+        }
+        for (int step = from + 1; step <= to; step++) {
+            cycleService.transition(cycle.getId(), PARTICIPANT_PATH.get(step), EQAStateMachine.PARTICIPANT, triggerType,
+                    triggerEvent, triggeredBy, reason, sysUserId);
+        }
+        return true;
+    }
+
+    private Long actingUser(String sysUserId) {
+        try {
+            return Long.valueOf(sysUserId);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private EQAPerformanceStatus verdictOf(Map<String, Object> entry) {
+        Object raw = entry.get("performance");
+        if (raw == null) {
+            throw new IllegalArgumentException("Each score needs a performance verdict");
+        }
+        try {
+            return EQAPerformanceStatus.valueOf(String.valueOf(raw).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown performance status: " + raw);
+        }
+    }
+
+    private Long longOf(Map<String, Object> entry, String key) {
+        Object raw = entry.get(key);
+        if (raw == null || String.valueOf(raw).isBlank()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(String.valueOf(raw));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(key + " must be a number");
+        }
+    }
+
+    private BigDecimal decimalOf(Map<String, Object> entry, String key) {
+        Object raw = entry.get(key);
+        if (raw == null || String.valueOf(raw).isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(String.valueOf(raw));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(key + " must be a number");
+        }
+    }
+
+    /** Analyses seen, analyses answered, and rows this sweep actually wrote. */
+    private static final class Tally {
+        private int expected;
+        private int answered;
+        private int written;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionService.java
@@ -6,6 +6,19 @@ public interface EQAFhirSubmissionService {
 
     Map<String, Object> submitResultsViaFhir(Long distributionId, Long organizationId);
 
+    /**
+     * Post one lab's participant results for a V2 cycle as a DiagnosticReport
+     * bundle (FR-V2.2-05). Cycle-grain, unlike
+     * {@link #submitResultsViaFhir(Long, Long)}, which serves the V1
+     * distribution/eqa_result pair.
+     *
+     * @return false when the FHIR store refuses the bundle, so the caller can count
+     *         a failed attempt and back off. A cycle with no submittable result
+     *         throws instead: that is a caller error, not a transport failure, and
+     *         counting it against the retry budget would hide it.
+     */
+    boolean submitCycleViaFhir(Long cycleId, Long labEnrollmentId);
+
     boolean isSubmissionLate(Long distributionId);
 
     Map<String, Object> approveLateSubmission(Long distributionId, Long organizationId, String justification,

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
@@ -17,14 +17,20 @@ import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.StringType;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQADistributionDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.dao.EQAResultDAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQADistribution;
+import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAResult;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +48,12 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
 
     @Autowired
     private EQAResultDAO resultDAO;
+
+    @Autowired
+    private EQACycleDAO cycleDAO;
+
+    @Autowired
+    private EQAParticipantResultDAO participantResultDAO;
 
     @Autowired
     private FhirPersistanceService fhirPersistanceService;
@@ -94,6 +106,125 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
         }
 
         return response;
+    }
+
+    @Override
+    public boolean submitCycleViaFhir(Long cycleId, Long labEnrollmentId) {
+        EQACycle cycle = cycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("Cycle not found: " + cycleId));
+
+        List<EQAParticipantResult> results = submittableResults(cycleId, labEnrollmentId);
+        if (results.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No submittable result for cycle " + cycleId + " and enrollment " + labEnrollmentId);
+        }
+
+        Map<String, Resource> fhirResources = new HashMap<>();
+        DiagnosticReport report = buildCycleReport(cycle, labEnrollmentId, results);
+        fhirResources.put(report.getId(), report);
+        for (EQAParticipantResult result : results) {
+            Observation observation = buildParticipantObservation(result);
+            fhirResources.put(observation.getId(), observation);
+        }
+
+        try {
+            Bundle responseBundle = fhirPersistanceService.createFhirResourcesInFhirStore(fhirResources);
+            LogEvent.logInfo(this.getClass().getSimpleName(), "submitCycleViaFhir",
+                    "EQA cycle submission successful: cycle=" + cycleId + ", enrollment=" + labEnrollmentId
+                            + ", resources=" + fhirResources.size() + ", bundle=" + responseBundle.getId());
+            return true;
+        } catch (FhirLocalPersistingException | RuntimeException e) {
+            // Any transport or serialization failure is a failed attempt, not a
+            // crash: the caller counts it and retries under FR-V2.2-05 backoff.
+            LogEvent.logError(this.getClass().getSimpleName(), "submitCycleViaFhir",
+                    "EQA cycle submission failed: cycle=" + cycleId + ", enrollment=" + labEnrollmentId + ": "
+                            + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Everything this lab has validated but not yet had scored. SUBMITTED rows are
+     * included so a retry after a partial failure resends the whole set rather than
+     * a fragment the provider cannot reconcile.
+     */
+    private List<EQAParticipantResult> submittableResults(Long cycleId, Long labEnrollmentId) {
+        return participantResultDAO.getAllMatching(Map.of("cycle.id", cycleId, "labEnrollmentId", labEnrollmentId))
+                .stream().filter(r -> r.getSubmissionStatus() == EQASubmissionStatus.VALIDATED_PARTIAL
+                        || r.getSubmissionStatus() == EQASubmissionStatus.SUBMITTED)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * No subject reference: a participant self-enrollment
+     * (eqa_lab_program_enrollment) records a free-text provider and no
+     * organization, so an Organization/{id} reference would point at nothing. The
+     * cycle and enrollment identifiers carry the routing instead.
+     */
+    private DiagnosticReport buildCycleReport(EQACycle cycle, Long labEnrollmentId,
+            List<EQAParticipantResult> results) {
+        DiagnosticReport report = new DiagnosticReport();
+        String reportId = cycle.getFhirUuid().toString() + "-enrollment-" + labEnrollmentId;
+        report.setId(reportId);
+        report.addIdentifier(
+                createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/diagnostic_report", reportId));
+        report.addIdentifier(
+                createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/cycle_id", cycle.getId().toString()));
+        report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/lab_enrollment_id",
+                labEnrollmentId.toString()));
+        report.setStatus(DiagnosticReportStatus.FINAL);
+
+        CodeableConcept category = new CodeableConcept();
+        category.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/v2-0074", "LAB", "Laboratory"));
+        report.addCategory(category);
+
+        CodeableConcept code = new CodeableConcept();
+        code.addCoding(new Coding(fhirConfig.getOeFhirSystem() + EQA_SYSTEM, "eqa-proficiency-test",
+                "EQA Proficiency Testing Results"));
+        code.setText("EQA Results: " + (cycle.getScheme() == null ? "" : cycle.getScheme().getName() + " ") + "cycle "
+                + cycle.getCycleNumber());
+        report.setCode(code);
+
+        for (EQAParticipantResult result : results) {
+            Reference obsRef = new Reference();
+            obsRef.setReference(ResourceType.Observation + "/" + result.getFhirUuid().toString());
+            report.addResult(obsRef);
+        }
+        return report;
+    }
+
+    /**
+     * A participant result value is free text on the wire: external PT covers
+     * qualitative analytes (HIV serology, blood-film ID) that have no numeric form,
+     * so it is sent as a Quantity only when it parses as one.
+     */
+    private Observation buildParticipantObservation(EQAParticipantResult result) {
+        Observation observation = new Observation();
+        observation.setId(result.getFhirUuid().toString());
+        observation
+                .addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/participant_result_uuid",
+                        result.getFhirUuid().toString()));
+        observation.setStatus(ObservationStatus.FINAL);
+
+        CodeableConcept code = new CodeableConcept();
+        code.addCoding(new Coding(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/analyte",
+                String.valueOf(result.getAnalyteId()), "EQA analyte " + result.getAnalyteId()));
+        observation.setCode(code);
+
+        String value = result.getResultValue();
+        if (value != null && !value.isBlank()) {
+            try {
+                Quantity quantity = new Quantity();
+                quantity.setValue(new java.math.BigDecimal(value.trim()));
+                if (result.getResultUnit() != null && !result.getResultUnit().isBlank()) {
+                    quantity.setUnit(result.getResultUnit());
+                }
+                observation.setValue(quantity);
+            } catch (NumberFormatException e) {
+                observation.setValue(new StringType(value.trim()));
+            }
+        }
+        return observation;
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentService.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa.service;
 
 import java.util.List;
+import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 
@@ -10,11 +11,17 @@ public interface EQALabProgramEnrollmentService extends BaseObjectService<EQALab
 
     List<EQALabProgramEnrollment> findActiveEnrollments();
 
+    /**
+     * @param testAnalytes which analyte each mapped test reports for this scheme,
+     *                     keyed by test id (qa/030). Optional, but a test with no
+     *                     analyte cannot be submitted automatically — see
+     *                     {@link EQACycleSubmissionService}.
+     */
     EQALabProgramEnrollment createEnrollment(EQALabProgramEnrollment enrollment, List<Long> labUnitIds,
-            List<Long> testIds, List<Long> panelIds);
+            List<Long> testIds, List<Long> panelIds, Map<Long, Long> testAnalytes);
 
     EQALabProgramEnrollment updateEnrollment(Long id, EQALabProgramEnrollment updated, List<Long> labUnitIds,
-            List<Long> testIds, List<Long> panelIds);
+            List<Long> testIds, List<Long> panelIds, Map<Long, Long> testAnalytes);
 
     void softDelete(Long id);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.openelisglobal.eqa.dao.EQALabProgramEnrollmentDAO;
 import org.openelisglobal.eqa.valueholder.EQALabEnrollmentLabUnit;
@@ -48,12 +49,12 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
 
     @Override
     public EQALabProgramEnrollment createEnrollment(EQALabProgramEnrollment enrollment, List<Long> labUnitIds,
-            List<Long> testIds, List<Long> panelIds) {
+            List<Long> testIds, List<Long> panelIds, Map<Long, Long> testAnalytes) {
 
         enrollment.setCreatedDate(new Date());
         enrollment.setIsActive(enrollment.getIsActive() != null ? enrollment.getIsActive() : true);
 
-        setMappings(enrollment, labUnitIds, testIds, panelIds);
+        setMappings(enrollment, labUnitIds, testIds, panelIds, testAnalytes);
 
         Long id = enrollmentDAO.insert(enrollment);
         return enrollmentDAO.get(id)
@@ -62,7 +63,7 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
 
     @Override
     public EQALabProgramEnrollment updateEnrollment(Long id, EQALabProgramEnrollment updated, List<Long> labUnitIds,
-            List<Long> testIds, List<Long> panelIds) {
+            List<Long> testIds, List<Long> panelIds, Map<Long, Long> testAnalytes) {
 
         EQALabProgramEnrollment existing = enrollmentDAO.get(id)
                 .orElseThrow(() -> new IllegalArgumentException("Enrollment not found: " + id));
@@ -79,7 +80,7 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
         existing = enrollmentDAO.update(existing);
         entityManager.flush();
 
-        setMappings(existing, labUnitIds, testIds, panelIds);
+        setMappings(existing, labUnitIds, testIds, panelIds, testAnalytes);
         enrollmentDAO.update(existing);
         entityManager.flush();
         entityManager.clear();
@@ -103,7 +104,7 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
     }
 
     private void setMappings(EQALabProgramEnrollment enrollment, List<Long> labUnitIds, List<Long> testIds,
-            List<Long> panelIds) {
+            List<Long> panelIds, Map<Long, Long> testAnalytes) {
 
         if (labUnitIds != null) {
             for (Long unitId : labUnitIds) {
@@ -121,6 +122,9 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
                 EQALabEnrollmentTestMap map = new EQALabEnrollmentTestMap();
                 map.setEnrollment(enrollment);
                 map.setTestId(testId);
+                if (testAnalytes != null) {
+                    map.setAnalyteId(testAnalytes.get(testId));
+                }
                 map.setSysUserId(enrollment.getSysUserId());
                 testMaps.add(map);
             }

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQACycle.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQACycle.java
@@ -80,8 +80,37 @@ public class EQACycle extends BaseObject<Long> {
     @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
     private SystemUser createdBy;
 
+    /**
+     * How many automatic FHIR submissions have been tried for this cycle
+     * (FR-V2.2-05, capped at 5). A failed attempt leaves the cycle in
+     * READY_TO_SUBMIT, and the participant machine has no self-edge, so the attempt
+     * cannot be recorded as a state transition.
+     */
+    @Column(name = "submission_attempts", nullable = false)
+    private Integer submissionAttempts = 0;
+
+    /** Backoff anchor: when the last automatic attempt ran. */
+    @Column(name = "last_submission_attempt_at")
+    private Timestamp lastSubmissionAttemptAt;
+
     @Column(name = "sys_user_id", nullable = false)
     private String sysUserId;
+
+    public Integer getSubmissionAttempts() {
+        return submissionAttempts;
+    }
+
+    public void setSubmissionAttempts(Integer submissionAttempts) {
+        this.submissionAttempts = submissionAttempts;
+    }
+
+    public Timestamp getLastSubmissionAttemptAt() {
+        return lastSubmissionAttemptAt;
+    }
+
+    public void setLastSubmissionAttemptAt(Timestamp lastSubmissionAttemptAt) {
+        this.lastSubmissionAttemptAt = lastSubmissionAttemptAt;
+    }
 
     @Override
     public String getSysUserId() {

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQALabEnrollmentTestMap.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQALabEnrollmentTestMap.java
@@ -38,6 +38,15 @@ public class EQALabEnrollmentTestMap extends BaseObject<Long> {
     @Column(name = "panel_id")
     private Long panelId;
 
+    /**
+     * The analyte this test reports for the scheme (qa/030). Auto-submission needs
+     * it because eqa_participant_result.analyte_id is NOT NULL and the clinical
+     * catalog cannot supply one: result.analyte_id is filled from test_analyte,
+     * which most test configurations do not have.
+     */
+    @Column(name = "analyte_id")
+    private Long analyteId;
+
     @Column(name = "sys_user_id", nullable = false)
     private String sysUserId;
 

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -109,4 +109,7 @@
 
   <!-- EQA V2 — OGC-610: point My Cycles at its real route, hide the rows with no page -->
   <include file="liquibase/qa/029-fix-eqa-my-cycles-menu-url.xml" />
+
+  <!-- EQA V2.2 — OGC-610: automatic-submission retry bookkeeping (FR-V2.2-05) -->
+  <include file="liquibase/qa/030-add-eqa-cycle-submission-retry.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/030-add-eqa-cycle-submission-retry.xml
+++ b/src/main/resources/liquibase/qa/030-add-eqa-cycle-submission-retry.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.2 (OGC-610): retry bookkeeping for automatic FHIR submission.
+
+    FR-V2.2-05 caps automatic submission at five attempts with exponential
+    backoff, so the sweep has to know how many times it has already tried and
+    when. Neither fact can be derived from what already ships:
+
+    - eqa_cycle_state_transition cannot hold it. A failed attempt leaves the
+      cycle in ready_to_submit, and the participant machine has no
+      ready_to_submit -> ready_to_submit edge, so EQACycleService.transition
+      refuses the write. The FHIR_SUBMIT_FAILURE_RETRY trigger event exists for
+      the audit row that cannot be written.
+    - The alert table cannot hold it either: alerts are user-facing and
+      acknowledgeable, so counting them would make a technician's acknowledgement
+      change the retry schedule.
+
+    The submission window itself is deliberately not a column: FR-V2.2-05 makes it
+    a deployment setting (org.openelisglobal.eqa.submission.windowHours, default 1).
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-056-add-eqa-cycle-submission-retry">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eqa_cycle" schemaName="clinlims"/>
+                <not>
+                    <columnExists tableName="eqa_cycle" columnName="submission_attempts" schemaName="clinlims"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>Attempt counter and backoff anchor for automatic submission (FR-V2.2-05)</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_cycle">
+            <column name="submission_attempts" type="numeric(2,0)" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_submission_attempt_at" type="TIMESTAMP WITHOUT TIME ZONE"/>
+        </addColumn>
+        <sql>
+            ALTER TABLE clinlims.eqa_cycle
+            ADD CONSTRAINT eqa_cycle_submission_attempts_chk
+            CHECK (submission_attempts >= 0 AND submission_attempts &lt;= 5)
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE clinlims.eqa_cycle DROP CONSTRAINT IF EXISTS eqa_cycle_submission_attempts_chk;
+            </sql>
+            <dropColumn schemaName="clinlims" tableName="eqa_cycle" columnName="last_submission_attempt_at"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_cycle" columnName="submission_attempts"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-057-extend-alert-type-check-for-eqa-submission">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="alert" schemaName="clinlims"/>
+        </preConditions>
+        <comment>
+            Extend the alert_type CHECK with EQA_SUBMISSION_FAILED. The Java enum alone is
+            not enough: alert_type is guarded by a DB CHECK (last set by
+            3.5.x.x/070-critical-result-alert-type.xml), so the insert that reports a failed
+            submission would itself fail — the one alert a lab must not miss.
+        </comment>
+        <sql>
+            ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+            ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+            CHECK (alert_type IN (
+            'FREEZER_TEMPERATURE', 'EQUIPMENT_FAILURE', 'INVENTORY_LOW', 'SAMPLE_TRACKING', 'OTHER',
+            'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING', 'STAT_OVERDUE', 'CRITICAL_UNACKNOWLEDGED',
+            'CRITICAL_RESULT', 'EQA_SUBMISSION_FAILED'
+            ));
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+                ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+                CHECK (alert_type IN (
+                'FREEZER_TEMPERATURE', 'EQUIPMENT_FAILURE', 'INVENTORY_LOW', 'SAMPLE_TRACKING', 'OTHER',
+                'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING', 'STAT_OVERDUE', 'CRITICAL_UNACKNOWLEDGED',
+                'CRITICAL_RESULT'
+                ));
+            </sql>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="openelisglobal" id="qa-058-add-enrollment-test-map-analyte">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="eqa_lab_enrollment_test_map" schemaName="clinlims"/>
+                <not>
+                    <columnExists tableName="eqa_lab_enrollment_test_map" columnName="analyte_id"
+                        schemaName="clinlims"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>
+            Which analyte a mapped test reports for this scheme (FR-V2.2-05). Auto-submission
+            has to name an analyte because eqa_participant_result.analyte_id is a NOT NULL FK,
+            and nothing else in the schema can supply one for an external scheme: eqa_panel_sample
+            carries analytes only for in-house panels a supervisor built, eqa_program_test maps
+            program to test, and this table mapped enrollment to test/panel. The clinical catalog
+            cannot stand in either — result.analyte_id is filled from test_analyte, which most
+            test configurations do not have, so it is null in practice.
+
+            Nullable: an enrollment predating this column, or one whose scheme is scored by hand,
+            stays valid. The bridge holds such a cycle short of submission rather than guessing.
+        </comment>
+        <addColumn schemaName="clinlims" tableName="eqa_lab_enrollment_test_map">
+            <column name="analyte_id" type="numeric(10,0)"/>
+        </addColumn>
+        <addForeignKeyConstraint
+            constraintName="fk_test_map_analyte"
+            baseTableSchemaName="clinlims" baseTableName="eqa_lab_enrollment_test_map"
+            baseColumnNames="analyte_id"
+            referencedTableSchemaName="clinlims" referencedTableName="analyte" referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableSchemaName="clinlims"
+                baseTableName="eqa_lab_enrollment_test_map" constraintName="fk_test_map_analyte"/>
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_enrollment_test_map" columnName="analyte_id"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -151,7 +152,7 @@ public class EQAMyProgramsRestControllerTest {
     @Test
     public void testCreateMyProgram_Success() {
         when(enrollmentService.createEnrollment(
-                        any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList()))
+                        any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList(), anyMap()))
                 .thenReturn(enrollment1);
 
         Map<String, Object> body = new HashMap<>();
@@ -193,7 +194,7 @@ public class EQAMyProgramsRestControllerTest {
     @Test
     public void testUpdateMyProgram_Success() {
         when(enrollmentService.updateEnrollment(
-                        eq(1L), any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList()))
+                        eq(1L), any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList(), anyMap()))
                 .thenReturn(enrollment1);
 
         Map<String, Object> body = new HashMap<>();
@@ -211,7 +212,7 @@ public class EQAMyProgramsRestControllerTest {
     @Test
     public void testUpdateMyProgram_NotFound() {
         when(enrollmentService.updateEnrollment(
-                        eq(999L), any(EQALabProgramEnrollment.class), any(), any(), any()))
+                        eq(999L), any(EQALabProgramEnrollment.class), any(), any(), any(), any()))
                 .thenThrow(new IllegalArgumentException("Not found"));
 
         Map<String, Object> body = new HashMap<>();

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -87,11 +87,14 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQAShipmentRestController#savePrep", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#saveShipment", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#ship", EQAGuards.PROVIDER);
+        // Score intake is the provider's verdict coming back (FR-V2.2-08)
+        WRITE_GUARDS.put("EQASubmissionRestController#intakeScores", EQAGuards.MANAGE);
         // Participant lane — bench work, so the legacy roles still admit it
         WRITE_GUARDS.put("EQAMyProgramsRestController#createMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAMyProgramsRestController#updateMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAMyProgramsRestController#deleteMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAPanelReceiptRestController#recordReceipt", EQAGuards.PARTICIPANT);
+        WRITE_GUARDS.put("EQASubmissionRestController#submitManually", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAParticipantResultRestController#createDraft", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAParticipantResultRestController#transition", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAResultRestController#submitResult", EQAGuards.PARTICIPANT);

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
@@ -189,6 +189,17 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
             return http.build();
         }
 
+        /**
+         * The enrollment form's analyte list (qa/030) rides the my-programs controller.
+         */
+        @Bean
+        org.openelisglobal.analyte.service.AnalyteService analyteService() {
+            org.openelisglobal.analyte.service.AnalyteService service = Mockito
+                    .mock(org.openelisglobal.analyte.service.AnalyteService.class);
+            Mockito.when(service.getAll()).thenReturn(List.of());
+            return service;
+        }
+
         @Bean
         EQALabProgramEnrollmentService labProgramEnrollmentService() {
             EQALabProgramEnrollmentService service = Mockito.mock(EQALabProgramEnrollmentService.class);

--- a/src/test/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertSchedulerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertSchedulerTest.java
@@ -25,6 +25,7 @@ import org.openelisglobal.alert.valueholder.AlertSeverity;
 import org.openelisglobal.alert.valueholder.AlertStatus;
 import org.openelisglobal.alert.valueholder.AlertType;
 import org.openelisglobal.eqa.dao.SampleEQADAO;
+import org.openelisglobal.eqa.service.EQACycleSubmissionService;
 import org.openelisglobal.eqa.valueholder.EQAPriority;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 
@@ -36,6 +37,9 @@ public class EQADeadlineAlertSchedulerTest {
 
     @Mock
     private SampleEQADAO sampleEQADAO;
+
+    @Mock
+    private EQACycleSubmissionService cycleSubmissionService;
 
     @InjectMocks
     private EQADeadlineAlertScheduler scheduler;
@@ -218,6 +222,24 @@ public class EQADeadlineAlertSchedulerTest {
                 eq(AlertSeverity.CRITICAL), anyString(), anyString());
         verify(alertService).createAlert(eq(AlertType.EQA_DEADLINE), eq("SampleEQA"), eq(21L),
                 eq(AlertSeverity.WARNING), anyString(), anyString());
+    }
+
+    /**
+     * FR-V2.2-05: the submission sweep visits every candidate even when one of them
+     * throws. Without the per-cycle catch, a single unreachable cycle would stop
+     * every other lab's submission for as long as it stayed broken — and the
+     * scheduler would look like it was running fine.
+     */
+    @Test
+    public void advanceEQASubmissions_survivesAFailingCycle() {
+        when(cycleSubmissionService.findAdvanceCandidates()).thenReturn(Arrays.asList(1L, 2L, 3L));
+        when(cycleSubmissionService.advanceCycle(2L)).thenThrow(new IllegalStateException("boom"));
+
+        scheduler.advanceEQASubmissions();
+
+        verify(cycleSubmissionService).advanceCycle(1L);
+        verify(cycleSubmissionService).advanceCycle(2L);
+        verify(cycleSubmissionService).advanceCycle(3L);
     }
 
     private SampleEQA createSampleEQA(Long id, Long sampleId, Timestamp deadline) {

--- a/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
@@ -1,0 +1,657 @@
+package org.openelisglobal.eqa.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.eqa.EQASpineTestBase;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * OGC-610 (EQA V2.2) — automatic submission end to end against the real schema:
+ * the bridge from the standard result pipeline into
+ * {@code eqa_participant_result}, the participant state walk, the FR-V2.2-05
+ * window and retry cap, and the two fallbacks.
+ *
+ * <p>
+ * The fixture enters results the way the pipeline does — a {@code result} row
+ * carrying {@code analyte_id}, which {@code ResultSaveService} fills from
+ * {@code test_analyte} — rather than writing
+ * {@code eqa_participant_result.result_value} directly. Writing that column in
+ * a test is what previously hid the fact that nothing in production filled it.
+ * {@link #analysisWithNoAnalyte_neverSubmitsAPartialSet()} pins the other half:
+ * a result the bridge cannot map must stop the submission, not shrink it.
+ *
+ * <p>
+ * The FHIR post itself is stubbed. What matters here is what the workflow does
+ * with success and failure; the bundle is asserted by the FHIR submission
+ * tests.
+ */
+public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
+
+    private static final long ENROLLMENT = 9901L;
+    private static final long VL_ANALYTE = 9802L;
+    private static final long SEROLOGY_ANALYTE = 9801L;
+    private static final long VL_TEST = 9702L;
+    private static final long SEROLOGY_TEST = 9701L;
+    private static final long SAMPLE = 9901L;
+    private static final long SAMPLE_ITEM = 9901L;
+    private static final long SAMPLE_EQA = 9901L;
+
+    /**
+     * Fixture ids are assigned here rather than from a sequence: the sample_eqa and
+     * analysis sequences are not in the clinlims schema, so nextval() on a
+     * schema-qualified name fails.
+     */
+    private long nextAnalysisId = 9911L;
+
+    @Autowired
+    private EQACycleSubmissionService cycleSubmissionService;
+
+    @Autowired
+    private IStatusService statusService;
+
+    @Autowired
+    private FhirConfig fhirConfig;
+
+    private EQACycleSubmissionServiceImpl target;
+    private EQAFhirSubmissionService fhirStub;
+    private EQAFhirSubmissionService realFhirService;
+
+    @Before
+    public void stubTransportAndSeedCatalog() {
+        target = AopTestUtils.getTargetObject(cycleSubmissionService);
+        fhirStub = mock(EQAFhirSubmissionService.class);
+        realFhirService = (EQAFhirSubmissionService) ReflectionTestUtils.getField(target, "fhirSubmissionService");
+        ReflectionTestUtils.setField(target, "fhirSubmissionService", fhirStub);
+
+        // submitIfDue refuses to spend a retry when no store is configured, which
+        // is exactly the manual-fallback deployment — so the automatic tests need
+        // one present. AppTestConfig supplies FhirConfig as a mock, so this is a
+        // stub rather than a field write.
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn("http://fhir.example/stub");
+
+        ensureAnalysisStatuses();
+        ensureOrderCatalog();
+        nextAnalysisId = 9911L;
+    }
+
+    /**
+     * Null-safe on purpose: when a fixture insert fails in setUp the collaborators
+     * were never swapped, and a second exception here would bury the first.
+     */
+    @After
+    public void restoreCollaborators() {
+        if (target != null) {
+            ReflectionTestUtils.setField(target, "fhirSubmissionService", realFhirService);
+            target.setClock(Clock.systemDefaultZone());
+        }
+        // Back to the shared mock's own default: unstubbed, it reports no store.
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn(null);
+        jdbc.update("DELETE FROM clinlims.alert WHERE alert_entity_type = 'EQACycle'");
+    }
+
+    /**
+     * sample_eqa carries FKs to eqa_cycle and eqa_round, so the order rows have to
+     * go before the base clears those tables — in the base's own @Before as well as
+     * its @After, which is why this is an override rather than another @After.
+     */
+    @Override
+    protected void cleanEqaTables() {
+        // eqa_participant_result FKs to analysis and sample_eqa FKs to eqa_round, so
+        // the EQA rows go first, then the base clears the cycle spine, then the
+        // orders themselves.
+        jdbc.update("DELETE FROM clinlims.eqa_participant_result");
+        jdbc.update("DELETE FROM clinlims.eqa_lab_enrollment_test_map WHERE enrollment_id = ?", ENROLLMENT);
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id = ?", SAMPLE);
+        super.cleanEqaTables();
+        cleanOrders();
+    }
+
+    /**
+     * Other fixtures truncate status_of_sample, and a later cache refresh rebuilds
+     * StatusService from whatever is left, so the ANALYSIS rows this class writes
+     * are restored by the exact names StatusService maps.
+     */
+    private void ensureAnalysisStatuses() {
+        // The names are the ones StatusService maps, not the enum constants:
+        // AnalysisStatus.NotStarted is "Not Tested" and Canceled is "Test Canceled".
+        // A row under any other name is never mapped, so getStatusID returns "-1"
+        // and the analysis insert fails its FK instead of saying why.
+        ensureStatus(9901, "ANALYSIS", "Finalized");
+        ensureStatus(9902, "ANALYSIS", "Not Tested");
+        ensureStatus(9903, "ANALYSIS", "Test Canceled");
+        statusService.refreshCache();
+        assertResolves(AnalysisStatus.Finalized);
+        assertResolves(AnalysisStatus.NotStarted);
+        assertResolves(AnalysisStatus.Canceled);
+    }
+
+    /** Fail on the cause, not on the foreign key three lines later. */
+    private void assertResolves(AnalysisStatus status) {
+        String id = statusService.getStatusID(status);
+        assertTrue(status + " did not resolve to a real status_of_sample row (got " + id
+                + "); check the name StatusService maps it by", id != null && !"-1".equals(id));
+    }
+
+    private void ensureStatus(long id, String type, String name) {
+        jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
+                + " SELECT ?, 1, ?, ?, 'restored by EQAAutoSubmissionIntegrationTest'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.status_of_sample WHERE name = ? AND status_type = ?)", id,
+                type, name, name, type);
+    }
+
+    private void ensureOrderCatalog() {
+        jdbc.update("INSERT INTO clinlims.localization (id, description) SELECT 9901, 'EQA T14'"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.localization WHERE id = 9901)");
+        jdbc.update("INSERT INTO clinlims.test_section (id, name, description, is_external, sort_order,"
+                + " name_localization_id) SELECT 9901, 'EQA T14', 'EQA T14 section', 'N',"
+                + " 9901, 9901 WHERE NOT EXISTS (SELECT 1 FROM clinlims.test_section WHERE id = 9901)");
+        jdbc.update("INSERT INTO clinlims.type_of_sample (id, description, domain, name_localization_id, lastupdated)"
+                + " SELECT 9901, 'EQA T14 specimen', 'H', 9901, now()"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.type_of_sample WHERE id = 9901)");
+    }
+
+    private void cleanOrders() {
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id = ?", SAMPLE);
+        jdbc.update("DELETE FROM clinlims.result WHERE analysis_id BETWEEN 9911 AND 9930");
+        jdbc.update("DELETE FROM clinlims.analysis WHERE sampitem_id = ?", SAMPLE_ITEM);
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id = ?", SAMPLE);
+        jdbc.update("DELETE FROM clinlims.sample_item WHERE id = ?", SAMPLE_ITEM);
+        jdbc.update("DELETE FROM clinlims.sample WHERE id = ?", SAMPLE);
+    }
+
+    // ---- fixture builders ----
+
+    private EQAProgram externalScheme(boolean requiresReview) {
+        EQAProgram scheme = insertScheme("NHLS VL Scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        if (requiresReview) {
+            jdbc.update("UPDATE clinlims.eqa_program SET requires_cycle_review = true WHERE id = ?", scheme.getId());
+            scheme = eqaProgramService.get(scheme.getId());
+        }
+        return scheme;
+    }
+
+    /**
+     * An EQA order on this cycle: sample, specimen, and the linking sample_eqa row.
+     */
+    private void eqaOrder(EQACycle cycle, Long roundId) {
+        seedEnrollment(ENROLLMENT, "NHLS VL");
+        jdbc.update("INSERT INTO clinlims.sample (id, accession_number, entered_date, received_date,"
+                + " collection_date, lastupdated) VALUES (?, 'EQAT14001', now(), now(), now(), now())", SAMPLE);
+        jdbc.update(
+                "INSERT INTO clinlims.sample_item (id, sort_order, status_id, samp_id, typeosamp_id,"
+                        + " collection_date, lastupdated) VALUES (?, 1, ?::numeric, ?, 9901, now(), now())",
+                SAMPLE_ITEM, statusService.getStatusID(AnalysisStatus.NotStarted), SAMPLE);
+        jdbc.update(
+                "INSERT INTO clinlims.sample_eqa (id, sample_id, is_eqa_sample, eqa_enrollment_id, cycle_id,"
+                        + " round_id, sys_user_id, last_updated) VALUES (?, ?, true, ?, ?, ?, ?, now())",
+                SAMPLE_EQA, SAMPLE, ENROLLMENT, cycle.getId(), roundId, USER);
+    }
+
+    /**
+     * What the lab declares when enrolling: this local test reports this scheme
+     * analyte (qa/030). Without it an external order has no resolvable analyte,
+     * because real result rows carry none.
+     */
+    private void mapTestToSchemeAnalyte(long testId, long analyteId) {
+        jdbc.update(
+                "INSERT INTO clinlims.eqa_lab_enrollment_test_map (id, enrollment_id, test_id, analyte_id,"
+                        + " sys_user_id, lastupdated) VALUES (?, ?, ?, ?, ?, now())",
+                9900L + testId, ENROLLMENT, testId, analyteId, USER);
+    }
+
+    /** A finalized analysis carrying one reported value, mapped to its analyte. */
+    private long finalizedAnalysis(long testId, long analyteId, String value) {
+        return analysis(testId, analyteId, value, AnalysisStatus.Finalized, true);
+    }
+
+    private long analysis(long testId, long analyteId, String value, AnalysisStatus status, boolean withAnalyte) {
+        long analysisId = nextAnalysisId++;
+        jdbc.update(
+                "INSERT INTO clinlims.analysis (id, sampitem_id, test_sect_id, test_id, revision, analysis_type,"
+                        + " entry_date, status_id, lastupdated, fhir_uuid)"
+                        + " VALUES (?, ?, 9901, ?, 1, 'ROUTINE', now(), ?::numeric, now(), gen_random_uuid())",
+                analysisId, SAMPLE_ITEM, testId, statusService.getStatusID(status));
+        if (value != null) {
+            // Result type and significant_digits are set the way a configured test
+            // sets them. On a numeric result left at 0 digits,
+            // ResultService.getResultValue truncates to the integer part (4.75 ->
+            // "4") — real shipped reporting behaviour, not an EQA rule. The bridge
+            // deliberately submits that same formatted value, because it is what the
+            // in-house scoring path compares against its sealed target.
+            boolean numeric = value.matches("-?\\d+(\\.\\d+)?");
+            jdbc.update(
+                    "INSERT INTO clinlims.result (id, analysis_id, analyte_id, result_type, value, sort_order,"
+                            + " significant_digits, is_reportable, lastupdated, fhir_uuid)"
+                            + " VALUES (?, ?, ?, ?, ?, 1, ?, 'Y', now(), gen_random_uuid())",
+                    analysisId + 500, analysisId, withAnalyte ? analyteId : null, numeric ? "N" : "A", value,
+                    numeric ? 2 : -1);
+        }
+        return analysisId;
+    }
+
+    private void windowElapsed() {
+        target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(2)));
+    }
+
+    private List<Map<String, Object>> participantResults(Long cycleId) {
+        return jdbc.queryForList("SELECT analyte_id, submission_status, result_value, submission_channel,"
+                + " manual_submission_reference, submitted_at, performance_status, z_score, analysis_id"
+                + " FROM clinlims.eqa_participant_result WHERE cycle_id = ? ORDER BY analyte_id", cycleId);
+    }
+
+    private List<String> auditTriggers(Long cycleId) {
+        return jdbc.queryForList(
+                "SELECT prior_state || '->' || new_state || ':' || trigger_event"
+                        + " FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ? ORDER BY id",
+                String.class, cycleId);
+    }
+
+    private int attempts(Long cycleId) {
+        return jdbc.queryForObject("SELECT submission_attempts FROM clinlims.eqa_cycle WHERE id = ?", Integer.class,
+                cycleId);
+    }
+
+    private int failureAlerts(Long cycleId) {
+        return jdbc.queryForObject("SELECT count(*) FROM clinlims.alert WHERE alert_type = 'EQA_SUBMISSION_FAILED'"
+                + " AND alert_entity_type = 'EQACycle' AND alert_entity_id = ?", Integer.class, cycleId);
+    }
+
+    // ---- the happy path ----
+
+    @Test
+    public void validatedOrder_bridgesResultWalksTheMachineAndSubmits() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        long analysisId = finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+
+        assertTrue("the sweep must report work done", cycleSubmissionService.advanceCycle(cycle.getId()));
+
+        List<Map<String, Object>> results = participantResults(cycle.getId());
+        assertEquals("one participant result, per reported analyte", 1, results.size());
+        Map<String, Object> row = results.get(0);
+        assertEquals(VL_ANALYTE, ((Number) row.get("analyte_id")).longValue());
+        assertEquals("4.75", row.get("result_value"));
+        assertEquals("SUBMITTED", row.get("submission_status"));
+        assertEquals("FHIR", row.get("submission_channel"));
+        assertEquals(analysisId, ((Number) row.get("analysis_id")).longValue());
+        assertTrue("a submitted result is stamped", row.get("submitted_at") != null);
+
+        assertEquals(EQACycleStatus.SUBMITTED, readBack(cycle.getId()).getStatus());
+        assertEquals(List.of("PLANNED->PANEL_RECEIVED:LAST_VALIDATED_RESULT",
+                "PANEL_RECEIVED->TESTING:LAST_VALIDATED_RESULT", "TESTING->READY_TO_SUBMIT:LAST_VALIDATED_RESULT",
+                "READY_TO_SUBMIT->SUBMITTED:FHIR_SUBMIT_SUCCESS"), auditTriggers(cycle.getId()));
+        verify(fhirStub).submitCycleViaFhir(cycle.getId(), ENROLLMENT);
+    }
+
+    @Test
+    public void rerunOverAnUnchangedCycle_writesNothingFurther() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 2));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        int auditRows = auditTriggers(cycle.getId()).size();
+
+        assertEquals("a SUBMITTED cycle is no longer a candidate", false,
+                cycleSubmissionService.advanceCycle(cycle.getId()));
+        assertEquals(auditRows, auditTriggers(cycle.getId()).size());
+        assertEquals(1, participantResults(cycle.getId()).size());
+    }
+
+    // ---- the window, the cap, and the gates ----
+
+    @Test
+    public void beforeTheWindowElapses_theCycleWaitsInReadyToSubmit() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 3));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+        assertEquals("VALIDATED_PARTIAL", participantResults(cycle.getId()).get(0).get("submission_status"));
+        assertEquals(0, attempts(cycle.getId()));
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+    }
+
+    @Test
+    public void aSchemeThatRequiresReview_isNeverSubmittedAutomatically() {
+        EQAProgram scheme = externalScheme(true);
+        EQACycle cycle = readBack(insertCycle(scheme, 4));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+    }
+
+    @Test
+    public void fiveFailures_stopRetryingAndRaiseExactlyOneAlert() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 5));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(false);
+
+        // Each pass jumps the clock past that attempt's backoff (15, 30, 60, 120
+        // minutes), so five attempts are genuinely spent rather than five calls
+        // being made in one backoff window.
+        long[] hoursOut = { 2, 3, 5, 8, 12 };
+        for (long hours : hoursOut) {
+            target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(hours)));
+            cycleSubmissionService.advanceCycle(cycle.getId());
+        }
+
+        assertEquals("the retry budget is spent", 5, attempts(cycle.getId()));
+        assertEquals("the cycle must not claim to have been submitted", EQACycleStatus.READY_TO_SUBMIT,
+                readBack(cycle.getId()).getStatus());
+        assertEquals("one alert, not one per attempt", 1, failureAlerts(cycle.getId()));
+
+        // A sixth pass long after the last backoff must not spend a sixth attempt.
+        target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(48)));
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        assertEquals(5, attempts(cycle.getId()));
+        assertEquals(1, failureAlerts(cycle.getId()));
+    }
+
+    @Test
+    public void withinTheBackoffWindow_noSecondAttemptIsSpent() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 6));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(false);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        assertEquals(1, attempts(cycle.getId()));
+
+        // Two minutes later: inside the 15-minute backoff.
+        target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(2).plusMinutes(2)));
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals("still one attempt", 1, attempts(cycle.getId()));
+    }
+
+    // ---- completeness and ownership ----
+
+    @Test
+    public void anUnfinishedAnalysis_holdsTheCycleInTesting() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 7));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, null, AnalysisStatus.NotStarted, true);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals(EQACycleStatus.TESTING, readBack(cycle.getId()).getStatus());
+        assertEquals("the finished analysis is still bridged", 1, participantResults(cycle.getId()).size());
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+    }
+
+    @Test
+    public void aCanceledAnalysis_doesNotCountAgainstCompleteness() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 8));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, null, AnalysisStatus.Canceled, true);
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals(EQACycleStatus.SUBMITTED, readBack(cycle.getId()).getStatus());
+    }
+
+    /**
+     * The inversion of the happy path: {@code analyte_id} is a NOT NULL FK, so a
+     * result the bridge cannot map produces no row — and the cycle must then stop
+     * short rather than submit a set that is missing an analyte the provider
+     * expects.
+     */
+    @Test
+    public void analysisWithNoAnalyte_neverSubmitsAPartialSet() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 9));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, "Positive", AnalysisStatus.Finalized, false);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals("only the mappable analyte is bridged", 1, participantResults(cycle.getId()).size());
+        assertEquals(EQACycleStatus.TESTING, readBack(cycle.getId()).getStatus());
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+    }
+
+    /**
+     * The shape production actually produces. Real result rows carry no analyte —
+     * ResultSaveService fills analyte_id from test_analyte, which most test
+     * configurations do not have — so the enrollment's scheme mapping is what makes
+     * an external order submittable.
+     */
+    @Test
+    public void resultWithoutItsOwnAnalyte_resolvesThroughTheEnrollmentMapping() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 16));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        mapTestToSchemeAnalyte(VL_TEST, VL_ANALYTE);
+        analysis(VL_TEST, VL_ANALYTE, "4.75", AnalysisStatus.Finalized, false);
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        List<Map<String, Object>> results = participantResults(cycle.getId());
+        assertEquals(1, results.size());
+        assertEquals("the analyte comes from the enrollment mapping, not the result", VL_ANALYTE,
+                ((Number) results.get(0).get("analyte_id")).longValue());
+        assertEquals("4.75", results.get(0).get("result_value"));
+        assertEquals("SUBMITTED", results.get(0).get("submission_status"));
+        assertEquals(EQACycleStatus.SUBMITTED, readBack(cycle.getId()).getStatus());
+    }
+
+    /**
+     * An unmapped test stays unbridgeable: the mapping is the only source once the
+     * result carries no analyte, so the cycle holds rather than submitting a set
+     * the provider cannot reconcile.
+     */
+    @Test
+    public void aTestWithNoSchemeMapping_holdsTheCycle() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 17));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        mapTestToSchemeAnalyte(VL_TEST, VL_ANALYTE);
+        analysis(VL_TEST, VL_ANALYTE, "4.75", AnalysisStatus.Finalized, false);
+        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, "Positive", AnalysisStatus.Finalized, false);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals("only the mapped test is bridged", 1, participantResults(cycle.getId()).size());
+        assertEquals(EQACycleStatus.TESTING, readBack(cycle.getId()).getStatus());
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+    }
+
+    @Test
+    public void anInHouseCycle_isLeftToTheBlindingService() {
+        EQAProgram scheme = insertScheme("In-house panel", EQASchemeType.IN_HOUSE, null);
+        EQACycle cycle = readBack(insertCycle(scheme, 10));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        windowElapsed();
+
+        assertEquals(false, cycleSubmissionService.advanceCycle(cycle.getId()));
+
+        assertEquals(EQACycleStatus.PLANNED, readBack(cycle.getId()).getStatus());
+        assertTrue("in-house results belong to the blinding path", participantResults(cycle.getId()).isEmpty());
+    }
+
+    /**
+     * The sweep's entry point, which the scheduler calls before anything else: a
+     * cycle in a state where results can still arrive is a candidate, one already
+     * submitted or scored is not. Untested, this is a silent no-op — the sweep
+     * would simply never visit anything.
+     */
+    @Test
+    public void advanceCandidates_areTheStatesWhereWorkCanStillArrive() {
+        EQAProgram scheme = externalScheme(false);
+        Long planned = insertCycle(scheme, 20);
+        Long testing = insertCycle(scheme, 21);
+        Long submitted = insertCycle(scheme, 22);
+        Long closed = insertCycle(scheme, 23);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'TESTING' WHERE id = ?", testing);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMITTED' WHERE id = ?", submitted);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", closed);
+
+        List<Long> candidates = cycleSubmissionService.findAdvanceCandidates();
+
+        assertTrue("a planned cycle is a candidate", candidates.contains(planned));
+        assertTrue("a testing cycle is a candidate", candidates.contains(testing));
+        assertFalse("a submitted cycle is not", candidates.contains(submitted));
+        assertFalse("a closed cycle is not", candidates.contains(closed));
+    }
+
+    // ---- fallbacks ----
+
+    @Test
+    public void manualSubmission_demandsTheProvidersReference() {
+        EQAProgram scheme = externalScheme(true);
+        EQACycle cycle = readBack(insertCycle(scheme, 11));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        IllegalArgumentException blank = assertThrows(IllegalArgumentException.class,
+                () -> cycleSubmissionService.submitManually(cycle.getId(), ENROLLMENT, "  ", USER));
+        assertTrue(blank.getMessage().contains("reference"));
+        assertEquals("nothing may move without one", "VALIDATED_PARTIAL",
+                participantResults(cycle.getId()).get(0).get("submission_status"));
+
+        EQACycle submitted = cycleSubmissionService.submitManually(cycle.getId(), ENROLLMENT, "NHLS-2026-0042", USER);
+
+        assertEquals(EQACycleStatus.SUBMITTED, submitted.getStatus());
+        Map<String, Object> row = participantResults(cycle.getId()).get(0);
+        assertEquals("SUBMITTED", row.get("submission_status"));
+        assertEquals("MANUAL", row.get("submission_channel"));
+        assertEquals("NHLS-2026-0042", row.get("manual_submission_reference"));
+        assertTrue("the manual move is audited as manual",
+                auditTriggers(cycle.getId()).contains("READY_TO_SUBMIT->SUBMITTED:MANUAL_OVERRIDE"));
+    }
+
+    @Test
+    public void exportBundle_carriesTheValidatedRowsAndQuotesSeparators() {
+        EQAProgram scheme = externalScheme(true);
+        EQACycle cycle = readBack(insertCycle(scheme, 12));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "Positive, weak");
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        String csv = cycleSubmissionService.exportBundleCsv(cycle.getId(), ENROLLMENT);
+
+        String[] lines = csv.split("\n");
+        assertEquals("header plus one row", 2, lines.length);
+        assertEquals("cycle_id,cycle_name,round_number,analyte_id,result_value,result_unit,submission_status,"
+                + "entered_at", lines[0]);
+        assertTrue("a value with a comma must be quoted, or the column count shifts: " + lines[1],
+                lines[1].contains("\"Positive, weak\""));
+        assertTrue(lines[1].startsWith(cycle.getId() + ",,1," + VL_ANALYTE + ","));
+    }
+
+    @Test
+    public void scoreIntake_writesTheVerdictAndZScoreAndScoresTheCycle() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 13));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        int scored = cycleSubmissionService.intakeScores(cycle.getId(), ENROLLMENT,
+                List.of(Map.of("analyteId", VL_ANALYTE, "performance", "acceptable", "zScore", "1.2")), USER);
+
+        assertEquals(1, scored);
+        Map<String, Object> row = participantResults(cycle.getId()).get(0);
+        assertEquals("SCORED", row.get("submission_status"));
+        assertEquals("ACCEPTABLE", row.get("performance_status"));
+        assertEquals(0, new BigDecimal("1.2").compareTo((BigDecimal) row.get("z_score")));
+        assertEquals(EQACycleStatus.SCORED, readBack(cycle.getId()).getStatus());
+        assertTrue(auditTriggers(cycle.getId()).contains("SUBMITTED->SCORED:SCORE_INTAKE"));
+    }
+
+    @Test
+    public void scoreIntake_refusesAResultFromAnotherCycle() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 14));
+        EQACycle other = readBack(insertCycle(scheme, 15));
+        insertRound(cycle, 1, "OPEN");
+        Long otherRound = insertRound(other, 1, "OPEN");
+        seedEnrollment(ENROLLMENT, "NHLS VL");
+        Long strayResult = insertParticipantResult(other, eqaRoundDAO.get(otherRound).orElseThrow(), ENROLLMENT,
+                VL_ANALYTE, null, "9.9");
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> cycleSubmissionService.intakeScores(cycle.getId(), ENROLLMENT,
+                        List.of(Map.of("resultId", strayResult, "performance", "ACCEPTABLE")), USER));
+
+        assertTrue(e.getMessage().contains("does not belong to cycle"));
+        assertNull("the stray result must be untouched",
+                participantResults(other.getId()).get(0).get("performance_status"));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
@@ -82,7 +82,7 @@ public class EQALabProgramEnrollmentServiceTest {
         input.setProvider("WHO");
         input.setSysUserId("1");
 
-        EQALabProgramEnrollment result = service.createEnrollment(input, labUnitIds, testIds, panelIds);
+        EQALabProgramEnrollment result = service.createEnrollment(input, labUnitIds, testIds, panelIds, null);
 
         assertNotNull(result);
         assertEquals("Chemistry PT", result.getProgramName());
@@ -106,7 +106,7 @@ public class EQALabProgramEnrollmentServiceTest {
         input.setProvider("CDC");
         input.setSysUserId("1");
 
-        EQALabProgramEnrollment result = service.createEnrollment(input, null, null, null);
+        EQALabProgramEnrollment result = service.createEnrollment(input, null, null, null, null);
 
         assertNotNull(result);
 
@@ -128,7 +128,7 @@ public class EQALabProgramEnrollmentServiceTest {
         input.setIsActive(null);
         input.setSysUserId("1");
 
-        service.createEnrollment(input, null, null, null);
+        service.createEnrollment(input, null, null, null, null);
 
         ArgumentCaptor<EQALabProgramEnrollment> captor =
                 ArgumentCaptor.forClass(EQALabProgramEnrollment.class);
@@ -157,7 +157,7 @@ public class EQALabProgramEnrollmentServiceTest {
         updated.setIsActive(true);
         updated.setSysUserId("1");
 
-        EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, List.of(30L), List.of(300L), null);
+        EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, List.of(30L), List.of(300L), null, null);
 
         assertNotNull(result);
         assertEquals("New Name", result.getProgramName());
@@ -174,7 +174,7 @@ public class EQALabProgramEnrollmentServiceTest {
         updated.setProvider("Whatever");
         updated.setSysUserId("1");
 
-        service.updateEnrollment(999L, updated, null, null, null);
+        service.updateEnrollment(999L, updated, null, null, null, null);
     }
 
     @Test


### PR DESCRIPTION
## What

Automatic submission of a participant cycle's results, with both fallbacks and score intake (OGC-610, FR-V2.2-05/-06/-08).

On the last validated result a cycle walks the participant machine to `ready_to_submit`; once the review window has elapsed (`org.openelisglobal.eqa.submission.windowHours`, default 1) it posts a `DiagnosticReport` bundle. A failure leaves the cycle where it is and retries with exponential backoff, capped at five attempts, then raises one alert.

## Why this is bigger than a submit button

`eqa_participant_result` had two writers — the participant-result controller and in-house blinding. A lab that ordered an EQA sample, entered its result and validated it produced **no EQA-side row at all**, so the derived cycle state never moved past whatever the panel receipt left it in. This adds that bridge for external schemes.

The analyte turned out to be the load-bearing detail. `eqa_participant_result.analyte_id` is a NOT NULL FK and nothing in the schema could supply one for an external scheme:

- `result.analyte_id` is filled from `test_analyte`, which most test configurations do not have — on a real instance, **0 of 22 results and 20 of 201 active tests** carry one;
- `eqa_panel_sample` carries analytes only for in-house panels a supervisor built;
- `eqa_program_test` maps program to test;
- `eqa_lab_enrollment_test_map` mapped enrollment to test/panel.

So the enrollment test map gains `analyte_id`: the lab declares which analyte each mapped test reports for the scheme, and the enrollment form gains a selector per selected test. Resolution tries the result's own analyte first (the only source with the right grain when one test reports several analytes), then the scheme mapping, then `test_analyte`. An unresolvable analyte holds the cycle short of submission rather than submitting a partial set the provider cannot reconcile.

## Also in here

- **FR-V2.2-06 manual fallback**, which requires the provider's reference — an unreferenced manual submission is a claim, not a record — plus a CSV export bundle for a portal upload.
- **FR-V2.2-08 score intake**, writing the verdict and the z-score the FR-V2.3-01 tiers read. The existing per-result score endpoint was silently dropping a client-sent `zScore`, sending every external score down the no-z path.
- `alert_type` gains `EQA_SUBMISSION_FAILED` in the **DB CHECK** as well as the enum. The Java value alone would have failed the very insert that reports a failed submission.

## Design notes

**A scheduled sweep, not a validation event listener.** FR-V2.2-05 needs a delayed submit with backoff, so a scheduled pass exists either way; a listener on top would be two mechanisms for one job. The sweep also covers every path that finalizes an analysis (validation, logbook, FHIR referral, retroCI) where a listener would have covered only the one it hooked. Cost: the flip to `ready_to_submit` lags up to 5 minutes, which is noise against a 1-hour window.

**Retry state is two columns on `eqa_cycle`.** It cannot live in the transition audit — a failed attempt stays in `ready_to_submit` and the participant machine has no self-edge, so `transition()` refuses the write (which is why `FHIR_SUBMIT_FAILURE_RETRY` has no audit row). Alerts are wrong too: they are acknowledgeable, so acknowledging one would change the retry schedule.

The sweep extends the existing EQA scheduler rather than adding a job, and calls per cycle inside a try/catch so one unreachable cycle cannot abort the pass.

## Liquibase

`qa/030` — `qa-056` (retry columns), `qa-057` (alert CHECK), `qa-058` (enrollment test-map analyte). Next free changeset id is `qa-059`.

## Tests

695 green across `eqa.**`, `qaevent.**`, `alert.**`; 9 frontend tests green. New coverage includes the production-shaped case (a result with no analyte resolved through the enrollment mapping), the inversion (an unmapped test holds the cycle rather than submitting a short set), the window, the backoff, the five-attempt cap with exactly one alert, and the sweep entry point.

## Live verification

Rebuilt onto an existing database, so the migrations ran as an upgrade rather than a clean provision. Exercised against an order the app itself created (`DEV01260000000000014`, HIV VIRAL LOAD):

| Step | Result |
| --- | --- |
| Migrations | `qa-056/057/058` EXECUTED against the pre-existing schema |
| Bridge, via the real 5-minute scheduler | analyte from the enrollment mapping, value `1500.00`, `VALIDATED_PARTIAL` |
| Round resolution | inferred from the cycle's single round — the order carried none |
| State walk | `PLANNED → PANEL_RECEIVED → TESTING → READY_TO_SUBMIT`, all `AUTO` / `LAST_VALIDATED_RESULT` |
| Export bundle | CSV with `text/csv` and the attachment filename |
| Manual submit | 400 without a reference; 200 with, channel `MANUAL`, audited `MANUAL_OVERRIDE` |
| Score intake | `SCORED`, `UNACCEPTABLE`, `z_score -3.40000`, cycle → `SCORED` |
| Cross-check | **NCE-2026-00048** auto-raised, `trigger_source_type EQA_UNACCEPTABLE` |

That last row only happens if the intake calls the z-carrying overload, so the ISO evidence loop closes end to end on real data.

**Not verified live:** the automatic FHIR post, which waits out the 1-hour window. Its bundle, the retry cap and the alert-on-exhaustion are covered by integration tests with a pinned clock.

## Follow-ups, deliberately not here

- The export bundle is CSV only. `EQAPerformanceReportPDFService` landed in #4096 while this was in flight, so the PDF half can now sit on top of it instead of adding a second renderer.
- No UI exposes manual submit, export or score intake yet; those belong to the My Cycles page.
- FR-V2.2-13's receipt-confirmation outbound event is skipped — the FRS leaves its resource shape open.
- Score intake persists the verdict and z-score only. Whether the printed report needs peer mean, SD and participant count is still an open question with CPHL, and the schema holds none of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
