### PR TITLE
feat(eqa-v2): pre-approved interpretive comments on the performance report (OGC-934)

### DIFF
--- a/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
@@ -29,6 +29,7 @@ import {
   fetchShipmentRows,
 } from "./workbenchApi";
 import PrepWorkbench from "./PrepWorkbench";
+import ReportComments from "./ReportComments";
 import ShipmentWorkbench from "./ShipmentWorkbench";
 
 const breadcrumbs = (cycleId) => {
@@ -204,6 +205,7 @@ const ProviderWorkbenchPage = () => {
               >
                 <Tab>{t("eqa.prep.tab", "Prep")}</Tab>
                 <Tab>{t("eqa.shipment.tab", "Shipments")}</Tab>
+                <Tab>{t("eqa.report.comments.tab", "Report comments")}</Tab>
               </TabList>
               <TabPanels>
                 <TabPanel>
@@ -223,6 +225,9 @@ const ProviderWorkbenchPage = () => {
                     onChanged={reload}
                     onNotice={setNotice}
                   />
+                </TabPanel>
+                <TabPanel>
+                  <ReportComments cycleId={cycleId} onNotice={setNotice} />
                 </TabPanel>
               </TabPanels>
             </Tabs>

--- a/frontend/src/components/eqa/Provider/Workbench/ReportComments.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReportComments.jsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from "react";
+import {
+  Button,
+  InlineNotification,
+  MultiSelect,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@carbon/react";
+import { useIntl } from "react-intl";
+import { resolveApiErrorMessage } from "../../../utils/Utils";
+import { hintStyle } from "../../eqaCommon";
+import {
+  attachComments,
+  detachComment,
+  fetchCommentLibrary,
+  fetchCycleComments,
+} from "./workbenchApi";
+
+/**
+ * Interpretive comments on the printed performance report (FR OGC-934).
+ *
+ * The picker is the only way in: it offers the pre-approved library and posts
+ * ids, so there is no free-text field to type an unreviewed judgement into. An
+ * attached comment keeps the wording it was attached with, which is why
+ * retiring a library entry never rewrites a report already issued.
+ */
+const ReportComments = ({ cycleId, onNotice }) => {
+  const intl = useIntl();
+  const t = (id, defaultMessage, values) =>
+    intl.formatMessage({ id, defaultMessage }, values);
+
+  const [library, setLibrary] = useState([]);
+  const [attached, setAttached] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const [busy, setBusy] = useState(null);
+
+  useEffect(() => {
+    fetchCommentLibrary(setLibrary);
+    fetchCycleComments(cycleId, setAttached);
+  }, [cycleId]);
+
+  const attachedIds = attached.map((comment) => comment.libraryEntryId);
+  // An attached entry drops out of the picker rather than being offered and
+  // then silently ignored by the server's skip.
+  const offered = library.filter((entry) => !attachedIds.includes(entry.id));
+
+  const add = () => {
+    setBusy("add");
+    attachComments(
+      cycleId,
+      selected.map((entry) => entry.id),
+      ({ ok, body }) => {
+        setBusy(null);
+        if (!ok) {
+          onNotice({
+            kind: "error",
+            text: resolveApiErrorMessage(
+              intl,
+              body,
+              "eqa.report.comments.addFailed",
+            ),
+          });
+          return;
+        }
+        setSelected([]);
+        fetchCycleComments(cycleId, setAttached);
+        onNotice({
+          kind: "success",
+          text: t(
+            "eqa.report.comments.added",
+            "{count} comment(s) added to the report",
+            { count: body?.length ?? 0 },
+          ),
+        });
+      },
+    );
+  };
+
+  const remove = (commentId) => {
+    setBusy(commentId);
+    detachComment(cycleId, commentId, ({ ok, body }) => {
+      setBusy(null);
+      if (!ok) {
+        onNotice({
+          kind: "error",
+          text: resolveApiErrorMessage(
+            intl,
+            body,
+            "eqa.report.comments.removeFailed",
+          ),
+        });
+        return;
+      }
+      fetchCycleComments(cycleId, setAttached);
+    });
+  };
+
+  return (
+    <>
+      <p style={hintStyle}>
+        {t(
+          "eqa.report.comments.hint",
+          "Only pre-approved comments can be printed. Edit the wording under Administration → Dictionary Management.",
+        )}
+      </p>
+
+      {library.length === 0 ? (
+        <InlineNotification
+          kind="info"
+          lowContrast
+          hideCloseButton
+          title={t(
+            "eqa.report.comments.emptyLibrary.title",
+            "No approved comments configured",
+          )}
+          subtitle={t(
+            "eqa.report.comments.emptyLibrary.body",
+            "Add entries to the EQA Report Comment dictionary category to make them selectable here.",
+          )}
+        />
+      ) : (
+        <div style={{ display: "flex", gap: "1rem", alignItems: "flex-end" }}>
+          <div style={{ flex: "1 1 30rem" }}>
+            <MultiSelect
+              id="eqa-report-comment-picker"
+              titleText={t("eqa.report.comments.picker", "Approved comments")}
+              label={t("eqa.report.comments.pickerLabel", "Select comments")}
+              items={offered}
+              itemToString={(item) => (item ? item.text : "")}
+              // The library is ordered deliberately (verdict first, then
+              // corrective actions); Carbon would otherwise sort it by text.
+              sortItems={(items) => items}
+              selectedItems={selected}
+              onChange={({ selectedItems }) => setSelected(selectedItems || [])}
+            />
+          </div>
+          <Button
+            kind="tertiary"
+            disabled={selected.length === 0 || busy === "add"}
+            onClick={add}
+          >
+            {t("eqa.report.comments.add", "Add to report")}
+          </Button>
+        </div>
+      )}
+
+      <Table size="sm" style={{ marginTop: "1rem" }}>
+        <TableHead>
+          <TableRow>
+            <TableHeader>
+              {t("eqa.report.comments.comment", "Comment")}
+            </TableHeader>
+            <TableHeader>
+              {t("eqa.report.comments.attribution", "Added by")}
+            </TableHeader>
+            <TableHeader />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {attached.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3}>
+                {t(
+                  "eqa.report.comments.none",
+                  "No comments on this cycle's report yet.",
+                )}
+              </TableCell>
+            </TableRow>
+          ) : (
+            attached.map((comment) => (
+              <TableRow key={comment.id}>
+                <TableCell>{comment.text}</TableCell>
+                <TableCell>
+                  {comment.attachedBy}
+                  {comment.attachedAt ? ` — ${comment.attachedAt}` : ""}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    kind="ghost"
+                    size="sm"
+                    disabled={busy === comment.id}
+                    onClick={() => remove(comment.id)}
+                  >
+                    {t("eqa.report.comments.remove", "Remove")}
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </>
+  );
+};
+
+export default ReportComments;

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReportComments.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReportComments.test.jsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../../../languages/en.json";
+import ReportComments from "../ReportComments";
+import {
+  attachComments,
+  detachComment,
+  fetchCommentLibrary,
+  fetchCycleComments,
+} from "../workbenchApi";
+
+/**
+ * OGC-934 — the picker's failure paths.
+ *
+ * Only the transport is mocked. `resolveApiErrorMessage` is deliberately the
+ * real implementation: it takes (intl, payload, fallbackId), and calling it
+ * with the payload alone throws inside the error branch, leaving the previous
+ * success notice on screen while the server refused the write. A mocked
+ * resolver accepts either argument order and hides that, which is how the
+ * defect reached a live walkthrough.
+ */
+vi.mock("../workbenchApi", () => ({
+  fetchCommentLibrary: vi.fn(),
+  fetchCycleComments: vi.fn(),
+  attachComments: vi.fn(),
+  detachComment: vi.fn(),
+}));
+
+const LIBRARY = [
+  { id: "4118", text: "Performance acceptable for this cycle." },
+  { id: "4119", text: "Result outside the acceptable range." },
+];
+
+const ATTACHED = [
+  {
+    id: "83",
+    libraryEntryId: "4119",
+    text: "Result outside the acceptable range.",
+    attachedBy: "Open ELIS",
+    attachedAt: "20/08/2026 19:08",
+  },
+];
+
+/** Carbon renders the option list only while the menu is open. */
+/**
+ * Carbon renders the option list only while the menu is open, and a controlled
+ * MultiSelect needs the full pointer sequence user-event dispatches — a bare
+ * fireEvent.click on the option leaves the selection empty and the Add button
+ * disabled.
+ */
+const pick = async (label) => {
+  const user = userEvent.setup();
+  await user.click(
+    screen.getByRole("combobox", { name: /approved comments/i }),
+  );
+  await user.click(screen.getByRole("option", { name: label }));
+};
+
+const renderPanel = (onNotice) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <ReportComments cycleId={4} onNotice={onNotice} />
+    </IntlProvider>,
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchCommentLibrary.mockImplementation((cb) => cb(LIBRARY));
+  fetchCycleComments.mockImplementation((_cycleId, cb) => cb(ATTACHED));
+});
+
+describe("ReportComments", () => {
+  it("surfaces the server's refusal when an attach is rejected", async () => {
+    attachComments.mockImplementation((_cycleId, _ids, cb) =>
+      cb({
+        ok: false,
+        body: {
+          error: "Comment 4123 is not an active entry of the library",
+        },
+      }),
+    );
+    const onNotice = vi.fn();
+    renderPanel(onNotice);
+
+    await pick("Performance acceptable for this cycle.");
+    fireEvent.click(screen.getByRole("button", { name: "Add to report" }));
+
+    expect(onNotice).toHaveBeenCalledTimes(1);
+    expect(onNotice).toHaveBeenCalledWith({
+      kind: "error",
+      text: "Comment 4123 is not an active entry of the library",
+    });
+  });
+
+  it("falls back to a message when a refusal carries no body", async () => {
+    attachComments.mockImplementation((_cycleId, _ids, cb) =>
+      cb({ ok: false, body: null }),
+    );
+    const onNotice = vi.fn();
+    renderPanel(onNotice);
+
+    await pick("Performance acceptable for this cycle.");
+    fireEvent.click(screen.getByRole("button", { name: "Add to report" }));
+
+    expect(onNotice).toHaveBeenCalledTimes(1);
+    expect(onNotice).toHaveBeenCalledWith({
+      kind: "error",
+      text: messages["eqa.report.comments.addFailed"],
+    });
+  });
+
+  it("surfaces the server's refusal when a remove is rejected", () => {
+    detachComment.mockImplementation((_cycleId, _commentId, cb) =>
+      cb({
+        ok: false,
+        body: { error: "Comment 83 is not attached to cycle 4" },
+      }),
+    );
+    const onNotice = vi.fn();
+    renderPanel(onNotice);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(onNotice).toHaveBeenCalledTimes(1);
+    expect(onNotice).toHaveBeenCalledWith({
+      kind: "error",
+      text: "Comment 83 is not attached to cycle 4",
+    });
+    expect(fetchCycleComments).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports how many comments were added and reloads the table", async () => {
+    attachComments.mockImplementation((_cycleId, ids, cb) => {
+      expect(ids).toEqual(["4118"]);
+      cb({ ok: true, body: [{ id: "84", libraryEntryId: "4118" }] });
+    });
+    const onNotice = vi.fn();
+    renderPanel(onNotice);
+
+    await pick("Performance acceptable for this cycle.");
+    fireEvent.click(screen.getByRole("button", { name: "Add to report" }));
+
+    expect(onNotice).toHaveBeenCalledTimes(1);
+    expect(onNotice).toHaveBeenCalledWith({
+      kind: "success",
+      text: "1 comment(s) added to the report",
+    });
+    expect(fetchCycleComments).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers only entries that are not attached yet", () => {
+    renderPanel(vi.fn());
+
+    fireEvent.click(
+      screen.getByRole("combobox", { name: /approved comments/i }),
+    );
+
+    // 4119 is attached, so the picker offers 4118 alone; the attached wording
+    // appears once, in the table rather than the menu.
+    const offered = screen.getAllByRole("option").map((o) => o.textContent);
+    expect(offered).toEqual(["Performance acceptable for this cycle."]);
+    expect(
+      screen.getAllByText("Result outside the acceptable range."),
+    ).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -3,6 +3,7 @@
 // box state) or 422 (bad input) reaches the operator verbatim — a JSON-only
 // helper would swallow the reason, which is the D-LIVE-1 mistake.
 import {
+  deleteFromOpenElisServerFullResponse,
   getFromOpenElisServer,
   patchToOpenElisServerFullResponse,
   postToOpenElisServerFullResponse,
@@ -84,3 +85,30 @@ export const requestReadyToShip = (cycleId, callback) =>
  */
 export const fetchPanelSamples = (panelId, callback) =>
   getFromOpenElisServer(`/rest/eqa/panels/${panelId}/samples`, callback);
+
+// --- OGC-934 report comments ---
+
+/** The pre-approved library the picker offers. */
+export const fetchCommentLibrary = (callback) =>
+  getFromOpenElisServer("/rest/eqa/report-comments", (data) =>
+    callback(data || []),
+  );
+
+export const fetchCycleComments = (cycleId, callback) =>
+  getFromOpenElisServer(`/rest/eqa/cycles/${cycleId}/report-comments`, (data) =>
+    callback(data || []),
+  );
+
+/** Ids only: the endpoint has no text field, so nothing unapproved can be sent. */
+export const attachComments = (cycleId, commentIds, callback) =>
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/report-comments`,
+    JSON.stringify({ commentIds }),
+    withBody(callback),
+  );
+
+export const detachComment = (cycleId, commentId, callback) =>
+  deleteFromOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/report-comments/${commentId}`,
+    withBody(callback),
+  );

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8311,5 +8311,19 @@
   "eqa.inhouse.cancel": "Cancel",
   "eqa.enrollment.testAnalytes": "Reporting analyte per test",
   "eqa.enrollment.testAnalytes.help": "Set which analyte each test reports for this scheme. Results are submitted to the provider under this analyte; a test left unset is not submitted automatically.",
-  "eqa.enrollment.selectAnalyte": "Choose an analyte"
+  "eqa.enrollment.selectAnalyte": "Choose an analyte",
+  "eqa.report.comments.tab": "Report comments",
+  "eqa.report.comments.hint": "Only pre-approved comments can be printed. Edit the wording under Administration → Dictionary Management.",
+  "eqa.report.comments.picker": "Approved comments",
+  "eqa.report.comments.pickerLabel": "Select comments",
+  "eqa.report.comments.add": "Add to report",
+  "eqa.report.comments.added": "{count} comment(s) added to the report",
+  "eqa.report.comments.comment": "Comment",
+  "eqa.report.comments.attribution": "Added by",
+  "eqa.report.comments.none": "No comments on this cycle's report yet.",
+  "eqa.report.comments.remove": "Remove",
+  "eqa.report.comments.emptyLibrary.title": "No approved comments configured",
+  "eqa.report.comments.emptyLibrary.body": "Add entries to the EQA Report Comment dictionary category to make them selectable here.",
+  "eqa.report.comments.addFailed": "The comment could not be added to the report.",
+  "eqa.report.comments.removeFailed": "The comment could not be removed from the report."
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -14,6 +14,7 @@ import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
+import org.openelisglobal.eqa.service.EQAReportCommentService;
 import org.openelisglobal.eqa.service.SampleEQAService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
@@ -31,6 +32,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -60,16 +62,18 @@ public class EQACycleRestController extends BaseRestController {
     private final AnalysisService analysisService;
     private final ResultService resultService;
     private final EQAPerformanceReportPDFService performanceReportService;
+    private final EQAReportCommentService reportCommentService;
 
     public EQACycleRestController(EQACycleService cycleService, SampleEQAService sampleEQAService,
             SampleService sampleService, AnalysisService analysisService, ResultService resultService,
-            EQAPerformanceReportPDFService performanceReportService) {
+            EQAPerformanceReportPDFService performanceReportService, EQAReportCommentService reportCommentService) {
         this.cycleService = cycleService;
         this.sampleEQAService = sampleEQAService;
         this.sampleService = sampleService;
         this.analysisService = analysisService;
         this.resultService = resultService;
         this.performanceReportService = performanceReportService;
+        this.reportCommentService = reportCommentService;
     }
 
     /**
@@ -92,6 +96,69 @@ public class EQACycleRestController extends BaseRestController {
         String filename = "eqa-performance-report-cycle-" + cycleId + ".pdf";
         return ResponseEntity.ok().header("Content-Disposition", "inline; filename=\"" + filename + "\"")
                 .contentType(MediaType.APPLICATION_PDF).body(pdf);
+    }
+
+    /**
+     * OGC-934: the pre-approved comment library the picker offers. Maintained as a
+     * dictionary category, so an installation edits the wording without a release.
+     */
+    @GetMapping(value = "/report-comments", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> reportCommentLibrary() {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAReportCommentService.LibraryEntry entry : reportCommentService.getLibrary()) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", entry.id());
+            dto.put("text", entry.text());
+            rows.add(dto);
+        }
+        return rows;
+    }
+
+    @GetMapping(value = "/cycles/{cycleId}/report-comments", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Map<String, Object>> reportComments(@PathVariable Long cycleId) {
+        return commentDtos(reportCommentService.getComments(cycleId));
+    }
+
+    /**
+     * Attaches library entries to the cycle's report. The body carries ids only —
+     * there is no text field to fill, so nothing but pre-approved wording can reach
+     * a signed report (FR-V2.3 interpretive comments, OGC-934).
+     */
+    @PostMapping(value = "/cycles/{cycleId}/report-comments", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<Map<String, Object>> attachReportComments(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestBody Map<String, Object> body) {
+        Object ids = body.get("commentIds");
+        if (!(ids instanceof List<?> list)) {
+            throw new IllegalArgumentException("commentIds is required");
+        }
+        List<String> commentIds = new ArrayList<>();
+        for (Object id : list) {
+            commentIds.add(String.valueOf(id));
+        }
+        return commentDtos(reportCommentService.attach(cycleId, commentIds, getSysUserId(request)));
+    }
+
+    @DeleteMapping(value = "/cycles/{cycleId}/report-comments/{commentId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public Map<String, Object> detachReportComment(@PathVariable Long cycleId, @PathVariable String commentId) {
+        reportCommentService.detach(cycleId, commentId);
+        return Map.of("removed", commentId);
+    }
+
+    private List<Map<String, Object>> commentDtos(List<EQAReportCommentService.AttachedComment> comments) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAReportCommentService.AttachedComment comment : comments) {
+            Map<String, Object> dto = new LinkedHashMap<>();
+            dto.put("id", comment.id());
+            dto.put("libraryEntryId", comment.libraryEntryId());
+            dto.put("text", comment.text());
+            dto.put("attachedBy", comment.attachedBy());
+            dto.put("attachedAt", comment.attachedAt());
+            rows.add(dto);
+        }
+        return rows;
     }
 
     /**

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFServiceImpl.java
@@ -87,6 +87,8 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
     private EQAPanelSampleDAO panelSampleDAO;
     @Autowired
     private NCEventService ncEventService;
+    @Autowired
+    private EQAReportCommentService reportCommentService;
 
     @Override
     public byte[] generatePerformanceReport(Long cycleId) {
@@ -107,6 +109,7 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
             addProgrammeSummary(document, rows);
             addSectionSummary(document, rows);
             addScoringTable(document, rows);
+            addInterpretiveComments(document, cycleId);
             addSignOff(document);
             document.close();
         } catch (DocumentException e) {
@@ -282,6 +285,39 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
             bodyRow(table, row.roundLabel(), row.analyteLabel(), row.reportedLabel(), row.targetLabel(), row.zLabel(),
                     row.performanceLabel(), dash(row.nceNumber()), dash(row.analyst()), dash(row.submittedAt()),
                     dash(row.scoredAt()));
+        }
+        document.add(table);
+    }
+
+    /**
+     * OGC-934: the reviewer's standardised commentary, printed under the scoring
+     * table it refers to. Wording comes from the pre-approved library, so a reader
+     * can hold two labs' reports side by side and compare the verdicts.
+     *
+     * <p>
+     * A cycle with no comment prints no heading: an empty section on a signed
+     * document reads as commentary that went missing.
+     */
+    private void addInterpretiveComments(Document document, Long cycleId) throws DocumentException {
+        List<EQAReportCommentService.AttachedComment> comments = reportCommentService.getComments(cycleId);
+        if (comments.isEmpty()) {
+            return;
+        }
+
+        document.add(paragraph(MessageUtil.getMessage("eqa.report.comments.title"), SECTION_FONT, 14f));
+        PdfPTable table = new PdfPTable(new float[] { 5f, 1.6f });
+        table.setWidthPercentage(100);
+        table.setHeaderRows(1);
+        headerRow(table, MessageUtil.getMessage("eqa.report.comments.comment"),
+                MessageUtil.getMessage("eqa.report.comments.attribution"));
+        for (EQAReportCommentService.AttachedComment comment : comments) {
+            // Who added it and when, on the page rather than only in the audit
+            // trail: the comment is a judgement, and a judgement carries a name.
+            String attribution = dash(comment.attachedBy());
+            if (comment.attachedAt() != null) {
+                attribution = attribution + " — " + comment.attachedAt();
+            }
+            bodyRow(table, dash(comment.text()), attribution);
         }
         document.add(table);
     }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAReportCommentService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAReportCommentService.java
@@ -1,0 +1,54 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+
+/**
+ * Pre-approved interpretive comments on a cycle's performance report (OGC-934).
+ *
+ * <p>
+ * The library is the {@code EQA Report Comment} dictionary category, so the
+ * existing Dictionary Management screen maintains it and deactivating an entry
+ * stops new use without touching text already printed. An attachment is a note
+ * against the cycle, which carries the author and the timestamp already.
+ *
+ * <p>
+ * Nothing here accepts comment text: a caller names a library entry by id and
+ * the service resolves the wording, so free text cannot reach a signed report.
+ */
+public interface EQAReportCommentService {
+
+    /** The dictionary category that holds the pre-approved wording. */
+    String CATEGORY_NAME = "EQA Report Comment";
+
+    /** One selectable library entry. */
+    record LibraryEntry(String id, String text) {
+    }
+
+    /** One comment attached to a cycle, with who attached it and when. */
+    record AttachedComment(String id, String libraryEntryId, String text, String attachedBy, String attachedAt) {
+    }
+
+    /** Active library entries in their configured order. */
+    List<LibraryEntry> getLibrary();
+
+    /** Comments attached to this cycle, oldest first — the order they print in. */
+    List<AttachedComment> getComments(Long cycleId);
+
+    /**
+     * Attaches each library entry that is not attached already and returns what was
+     * added. Re-sending an attached id is a no-op rather than a second identical
+     * paragraph on the report.
+     *
+     * @throws IllegalArgumentException if an id is not an active entry of
+     *                                  {@link #CATEGORY_NAME}, or if its wording is
+     *                                  too long to store as a note
+     */
+    List<AttachedComment> attach(Long cycleId, List<String> libraryEntryIds, String currentUserId);
+
+    /**
+     * Removes one attached comment.
+     *
+     * @throws IllegalArgumentException if the comment is not attached to this cycle
+     */
+    void detach(Long cycleId, String commentId);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAReportCommentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAReportCommentServiceImpl.java
@@ -1,0 +1,171 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.openelisglobal.common.util.DateUtil;
+import org.openelisglobal.dictionary.service.DictionaryService;
+import org.openelisglobal.dictionary.valueholder.Dictionary;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
+import org.openelisglobal.note.service.NoteService;
+import org.openelisglobal.note.service.NoteServiceImpl;
+import org.openelisglobal.note.service.NoteServiceImpl.NoteType;
+import org.openelisglobal.note.valueholder.Note;
+import org.openelisglobal.referencetables.service.ReferenceTablesService;
+import org.openelisglobal.referencetables.valueholder.ReferenceTables;
+import org.openelisglobal.systemuser.valueholder.SystemUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class EQAReportCommentServiceImpl implements EQAReportCommentService {
+
+    /** The table a report comment's note points at. */
+    private static final String REFERENCE_TABLE = "eqa_cycle";
+
+    /**
+     * note.text is varchar(1000) while dict_entry allows 4000. A library entry
+     * longer than the column is a configuration fault, and truncating it would put
+     * half a sentence on a document someone signs.
+     */
+    private static final int MAX_TEXT_LENGTH = 1000;
+
+    /** Hibernate maps dictionary_category.name to this property. */
+    private static final String CATEGORY_FIELD = "categoryName";
+
+    @Autowired
+    private DictionaryService dictionaryService;
+    @Autowired
+    private NoteService noteService;
+    @Autowired
+    private ReferenceTablesService referenceTablesService;
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
+
+    @Override
+    public List<LibraryEntry> getLibrary() {
+        List<LibraryEntry> entries = new ArrayList<>();
+        for (Dictionary entry : activeLibrary()) {
+            entries.add(new LibraryEntry(entry.getId(), entry.getDictEntry()));
+        }
+        return entries;
+    }
+
+    @Override
+    public List<AttachedComment> getComments(Long cycleId) {
+        List<AttachedComment> comments = new ArrayList<>();
+        for (Note note : attachedNotes(cycleId)) {
+            comments.add(toComment(note));
+        }
+        return comments;
+    }
+
+    @Override
+    @Transactional
+    public List<AttachedComment> attach(Long cycleId, List<String> libraryEntryIds, String currentUserId) {
+        requireCycle(cycleId);
+        if (libraryEntryIds == null || libraryEntryIds.isEmpty()) {
+            throw new IllegalArgumentException("No comment was selected");
+        }
+
+        Map<String, String> library = new LinkedHashMap<>();
+        for (Dictionary entry : activeLibrary()) {
+            library.put(entry.getId(), entry.getDictEntry());
+        }
+
+        // Already-attached ids are skipped rather than rejected: a resent
+        // selection must not print the same paragraph twice, and must not fail
+        // the ids alongside it either.
+        Set<String> attached = new HashSet<>();
+        for (Note note : attachedNotes(cycleId)) {
+            attached.add(note.getSubject());
+        }
+
+        String referenceTableId = referenceTableId();
+        List<AttachedComment> added = new ArrayList<>();
+        for (String entryId : libraryEntryIds) {
+            String text = library.get(entryId);
+            if (text == null) {
+                throw new IllegalArgumentException(
+                        "Comment " + entryId + " is not an active entry of the " + CATEGORY_NAME + " library");
+            }
+            if (text.length() > MAX_TEXT_LENGTH) {
+                throw new IllegalArgumentException("Comment " + entryId + " is longer than " + MAX_TEXT_LENGTH
+                        + " characters and cannot be stored");
+            }
+            if (!attached.add(entryId)) {
+                continue;
+            }
+
+            Note note = new Note();
+            note.setReferenceId(String.valueOf(cycleId));
+            note.setReferenceTableId(referenceTableId);
+            note.setNoteType(NoteType.EXTERNAL.getDBCode());
+            // The library entry id, so an attachment stays traceable to the phrase
+            // it came from even after the phrase is reworded or retired.
+            note.setSubject(entryId);
+            note.setText(text);
+            // SYS_USER_ID is mapped through the systemUser relation, not the
+            // systemUserId field: setting the field alone would persist no author.
+            note.setSystemUser(NoteServiceImpl.createSystemUser(currentUserId));
+            note.setSysUserId(currentUserId);
+            noteService.insert(note);
+            added.add(toComment(note));
+        }
+        return added;
+    }
+
+    @Override
+    @Transactional
+    public void detach(Long cycleId, String commentId) {
+        // Searched among this cycle's attachments rather than fetched by id: a
+        // note belonging to another cycle, or already gone, is the same answer
+        // here, and looking it up by id alone throws instead of saying so.
+        Note note = attachedNotes(cycleId).stream().filter(candidate -> commentId.equals(candidate.getId())).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Comment " + commentId + " is not attached to cycle " + cycleId));
+        noteService.delete(note);
+    }
+
+    private AttachedComment toComment(Note note) {
+        return new AttachedComment(note.getId(), note.getSubject(), note.getText(), authorName(note),
+                note.getLastupdated() == null ? null : DateUtil.formatDateTimeAsText(note.getLastupdated()));
+    }
+
+    /** Active entries of the library category, in their configured order. */
+    private List<Dictionary> activeLibrary() {
+        return dictionaryService.getDictionaryEntrysByCategoryAbbreviation(CATEGORY_FIELD, CATEGORY_NAME, false);
+    }
+
+    private List<Note> attachedNotes(Long cycleId) {
+        List<Note> notes = noteService.getNotesChronologicallyByRefIdAndRefTableAndType(String.valueOf(cycleId),
+                referenceTableId(), List.of(NoteType.EXTERNAL.getDBCode()));
+        return notes == null ? List.of() : notes;
+    }
+
+    private String referenceTableId() {
+        ReferenceTables table = referenceTablesService.getReferenceTableByName(REFERENCE_TABLE);
+        if (table == null) {
+            throw new IllegalStateException(
+                    "reference_tables has no " + REFERENCE_TABLE + " row; liquibase qa/032 has not run");
+        }
+        return table.getId();
+    }
+
+    private void requireCycle(Long cycleId) {
+        if (cycleId == null || eqaCycleDAO.get(cycleId).isEmpty()) {
+            throw new IllegalArgumentException("Unknown cycle " + cycleId);
+        }
+    }
+
+    /** Resolved inside the transaction: the relation is fetched, not eager. */
+    private String authorName(Note note) {
+        SystemUser author = note.getSystemUser();
+        return author == null ? null : author.getNameForDisplay();
+    }
+}

--- a/src/main/resources/languages/message_en.properties
+++ b/src/main/resources/languages/message_en.properties
@@ -8521,6 +8521,11 @@ eqa.report.signoff.title = Review and sign-off
 eqa.report.signoff.reviewedBy = Reviewed by
 eqa.report.signoff.date = Date
 
+# OGC-934 — pre-approved interpretive comments printed under the scoring table.
+eqa.report.comments.title = Interpretive comments
+eqa.report.comments.comment = Comment
+eqa.report.comments.attribution = Added by
+
 # Enum labels the printed report renders; the frontend carries the same
 # lower-cased naming in en.json.
 eqa.schemeType.international_pt = International PT

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -112,4 +112,7 @@
 
   <!-- EQA V2.2 — OGC-610: automatic-submission retry bookkeeping (FR-V2.2-05) -->
   <include file="liquibase/qa/030-add-eqa-cycle-submission-retry.xml" />
+
+  <!-- EQA V2 — OGC-934: pre-approved interpretive comments for the performance report -->
+  <include file="liquibase/qa/032-eqa-report-comments.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/032-eqa-report-comments.xml
+++ b/src/main/resources/liquibase/qa/032-eqa-report-comments.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    OGC-934 — pre-approved interpretive comments for the EQA performance report.
+
+    No new table. The library is a dictionary category: dictionary already carries
+    dict_entry (4000 chars), is_active and sort_order, and the Dictionary
+    Management admin screen already maintains it, so retiring a phrase needs no
+    code. The attachment side reuses the note table, which is keyed by
+    (reference_table, reference_id) and records sys_user_id and lastupdated, so
+    attribution comes for free.
+
+    The seeded wording is operational QA guidance, not clinical interpretation,
+    and is a starting library CPHL is expected to edit in place.
+    -->
+
+    <changeSet author="openelisglobal" id="qa-060-seed-eqa-report-comment-library">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment'
+            </sqlCheck>
+        </preConditions>
+        <comment>Dictionary category + starter set of pre-approved EQA report comments</comment>
+
+        <insert schemaName="clinlims" tableName="dictionary_category">
+            <column name="id" valueSequenceNext="dictionary_category_seq"/>
+            <column name="name" value="EQA Report Comment"/>
+            <column name="description" value="Pre-approved EQA report interpretive comments"/>
+            <column name="local_abbrev" value="EQARC"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+
+        <!-- sort_order drives the order the picker offers them in. -->
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Performance acceptable for this cycle. No corrective action required."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="10"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Result outside the acceptable range. Review specimen handling and repeat the analysis."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="20"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Review instrument calibration and maintenance records before the next cycle."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="30"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Check the reagent lot, storage conditions and expiry dates used for this panel."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="40"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Retrain the analyst on this procedure and file the competency assessment."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="50"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+        <insert schemaName="clinlims" tableName="dictionary">
+            <column name="id" valueSequenceNext="dictionary_seq"/>
+            <column name="dictionary_category_id"
+                    valueComputed="(SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')"/>
+            <column name="dict_entry" value="Submit a corrective action plan to the scheme provider within 30 days."/>
+            <column name="is_active" value="Y"/>
+            <column name="sort_order" valueNumeric="60"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+
+        <rollback>
+            <delete schemaName="clinlims" tableName="dictionary">
+                <where>dictionary_category_id = (SELECT id FROM clinlims.dictionary_category WHERE name = 'EQA Report Comment')</where>
+            </delete>
+            <delete schemaName="clinlims" tableName="dictionary_category">
+                <where>name = 'EQA Report Comment'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <!-- note.reference_table is a FK-by-convention into reference_tables; a note
+         whose table has no row here cannot be read back by name. -->
+    <changeSet author="openelisglobal" id="qa-061-register-eqa-cycle-ref-table">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM clinlims.reference_tables WHERE LOWER(name) = 'eqa_cycle'</sqlCheck>
+        </preConditions>
+        <comment>Register eqa_cycle so report comments can be stored as notes against a cycle</comment>
+
+        <insert schemaName="clinlims" tableName="reference_tables">
+            <column name="id" valueSequenceNext="reference_tables_seq"/>
+            <column name="name" value="eqa_cycle"/>
+            <column name="keep_history" value="Y"/>
+            <column name="lastupdated" valueDate="now()"/>
+        </insert>
+
+        <rollback>
+            <delete schemaName="clinlims" tableName="reference_tables">
+                <where>LOWER(name) = 'eqa_cycle'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
@@ -15,6 +15,7 @@ import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
+import org.openelisglobal.eqa.service.EQAReportCommentService;
 import org.openelisglobal.eqa.service.SampleEQAService;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
@@ -59,6 +60,9 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     @Autowired
     private EQAPerformanceReportPDFService performanceReportService;
 
+    @Autowired
+    private EQAReportCommentService reportCommentService;
+
     // eqa.controller.* is excluded from the test component scan — construct it
     private EQACycleRestController controller;
 
@@ -67,7 +71,7 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     public void setUp() throws Exception {
         super.setUp();
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, performanceReportService);
+                resultService, performanceReportService, reportCommentService);
         ensureStatusRows();
         cleanupSeed();
     }

--- a/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
@@ -12,16 +12,19 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAParticipantResultService;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
+import org.openelisglobal.eqa.service.EQAReportCommentService;
 import org.openelisglobal.eqa.service.SampleEQAService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
@@ -33,6 +36,7 @@ import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.result.service.ResultService;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.systemuser.service.SystemUserService;
@@ -40,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * OGC-933 — the printed CPHL-format performance report against the real schema:
@@ -86,9 +91,17 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
     private static final String SECTION_SUMMARY = "Section summary";
     private static final String SCORING_DETAIL = "Scoring detail";
     private static final String SIGN_OFF = "Review and sign-off";
+    private static final String COMMENTS_TITLE = "Interpretive comments";
+    private static final String COMMENT_ONE = "Cycle reviewed against the scheme's acceptance limits.";
+    private static final String COMMENT_TWO = "Repeat the unacceptable analyte in the next cycle.";
+    private static final String UNRELATED_COMMENT = "Wording from another dictionary category.";
+    private static final String OTHER_CATEGORY = "EQA Report Comment Test Foil";
 
     @Autowired
     private EQAPerformanceReportPDFService reportService;
+
+    @Autowired
+    private EQAReportCommentService reportCommentService;
 
     @Autowired
     private SystemUserService systemUserService;
@@ -122,7 +135,7 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
     @Before
     public void seedCycleWithScores() {
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, reportService);
+                resultService, reportService, reportCommentService);
 
         jdbc.update("INSERT INTO clinlims.localization (id, description)"
                 + " SELECT ?, 'EQA Report Section' WHERE NOT EXISTS"
@@ -167,6 +180,16 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
      * Runs before the spine's own cleanup, so release the participant result's
      * reference to the analysis before dropping the row it points at.
      */
+    /** Comment attachments and the library rows this suite created. */
+    @After
+    public void dropCommentSeed() {
+        jdbc.update("DELETE FROM clinlims.note WHERE reference_table ="
+                + " (SELECT id FROM clinlims.reference_tables WHERE LOWER(name) = 'eqa_cycle')");
+        jdbc.update("DELETE FROM clinlims.dictionary WHERE dict_entry IN (?, ?, ?)", COMMENT_ONE, COMMENT_TWO,
+                UNRELATED_COMMENT);
+        jdbc.update("DELETE FROM clinlims.dictionary_category WHERE name = ?", OTHER_CATEGORY);
+    }
+
     @After
     public void dropAnalysisLinkedSeed() {
         // Panel-backed results outlive the spine's delete order, which drops
@@ -442,7 +465,181 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
+    // ---- OGC-934 interpretive comments ----
+
+    @Test
+    public void attachedCommentsPrintUnderTheScoringTableWithTheirAttribution() throws IOException {
+        seedCommentLibrary();
+        String analyst = systemUserService.get(String.valueOf(ADMIN_USER_ID)).getNameForDisplay();
+
+        List<Map<String, Object>> added = controller.attachReportComments(requestForAdmin(), cycle.getId(),
+                Map.of("commentIds", List.of(libraryId(COMMENT_ONE), libraryId(COMMENT_TWO))));
+
+        assertEquals("both selections are attached", 2, added.size());
+        assertEquals(COMMENT_ONE, added.get(0).get("text"));
+        assertEquals(COMMENT_TWO, added.get(1).get("text"));
+        assertEquals("the comment is attributed to the user who attached it", analyst, added.get(0).get("attachedBy"));
+        assertEquals("the library entry stays traceable", libraryId(COMMENT_ONE), added.get(0).get("libraryEntryId"));
+
+        String comments = block(reportText(), COMMENTS_TITLE, SIGN_OFF);
+        assertTrue("the first comment prints", comments.contains(COMMENT_ONE));
+        assertTrue("the second comment prints", comments.contains(COMMENT_TWO));
+        assertTrue("the reviewer's name prints beside the comment", rowIn(comments, COMMENT_ONE, analyst));
+        assertTrue("comments print in the order they were attached",
+                comments.indexOf(COMMENT_ONE) < comments.indexOf(COMMENT_TWO));
+    }
+
+    /**
+     * The report carries no comment heading until a comment exists: an empty
+     * section reads as commentary that went missing.
+     */
+    @Test
+    public void aCycleWithNoCommentsPrintsNoCommentSection() throws IOException {
+        seedCommentLibrary();
+
+        String text = reportText();
+
+        assertFalse("no heading without a comment", text.contains(COMMENTS_TITLE));
+        assertEquals("nothing is attached", 0, reportCommentService.getComments(cycle.getId()).size());
+    }
+
+    /**
+     * FR: the picker is the only way in. The endpoint takes ids, and an id outside
+     * the pre-approved category is refused, so free text cannot reach the page.
+     */
+    @Test
+    public void onlyIdsFromTheApprovedLibraryCanBeAttached() throws IOException {
+        seedCommentLibrary();
+        String foreignId = dictionaryIdByEntry(UNRELATED_COMMENT);
+
+        try {
+            controller.attachReportComments(requestForAdmin(), cycle.getId(), Map.of("commentIds", List.of(foreignId)));
+            fail("an entry from another category is not pre-approved wording");
+        } catch (IllegalArgumentException expected) {
+            assertTrue("the message names the library", expected.getMessage().contains("EQA Report Comment"));
+        }
+
+        assertEquals("nothing was attached", 0, reportCommentService.getComments(cycle.getId()).size());
+        assertFalse("the foreign wording never reaches the page", reportText().contains(UNRELATED_COMMENT));
+    }
+
+    /**
+     * Deactivating a library entry stops new use without rewriting a report that
+     * already printed it — the reason the attachment stores the wording rather than
+     * a live reference to the dictionary row.
+     */
+    @Test
+    public void retiringALibraryEntryLeavesAlreadyAttachedTextIntact() throws IOException {
+        seedCommentLibrary();
+        String entryId = libraryId(COMMENT_ONE);
+        controller.attachReportComments(requestForAdmin(), cycle.getId(), Map.of("commentIds", List.of(entryId)));
+
+        jdbc.update("UPDATE clinlims.dictionary SET is_active = 'N' WHERE id = ?", Long.valueOf(entryId));
+
+        assertFalse("the retired entry is no longer offered",
+                controller.reportCommentLibrary().stream().anyMatch(row -> entryId.equals(row.get("id"))));
+        assertTrue("the wording already attached still prints",
+                block(reportText(), COMMENTS_TITLE, SIGN_OFF).contains(COMMENT_ONE));
+        try {
+            controller.attachReportComments(requestForAdmin(), cycle.getId(), Map.of("commentIds", List.of(entryId)));
+            fail("a retired entry cannot be attached again");
+        } catch (IllegalArgumentException expected) {
+            assertTrue("the message names the entry", expected.getMessage().contains(entryId));
+        }
+    }
+
+    @Test
+    public void reattachingAnAttachedCommentDoesNotPrintItTwice() throws IOException {
+        seedCommentLibrary();
+        String entryId = libraryId(COMMENT_ONE);
+        controller.attachReportComments(requestForAdmin(), cycle.getId(), Map.of("commentIds", List.of(entryId)));
+
+        List<Map<String, Object>> second = controller.attachReportComments(requestForAdmin(), cycle.getId(),
+                Map.of("commentIds", List.of(entryId)));
+
+        assertEquals("the resent id adds nothing", 0, second.size());
+        assertEquals("one attachment is stored", 1, reportCommentService.getComments(cycle.getId()).size());
+        assertEquals("the sentence prints once", 1, occurrences(reportText(), COMMENT_ONE));
+    }
+
+    @Test
+    public void detachedCommentsLeaveThePrintedReport() throws IOException {
+        seedCommentLibrary();
+        List<Map<String, Object>> added = controller.attachReportComments(requestForAdmin(), cycle.getId(),
+                Map.of("commentIds", List.of(libraryId(COMMENT_ONE), libraryId(COMMENT_TWO))));
+        String firstCommentId = String.valueOf(added.get(0).get("id"));
+
+        controller.detachReportComment(cycle.getId(), firstCommentId);
+
+        String text = reportText();
+        assertFalse("the removed comment is gone from the page", text.contains(COMMENT_ONE));
+        assertTrue("the comment left in place still prints", text.contains(COMMENT_TWO));
+        assertEquals("one attachment remains", 1, reportCommentService.getComments(cycle.getId()).size());
+        try {
+            controller.detachReportComment(cycle.getId(), firstCommentId);
+            fail("a comment that is not attached cannot be detached");
+        } catch (IllegalArgumentException expected) {
+            assertTrue("the message names the cycle", expected.getMessage().contains(String.valueOf(cycle.getId())));
+        }
+    }
+
     // ---- helpers ----
+    /**
+     * The library the service reads, ensured rather than assumed: other suites
+     * truncate dictionary, and a full-suite run must not depend on whether
+     * liquibase qa/032's seed survived. Rows are matched on wording, so this is
+     * idempotent whether or not the shipped category is already present.
+     */
+    private void seedCommentLibrary() {
+        jdbc.update("INSERT INTO clinlims.reference_tables (id, name, keep_history, lastupdated)"
+                + " SELECT nextval('clinlims.reference_tables_seq'), 'eqa_cycle', 'Y', now() WHERE NOT EXISTS"
+                + " (SELECT 1 FROM clinlims.reference_tables WHERE LOWER(name) = 'eqa_cycle')");
+        ensureCategory(EQAReportCommentService.CATEGORY_NAME, "EQARC");
+        ensureCategory(OTHER_CATEGORY, "EQARCF");
+        ensureEntry(EQAReportCommentService.CATEGORY_NAME, COMMENT_ONE, 910);
+        ensureEntry(EQAReportCommentService.CATEGORY_NAME, COMMENT_TWO, 920);
+        ensureEntry(OTHER_CATEGORY, UNRELATED_COMMENT, 930);
+    }
+
+    private void ensureCategory(String name, String abbreviation) {
+        jdbc.update(
+                "INSERT INTO clinlims.dictionary_category (id, name, description, local_abbrev, lastupdated)"
+                        + " SELECT nextval('clinlims.dictionary_category_seq'), ?, ?, ?, now() WHERE NOT EXISTS"
+                        + " (SELECT 1 FROM clinlims.dictionary_category WHERE name = ?)",
+                name, name, abbreviation, name);
+    }
+
+    private void ensureEntry(String category, String text, int sortOrder) {
+        jdbc.update(
+                "INSERT INTO clinlims.dictionary (id, dictionary_category_id, dict_entry, is_active,"
+                        + " sort_order, lastupdated) SELECT nextval('clinlims.dictionary_seq'),"
+                        + " (SELECT id FROM clinlims.dictionary_category WHERE name = ?), ?, 'Y', ?, now()"
+                        + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.dictionary WHERE dict_entry = ?)",
+                category, text, sortOrder, text);
+        jdbc.update("UPDATE clinlims.dictionary SET is_active = 'Y' WHERE dict_entry = ?", text);
+    }
+
+    /** The id the picker would send for this wording. */
+    private String libraryId(String text) {
+        for (Map<String, Object> entry : controller.reportCommentLibrary()) {
+            if (text.equals(entry.get("text"))) {
+                return String.valueOf(entry.get("id"));
+            }
+        }
+        throw new AssertionError("the library does not offer: " + text);
+    }
+
+    private String dictionaryIdByEntry(String text) {
+        return jdbc.queryForObject("SELECT id::text FROM clinlims.dictionary WHERE dict_entry = ?", String.class, text);
+    }
+
+    private MockHttpServletRequest requestForAdmin() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId((int) ADMIN_USER_ID);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession(true).setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
+        return request;
+    }
 
     private void scored(long analyteId, String value, String unit, BigDecimal zScore, EQAPerformanceStatus performance,
             long enrollmentId) {

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -70,6 +70,9 @@ public class EQARestGuardMatrixTest {
         // Cycle lifecycle
         WRITE_GUARDS.put("EQACycleRestController#createCycle", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQACycleRestController#transition", EQAGuards.MANAGE);
+        // OGC-934: commentary on a signed report is a scoring-lane act.
+        WRITE_GUARDS.put("EQACycleRestController#attachReportComments", EQAGuards.MANAGE);
+        WRITE_GUARDS.put("EQACycleRestController#detachReportComment", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQAFollowupRestController#escalate", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQAFollowupRestController#dismiss", EQAGuards.MANAGE);
         // Provider-round management


### PR DESCRIPTION
## What this adds

The printed CPHL performance report gains an **Interpretive comments** block between the scoring table and the sign-off, filled from a pre-approved library rather than from free text (OGC-934, FR-V2.3).

A cycle with no comments prints no heading — an empty section on a signed document reads as commentary that went missing.

## Why there is no new table

Two mechanisms already in the codebase cover this:

- **The library is a `dictionary` category** (`EQA Report Comment`). `dict_entry` holds 4000 characters and the table already carries `is_active` and `sort_order`, so the existing **Dictionary Management** screen maintains the wording and retiring a phrase needs no release.
- **An attachment is a `note`** against the cycle. `note` is keyed by `(reference_table, reference_id)` and records its author and timestamp, so attribution came for free.

`SYS_USER_ID` on `note` is mapped through the `systemUser` relation rather than the `systemUserId` field, so the write goes through `NoteServiceImpl.createSystemUser`. Setting the field alone persists no author.

## Free text cannot reach the page

`POST /rest/eqa/cycles/{id}/report-comments` accepts `{"commentIds": [...]}` and nothing else. There is no text field to fill. The service resolves the wording server-side and refuses an id outside the active category with 422. Attach and detach sit in the scoring lane, `qa.manage.eqa`, asserted in `EQARestGuardMatrixTest`.

An attachment stores the wording it was made with, so deactivating a library entry stops new use without rewriting a report that already printed it. Re-sending an attached id is a no-op rather than a second identical paragraph.

## Endpoints

| Method | Path | Guard |
|---|---|---|
| GET | `/rest/eqa/report-comments` | read |
| GET | `/rest/eqa/cycles/{id}/report-comments` | read |
| POST | `/rest/eqa/cycles/{id}/report-comments` | `qa.manage.eqa` |
| DELETE | `/rest/eqa/cycles/{id}/report-comments/{commentId}` | `qa.manage.eqa` |

## Liquibase

`qa/032`, changesets `qa-060` and `qa-061`: the dictionary category, six starter comments, and the `eqa_cycle` row in `reference_tables` that a note against a cycle requires. The seeded wording is operational QA guidance, not clinical interpretation, and **CPHL is expected to edit it in place** — that review has not happened yet.

## Testing

- 408 backend tests green across `org.openelisglobal.eqa.**`, including 6 new cases in `EQAPerformanceReportIntegrationTest` that assert against the rendered PDF text. One covers the design decision directly: retiring a library entry removes it from the picker and refuses re-attachment, while the wording already printed stays intact.
- 124 frontend tests green across `components/eqa/`, including a new `ReportComments` suite for the failure paths. It mocks only the transport and keeps `resolveApiErrorMessage` real — a mocked resolver accepts any argument order and hid a live defect where a refused write left a stale success notice on screen. Verified by inversion: reintroducing the defect fails the suite.
- Live UAT on the dev stack: two comments attached through the picker print under the scoring table, confirmed with `pdftotext`; the panel exposes no free-text input; a stale picker surfaces the server's refusal verbatim. Both changesets also ran clean on a virgin database.

## Notes for review

- The picker rides the provider workbench as a third tab. The provider scoring surface that should host it does not exist yet, so this is deliberate and should be re-homed when that lands.
- Comments attach per cycle. The report prints a cycle without a participant column, so a per-result grain would have nowhere to render; `note` is polymorphic, so moving to result grain later needs no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
