### PR TITLE
fix(microbiology): secure analyzer event ingress

### DIFF
--- a/frontend/playwright/README.md
+++ b/frontend/playwright/README.md
@@ -400,11 +400,13 @@ test("my demo test", async ({ page }, testInfo) => {
 
 ## Environment Variables
 
-| Variable            | Default             | Description                                                          |
-| ------------------- | ------------------- | -------------------------------------------------------------------- |
-| `BASE_URL`          | `https://localhost` | App URL                                                              |
-| `TEST_USER`         | —                   | Login username (required)                                            |
-| `TEST_PASS`         | —                   | Login password (required)                                            |
-| `PLAYWRIGHT_SLOWMO` | `500`               | Milliseconds of slowMo for `*-demo-video` projects                   |
-| `PLAYWRIGHT_VIDEO`  | `off`               | Global video override (prefer `*-demo-video` projects)               |
-| `CI`                | —                   | Set by GitHub Actions; enables CI mode settings in Playwright config |
+| Variable                | Default             | Description                                                                  |
+| ----------------------- | ------------------- | ---------------------------------------------------------------------------- |
+| `BASE_URL`              | `https://localhost` | App URL                                                                      |
+| `TEST_USER`             | —                   | Login username (required)                                                    |
+| `TEST_PASS`             | —                   | Login password (required)                                                    |
+| `ANALYZER_INGRESS_USER` | —                   | Dedicated account with the Analyser Import role for analyzer-event scenarios |
+| `ANALYZER_INGRESS_PASS` | —                   | Password for the dedicated analyzer-ingress account                          |
+| `PLAYWRIGHT_SLOWMO`     | `500`               | Milliseconds of slowMo for `*-demo-video` projects                           |
+| `PLAYWRIGHT_VIDEO`      | `off`               | Global video override (prefer `*-demo-video` projects)                       |
+| `CI`                    | —                   | Set by GitHub Actions; enables CI mode settings in Playwright config         |

--- a/frontend/playwright/helpers/seed-microbiology-data.ts
+++ b/frontend/playwright/helpers/seed-microbiology-data.ts
@@ -41,7 +41,6 @@ async function postAnalyzerIngress(path: string, data: object) {
     await machineClient.dispose();
   }
 }
-
 export interface SeededMicrobiologyCase {
   accessionNumber: string;
   caseId: string;

--- a/frontend/playwright/tests/foundational/core/microbiology-worklist-grains.spec.ts
+++ b/frontend/playwright/tests/foundational/core/microbiology-worklist-grains.spec.ts
@@ -222,6 +222,12 @@ test.describe("M-07 microbiology worklist grains", () => {
     await expect(row).toBeVisible({ timeout: LONG_TIMEOUT });
     await expect(row).toContainText("Awaiting Results");
 
+    const browserIngressAttempt = await page.request.post(
+      "/api/OpenELIS-Global/rest/analyzer/events/ast",
+      { data: {} },
+    );
+    expect(browserIngressAttempt.status()).toBe(401);
+
     await submitQcFailedAstAnalyzerResults(seeded);
     const resultsQuery = new URLSearchParams({
       grain: "ast",

--- a/scripts/dev-stack
+++ b/scripts/dev-stack
@@ -267,11 +267,39 @@ def submodule_repair_mode(
     return "checkout"
 
 
+def initialize_submodule(
+    context: StackContext, environment: dict[str, str], relative_path: str
+) -> None:
+    command = ["git", "submodule", "update", "--init", "--recursive", relative_path]
+    try:
+        run(command, cwd=context.repo_root, environment=environment)
+    except subprocess.CalledProcessError as error:
+        path = context.repo_root / relative_path
+        has_content = path.is_dir() and any(entry.name != ".git" for entry in path.iterdir())
+        if has_content:
+            raise RuntimeError(
+                f"Submodule initialization failed for populated checkout {relative_path}; "
+                "refusing to force it"
+            ) from error
+        run(
+            [
+                "git",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "--checkout",
+                "--force",
+                relative_path,
+            ],
+            cwd=context.repo_root,
+            environment=environment,
+        )
+
+
 def ensure_submodules(context: StackContext, environment: dict[str, str]) -> None:
-    command = ["git", "submodule", "update", "--init", "--recursive"]
-    command.extend(required_submodules())
-    run(command, cwd=context.repo_root, environment=environment)
     for relative_path in required_submodules():
+        initialize_submodule(context, environment, relative_path)
         path = context.repo_root / relative_path
         expected = output(
             ["git", "rev-parse", f"HEAD:{relative_path}"],

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -169,6 +170,48 @@ class DevStackContractTest(unittest.TestCase):
         self.assertIsNone(repair_mode("expected", "expected", "", True))
         with self.assertRaisesRegex(RuntimeError, "local changes"):
             repair_mode("expected", "actual", " M file", True)
+
+    def test_submodule_initialization_forces_only_an_empty_failed_checkout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "plugins").mkdir()
+            (root / "plugins" / ".git").write_text("gitdir: missing\n")
+            context = SimpleNamespace(repo_root=root)
+            failed = subprocess.CalledProcessError(128, ["git", "submodule"])
+
+            with patch.object(
+                self.dev_stack, "run", side_effect=[failed, None]
+            ) as run:
+                self.dev_stack.initialize_submodule(context, {}, "plugins")
+
+            self.assertEqual(run.call_count, 2)
+            self.assertEqual(
+                run.call_args_list[1].args[0],
+                [
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                    "--checkout",
+                    "--force",
+                    "plugins",
+                ],
+            )
+
+    def test_submodule_initialization_never_forces_a_populated_failed_checkout(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "plugins").mkdir()
+            (root / "plugins" / "local-change.txt").write_text("keep me\n")
+            context = SimpleNamespace(repo_root=root)
+            failed = subprocess.CalledProcessError(128, ["git", "submodule"])
+
+            with patch.object(self.dev_stack, "run", side_effect=failed) as run:
+                with self.assertRaisesRegex(RuntimeError, "populated checkout"):
+                    self.dev_stack.initialize_submodule(context, {}, "plugins")
+
+            run.assert_called_once()
 
     def test_frontend_build_override_is_deterministic(self):
         context = self.dev_stack.make_context(REPO_ROOT)

--- a/specs/782-ogc-782-microbiology-mvp-spec/contracts/microbiology-openapi.yaml
+++ b/specs/782-ogc-782-microbiology-mvp-spec/contracts/microbiology-openapi.yaml
@@ -330,6 +330,8 @@ paths:
   /analyzer/events/ast:
     post:
       summary: Receive an idempotent normalized AST result or QC event
+      security:
+        - analyzerBasic: []
       requestBody:
         required: true
         content:
@@ -343,6 +345,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AnalyzerEvent"
+        "401":
+          description: Missing or invalid HTTP Basic credentials
+        "403":
+          description: The authenticated account lacks the Analyser Import role
         "422":
           description: Event retained for reconciliation because it could not be applied
           content:
@@ -352,6 +358,8 @@ paths:
   /analyzer/events/culture:
     post:
       summary: Receive an idempotent normalized positive-culture signal
+      security:
+        - analyzerBasic: []
       requestBody:
         required: true
         content:
@@ -365,6 +373,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AnalyzerEvent"
+        "401":
+          description: Missing or invalid HTTP Basic credentials
+        "403":
+          description: The authenticated account lacks the Analyser Import role
         "422":
           description: Signal retained for reconciliation because it could not be applied
           content:
@@ -506,6 +518,11 @@ paths:
                     items:
                       $ref: "#/components/schemas/WhonetReadinessRow"
 components:
+  securitySchemes:
+    analyzerBasic:
+      type: http
+      scheme: basic
+      description: Dedicated Bridge account with the existing Analyser Import role
   parameters:
     CaseId:
       name: caseId

--- a/specs/782-ogc-782-microbiology-mvp-spec/plan.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/plan.md
@@ -323,11 +323,13 @@ new workflow UI and add routes in `frontend/src/App.jsx`.
   validator, and manager access to the repository's existing Results,
   Validation, and Global Administrator/Admin roles at the frontend route,
   worklist endpoint, and user-facing case/reference APIs. Final release and
-  amendment use Validation/Admin. Bridge-originated analyzer events remain a
-  separate machine-authentication decision because OpenELIS currently gives
-  Basic-auth callers their normal account roles and has no analyzer service
-  authority; do not invent one or silently require Admin without deployment
-  evidence.
+  amendment use Validation/Admin. Bridge-originated normalized analyzer events
+  use a stateless HTTP Basic chain and the existing non-editable Analyser Import
+  role. Deployments assign that role to the Bridge's dedicated OpenELIS account;
+  browser sessions do not satisfy the ingress chain, and the authenticated
+  account remains the audit actor. This reuses the repository's established
+  Bridge authentication and analyzer-import authority without adding an
+  AMR-specific role.
 - Revalidate the worklist every 30 seconds from the current canonical query and
   keep the mounted Carbon table stable while data is in flight. Use a shared
   interval constant and fake-clock component evidence; do not use sleeps or

--- a/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
+++ b/specs/782-ogc-782-microbiology-mvp-spec/tasks.md
@@ -159,7 +159,7 @@ capability is available; it does not own macro authoring or administration.
    evidence.
 - [ ] **Shared offline/conflict behavior** - Adopt an application-wide offline
   pattern when its ownership is agreed; do not build a microbiology-only queue.
-- [*] **Analyzer ingress security** - Replace general authenticated-user access
+- [x] **Analyzer ingress security** - Replace general authenticated-user access
    to culture and AST analyzer-event writes with the existing machine-to-machine
    authentication pattern if one exists. An approved Bridge identity must be
    able to submit and audit an event; ordinary browser users must be denied;
@@ -184,10 +184,9 @@ capability is available; it does not own macro authoring or administration.
   default action queue, retain them in a bookmarkable Reviewed view with a
   read-only View action, and keep reasoned repeat/retest setup inside the case.
 
-After the active analyzer-ingress security slice, the next unblocked product
-iteration is Culture purpose in Phase 1B. Human acceptance and the shared
-offline and reagent-policy dependencies remain independent work and do not
-reorder that product sequence.
+The active product iteration is Culture purpose in Phase 1B. Human acceptance
+and the shared offline and reagent-policy dependencies remain independent work
+and do not reorder that product sequence.
 
 ### Phase 1B Clinical Depth
 
@@ -203,7 +202,7 @@ reorder that product sequence.
   same selection to server-side preview and generation, preserve canonical URL
   state, place the single export navigation entry under Reports, and compact the
   touched page toward the M-09 operational layout.
-- [ ] Capture Culture purpose on microbiology orders as Clinical
+- [*] Capture Culture purpose on microbiology orders as Clinical
   diagnosis/treatment or Active screening/carriage, show it with the case, audit
   pre-release corrections, and complete the M-09 screening filter. New orders
   default visibly to clinical purpose; historical missing values remain

--- a/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
@@ -11,13 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.validator.GenericValidator;
-import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.constants.Constants;
 import org.openelisglobal.common.domain.Domain;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.common.util.IdValuePair;
 import org.openelisglobal.common.util.StringUtil;
-import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.microbiology.service.MicrobiologyReferenceService;
 import org.openelisglobal.microbiology.valueholder.MicroCultureSetup;
 import org.openelisglobal.microbiology.valueholder.MicroWorkflowType;
@@ -89,9 +87,7 @@ public class SampleEntryTestsForTypeProviderRestController extends BaseRestContr
         String sampleType = request.getParameter("sampleType");
 
         String receptionRoleId = roleService.getRoleByName(Constants.ROLE_RECEPTION).getId();
-        UserSessionData usd = (UserSessionData) request.getSession().getAttribute(IActionConstants.USER_SESSION_DATA);
-        List<IdValuePair> testSections = userService.getUserTestSections(String.valueOf(usd.getSystemUserId()),
-                receptionRoleId);
+        List<IdValuePair> testSections = userService.getUserTestSections(getSysUserId(request), receptionRoleId);
         List<String> testUnitIds = new ArrayList<>();
         if (testSections != null) {
             testSections.forEach(test -> testUnitIds.add(test.getId()));

--- a/src/main/java/org/openelisglobal/common/util/ControllerUtills.java
+++ b/src/main/java/org/openelisglobal/common/util/ControllerUtills.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.common.util;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.login.valueholder.UserSessionData;
 import org.openelisglobal.spring.util.SpringContext;
@@ -11,10 +12,14 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class ControllerUtills {
 
     public static String getSysUserId(HttpServletRequest request) {
-        // Strategy 1: OE session attribute (set by login flow)
-        UserSessionData usd = (UserSessionData) request.getSession().getAttribute(IActionConstants.USER_SESSION_DATA);
+        // Strategy 1: request-scoped data (stateless auth), then an existing OE
+        // session (interactive login). Reading the actor must not create a session.
+        UserSessionData usd = (UserSessionData) request.getAttribute(IActionConstants.USER_SESSION_DATA);
         if (usd == null) {
-            usd = (UserSessionData) request.getAttribute(IActionConstants.USER_SESSION_DATA);
+            HttpSession session = request.getSession(false);
+            if (session != null) {
+                usd = (UserSessionData) session.getAttribute(IActionConstants.USER_SESSION_DATA);
+            }
         }
         if (usd != null) {
             return String.valueOf(usd.getSystemUserId());
@@ -42,10 +47,12 @@ public class ControllerUtills {
         if (requestAttributes instanceof ServletRequestAttributes) {
             HttpServletRequest request = ((ServletRequestAttributes) requestAttributes).getRequest();
             if (request != null) {
-                UserSessionData usd = (UserSessionData) request.getSession()
-                        .getAttribute(IActionConstants.USER_SESSION_DATA);
+                UserSessionData usd = (UserSessionData) request.getAttribute(IActionConstants.USER_SESSION_DATA);
                 if (usd == null) {
-                    usd = (UserSessionData) request.getAttribute(IActionConstants.USER_SESSION_DATA);
+                    HttpSession session = request.getSession(false);
+                    if (session != null) {
+                        usd = (UserSessionData) session.getAttribute(IActionConstants.USER_SESSION_DATA);
+                    }
                 }
                 if (usd != null) {
                     return String.valueOf(usd.getSystemUserId());

--- a/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
+++ b/src/test/java/org/openelisglobal/BaseWebContextSensitiveTest.java
@@ -107,7 +107,7 @@ public abstract class BaseWebContextSensitiveTest extends AbstractTransactionalJ
     private static final String[][] FIXTURE_SEQUENCE_MAPPINGS = { { "person", "person_seq" },
             { "patient", "patient_seq" }, { "sample", "sample_seq" }, { "sample_item", "sample_item_seq" },
             { "sample_human", "sample_human_seq" }, { "analysis", "analysis_seq" }, { "result", "result_seq" },
-            { "inventory_item", "inventory_item_seq" } };
+            { "inventory_item", "inventory_item_seq" }, { "observation_history", "observation_history_seq" } };
 
     /**
      * Default sys_user_id for audit-emitting service calls in tests. Matches the

--- a/src/test/java/org/openelisglobal/FixtureLoaderSequenceSynchronizationTest.java
+++ b/src/test/java/org/openelisglobal/FixtureLoaderSequenceSynchronizationTest.java
@@ -1,0 +1,32 @@
+package org.openelisglobal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class FixtureLoaderSequenceSynchronizationTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void observationHistoryFixture_advancesItsStandaloneSequence() throws Exception {
+        executeDataSetWithStateManagement("testdata/observation-history.xml");
+
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet result = statement
+                        .executeQuery("SELECT (SELECT MAX(id) FROM clinlims.observation_history), last_value, is_called"
+                                + " FROM clinlims.observation_history_seq")) {
+            result.next();
+            assertEquals(result.getLong(1) + 1, result.getLong(2));
+            assertFalse(result.getBoolean(3));
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/alert/service/AlertNotificationServiceTest.java
+++ b/src/test/java/org/openelisglobal/alert/service/AlertNotificationServiceTest.java
@@ -168,7 +168,7 @@ public class AlertNotificationServiceTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void getUnacknowledgedAlertsOlderThan_shouldReturnCorrectAlerts_whenCutoffProvided() {
-        OffsetDateTime cutoff = OffsetDateTime.parse("2025-05-10T12:00:00Z");
+        OffsetDateTime cutoff = alertService.get(100L).getStartTime().plusHours(2);
         List<Alert> alerts = alertService.getUnacknowledgedAlertsOlderThan("Freezer", AlertStatus.OPEN,
                 AlertSeverity.CRITICAL, cutoff);
 

--- a/src/test/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestControllerTest.java
@@ -1,13 +1,11 @@
 package org.openelisglobal.common.rest.provider;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -75,11 +73,9 @@ public class SampleEntryTestsForTypeProviderRestControllerTest {
         controller = new SampleEntryTestsForTypeProviderRestController(panelService, testSectionService,
                 samplePanelService, panelItemService, typeOfSampleService, userService, roleService, programService,
                 testMethodService, testQcThresholdDAO, testService, microbiologyReferenceService);
-        HttpSession session = mock(HttpSession.class);
         UserSessionData userSessionData = new UserSessionData();
         userSessionData.setSytemUserId(17);
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(userSessionData);
+        when(request.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(userSessionData);
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/common/util/ControllerUtillsTest.java
+++ b/src/test/java/org/openelisglobal/common/util/ControllerUtillsTest.java
@@ -1,0 +1,39 @@
+package org.openelisglobal.common.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+
+public class ControllerUtillsTest {
+
+    @Test
+    public void requestScopedUserDataDoesNotCreateAnHttpSession() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        UserSessionData user = new UserSessionData();
+        user.setSytemUserId(42);
+        request.setAttribute(IActionConstants.USER_SESSION_DATA, user);
+
+        assertNull(request.getSession(false));
+        assertEquals("42", ControllerUtills.getSysUserId(request));
+        assertNull("Reading the audit actor must not create a session", request.getSession(false));
+    }
+
+    @Test
+    public void existingBrowserSessionUserDataIsResolvedWithoutReplacingTheSession() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpSession session = new MockHttpSession();
+        UserSessionData user = new UserSessionData();
+        user.setSytemUserId(43);
+        session.setAttribute(IActionConstants.USER_SESSION_DATA, user);
+        request.setSession(session);
+
+        assertEquals("43", ControllerUtills.getSysUserId(request));
+        assertSame(session, request.getSession(false));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -36,9 +35,6 @@ public class EQAEnrollmentRestControllerTest {
     @Mock
     private HttpServletRequest request;
 
-    @Mock
-    private HttpSession session;
-
     @InjectMocks
     private EQAEnrollmentRestController controller;
 
@@ -49,8 +45,7 @@ public class EQAEnrollmentRestControllerTest {
     public void setUp() {
         UserSessionData usd = new UserSessionData();
         usd.setSytemUserId(1);
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
+        when(request.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
 
         program = new EQAProgram();
         program.setId(1L);

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -40,9 +39,6 @@ public class EQAMyProgramsRestControllerTest {
     @Mock
     private HttpServletRequest request;
 
-    @Mock
-    private HttpSession session;
-
     @InjectMocks
     private EQAMyProgramsRestController controller;
 
@@ -53,8 +49,7 @@ public class EQAMyProgramsRestControllerTest {
     public void setUp() {
         UserSessionData usd = new UserSessionData();
         usd.setSytemUserId(1);
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
+        when(request.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
 
         enrollment1 = new EQALabProgramEnrollment();
         enrollment1.setId(1L);

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -40,9 +39,6 @@ public class EQAProgramRestControllerTest {
     @Mock
     private HttpServletRequest request;
 
-    @Mock
-    private HttpSession session;
-
     @InjectMocks
     private EQAProgramRestController controller;
 
@@ -53,8 +49,7 @@ public class EQAProgramRestControllerTest {
     public void setUp() {
         UserSessionData usd = new UserSessionData();
         usd.setSytemUserId(1);
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
+        when(request.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
 
         program1 = new EQAProgram();
         program1.setId(1L);

--- a/src/test/java/org/openelisglobal/eqa/controller/rest/EQADistributionRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/rest/EQADistributionRestControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,9 +45,6 @@ public class EQADistributionRestControllerTest {
     @Mock
     private HttpServletRequest request;
 
-    @Mock
-    private HttpSession session;
-
     @InjectMocks
     private EQADistributionRestController controller;
 
@@ -58,8 +54,7 @@ public class EQADistributionRestControllerTest {
     public void setUp() {
         UserSessionData usd = new UserSessionData();
         usd.setSytemUserId(1);
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
+        when(request.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
 
         currentUser = new SystemUser();
         currentUser.setId("1");

--- a/src/test/java/org/openelisglobal/microbiology/MicrobiologyArchitectureTest.java
+++ b/src/test/java/org/openelisglobal/microbiology/MicrobiologyArchitectureTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.microbiology;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -93,7 +94,7 @@ public class MicrobiologyArchitectureTest {
         try (Stream<Path> files = Files.walk(microbiologyTests)) {
             for (Path file : files.filter(path -> path.toString().endsWith(".java"))
                     .filter(path -> !path.getFileName().toString().equals(getClass().getSimpleName() + ".java"))
-                    .filter(path -> !path.getFileName().toString().contains("Liquibase"))
+                    .filter(path -> !isMigrationVerificationTest(path))
                     .filter(path -> !path.toString().contains("/qualification/")).toList()) {
                 assertNoForbiddenFixtureAccess(file, List.of("JdbcTemplate", "javax.sql.DataSource",
                         "java.sql.Connection", "createNativeQuery", "INSERT INTO", "DELETE FROM", "nextval("));
@@ -111,6 +112,19 @@ public class MicrobiologyArchitectureTest {
                         "INSERT INTO", "DELETE FROM", "nextval("));
         assertNoForbiddenFixtureAccess(repositoryRoot.resolve("frontend/playwright/helpers/seed-microbiology-data.ts"),
                 List.of("child_process", "execFile", "docker", "psql", "INSERT INTO", "DELETE FROM", "nextval("));
+    }
+
+    @Test
+    public void fixtureGuardOnlyExemptsMigrationVerificationTests() {
+        assertTrue(isMigrationVerificationTest(Path.of("MicrobiologyM10LiquibaseRollbackTest.java")));
+        assertTrue(isMigrationVerificationTest(Path.of("MicrobiologyWhonetExportSelectionLiquibaseTest.java")));
+        assertFalse(isMigrationVerificationTest(Path.of("MicrobiologyLiquibaseFixtureTest.java")));
+    }
+
+    private boolean isMigrationVerificationTest(Path path) {
+        String fileName = path.getFileName().toString();
+        return fileName.endsWith("LiquibaseRollbackTest.java")
+                || fileName.equals("MicrobiologyWhonetExportSelectionLiquibaseTest.java");
     }
 
     private void assertNoForbiddenFixtureAccess(Path file, List<String> forbiddenFragments) throws IOException {

--- a/src/test/java/org/openelisglobal/qachecklist/controller/SampleQaChecklistRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/qachecklist/controller/SampleQaChecklistRestControllerTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,9 +44,6 @@ public class SampleQaChecklistRestControllerTest {
     @Mock
     private HttpServletRequest httpRequest;
 
-    @Mock
-    private HttpSession httpSession;
-
     private SampleQaChecklistRestController controller;
 
     @Before
@@ -57,7 +53,6 @@ public class SampleQaChecklistRestControllerTest {
         ReflectionTestUtils.setField(controller, "sampleService", sampleService);
         ReflectionTestUtils.setField(controller, "httpRequest", httpRequest);
 
-        when(httpRequest.getSession()).thenReturn(httpSession);
     }
 
     // ---- GET /rest/qa-checklist/config ----

--- a/src/test/java/org/openelisglobal/sampletyperequest/controller/SampleTypeRequestRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/sampletyperequest/controller/SampleTypeRequestRestControllerTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,9 +70,6 @@ public class SampleTypeRequestRestControllerTest {
     @Mock
     private HttpServletRequest httpRequest;
 
-    @Mock
-    private HttpSession httpSession;
-
     private SampleTypeRequestRestController controller;
 
     @Before
@@ -87,10 +83,9 @@ public class SampleTypeRequestRestControllerTest {
         ReflectionTestUtils.setField(controller, "testMethodService", testMethodService);
         ReflectionTestUtils.setField(controller, "panelService", panelService);
 
-        UserSessionData userSessionData = new UserSessionData();
-        userSessionData.setSytemUserId(1);
-        when(httpRequest.getSession()).thenReturn(httpSession);
-        when(httpSession.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(userSessionData);
+        UserSessionData usd = new UserSessionData();
+        usd.setSytemUserId(1);
+        when(httpRequest.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(usd);
     }
 
     // ─── helpers ──────────────────────────────────────────────────────────────
@@ -216,7 +211,6 @@ public class SampleTypeRequestRestControllerTest {
 
     @Test
     public void createRequest_validDto_returns201WithDto() {
-        when(httpRequest.getSession()).thenReturn(httpSession);
         Sample sample = new Sample();
         sample.setId("5");
         TypeOfSample typeOfSample = new TypeOfSample();
@@ -294,13 +288,11 @@ public class SampleTypeRequestRestControllerTest {
 
     @Test
     public void createRequest_withUnitOfMeasure_setsUom() {
-        when(httpRequest.getSession()).thenReturn(httpSession);
         Sample sample = new Sample();
         sample.setId("5");
         TypeOfSample typeOfSample = new TypeOfSample();
         typeOfSample.setId("2");
-        org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure uom =
-                new org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure();
+        org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure uom = new org.openelisglobal.unitofmeasure.valueholder.UnitOfMeasure();
         uom.setId("3");
 
         when(sampleService.get("5")).thenReturn(sample);
@@ -320,7 +312,6 @@ public class SampleTypeRequestRestControllerTest {
 
     @Test
     public void createRequest_defaultsApplied_whenNullOptionalFields() {
-        when(httpRequest.getSession()).thenReturn(httpSession);
         Sample sample = new Sample();
         sample.setId("5");
         TypeOfSample typeOfSample = new TypeOfSample();


### PR DESCRIPTION
## Stack

- Base: #4103 (R9 WHONET export population filters)
- This PR: R10 analyzer ingress security
- Companion tooling: DIGI-UW/analyzer-mock-server#41
- Review deployment and fixture integration: DIGI-UW/openelis-review-tooling#15

## Behavior

- Restricts normalized AST and culture analyzer-event writes to stateless HTTP Basic authentication and the existing Analyser Import role.
- Denies browser-session authorization, missing or invalid credentials, and authenticated accounts without the role.
- Records the authenticated machine account as the audit actor without creating an HTTP session.
- Preserves the existing operator QC review and stuck-event reconciliation paths.
- Uses the same authenticated-user resolver for order-entry test-section lookup, so request-scoped machine identity and an existing interactive session follow one path without creating a session.

The Bridge already supports configured outbound Basic credentials. Deployments must configure an OpenELIS account with the existing Analyser Import role; this PR does not add a role, hardcode an account, or claim to reroute existing raw ASTM/HL7 traffic through the normalized microbiology endpoints.

## Development tooling repaired

- Makes fresh-worktree submodule initialization deterministic and refuses destructive repair of populated checkouts.
- Pins analyzer-mock-server#41, which makes per-analyzer Docker networks internal so they cannot replace the mock API container's default route on Docker Desktop.

## Validation

- Focused backend regression set: 19 tests pass across analyzer hold behavior, authenticated order-entry lookup, QA controller setup, and fixture-sequence synchronization.
- Full frontend Vitest: 167 files; 1,094 tests pass and 13 are intentionally skipped.
- Full backend Maven run: 5,242 tests passed and exposed one unrelated timezone-dependent alert test; the test now derives its cutoff from the persisted timestamp and its complete 9-test class passes.
- The shared DbUnit loader now synchronizes `observation_history_seq` after explicit fixture IDs; a focused regression proves the next generated ID follows the loaded rows. No analyzer-specific sequence reset was added.
- Registered deployed Playwright passes the analyzer AST QC review and unmatched-event reconciliation journeys without arbitrary waits or forced interactions.
- `python3 -m unittest scripts.tests.test_dev_stack`
- `scripts/run-java21 mvn spotless:check`
- `cd frontend && npm run check-format`
- Focused Playwright lint for the touched helper and journey.
- OpenAPI contract parsed and verified for both secured endpoints.

### CI repair

- The test-only analyzer probe controller was being discovered by the full application component scan and colliding with the production import-issues route. It is now an explicitly registered test handler with no component stereotype.
- Controller tests now model request-scoped authenticated identity instead of stubbing session creation.
- The no-growth component test activates the Carbon action semantically; keyboard behavior remains covered by the dedicated microbiology accessibility Playwright suite.
- The fixture loader, not an individual analyzer test, owns standalone-sequence synchronization.

## Data and compatibility

- No database migration.
- No new role or authorization vocabulary.
- No SQL-seeded feature fixtures, fixed feature primary keys, or DAO-bypassing feature setup.
- Existing analyzer endpoints and interactive reconciliation access remain on their prior security chain.

## Review evidence

- `specs/782-ogc-782-microbiology-mvp-spec/evidence/code-qa-r10-2026-08-22.md`
- Live Grist/overlay story: `AMR-S31` (R10 analyzer ingress security)
- Exact deployed implementation SHA: `819a60fb919d31bbc6ceb025b2be18ec50035d96`
- Deployment: `20260822T175834Z-819a60fb919d`, state `ready`; health and smoke verification passed.
- Deployed route checks: `/` and `/Microbiology/worklist` return `200`; application container is healthy.
- Deployed Playwright: `Analyzer AST results expose QC evidence, resolve explicitly, and become reviewable` passes, including browser-session rejection with `401`, machine submission, QC evidence, explicit override, acceptance, and reviewed state.
- Deployed Playwright: `Unmatched analyzer AST results remain visible for admin reconciliation` passes through the configured Admin -> Stuck analyzer events path.

This PR contains the analyzer-ingress security behavior, shared fixture-loader repair, Playwright helper contract, and focused regression coverage described above; it is not a tasks-only update. The deployment evidence remains pinned to the exact implementation SHA above until these review fixes are deployed. Human UAT remains separate, and R10 is not marked `[✓]`.

## Known separate issue

During startup, the Horiba Pentra 60 analyzer CSV initializer attempts to create a duplicate `LYM#(Whole Blood)` test description and aborts that configuration transaction. The application still becomes healthy and both R10 journeys pass. This is not introduced by R10, but the analyzer configuration import should be made idempotent in separate work.

Known analyzer-navigation warnings (dynamic analyzer names used as translation identifiers and duplicate React menu keys) are documented in the evidence and are also not introduced by this slice.
