### PR TITLE
feat(eqa-v2): cross-site EQA shipping — box contents, FHIR loop fixes, delivery backflow and gap fixes T-40–T-46 (OGC-613)

### DIFF
--- a/frontend/playwright/helpers/seed-eqa-shipped-cycle.ts
+++ b/frontend/playwright/helpers/seed-eqa-shipped-cycle.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import { resolveDbContainer } from "./db-container";
+
+/**
+ * EQA T-46 E2E seeding — a provider cycle parked in SHIPPED with a partial
+ * roster: participant A's shipment DELIVERED, participant B never shipped.
+ * That is exactly the state the Receipt Monitor's "Open submissions" manual
+ * override exists for.
+ *
+ * Seeded directly via `docker exec psql` (same pattern as
+ * seed-qc-sigma-data.ts): the cycle wizard REST endpoint could create the
+ * cycle, but walking it to SHIPPED requires the prep gate (panel material,
+ * aliquot arithmetic, QC) which is irrelevant to what this spec asserts. The
+ * DB rows mirror what dispatch itself writes.
+ */
+
+const SCHEMA = "clinlims";
+
+function psql(sql: string): string {
+  const container = resolveDbContainer();
+  // First line only: a RETURNING insert prints the value and then the
+  // "INSERT 0 1" command tag, which -tA does not suppress.
+  return execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      "clinlims",
+      "-d",
+      "clinlims",
+      "-tAc",
+      sql,
+    ],
+    { encoding: "utf8" },
+  )
+    .trim()
+    .split("\n")[0]
+    .trim();
+}
+
+/** Guard against anything but a safe token reaching an interpolated SQL string. */
+function asSafeString(value: string, label: string): string {
+  if (!/^[A-Za-z0-9 _-]+$/.test(value)) {
+    throw new Error(
+      `Expected a plain alphanumeric string for ${label}, got: ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+/** Guard against anything but a bare integer reaching an interpolated SQL id. */
+function asInt(value: string, label: string): string {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(
+      `Expected integer for ${label}, got: ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+export interface ShippedCycleSeed {
+  cycleId: string;
+  deliveredOrgName: string;
+  unshippedOrgName: string;
+  /** Remove every seeded row (children before parents). */
+  restore: () => void;
+}
+
+export function seedShippedCycleWithPartialDelivery(
+  runTag: string,
+): ShippedCycleSeed {
+  asSafeString(runTag, "runTag");
+  // High id range, unique per run — organization.id has no sequence contract
+  // we can borrow, and workers=1 means no same-stack concurrency. Milliseconds
+  // over a ~27h window so a crashed run's leftovers cannot collide with the
+  // next run's ids; a collision still fails loudly on the PK. The ids MUST fit
+  // a signed 32-bit int: parts of the codebase read organization.id as int,
+  // and one larger row kills displayListService — and with it the whole webapp
+  // boot (learned live, 2026-08-26).
+  const orgA = String(1900000000 + (Date.now() % 100000000));
+  const orgB = String(Number(orgA) + 1);
+  const deliveredOrgName = `E2E ${runTag} Delivered Lab`;
+  const unshippedOrgName = `E2E ${runTag} Dormant Lab`;
+
+  for (const [id, name] of [
+    [orgA, deliveredOrgName],
+    [orgB, unshippedOrgName],
+  ]) {
+    psql(
+      `INSERT INTO ${SCHEMA}.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)` +
+        ` VALUES (${asInt(id, "org id")}, '${asSafeString(name, "org name")}', 'N', 'Y', now())`,
+    );
+  }
+
+  const schemeId = asInt(
+    psql(
+      `INSERT INTO ${SCHEMA}.eqa_program (id, fhir_uuid, name, is_active, sys_user_id, provider, scheme_type)` +
+        ` VALUES (nextval('${SCHEMA}.eqa_program_seq'), gen_random_uuid(), 'E2E ${runTag} scheme', true, '1',` +
+        ` 'This laboratory', 'REGIONAL_PT') RETURNING id`,
+    ),
+    "scheme id",
+  );
+
+  const cycleId = asInt(
+    psql(
+      `INSERT INTO ${SCHEMA}.eqa_cycle (id, fhir_uuid, scheme_id, cycle_number, cycle_name, status, created_by,` +
+        ` sys_user_id) VALUES (nextval('${SCHEMA}.eqa_cycle_seq'), gen_random_uuid(), ${schemeId}, 1,` +
+        ` 'E2E ${runTag} cycle', 'SHIPPED', 1, '1') RETURNING id`,
+    ),
+    "cycle id",
+  );
+
+  for (const org of [orgA, orgB]) {
+    psql(
+      `INSERT INTO ${SCHEMA}.eqa_cycle_participant (id, cycle_id, organization_id, sys_user_id)` +
+        ` VALUES (nextval('${SCHEMA}.eqa_cycle_participant_seq'), ${cycleId}, ${asInt(org, "roster org")}, '1')`,
+    );
+  }
+
+  // Participant A's box, dispatched and delivered — the exact rows dispatch +
+  // delivery confirmation write (box code convention EQA-C{cycle}-{org}).
+  const boxId = asInt(
+    psql(
+      `INSERT INTO ${SCHEMA}.shipping_box (id, box_id, fhir_uuid, destination_facility_id, state, created_date,` +
+        ` archived, sys_user_id, lastupdated, eqa_cycle_id, sent_date, received_date)` +
+        ` VALUES (nextval('${SCHEMA}.shipping_box_seq'), 'EQA-C${cycleId}-${orgA}', gen_random_uuid(), ${orgA},` +
+        ` 'RECEIVED', now(), false, 1, now(), ${cycleId}, now(), now()) RETURNING id`,
+    ),
+    "box id",
+  );
+  const shipmentId = asInt(
+    psql(
+      `INSERT INTO ${SCHEMA}.shipment (id, shipping_box_id, courier, tracking_number, shipped_date,` +
+        ` actual_delivery_date, status, sys_user_id, lastupdated)` +
+        ` VALUES (nextval('${SCHEMA}.shipment_seq'), ${boxId}, 'E2E courier', 'TRK-${runTag}', now(), now(),` +
+        ` 'DELIVERED', 1, now()) RETURNING id`,
+    ),
+    "shipment id",
+  );
+
+  return {
+    cycleId,
+    deliveredOrgName,
+    unshippedOrgName,
+    restore: () => {
+      psql(
+        `DELETE FROM ${SCHEMA}.eqa_cycle_state_transition WHERE cycle_id = ${cycleId}`,
+      );
+      psql(`DELETE FROM ${SCHEMA}.shipment WHERE id = ${shipmentId}`);
+      psql(`DELETE FROM ${SCHEMA}.shipping_box WHERE id = ${boxId}`);
+      psql(
+        `DELETE FROM ${SCHEMA}.eqa_cycle_participant WHERE cycle_id = ${cycleId}`,
+      );
+      psql(`DELETE FROM ${SCHEMA}.eqa_cycle WHERE id = ${cycleId}`);
+      psql(`DELETE FROM ${SCHEMA}.eqa_program WHERE id = ${schemeId}`);
+      psql(`DELETE FROM ${SCHEMA}.organization WHERE id IN (${orgA}, ${orgB})`);
+    },
+  };
+}

--- a/frontend/playwright/tests/foundational/core/eqa-open-submissions.spec.ts
+++ b/frontend/playwright/tests/foundational/core/eqa-open-submissions.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "../../../helpers/test-base";
+import { SHORT_TIMEOUT } from "../../../helpers/timeouts";
+import {
+  seedShippedCycleWithPartialDelivery,
+  ShippedCycleSeed,
+} from "../../../helpers/seed-eqa-shipped-cycle";
+
+/**
+ * EQA T-46 — opening submissions on a partial roster (OGC-613).
+ *
+ * A SHIPPED cycle with one participant delivered and one dormant must offer
+ * the provider an explicit, audited way to open submissions: the "Open
+ * submissions" action on the Receipt Monitor, riding the generic transition
+ * endpoint as a MANUAL override with a mandatory written reason.
+ *
+ * Seeded straight into the DB (see seed-eqa-shipped-cycle.ts); the assertions
+ * are all on visible UI state per the Playwright guide.
+ */
+
+const RUN = Date.now().toString(36);
+
+test.describe("EQA open submissions on a partial roster (T-46)", () => {
+  let seed: ShippedCycleSeed;
+
+  test.beforeAll(() => {
+    seed = seedShippedCycleWithPartialDelivery(RUN);
+  });
+
+  test.afterAll(() => {
+    seed?.restore();
+  });
+
+  test("a partially delivered cycle opens submissions through the audited manual action", async ({
+    page,
+  }) => {
+    await page.goto(`/qa/eqa/provider/cycles/${seed.cycleId}/workbench`);
+
+    // The cycle arrives parked in SHIPPED with a split roster.
+    await expect(page.getByText("Shipped").first()).toBeVisible({
+      timeout: SHORT_TIMEOUT,
+    });
+    await page.getByRole("tab", { name: "Receipts & scoring" }).click();
+    const receipts = page.getByRole("tabpanel", { name: "Receipts & scoring" });
+    await expect(
+      receipts.getByRole("cell", { name: seed.deliveredOrgName }),
+    ).toBeVisible();
+    await expect(
+      receipts.getByRole("cell", { name: seed.unshippedOrgName }),
+    ).toBeVisible();
+    await expect(
+      receipts.getByText("Delivered", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      receipts.getByText("Not shipped", { exact: true }),
+    ).toBeVisible();
+
+    // The action is offered, and it refuses to fire without a written reason.
+    const openButton = page.getByRole("button", { name: "Open submissions" });
+    await expect(openButton).toBeVisible();
+    await openButton.click();
+    const dialog = page.getByRole("dialog", {
+      name: "Open submissions with undelivered panels",
+    });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Open submissions" }),
+    ).toBeDisabled();
+
+    await dialog
+      .getByRole("textbox", { name: "Reason" })
+      .fill(`E2E ${RUN}: second lab dormant, first lab holds its panel`);
+    await dialog.getByRole("button", { name: "Open submissions" }).click();
+
+    // The cycle visibly advances and the action disappears with it.
+    await expect(page.getByText("Submissions are open.")).toBeVisible();
+    await expect(page.getByText("Submissions open").first()).toBeVisible();
+    await expect(openButton).not.toBeVisible();
+
+    // The override is on the audited timeline with its reason.
+    await page.getByRole("button", { name: "Cycle history" }).click();
+    await expect(page.getByText("Manual override").last()).toBeVisible();
+    await expect(
+      page.getByText(
+        `E2E ${RUN}: second lab dormant, first lab holds its panel`,
+      ),
+    ).toBeVisible();
+  });
+});

--- a/frontend/playwright/tests/foundational/core/shipment-imported-box-contents.spec.ts
+++ b/frontend/playwright/tests/foundational/core/shipment-imported-box-contents.spec.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "node:child_process";
+import { test, expect, Page } from "../../../helpers/test-base";
+import { SHORT_TIMEOUT } from "../../../helpers/timeouts";
+import { resolveDbContainer } from "../../../helpers/db-container";
+
+/**
+ * Imported box contents (T-42, OGC-613 cross-site gap fixes).
+ *
+ * A box imported from a partner site has no local box_sample_item rows — the
+ * FKs name rows only the sender has. What the consignment says it holds
+ * arrives as content-item extensions and is kept read-side on
+ * shipping_box.imported_contents; BoxDetails must render that manifest as
+ * labelled rows instead of an empty table.
+ *
+ * The box is created through the real REST write path; the manifest column is
+ * set directly in the DB because only the FHIR import poll writes it, and a
+ * remote FHIR store is not part of this stack's contract.
+ */
+
+const REST = "/api/OpenELIS-Global/rest";
+const RUN = Date.now().toString(36);
+const BOX_CODE = `E2E-T42-${RUN}`;
+
+function psql(sql: string): string {
+  return execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      resolveDbContainer(),
+      "psql",
+      "-U",
+      "clinlims",
+      "-d",
+      "clinlims",
+      "-tAc",
+      sql,
+    ],
+    { encoding: "utf8" },
+  ).trim();
+}
+
+async function csrfToken(page: Page): Promise<string> {
+  const state = await page.context().storageState();
+  for (const origin of state.origins) {
+    for (const item of origin.localStorage) {
+      if (item.name === "CSRF") return item.value;
+    }
+  }
+  throw new Error("No CSRF token in storage state — auth.setup did not run?");
+}
+
+test.describe("Imported box renders its manifest (T-42)", () => {
+  let boxDbId: number | undefined;
+
+  test.afterAll(() => {
+    if (boxDbId !== undefined) {
+      psql(
+        `DELETE FROM clinlims.shipping_box WHERE id = ${Math.trunc(boxDbId)}`,
+      );
+    }
+  });
+
+  test("a box with no local contents rows lists the consignment's labelled items", async ({
+    page,
+  }) => {
+    const csrf = await csrfToken(page);
+
+    // Any destination organization will do — take the first the picker offers.
+    const orgs = (await (
+      await page.request.get(`${REST}/displayList/REFERRAL_ORGANIZATIONS`)
+    ).json()) as Array<{ id: string }>;
+    expect(
+      orgs.length,
+      "the stack needs at least one referral organization",
+    ).toBeGreaterThan(0);
+
+    const created = await page.request.post(`${REST}/shipping-box`, {
+      headers: { "X-CSRF-Token": csrf, "Content-Type": "application/json" },
+      data: {
+        boxId: BOX_CODE,
+        destinationFacilityId: Number(orgs[0].id),
+        capacity: 10,
+        state: "DRAFT",
+      },
+    });
+    expect(created.ok()).toBeTruthy();
+    boxDbId = ((await created.json()) as { id: number }).id;
+
+    // What the import poll would have stored off the SupplyDelivery.
+    psql(
+      `UPDATE clinlims.shipping_box SET imported_contents =` +
+        ` '[{"label":"E2E-PS-1","type":"E2E panel"},{"label":"E2E-PS-2","type":"E2E panel"}]'` +
+        ` WHERE id = ${Math.trunc(boxDbId)}`,
+    );
+
+    await page.goto(`/SampleShipment/box/${boxDbId}`);
+    await expect(
+      page.getByRole("heading", { name: `Box ${BOX_CODE}` }),
+    ).toBeVisible({
+      timeout: SHORT_TIMEOUT,
+    });
+
+    // The manifest renders as rows — label and type — not an empty table.
+    await expect(page.getByRole("cell", { name: "E2E-PS-1" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "E2E-PS-2" })).toBeVisible();
+    await expect(
+      page.getByRole("cell", { name: "E2E panel" }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("2 Samples")).toBeVisible();
+  });
+});

--- a/frontend/playwright/tests/foundational/core/shipment-settings-fhir.spec.ts
+++ b/frontend/playwright/tests/foundational/core/shipment-settings-fhir.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, Page } from "../../../helpers/test-base";
+import { SHORT_TIMEOUT } from "../../../helpers/timeouts";
+
+/**
+ * Shipment Settings — cross-site identity and FHIR mapping (T-45 + T-44,
+ * OGC-613 cross-site gap fixes).
+ *
+ * T-45: siteOrganizationFhirUuid is what makes cross-site shipping
+ * addressable. Unset, the import filter is off and exports carry no supplier —
+ * the Settings page must say so with a warning banner, and the banner must
+ * clear once an organization is chosen.
+ *
+ * T-44: the non-conformity SNOMED codes are edited here and consumed by the
+ * export transform through a real JSON parse; this asserts the UI write path
+ * round-trips into the stored config.
+ */
+
+const REST = "/api/OpenELIS-Global/rest";
+const SETTINGS_URL = "/SampleShipment/settings";
+const RUN = Date.now().toString(36);
+
+async function csrfToken(page: Page): Promise<string> {
+  const state = await page.context().storageState();
+  for (const origin of state.origins) {
+    for (const item of origin.localStorage) {
+      if (item.name === "CSRF") return item.value;
+    }
+  }
+  throw new Error("No CSRF token in storage state — auth.setup did not run?");
+}
+
+test.describe("Shipment Settings site organization warning (T-45)", () => {
+  test("the banner shows while the site organization is unset and clears when it is chosen", async ({
+    page,
+  }) => {
+    const csrf = await csrfToken(page);
+    const headers = {
+      "X-CSRF-Token": csrf,
+      "Content-Type": "application/json",
+    };
+
+    // Remember what the stack had, restore no matter how the test ends.
+    const before = await page.request.get(
+      `${REST}/shipping-box/site-organization-uuid`,
+    );
+    expect(before.ok()).toBeTruthy();
+    const original = (await before.json()) as { orgId?: string };
+
+    try {
+      // Unset ⇒ the warning is on the page.
+      const cleared = await page.request.put(
+        `${REST}/shipping-box/site-organization-uuid`,
+        {
+          headers,
+          data: JSON.stringify(""),
+        },
+      );
+      expect(cleared.ok()).toBeTruthy();
+
+      await page.goto(SETTINGS_URL);
+      await expect(page.getByText("Site organization not set")).toBeVisible({
+        timeout: SHORT_TIMEOUT,
+      });
+
+      // Choose an organization through the picker ⇒ the warning clears and the
+      // resolved FHIR UUID is shown.
+      const picker = page.getByRole("combobox", { name: "This Laboratory" });
+      await picker.click();
+      const listbox = page.getByRole("listbox", { name: "This Laboratory" });
+      const realOptions = listbox
+        .getByRole("option")
+        .filter({ hasNotText: "None (no filter)" });
+      expect(
+        await realOptions.count(),
+        "the stack needs at least one referral organization to pick",
+      ).toBeGreaterThan(0);
+      await realOptions.first().click();
+      // Scoped to the tile so new Save buttons elsewhere cannot shift the index.
+      await page
+        .locator(".cds--tile", {
+          has: page.getByRole("heading", { name: "Site Organization (FHIR)" }),
+        })
+        .getByRole("button", { name: "Save" })
+        .click();
+
+      await expect(
+        page.getByText("Site organization not set"),
+      ).not.toBeVisible();
+      // Scoped to the paragraph: the save toast can quote the UUID too.
+      await expect(page.locator("p", { hasText: /^FHIR UUID:/ })).toBeVisible();
+    } finally {
+      await page.request.put(`${REST}/shipping-box/site-organization-uuid`, {
+        headers,
+        data: JSON.stringify(original.orgId ?? ""),
+      });
+    }
+  });
+});
+
+test.describe("Shipment Settings non-conformity codes (T-44)", () => {
+  test("a code edited in the UI round-trips into the stored FHIR mapping config", async ({
+    page,
+  }) => {
+    const csrf = await csrfToken(page);
+    const headers = {
+      "X-CSRF-Token": csrf,
+      "Content-Type": "application/json",
+    };
+
+    const before = await page.request.get(
+      `${REST}/shipping-box/fhir-mapping-config`,
+    );
+    expect(before.ok()).toBeTruthy();
+    const original = await before.json();
+
+    const customCode = `999${RUN.replace(/\D/g, "")}1`.slice(0, 9);
+    try {
+      await page.goto(SETTINGS_URL);
+      const damagedCode = page.locator("#nc-RECEIVED_DAMAGED");
+      await expect(damagedCode).toBeVisible({ timeout: SHORT_TIMEOUT });
+      await damagedCode.fill(customCode);
+      await page
+        .locator(".cds--tile", {
+          has: page.getByRole("heading", { name: "FHIR Mapping Options" }),
+        })
+        .getByRole("button", { name: "Save" })
+        .click();
+
+      // The stored config — what the export transform parses — carries the
+      // code. Polled: the button disables while the save is still in flight,
+      // so there is no visible "saved" moment to key off deterministically.
+      await expect
+        .poll(
+          async () => {
+            const after = await page.request.get(
+              `${REST}/shipping-box/fhir-mapping-config`,
+            );
+            if (!after.ok()) return "";
+            return ((await after.json()) as { nonConformityCodes: string })
+              .nonConformityCodes;
+          },
+          { timeout: SHORT_TIMEOUT },
+        )
+        .toContain(customCode);
+    } finally {
+      await page.request.put(`${REST}/shipping-box/fhir-mapping-config`, {
+        headers,
+        data: JSON.stringify({
+          containerTypeCode: original.containerTypeCode,
+          containerTypeDisplay: original.containerTypeDisplay,
+          nonConformityCodes: original.nonConformityCodes,
+        }),
+      });
+    }
+  });
+});

--- a/frontend/playwright/tests/foundational/core/shipment-settings-fhir.spec.ts
+++ b/frontend/playwright/tests/foundational/core/shipment-settings-fhir.spec.ts
@@ -70,10 +70,9 @@ test.describe("Shipment Settings site organization warning (T-45)", () => {
       const realOptions = listbox
         .getByRole("option")
         .filter({ hasNotText: "None (no filter)" });
-      expect(
-        await realOptions.count(),
-        "the stack needs at least one referral organization to pick",
-      ).toBeGreaterThan(0);
+      // Retrying visibility check doubles as "the stack has at least one
+      // referral organization to pick" — count() would be a one-shot snapshot.
+      await expect(realOptions.first()).toBeVisible();
       await realOptions.first().click();
       // Scoped to the tile so new Save buttons elsewhere cannot shift the index.
       await page

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -21,6 +21,7 @@ import {
   fetchReceiptRows,
   fetchScoreRows,
   markDelivered,
+  openSubmissions,
   scoreCycle,
   scoresCsvUrl,
   sendRepeat,
@@ -69,6 +70,8 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
   const [repeating, setRepeating] = useState(null);
   const [overrideNote, setOverrideNote] = useState("");
   const [busy, setBusy] = useState(null);
+  const [openingSubmissions, setOpeningSubmissions] = useState(false);
+  const [openReason, setOpenReason] = useState("");
 
   const load = useCallback(() => {
     fetchReceiptRows(cycleId, setRows);
@@ -122,6 +125,26 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.repeatSent",
         "Repeat panel dispatched.",
         "eqa.receipt.repeatFailed",
+      );
+    });
+  };
+
+  /**
+   * T-46: open submissions on a partial roster. Auto-advance only fires when
+   * every participant is delivered; one dormant lab must not keep submissions
+   * closed for the labs that hold their panels. Audited MANUAL override —
+   * reason required by the transition endpoint itself.
+   */
+  const handleOpenSubmissions = () => {
+    setBusy("open-submissions");
+    openSubmissions(cycleId, openReason, (response) => {
+      setOpeningSubmissions(false);
+      setOpenReason("");
+      report(
+        response,
+        "eqa.receipt.submissionsOpened",
+        "Submissions are open.",
+        "eqa.receipt.submissionsOpenFailed",
       );
     });
   };
@@ -181,6 +204,24 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                 {t("eqa.score.scoreCycle", "Score cycle")}
               </Button>
             )}
+            {["SHIPPED", "DELIVERED"].includes(cycleStatus) &&
+              rows.some(
+                (row) =>
+                  row.receiptStatus === "DELIVERED" ||
+                  row.receiptStatus === "EXCEPTION",
+              ) && (
+                <Button
+                  size="sm"
+                  kind="tertiary"
+                  disabled={busy !== null}
+                  onClick={() => {
+                    setOpeningSubmissions(true);
+                    setOpenReason("");
+                  }}
+                >
+                  {t("eqa.receipt.openSubmissions", "Open submissions")}
+                </Button>
+              )}
             <Button
               kind="ghost"
               size="sm"
@@ -320,6 +361,39 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
             </TableBody>
           </Table>
         </>
+      )}
+
+      {openingSubmissions && (
+        <Modal
+          open
+          modalHeading={t(
+            "eqa.receipt.openSubmissionsHeading",
+            "Open submissions with undelivered panels",
+          )}
+          primaryButtonText={t(
+            "eqa.receipt.openSubmissions",
+            "Open submissions",
+          )}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={busy !== null || !openReason.trim()}
+          onRequestClose={() => setOpeningSubmissions(false)}
+          onSecondarySubmit={() => setOpeningSubmissions(false)}
+          onRequestSubmit={handleOpenSubmissions}
+        >
+          <p style={{ ...hintStyle, marginBottom: "1rem" }}>
+            {t(
+              "eqa.receipt.openSubmissionsHelp",
+              "Participants that have not received their panel stay on the roster as late. This is a recorded manual override — give the reason.",
+            )}
+          </p>
+          <TextArea
+            id="eqa-open-submissions-reason"
+            labelText={t("eqa.receipt.openSubmissionsReason", "Reason")}
+            value={openReason}
+            onChange={(event) => setOpenReason(event.target.value)}
+            rows={3}
+          />
+        </Modal>
       )}
 
       {repeating && (

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -136,6 +136,22 @@ export const sendRepeat = (cycleId, organizationId, overrideNote, callback) =>
     withBody(callback),
   );
 
+/**
+ * T-46: the operator's audited override — open submissions while part of the
+ * roster is still undelivered. MANUAL with a written reason by construction:
+ * it rides the generic transition endpoint, which refuses a blank reason.
+ */
+export const openSubmissions = (cycleId, reason, callback) =>
+  patchToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/transition`,
+    JSON.stringify({
+      newState: "SUBMISSIONS_OPEN",
+      stateMachine: "PROVIDER",
+      reason,
+    }),
+    withBody(callback),
+  );
+
 export const scoreCycle = (cycleId, callback) =>
   postToOpenElisServerFullResponse(
     `/rest/eqa/cycles/${cycleId}/score`,

--- a/frontend/src/components/shipment/AddToBoxModal.jsx
+++ b/frontend/src/components/shipment/AddToBoxModal.jsx
@@ -47,8 +47,11 @@ const AddToBoxModal = ({ open, onClose, sample, onSuccess }) => {
       `/rest/shipping-box/by-facility/${sample.destinationFacilityId}`,
       (response) => {
         if (response) {
-          // Filter to only show DRAFT boxes
-          const draftBoxes = response.filter((box) => box.state === "DRAFT");
+          // Filter to DRAFT boxes, minus EQA boxes: those carry provider panel
+          // material to another lab and the server refuses a patient sample in one.
+          const draftBoxes = response.filter(
+            (box) => box.state === "DRAFT" && !box.eqaCycleId,
+          );
           setAvailableBoxes(draftBoxes);
 
           if (draftBoxes.length === 0) {

--- a/frontend/src/components/shipment/BoxDetails.jsx
+++ b/frontend/src/components/shipment/BoxDetails.jsx
@@ -21,10 +21,11 @@ import {
   TableRow,
   Tag,
 } from "@carbon/react";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
 import PageBreadCrumb from "../common/PageBreadCrumb";
+import EQABadge from "../eqa/EQABadge";
 import { NotificationContext } from "../layout/Layout";
 import {
   getFromOpenElisServerV2,
@@ -403,9 +404,44 @@ const BoxDetails = () => {
     { key: "actions", header: intl.formatMessage({ id: "label.actions" }) },
   ];
 
+  // T-42: an imported box has no local contents rows — its manifest travels as
+  // JSON [{label, type}] on the box itself. Render-only: no reception status,
+  // no per-item actions.
+  const importedRows = useMemo(() => {
+    if (samples.length > 0 || !box?.importedContents) {
+      return [];
+    }
+    try {
+      const items = JSON.parse(box.importedContents);
+      return Array.isArray(items)
+        ? items.map((item, i) => ({
+            id: `imported-${i}`,
+            accessionNumber: item.label || "-",
+            typeOfSample: item.type || "-",
+            referralTests: "-",
+            collectionDate: "-",
+            receptionStatus: "-",
+            receptionNotes: "-",
+            actions: "-",
+          }))
+        : [];
+    } catch {
+      return [];
+    }
+  }, [samples, box?.importedContents]);
+
   const renderSampleRows = () => {
+    if (samples.length === 0 && importedRows.length > 0) {
+      return importedRows;
+    }
     return samples.map((sample) => ({
-      id: sample.sampleItemId || sample.id?.toString() || "-",
+      // EQA panel material has no sample item, so its contents row identifies
+      // itself by the box_sample_item id instead.
+      id:
+        sample.sampleItemId ||
+        sample.boxSampleItemId?.toString() ||
+        sample.id?.toString() ||
+        "-",
       accessionNumber: sample.accessionNumber,
       typeOfSample: sample.typeOfSample || "-",
       referralTests: sample.referralTests
@@ -474,8 +510,9 @@ const BoxDetails = () => {
               </h2>
               <div className="box-meta">
                 {renderStateTag(box.state)}
+                {box.eqaCycleId && <EQABadge />}
                 <span className="box-sample-count">
-                  {samples.length}{" "}
+                  {samples.length || importedRows.length}{" "}
                   <FormattedMessage id="shipment.label.samples" />
                 </span>
               </div>
@@ -633,7 +670,7 @@ const BoxDetails = () => {
               <FormattedMessage id="shipment.label.samples" />
             </h3>
 
-            {samples.length === 0 ? (
+            {samples.length === 0 && importedRows.length === 0 ? (
               <div className="empty-state">
                 <p>
                   <FormattedMessage id="shipment.box.noSamples" />

--- a/frontend/src/components/shipment/ShipmentSettings.jsx
+++ b/frontend/src/components/shipment/ShipmentSettings.jsx
@@ -5,6 +5,7 @@ import {
   Column,
   Dropdown,
   Grid,
+  InlineNotification,
   Loading,
   TextInput,
   Tile,
@@ -33,7 +34,8 @@ const ShipmentSettings = () => {
   // Site organization — orgId for dropdown, fhirUuid for display/storage
   const [siteOrgId, setSiteOrgId] = useState("");
   const [originalSiteOrgId, setOriginalSiteOrgId] = useState("");
-  const [siteOrgFhirUuid, setSiteOrgFhirUuid] = useState("");
+  // null = not fetched yet, "" = fetched and unset (drives the warning banner)
+  const [siteOrgFhirUuid, setSiteOrgFhirUuid] = useState(null);
   const [organizations, setOrganizations] = useState([]);
   const [savingSiteOrg, setSavingSiteOrg] = useState(false);
 
@@ -363,6 +365,20 @@ const ShipmentSettings = () => {
               >
                 <FormattedMessage id="shipment.settings.siteOrgDescription" />
               </p>
+              {siteOrgFhirUuid === "" && (
+                <InlineNotification
+                  kind="warning"
+                  lowContrast
+                  hideCloseButton
+                  title={intl.formatMessage({
+                    id: "shipment.settings.siteOrgUnsetTitle",
+                  })}
+                  subtitle={intl.formatMessage({
+                    id: "shipment.settings.siteOrgUnsetSubtitle",
+                  })}
+                  style={{ marginBottom: "1rem" }}
+                />
+              )}
               <Dropdown
                 id="site-org-uuid"
                 titleText={intl.formatMessage({

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8592,5 +8592,15 @@
   "eqa.program.perAnalyst": "Record the analyst on every result",
   "eqa.program.perAnalyst.on": "Analyst recorded",
   "eqa.program.perAnalyst.off": "Not recorded",
-  "eqa.result.analyst.tooltip": "Shown because this run includes an EQA sample whose scheme records who ran each sample. Non-EQA rows take no input."
+  "eqa.result.analyst.tooltip": "Shown because this run includes an EQA sample whose scheme records who ran each sample. Non-EQA rows take no input.",
+  "shipment.settings.siteOrgUnsetTitle": "Site organization not set",
+  "shipment.settings.siteOrgUnsetSubtitle": "Incoming consignments are not filtered to this site and outgoing boxes carry no sender. Select the organization that represents this laboratory.",
+  "eqa.receipt.openSubmissions": "Open submissions",
+  "eqa.receipt.openSubmissionsHeading": "Open submissions with undelivered panels",
+  "eqa.receipt.openSubmissionsHelp": "Participants that have not received their panel stay on the roster as late. This is a recorded manual override — give the reason.",
+  "eqa.receipt.openSubmissionsReason": "Reason",
+  "eqa.receipt.submissionsOpened": "Submissions are open.",
+  "eqa.receipt.submissionsOpenFailed": "Could not open submissions.",
+  "notification.success": "Success",
+  "notification.warning": "Warning"
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -86,7 +86,13 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         PROVIDER_EDGES.put(PLANNED, EnumSet.of(PREP_IN_PROGRESS));
         PROVIDER_EDGES.put(PREP_IN_PROGRESS, EnumSet.of(READY_TO_SHIP));
         PROVIDER_EDGES.put(READY_TO_SHIP, EnumSet.of(SHIPPED));
-        PROVIDER_EDGES.put(SHIPPED, EnumSet.of(DELIVERED));
+        // SHIPPED → SUBMISSIONS_OPEN (T-46, decided 2026-08-26): a partial roster is
+        // a legal place to open submissions from — one dormant lab must not park the
+        // cycle in SHIPPED for the labs that hold their panels. Manual-only in
+        // practice: the auto path (openSubmissionsIfAllDelivered) still walks
+        // SHIPPED → DELIVERED → SUBMISSIONS_OPEN only when every participant has its
+        // panel; this edge is what an operator's audited override rides.
+        PROVIDER_EDGES.put(SHIPPED, EnumSet.of(DELIVERED, SUBMISSIONS_OPEN));
         PROVIDER_EDGES.put(DELIVERED, EnumSet.of(SUBMISSIONS_OPEN));
         PROVIDER_EDGES.put(SUBMISSIONS_OPEN, EnumSet.of(SUBMISSIONS_CLOSED));
         PROVIDER_EDGES.put(SUBMISSIONS_CLOSED, EnumSet.of(SCORING));

--- a/src/main/java/org/openelisglobal/eqa/service/EQAShipmentService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAShipmentService.java
@@ -53,6 +53,19 @@ public interface EQAShipmentService {
     List<Map<String, Object>> getShipmentRows(Long cycleId);
 
     /**
+     * T-41: a partner lab's receipt reached this provider over FHIR (the box's
+     * own-store SupplyDelivery reads completed), so record the delivery here. When
+     * the box is the participant's current shipment this is exactly the Receipt
+     * Monitor's "Mark delivered" — cycle auto-advance and audit included; an
+     * outdated box (a repeat superseded it) is closed off quietly without touching
+     * the cycle.
+     *
+     * @param shippingBoxId the delivered box
+     * @param sysUserId     the automated user the delivery is attributed to
+     */
+    void applyRemoteDelivery(Integer shippingBoxId, String sysUserId);
+
+    /**
      * Create or update this participant's box and shipment details. Idempotent: the
      * box id is derived from cycle + organization.
      */

--- a/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
@@ -24,12 +24,14 @@ import org.openelisglobal.eqa.valueholder.EQACycleParticipant;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelReceipt;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
 import org.openelisglobal.eqa.valueholder.EQATriggerType;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.shipment.service.BoxSampleItemService;
 import org.openelisglobal.shipment.service.ShipmentService;
 import org.openelisglobal.shipment.service.ShippingBoxService;
 import org.openelisglobal.shipment.valueholder.BoxState;
@@ -77,6 +79,9 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
 
     @Autowired
     private ShipmentService shipmentService;
+
+    @Autowired
+    private BoxSampleItemService boxSampleItemService;
 
     @Override
     @Transactional(readOnly = true)
@@ -264,12 +269,11 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         shipment.setSystemUserId(userId(sysUserId));
         shipment = isNew ? shipmentService.createShipment(shipment) : shipmentService.updateShipment(shipment);
 
-        // A packed box waiting for dispatch: the EQA prep gate, not the box's own
-        // sample count, is what says this box may go out — so this walks the state
-        // directly rather than through markReadyToSend(), which refuses a box with
-        // no sample items (panel material is not a lab SampleItem).
+        // A packed box waiting for dispatch. Since T-40 the box genuinely holds its
+        // panel material, so markReadyToSend()'s "no contents" refusal is a real check
+        // here rather than an obstacle to route around.
         if (box.getState() == BoxState.DRAFT) {
-            box = shippingBoxService.changeBoxState(box.getId(), BoxState.READY_TO_SEND, userId(sysUserId));
+            box = shippingBoxService.markReadyToSend(box.getId(), userId(sysUserId));
         }
         return toShipmentRow(organizationId, box, shipment);
     }
@@ -436,6 +440,36 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         }
     }
 
+    @Override
+    public void applyRemoteDelivery(Integer shippingBoxId, String sysUserId) {
+        ShippingBox box = shippingBoxService.getBoxById(shippingBoxId);
+        if (box == null || box.getEqaCycleId() == null || box.getDestinationFacility() == null) {
+            return;
+        }
+        if (box.getState() != BoxState.SENT && box.getState() != BoxState.IN_TRANSIT) {
+            return;
+        }
+        Long organizationId = Long.valueOf(box.getDestinationFacility().getId());
+
+        // The participant's current shipment takes the Receipt Monitor's own path,
+        // so a remote receipt and a manual click write identical rows and the cycle
+        // advances the same way. A superseded box (a repeat replaced it) must not
+        // mark the participant delivered — the monitor follows the repeat — so it is
+        // only closed off.
+        ShippingBox latest = latestBoxes(box.getEqaCycleId()).get(organizationId);
+        if (latest != null && latest.getId().equals(box.getId())) {
+            markDelivered(box.getEqaCycleId(), organizationId, sysUserId);
+            return;
+        }
+        box = shippingBoxService.changeBoxState(box.getId(), BoxState.RECEIVED, userId(sysUserId));
+        Shipment shipment = box.getShipment();
+        if (shipment != null && shipment.getStatus() != ShipmentStatus.DELIVERED) {
+            shipment = shipmentService.updateShipmentStatus(shipment.getId(), ShipmentStatus.DELIVERED);
+            shipment.setSysUserId(sysUserId);
+            shipment.setSystemUserId(userId(sysUserId));
+        }
+    }
+
     // ---- FR-V2.5-15 reprovisioning ----
 
     @Override
@@ -498,7 +532,7 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
 
         // A repeat is dispatched by the act of sending it: there is no second decision
         // to make, and the courier details come from the shipment it replaces.
-        repeat = shippingBoxService.changeBoxState(repeat.getId(), BoxState.READY_TO_SEND, userId(sysUserId));
+        repeat = shippingBoxService.markReadyToSend(repeat.getId(), userId(sysUserId));
         repeat = shippingBoxService.changeBoxState(repeat.getId(), BoxState.SENT, userId(sysUserId));
         shipment = shipmentService.updateShipmentStatus(shipment.getId(), ShipmentStatus.IN_TRANSIT);
         shipment.setSysUserId(sysUserId);
@@ -684,6 +718,13 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
      * Creating the box publishes it to the FHIR store as a SupplyDelivery, as any
      * other shipping box would be (failures are logged, not fatal). Nothing on it
      * carries a target value.
+     *
+     * <p>
+     * The box is packed in the same breath (T-40): one contents row per panel
+     * sample, the grain dispatch already consumes aliquots at (FR-V2.5-12), so a
+     * provider box is never contentless. Inventory stays owned by
+     * {@code eqa_panel.aliquots_shipped} — these rows say what is in the box, they
+     * do not count it a second time.
      */
     private ShippingBox createBox(EQACycle cycle, Long organizationId, String boxCode, String sysUserId) {
         Organization participant = organizationService.getOrganizationById(String.valueOf(organizationId));
@@ -696,15 +737,24 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         box.setEqaCycleId(cycle.getId());
         box.setSystemUserId(userId(sysUserId));
         box.setNotes("EQA panel material for cycle " + displayName(cycle));
-        // Panel storage temperature is the box's temperature requirement — the
-        // material's constraint, not a separate choice.
+
+        List<EQAPanelSample> material = new ArrayList<>();
         for (EQAPanel panel : panelsOf(cycle.getId())) {
-            if (panel.getStorageTemp() != null) {
+            // Panel storage temperature is the box's temperature requirement — the
+            // material's constraint, not a separate choice.
+            if (box.getTemperatureRequirement() == null && panel.getStorageTemp() != null) {
                 box.setTemperatureRequirement(panel.getStorageTemp().name());
-                break;
             }
+            material.addAll(eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId()));
         }
-        return shippingBoxService.createBox(box);
+        if (material.isEmpty()) {
+            throw new IllegalStateException("Cycle " + displayName(cycle)
+                    + " holds no panel material yet, so there is nothing to pack for this participant");
+        }
+
+        ShippingBox created = shippingBoxService.createBox(box);
+        boxSampleItemService.addPanelSamplesToBox(created.getId(), material, userId(sysUserId));
+        return created;
     }
 
     private Map<String, Object> toShipmentRow(Long organizationId, ShippingBox box, Shipment shipment) {

--- a/src/main/java/org/openelisglobal/referral/dao/ReferralDAO.java
+++ b/src/main/java/org/openelisglobal/referral/dao/ReferralDAO.java
@@ -68,10 +68,11 @@ public interface ReferralDAO extends BaseDAO<Referral, String> {
      * Get all referrals for a specific sample item. Used to group referrals by
      * sample item for shipment operations.
      *
-     * @param sampleItemId - the PK of a SampleItem
+     * @param sampleItemId - the PK of a SampleItem (a String, as on the entity —
+     *                     binding a number here throws before the query even runs)
      * @return list of referrals for this sample item
      */
-    public List<Referral> getReferralsBySampleItemId(Integer sampleItemId);
+    public List<Referral> getReferralsBySampleItemId(String sampleItemId);
 
     /**
      * Get all unassigned referrals grouped by sample item. Returns distinct sample

--- a/src/main/java/org/openelisglobal/referral/daoimpl/ReferralDAOImpl.java
+++ b/src/main/java/org/openelisglobal/referral/daoimpl/ReferralDAOImpl.java
@@ -238,7 +238,7 @@ public class ReferralDAOImpl extends BaseDAOImpl<Referral, String> implements Re
 
     @Transactional(readOnly = true)
     @Override
-    public List<Referral> getReferralsBySampleItemId(Integer sampleItemId) {
+    public List<Referral> getReferralsBySampleItemId(String sampleItemId) {
         String hql = "SELECT DISTINCT r" + " FROM Referral r" + " JOIN FETCH r.analysis a"
                 + " JOIN FETCH a.sampleItem si" + " LEFT JOIN FETCH a.test t" + " LEFT JOIN FETCH r.organization org"
                 + " WHERE si.id = :sampleItemId" + "   AND r.status != 'CANCELED'"

--- a/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
+++ b/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
@@ -727,12 +727,17 @@ public class ShippingBoxRestController extends BaseRestController {
         form.setCapacity(box.getCapacity());
         form.setActualSampleCount(box.getActualSampleCount());
         form.setNotes(box.getNotes());
+        form.setImportedContents(box.getImportedContents());
         form.setCreatedDate(box.getCreatedDate());
         form.setSentDate(box.getSentDate());
         form.setReceivedDate(box.getReceivedDate());
         form.setReconciledDate(box.getReconciledDate());
         form.setArchived(box.getArchived());
         form.setArchivedDate(box.getArchivedDate());
+        // T-40: an EQA box is packed by the provider workbench and must not be offered
+        // as a destination for patient samples, which the client can only know from
+        // here.
+        form.setEqaCycleId(box.getEqaCycleId());
 
         if (box.getDestinationFacility() != null && box.getDestinationFacility().getId() != null) {
             try {

--- a/src/main/java/org/openelisglobal/shipment/dao/BoxSampleItemDAOImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/BoxSampleItemDAOImpl.java
@@ -110,7 +110,10 @@ public class BoxSampleItemDAOImpl extends BaseDAOImpl<BoxSampleItem, Integer> im
     @Override
     public List<String> getAllAssignedSampleItemIds() {
         try {
-            String hql = "SELECT DISTINCT bsi.sampleItem.id FROM BoxSampleItem bsi";
+            // EQA panel material carries no sample item (T-40), and a NULL inside the
+            // NOT IN list this feeds would make the unassigned-sample search return
+            // nothing at all.
+            String hql = "SELECT DISTINCT bsi.sampleItem.id FROM BoxSampleItem bsi WHERE bsi.sampleItem IS NOT NULL";
             Query<String> query = entityManager.unwrap(Session.class).createQuery(hql, String.class);
             return query.list();
         } catch (Exception e) {

--- a/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
@@ -1,31 +1,47 @@
 package org.openelisglobal.shipment.fhir;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.ResourceGoneException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Location;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.SupplyDelivery;
 import org.hl7.fhir.r4.model.SupplyDelivery.SupplyDeliveryStatus;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.eqa.service.EQAShipmentService;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.shipment.dao.ShippingBoxDAO;
+import org.openelisglobal.shipment.service.ShipmentService;
+import org.openelisglobal.shipment.service.ShippingBoxService;
 import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.Shipment;
+import org.openelisglobal.shipment.valueholder.ShipmentStatus;
 import org.openelisglobal.shipment.valueholder.ShippingBox;
 import org.openelisglobal.siteinformation.service.SiteInformationService;
 import org.openelisglobal.siteinformation.valueholder.SiteInformation;
+import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +51,11 @@ import org.springframework.transaction.annotation.Transactional;
  * reconciliation.
  *
  * Follows the same polling pattern as FhirApiWorkFlowServiceImpl for Task
- * resources.
+ * resources — including status backflow (T-41): when this lab receives an
+ * imported box, the origin store's SupplyDelivery is completed, and a sender
+ * polls its own store to learn its consignments arrived. Both directions ride
+ * the same {@code org.openelisglobal.remote.source.updateStatus} flag the Task
+ * workflow honours, so switching it off restores strictly manual confirmation.
  */
 @Service
 public class ShipmentFhirImportService {
@@ -63,6 +83,21 @@ public class ShipmentFhirImportService {
     @Autowired
     private SystemUserService systemUserService;
 
+    @Value("${org.openelisglobal.remote.source.updateStatus:false}")
+    private Optional<Boolean> remoteStoreUpdateStatus;
+
+    /**
+     * T-43: consignments whose occurrence is older than this many days are not
+     * imported — dedup is local-only, so a fresh install would otherwise resurrect
+     * long-delivered consignments whose sender never advanced the status.
+     */
+    @Value("${org.openelisglobal.shipment.import.maxAgeDays:30}")
+    private int importMaxAgeDays;
+
+    private boolean statusBackflowEnabled() {
+        return remoteStoreUpdateStatus.isPresent() && remoteStoreUpdateStatus.get();
+    }
+
     /**
      * Poll all configured remote FHIR servers for SupplyDelivery resources with
      * status in-progress (SENT/IN_TRANSIT boxes). Import them as local ShippingBox
@@ -71,6 +106,14 @@ public class ShipmentFhirImportService {
     @Async
     @Transactional
     public void pollAndImportShipments() {
+        // T-45: with no site organization configured the addressed-to-us filter is
+        // off, and any consignment matching any local organization is imported. Said
+        // once per poll so the log distinguishes over-import from intent.
+        if (getSiteOrganizationFhirUuid() == null) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "pollAndImportShipments",
+                    "site organization not configured — accepting all consignments (set siteOrganizationFhirUuid on"
+                            + " Shipment Settings to filter to this site)");
+        }
         int totalImported = 0;
         for (String remoteStorePath : fhirConfig.getRemoteStorePaths()) {
             if (remoteStorePath == null || remoteStorePath.isBlank()) {
@@ -115,10 +158,10 @@ public class ShipmentFhirImportService {
             }
         }
 
-        if (imported > 0) {
-            LogEvent.logInfo(this.getClass().getSimpleName(), "importFromRemote",
-                    "Imported " + imported + " shipments from " + remoteStorePath);
-        }
+        // Always reported: a poll that finds consignments and imports none of them is
+        // the failure mode that looks exactly like success from the outside.
+        LogEvent.logInfo(this.getClass().getSimpleName(), "importFromRemote", "Polled " + remoteStorePath + ": "
+                + allDeliveries.size() + " in-progress deliveries, " + imported + " imported");
 
         return imported;
     }
@@ -166,6 +209,21 @@ public class ShipmentFhirImportService {
                 return false; // Already exists
             }
 
+            // T-43: staleness window. A consignment sent long ago whose status never
+            // advanced is history, not an arrival — importing it as IN_TRANSIT invents
+            // a ghost. No occurrence date means age is unknowable: imported as today,
+            // matching prior behaviour.
+            if (delivery.hasOccurrenceDateTimeType() && delivery.getOccurrenceDateTimeType().getValue() != null) {
+                long ageDays = java.time.temporal.ChronoUnit.DAYS
+                        .between(delivery.getOccurrenceDateTimeType().getValue().toInstant(), java.time.Instant.now());
+                if (ageDays > importMaxAgeDays) {
+                    LogEvent.logInfo(this.getClass().getSimpleName(), "importSupplyDelivery", "Box " + boxId
+                            + " occurrence is " + ageDays + " days old, beyond the " + importMaxAgeDays
+                            + "-day import window (org.openelisglobal.shipment.import.maxAgeDays); skipping (age)");
+                    return false;
+                }
+            }
+
             // Create new local ShippingBox from SupplyDelivery
             ShippingBox box = new ShippingBox();
             box.setBoxId(boxId);
@@ -199,28 +257,34 @@ public class ShipmentFhirImportService {
                 box.setActualSampleCount(delivery.getSuppliedItem().getQuantity().getValue().intValue());
             }
 
+            // T-42: the consignment's manifest. Contents rows cannot be created here
+            // (their FKs name rows only the sender has), so what the payload says is
+            // inside is kept read-side for BoxDetails to render.
+            box.setImportedContents(extractImportedContents(delivery));
+
             // Sent date from occurrence
             if (delivery.hasOccurrenceDateTimeType()) {
                 box.setSentDate(new Timestamp(delivery.getOccurrenceDateTimeType().getValue().getTime()));
             }
 
-            // Destination facility — match by FHIR UUID first, fallback to name
+            // Destination facility — match by FHIR UUID first, fallback to name.
+            // The receiving lab rides on receiver: destination is Reference(Location) in
+            // R4 and an Organization there is rejected by the server outright.
             Organization destinationOrg = null;
-            String destinationUuid = null;
-
-            if (delivery.hasDestination() && delivery.getDestination().hasReference()) {
-                // Extract UUID from "Organization/{uuid}" reference
-                String ref = delivery.getDestination().getReference();
-                if (ref != null && ref.startsWith("Organization/")) {
-                    destinationUuid = ref.substring("Organization/".length());
-                }
-            }
+            String destinationUuid = destinationOrganizationUuid(delivery);
 
             // Filter: only accept boxes destined for THIS lab
             String siteOrgUuid = getSiteOrganizationFhirUuid();
             if (siteOrgUuid != null && !siteOrgUuid.isBlank()) {
                 if (destinationUuid == null || !destinationUuid.equalsIgnoreCase(siteOrgUuid)) {
-                    // This box is not destined for us — skip
+                    // Not addressed to us. Said out loud, because a site that has its own
+                    // organization configured wrongly cannot otherwise tell this apart from
+                    // "the partner has sent nothing".
+                    LogEvent.logInfo(this.getClass().getSimpleName(), "importSupplyDelivery",
+                            "Box " + boxId + " is addressed to " + destinationUuid + ", not to this site ("
+                                    + siteOrgUuid + "); skipping [destinationRef="
+                                    + (delivery.hasDestination() ? delivery.getDestination().getReference() : "none")
+                                    + ", contained=" + delivery.getContained().size() + "]");
                     return false;
                 }
             }
@@ -231,8 +295,14 @@ public class ShipmentFhirImportService {
             }
 
             // Fallback: match by name
-            if (destinationOrg == null && delivery.hasDestination() && delivery.getDestination().hasDisplay()) {
-                destinationOrg = findOrganizationByName(delivery.getDestination().getDisplay());
+            if (destinationOrg == null) {
+                String display = receiverDisplay(delivery);
+                if (display == null && delivery.hasDestination()) {
+                    display = delivery.getDestination().getDisplay();
+                }
+                if (display != null) {
+                    destinationOrg = findOrganizationByName(display);
+                }
             }
 
             if (destinationOrg != null) {
@@ -252,6 +322,166 @@ public class ShipmentFhirImportService {
             LogEvent.logError(this.getClass().getSimpleName(), "importSupplyDelivery",
                     "Error importing SupplyDelivery: " + e.getMessage());
             return false;
+        }
+    }
+
+    /**
+     * The laboratory a consignment is addressed to. The sender writes it as the
+     * managingOrganization of the contained Location destination points at (R4
+     * types destination as Reference(Location)); a bare Organization reference is
+     * still read so anything written by an older sender is not silently ignored.
+     */
+    private String destinationOrganizationUuid(SupplyDelivery delivery) {
+        if (!delivery.hasDestination()) {
+            return null;
+        }
+        Reference destination = delivery.getDestination();
+        String reference = destination.getReference();
+        if (reference != null && reference.startsWith("Organization/")) {
+            return reference.substring("Organization/".length());
+        }
+
+        // The parser may hand back the contained Location already resolved onto the
+        // reference, or leave it as a "#id" pointer into contained — accept either,
+        // since which one you get depends on how the resource was parsed.
+        Location destinationLocation = null;
+        if (destination.getResource() instanceof Location resolved) {
+            destinationLocation = resolved;
+        } else if (reference != null && reference.startsWith("#")) {
+            String containedId = reference.substring(1);
+            for (Resource contained : delivery.getContained()) {
+                if (contained instanceof Location location && containedId.equals(location.getIdElement().getIdPart())) {
+                    destinationLocation = location;
+                    break;
+                }
+            }
+        }
+
+        if (destinationLocation != null && destinationLocation.hasManagingOrganization()) {
+            String managing = destinationLocation.getManagingOrganization().getReference();
+            if (managing != null && managing.startsWith("Organization/")) {
+                return managing.substring("Organization/".length());
+            }
+        }
+        return null;
+    }
+
+    private String receiverDisplay(SupplyDelivery delivery) {
+        for (var receiver : delivery.getReceiver()) {
+            if (receiver.hasDisplay()) {
+                return receiver.getDisplay();
+            }
+        }
+        return null;
+    }
+
+    // ---- T-41: delivery-status backflow ----
+
+    /**
+     * Receiver side: this lab has taken delivery of a box, so the store it was
+     * imported from should say {@code completed} — that is the only signal the
+     * sender's monitor can see. The origin store is discovered rather than stored:
+     * the box's FHIR UUID is the origin's resource id, so whichever configured
+     * remote answers the read is where it came from. A box created locally exists
+     * on no remote and every read misses, which is exactly the no-op it should be.
+     */
+    @Async
+    public void completeRemoteSupplyDelivery(ShippingBox box) {
+        if (!statusBackflowEnabled() || box == null || box.getFhirUuid() == null
+                || fhirConfig.getRemoteStorePaths() == null) {
+            return;
+        }
+        for (String remoteStorePath : fhirConfig.getRemoteStorePaths()) {
+            if (remoteStorePath == null || remoteStorePath.isBlank()) {
+                continue;
+            }
+            try {
+                IGenericClient remoteClient = fhirUtil.getFhirClient(remoteStorePath);
+                SupplyDelivery delivery = remoteClient.read().resource(SupplyDelivery.class)
+                        .withId(box.getFhirUuidAsString()).execute();
+                if (delivery.getStatus() == SupplyDeliveryStatus.COMPLETED) {
+                    return;
+                }
+                delivery.setStatus(SupplyDeliveryStatus.COMPLETED);
+                remoteClient.update().resource(delivery).execute();
+                LogEvent.logInfo(this.getClass().getSimpleName(), "completeRemoteSupplyDelivery",
+                        "Completed SupplyDelivery for box " + box.getBoxId() + " on " + remoteStorePath);
+                return;
+            } catch (ResourceNotFoundException | ResourceGoneException e) {
+                // Not this remote's consignment — or not a consignment at all.
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "completeRemoteSupplyDelivery",
+                        "Could not complete SupplyDelivery for box " + box.getBoxId() + " on " + remoteStorePath + ": "
+                                + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Sender side: a dispatched box whose own-store SupplyDelivery reads
+     * {@code completed} was received by the partner (their backflow wrote it), so
+     * delivery is recorded here without anyone clicking — an EQA box through the
+     * same path the Receipt Monitor's manual confirm uses (cycle auto-advance and
+     * audit included), any other box as box RECEIVED + shipment DELIVERED.
+     *
+     * <p>
+     * Collaborators are fetched at call time, not injected: this service sits below
+     * ShippingBoxService (which calls the backflow above on every RECEIVED), so
+     * injecting them back up would be a bean cycle.
+     *
+     * <p>
+     * Deliberately not atomic across boxes: each delivery is applied in its own
+     * transaction, so a fault mid-loop keeps every box already applied and the next
+     * run picks up the rest.
+     */
+    @Scheduled(initialDelay = 30 * 1000, fixedRateString = "${org.openelisglobal.remote.poll.frequency:120000}")
+    public void reconcileDeliveredShipments() {
+        if (!statusBackflowEnabled()) {
+            return;
+        }
+        List<ShippingBox> inFlight = new ArrayList<>();
+        inFlight.addAll(shippingBoxDAO.findByState(BoxState.SENT));
+        inFlight.addAll(shippingBoxDAO.findByState(BoxState.IN_TRANSIT));
+
+        int delivered = 0;
+        IGenericClient ownStore = fhirUtil.getLocalFhirClient();
+        for (ShippingBox box : inFlight) {
+            if (box.getFhirUuid() == null) {
+                continue;
+            }
+            try {
+                SupplyDelivery delivery = ownStore.read().resource(SupplyDelivery.class)
+                        .withId(box.getFhirUuidAsString()).execute();
+                if (delivery.getStatus() != SupplyDeliveryStatus.COMPLETED) {
+                    continue;
+                }
+                applyRemoteDelivery(box);
+                delivered++;
+            } catch (ResourceNotFoundException | ResourceGoneException e) {
+                // Never exported (or imported-only) — nothing to reconcile against.
+            } catch (Exception e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "reconcileDeliveredShipments",
+                        "Could not reconcile box " + box.getBoxId() + ": " + e.getMessage());
+            }
+        }
+        if (delivered > 0) {
+            LogEvent.logInfo(this.getClass().getSimpleName(), "reconcileDeliveredShipments",
+                    delivered + " shipment(s) recorded as delivered from partner receipts");
+        }
+    }
+
+    private void applyRemoteDelivery(ShippingBox box) {
+        String sysUserId = String.valueOf(getAutomatedImportUserId());
+        if (box.getEqaCycleId() != null) {
+            SpringContext.getBean(EQAShipmentService.class).applyRemoteDelivery(box.getId(), sysUserId);
+            return;
+        }
+        SpringContext.getBean(ShippingBoxService.class).changeBoxState(box.getId(), BoxState.RECEIVED,
+                getAutomatedImportUserId());
+        ShipmentService shipmentService = SpringContext.getBean(ShipmentService.class);
+        Shipment shipment = shipmentService.getShipmentByShippingBoxId(box.getId());
+        if (shipment != null && shipment.getStatus() != ShipmentStatus.DELIVERED) {
+            shipmentService.updateShipmentStatus(shipment.getId(), ShipmentStatus.DELIVERED);
         }
     }
 
@@ -280,6 +510,49 @@ public class ShipmentFhirImportService {
             // Not a valid UUID, ignore
         }
         return null;
+    }
+
+    /**
+     * T-42: read the consignment's manifest off the SupplyDelivery as a JSON list
+     * of {label, type}. Prefers the content-item extensions (nested label/type);
+     * falls back to the bare specimen-reference displays an older sender writes,
+     * which carry only a type. Null when the payload names nothing.
+     */
+    private String extractImportedContents(SupplyDelivery delivery) {
+        List<Map<String, String>> items = new ArrayList<>();
+        for (Extension ext : delivery.getExtensionsByUrl(ShippingBoxFhirTransform.EXT_CONTENT_ITEM)) {
+            Map<String, String> item = new LinkedHashMap<>();
+            Extension label = ext.getExtensionByUrl("label");
+            if (label != null && label.getValue() instanceof StringType st) {
+                item.put("label", st.getValue());
+            }
+            Extension type = ext.getExtensionByUrl("type");
+            if (type != null && type.getValue() instanceof StringType st) {
+                item.put("type", st.getValue());
+            }
+            if (!item.isEmpty()) {
+                items.add(item);
+            }
+        }
+        if (items.isEmpty()) {
+            for (Extension ext : delivery.getExtensionsByUrl("http://openelis.org/fhir/extension/shipment-specimen")) {
+                if (ext.getValue() instanceof Reference ref && ref.hasDisplay()) {
+                    Map<String, String> item = new LinkedHashMap<>();
+                    item.put("type", ref.getDisplay());
+                    items.add(item);
+                }
+            }
+        }
+        if (items.isEmpty()) {
+            return null;
+        }
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(items);
+        } catch (Exception e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "extractImportedContents",
+                    "Could not serialise imported contents: " + e.getMessage());
+            return null;
+        }
     }
 
     private String extractExtensionString(SupplyDelivery delivery, String url) {

--- a/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.SimpleQuantity;
@@ -49,6 +50,14 @@ public class ShippingBoxFhirTransform {
     private static final String EXT_SPECIMEN = "http://openelis.org/fhir/extension/shipment-specimen";
     private static final String EXT_SPECIMEN_TYPE_SUMMARY = "http://openelis.org/fhir/extension/shipment-specimen-type-summary";
     private static final String EXT_NON_CONFORMITY = "http://openelis.org/fhir/extension/shipment-non-conformity";
+    /**
+     * T-42: one per contents row, nested {label, type} — what a receiving site
+     * renders as the box's manifest, since the row FKs mean nothing to it. Carries
+     * panel material too, which has no Specimen resource and so no EXT_SPECIMEN.
+     */
+    public static final String EXT_CONTENT_ITEM = "http://openelis.org/fhir/extension/shipment-content-item";
+    /** Anchor for the contained Location the destination reference points at. */
+    static final String CONTAINED_DESTINATION_ID = "destination-facility";
 
     @Autowired
     private BoxSampleItemDAO boxSampleItemDAO;
@@ -59,7 +68,14 @@ public class ShippingBoxFhirTransform {
     /**
      * Transform a ShippingBox to a FHIR SupplyDelivery resource, including
      * references to contained Specimen resources (SampleItem FHIR UUIDs).
+     *
+     * <p>
+     * Transactional in its own right: the transform walks lazy associations (panel
+     * sample → panel, sample item → sample), and a future caller outside a
+     * transaction would otherwise die on LazyInitializationException. Inside
+     * {@link #syncToFhir} it simply joins the transaction already open.
      */
+    @Transactional(readOnly = true)
     public SupplyDelivery transformToSupplyDelivery(ShippingBox box) {
         SupplyDelivery supplyDelivery = new SupplyDelivery();
 
@@ -111,19 +127,43 @@ public class ShippingBoxFhirTransform {
             supplyDelivery.setOccurrence(new DateTimeType(new Date(box.getCreatedDate().getTime())));
         }
 
-        // Destination — reference to Organization (must include UUID for cross-site
-        // matching)
+        // Destination — the laboratory this box is going to, carrying its FHIR UUID so
+        // a remote site can recognise its own consignments.
+        //
+        // R4 types destination as Reference(Location) and receiver as
+        // Reference(Practitioner|PractitionerRole) — an Organization in either is
+        // rejected outright by a validating server ("HAPI-0931: Invalid reference
+        // found at path 'SupplyDelivery.destination'"), which is why no box ever
+        // reached the store before. The receiving laboratory therefore travels as a
+        // contained Location whose managingOrganization is that laboratory: legal R4,
+        // and it needs no second resource written to the partner's server.
         if (box.getDestinationFacility() != null) {
-            Reference destination = new Reference();
+            String facilityName = box.getDestinationFacility().getOrganizationName();
+            Location destination = new Location();
+            destination.setId(CONTAINED_DESTINATION_ID);
+            destination.setName(facilityName);
             if (box.getDestinationFacility().getFhirUuid() != null) {
-                destination.setReference("Organization/" + box.getDestinationFacility().getFhirUuid().toString());
+                destination.setManagingOrganization(
+                        new Reference("Organization/" + box.getDestinationFacility().getFhirUuid().toString())
+                                .setDisplay(facilityName));
             } else {
-                LogEvent.logWarn(this.getClass().getSimpleName(), "transformToSupplyDelivery",
-                        "Destination facility '" + box.getDestinationFacility().getOrganizationName()
-                                + "' has no FHIR UUID — remote sites may not be able to match it");
+                LogEvent.logWarn(this.getClass().getSimpleName(), "transformToSupplyDelivery", "Destination facility '"
+                        + facilityName + "' has no FHIR UUID — remote sites may not be able to match it");
             }
-            destination.setDisplay(box.getDestinationFacility().getOrganizationName());
-            supplyDelivery.setDestination(destination);
+            supplyDelivery.addContained(destination);
+            supplyDelivery.setDestination(new Reference("#" + CONTAINED_DESTINATION_ID).setDisplay(facilityName));
+        }
+
+        // Supplier — this laboratory, when it knows which Organization represents it.
+        // Without it a receiving site can tell a consignment is for them but not who
+        // sent it.
+        String siteOrgUuid = getConfigValue("siteOrganizationFhirUuid", "");
+        if (!siteOrgUuid.isBlank()) {
+            supplyDelivery.setSupplier(new Reference("Organization/" + siteOrgUuid));
+        } else {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "transformToSupplyDelivery",
+                    "siteOrganizationFhirUuid not configured — box " + box.getBoxId()
+                            + " exports with no supplier; receiving sites cannot tell who shipped it");
         }
 
         // Extensions — temperature requirement
@@ -159,15 +199,43 @@ public class ShippingBoxFhirTransform {
      */
     private void addSpecimenExtensions(SupplyDelivery supplyDelivery, List<BoxSampleItem> boxSampleItems) {
         Map<String, Integer> specimenTypeCounts = new HashMap<>();
+        Map<String, String> nonConformityOverrides = null;
 
         for (BoxSampleItem bsi : boxSampleItems) {
+            // T-42: every contents row — patient specimen or panel material — travels
+            // as a labelled content item so the receiver can render a manifest.
+            String label = null;
+            String typeDescription = null;
             SampleItem sampleItem = bsi.getSampleItem();
+            if (bsi.getEqaPanelSample() != null) {
+                label = bsi.getEqaPanelSample().getSampleCode();
+                if (bsi.getEqaPanelSample().getPanel() != null) {
+                    typeDescription = bsi.getEqaPanelSample().getPanel().getPanelName();
+                }
+            } else if (sampleItem != null) {
+                typeDescription = getTypeDescription(sampleItem);
+                if (sampleItem.getSample() != null) {
+                    label = sampleItem.getSample().getAccessionNumber();
+                }
+            }
+            if (label != null || typeDescription != null) {
+                Extension contentExt = new Extension(EXT_CONTENT_ITEM);
+                if (label != null) {
+                    contentExt.addExtension(new Extension("label", new StringType(label)));
+                }
+                if (typeDescription != null) {
+                    contentExt.addExtension(new Extension("type", new StringType(typeDescription)));
+                }
+                supplyDelivery.addExtension(contentExt);
+            }
+
             if (sampleItem == null || sampleItem.getFhirUuid() == null) {
+                String typeKey = typeDescription != null ? typeDescription : "Unknown";
+                specimenTypeCounts.put(typeKey, specimenTypeCounts.getOrDefault(typeKey, 0) + 1);
                 continue;
             }
 
             Reference specimenRef = new Reference("Specimen/" + sampleItem.getFhirUuidAsString());
-            String typeDescription = getTypeDescription(sampleItem);
             if (typeDescription != null) {
                 specimenRef.setDisplay(typeDescription);
             }
@@ -177,8 +245,11 @@ public class ShippingBoxFhirTransform {
             // Non-conformity extension with SNOMED CT codes (Rule 6)
             if (bsi.getReceptionStatus() != null && bsi.getReceptionStatus() != ReceptionStatus.PENDING
                     && bsi.getReceptionStatus() != ReceptionStatus.RECEIVED_GOOD) {
+                if (nonConformityOverrides == null) {
+                    nonConformityOverrides = parseNonConformityCodes(getConfigValue("fhirNonConformityCodes", ""));
+                }
                 Extension ncExt = new Extension(EXT_NON_CONFORMITY);
-                CodeableConcept ncCode = mapReceptionStatusToSnomedCt(bsi.getReceptionStatus());
+                CodeableConcept ncCode = mapReceptionStatusToSnomedCt(bsi.getReceptionStatus(), nonConformityOverrides);
                 ncExt.setValue(ncCode);
                 supplyDelivery.addExtension(ncExt);
             }
@@ -207,7 +278,7 @@ public class ShippingBoxFhirTransform {
      * (Rule 6). Codes are configurable via SiteInformation
      * 'fhirNonConformityCodes'.
      */
-    private CodeableConcept mapReceptionStatusToSnomedCt(ReceptionStatus status) {
+    private CodeableConcept mapReceptionStatusToSnomedCt(ReceptionStatus status, Map<String, String> overrides) {
         CodeableConcept concept = new CodeableConcept();
         Coding coding = new Coding().setSystem("http://snomed.info/sct");
 
@@ -215,7 +286,7 @@ public class ShippingBoxFhirTransform {
         java.util.Map<String, String> defaults = java.util.Map.of("RECEIVED_DAMAGED", "281411007", "RECEIVED_LEAKED",
                 "281412000", "MISSING", "281264009", "REJECTED", "123840003");
 
-        String code = getNonConformityCode(status.name(), defaults.getOrDefault(status.name(), "281411007"));
+        String code = overrides.getOrDefault(status.name(), defaults.getOrDefault(status.name(), "281411007"));
         coding.setCode(code).setDisplay(status.name().replace("_", " ").toLowerCase());
 
         concept.addCoding(coding);
@@ -224,28 +295,24 @@ public class ShippingBoxFhirTransform {
     }
 
     /**
-     * Get a non-conformity SNOMED CT code from config, with fallback to default.
+     * Parse the SiteInformation 'fhirNonConformityCodes' JSON config (a flat
+     * {"STATUS":"snomedCode"} object) into a map. Malformed JSON logs one warn and
+     * yields an empty map so default codes apply.
      */
-    private String getNonConformityCode(String statusName, String defaultCode) {
-        try {
-            String json = getConfigValue("fhirNonConformityCodes", "");
-            if (!json.isBlank()) {
-                // Simple JSON parsing without external library
-                // Format: {"RECEIVED_DAMAGED":"281411007","MISSING":"281264009",...}
-                String key = "\"" + statusName + "\":\"";
-                int start = json.indexOf(key);
-                if (start >= 0) {
-                    start += key.length();
-                    int end = json.indexOf("\"", start);
-                    if (end > start) {
-                        return json.substring(start, end);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // Fall through to default
+    static Map<String, String> parseNonConformityCodes(String json) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
         }
-        return defaultCode;
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper().readValue(json,
+                    new com.fasterxml.jackson.core.type.TypeReference<Map<String, String>>() {
+                    });
+        } catch (Exception e) {
+            LogEvent.logWarn(ShippingBoxFhirTransform.class.getSimpleName(), "parseNonConformityCodes",
+                    "fhirNonConformityCodes is not a valid JSON object of string pairs — using default SNOMED codes: "
+                            + e.getMessage());
+            return Map.of();
+        }
     }
 
     /**
@@ -321,11 +388,13 @@ public class ShippingBoxFhirTransform {
             }
             resourceMap.put(resourceId != null ? resourceId : "", supplyDelivery);
 
-            if (isCreate) {
-                fhirPersistanceService.createFhirResourcesInFhirStore(resourceMap);
-            } else {
-                fhirPersistanceService.updateFhirResourcesInFhirStore(resourceMap);
-            }
+            // Always a PUT to the box's own FHIR UUID, create or not: the create path
+            // mints a random resource id and ignores the one on the resource, so a box
+            // synced on creation and again on every state change ends up as several
+            // resources — and a partner site polling for consignments can then import
+            // the oldest snapshot of a box (empty, not yet packed) as if it were
+            // current. One box is one SupplyDelivery; PUT to a fresh id creates it.
+            fhirPersistanceService.updateFhirResourcesInFhirStore(resourceMap);
         } catch (Exception e) {
             LogEvent.logError("Error persisting SupplyDelivery to FHIR server: " + e.getMessage(), e);
             throw new FhirLocalPersistingException(e);

--- a/src/main/java/org/openelisglobal/shipment/form/ShippingBoxForm.java
+++ b/src/main/java/org/openelisglobal/shipment/form/ShippingBoxForm.java
@@ -38,6 +38,9 @@ public class ShippingBoxForm extends BaseForm {
     @Size(max = 2000)
     private String notes;
 
+    /** T-42: JSON [{label, type}] manifest of an imported box; null otherwise. */
+    private String importedContents;
+
     private Timestamp createdDate;
 
     private Integer createdBy;
@@ -59,6 +62,13 @@ public class ShippingBoxForm extends BaseForm {
 
     @Size(max = 2000)
     private String contents;
+
+    /**
+     * Set when this box carries EQA panel material for a provider cycle (T-40).
+     * Without it nothing outside the EQA workbench can tell an EQA box from a
+     * referral box.
+     */
+    private Long eqaCycleId;
 
     private List<BoxSampleInfo> samples;
 
@@ -197,6 +207,14 @@ public class ShippingBoxForm extends BaseForm {
         this.notes = notes;
     }
 
+    public String getImportedContents() {
+        return importedContents;
+    }
+
+    public void setImportedContents(String importedContents) {
+        this.importedContents = importedContents;
+    }
+
     public Timestamp getCreatedDate() {
         return createdDate;
     }
@@ -275,6 +293,14 @@ public class ShippingBoxForm extends BaseForm {
 
     public void setContents(String contents) {
         this.contents = contents;
+    }
+
+    public Long getEqaCycleId() {
+        return eqaCycleId;
+    }
+
+    public void setEqaCycleId(Long eqaCycleId) {
+        this.eqaCycleId = eqaCycleId;
     }
 
     public List<BoxSampleInfo> getSamples() {

--- a/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemService.java
+++ b/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemService.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.shipment.service;
 
 import java.util.List;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.shipment.dto.SampleItemDTO;
 import org.openelisglobal.shipment.valueholder.BoxSampleItem;
 import org.openelisglobal.shipment.valueholder.ReceptionStatus;
@@ -68,6 +69,23 @@ public interface BoxSampleItemService {
      * @throws IllegalArgumentException if sample item or box not found
      */
     BoxSampleItem addSampleItemToBox(Integer shippingBoxId, String sampleItemId, Integer systemUserId);
+
+    /**
+     * Pack EQA panel material into a box as its contents (T-40, FR-V2.5-13). One
+     * row per panel sample per box — the same grain the aliquot arithmetic
+     * dispatches — so a provider box is never contentless. Inventory stays owned by
+     * {@code eqa_panel.aliquots_shipped}; these rows are what the box holds, not a
+     * second count of it.
+     *
+     * @param shippingBoxId Shipping box ID
+     * @param panelSamples  Panel material to pack, in packing order
+     * @param systemUserId  System user ID for audit trail
+     * @return the created contents rows
+     * @throws IllegalArgumentException if the box does not exist or nothing was
+     *                                  given to pack
+     */
+    List<BoxSampleItem> addPanelSamplesToBox(Integer shippingBoxId, List<EQAPanelSample> panelSamples,
+            Integer systemUserId);
 
     /**
      * Remove sample item from box. Also unassigns all associated referrals from

--- a/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.referral.valueholder.Referral;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.shipment.dao.BoxSampleItemDAO;
@@ -86,7 +87,12 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
                 initializeAssociations(boxSampleItem);
 
                 SampleItem sampleItem = boxSampleItem.getSampleItem();
-                if (sampleItem != null) {
+                if (sampleItem == null) {
+                    // EQA panel material (T-40): it has no accession number and no referral,
+                    // but it is what the box holds, so it renders in the same table rather
+                    // than leaving the box reading as empty.
+                    dtos.add(toPanelMaterialDTO(boxSampleItem, shippingBoxId));
+                } else {
                     // Use UnassignedSampleItemService to get full DTO with referrals
                     SampleItemDTO dto = unassignedSampleItemService.getSampleItemById(sampleItem.getId());
                     if (dto != null) {
@@ -147,9 +153,44 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
     }
 
     /**
+     * The contents row for EQA panel material, in the shape the box contents table
+     * already renders: the panel sample's own code stands in for an accession
+     * number and the panel's material type for the specimen type. Nothing here may
+     * carry the sealed target value (FR-V2.1-16).
+     */
+    private SampleItemDTO toPanelMaterialDTO(BoxSampleItem boxSampleItem, Integer shippingBoxId) {
+        EQAPanelSample panelSample = boxSampleItem.getEqaPanelSample();
+        SampleItemDTO dto = new SampleItemDTO();
+        dto.setAccessionNumber(panelSample == null ? null : panelSample.getSampleCode());
+        if (panelSample != null && panelSample.getPanel() != null) {
+            // The panel this material came out of. Not eqa_panel.panel_type: that holds
+            // the scheme kind (international_pt, in_house), which under a "Sample type"
+            // column would read as a specimen type it is not.
+            dto.setTypeOfSample(panelSample.getPanel().getPanelName());
+        }
+        dto.setAssignedBoxId(shippingBoxId);
+        if (boxSampleItem.getShippingBox() != null) {
+            dto.setAssignedBoxName(boxSampleItem.getShippingBox().getBoxId());
+        }
+        dto.setBoxSampleItemId(boxSampleItem.getId());
+        if (boxSampleItem.getReceptionStatus() != null) {
+            dto.setReceptionStatus(boxSampleItem.getReceptionStatus().name());
+        }
+        dto.setReceptionNotes(boxSampleItem.getReceptionNotes());
+        return dto;
+    }
+
+    /**
      * Initialize lazy loaded associations to prevent LazyInitializationException
      */
     private void initializeAssociations(BoxSampleItem boxSampleItem) {
+        if (boxSampleItem.getEqaPanelSample() != null) {
+            EQAPanelSample panelSample = boxSampleItem.getEqaPanelSample();
+            panelSample.getSampleCode(); // Force initialization
+            if (panelSample.getPanel() != null) {
+                panelSample.getPanel().getPanelName(); // Force initialization
+            }
+        }
         if (boxSampleItem.getSampleItem() != null) {
             SampleItem si = boxSampleItem.getSampleItem();
             si.getId(); // Force initialization
@@ -176,6 +217,14 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             // Get shipping box
             ShippingBox box = shippingBoxDAO.get(shippingBoxId).orElseThrow(
                     () -> new IllegalArgumentException("Shipping box not found with ID: " + shippingBoxId));
+
+            // An EQA box carries panel material to another laboratory; a patient
+            // specimen packed into it would leave this lab outside both the referral
+            // workflow and the cycle's aliquot arithmetic.
+            if (box.getEqaCycleId() != null) {
+                throw new IllegalStateException(
+                        "Box " + box.getBoxId() + " carries EQA panel material, so a patient sample cannot be added");
+            }
 
             // Validate capacity
             if (box.getCapacity() != null && box.getCapacity() > 0) {
@@ -209,8 +258,7 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             shippingBoxDAO.update(box);
 
             // Assign all referrals for this sample item to this box
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
             for (Referral referral : referrals) {
                 if (referral.getAssignedBox() == null) {
                     referral.setAssignedBox(box);
@@ -229,9 +277,53 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             }
 
             return savedBoxSampleItem;
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            // A refusal the caller can act on — already boxed, at capacity, an EQA box —
+            // reads as a 400 with its own sentence rather than a 500 that loses it.
+            logger.error("Refused adding sample item to box: {}", e.getMessage());
+            throw e;
         } catch (Exception e) {
             logger.error("Error adding sample item to box", e);
             throw new LIMSRuntimeException("Error adding sample item to box", e);
+        }
+    }
+
+    @Override
+    public List<BoxSampleItem> addPanelSamplesToBox(Integer shippingBoxId, List<EQAPanelSample> panelSamples,
+            Integer systemUserId) {
+        if (panelSamples == null || panelSamples.isEmpty()) {
+            throw new IllegalArgumentException("No panel material was given to pack into box " + shippingBoxId);
+        }
+        try {
+            ShippingBox box = shippingBoxDAO.get(shippingBoxId).orElseThrow(
+                    () -> new IllegalArgumentException("Shipping box not found with ID: " + shippingBoxId));
+
+            Timestamp now = new Timestamp(System.currentTimeMillis());
+            int position = boxSampleItemDAO.countByShippingBoxId(shippingBoxId);
+            List<BoxSampleItem> packed = new ArrayList<>();
+            for (EQAPanelSample panelSample : panelSamples) {
+                BoxSampleItem contents = new BoxSampleItem();
+                contents.setShippingBox(box);
+                contents.setEqaPanelSample(panelSample);
+                contents.setSystemUserId(systemUserId);
+                contents.setAddedDate(now);
+                contents.setPositionInBox(++position);
+                contents.setReceptionStatus(ReceptionStatus.PENDING);
+                contents.setLastupdated(now);
+                packed.add(boxSampleItemDAO.get(boxSampleItemDAO.insert(contents)).orElse(contents));
+            }
+
+            box.setActualSampleCount(position);
+            box.setLastupdated(now);
+            shippingBoxDAO.update(box);
+            logger.info("Packed {} panel samples into box {}", packed.size(), shippingBoxId);
+            return packed;
+        } catch (IllegalArgumentException e) {
+            logger.error("Refused packing panel material: {}", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            logger.error("Error packing panel material into box", e);
+            throw new LIMSRuntimeException("Error packing panel material into box", e);
         }
     }
 
@@ -249,7 +341,7 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
 
             // Unassign all referrals for this sample item that are assigned to this box
             if (sampleItem != null && shippingBox != null) {
-                List<Referral> referrals = referralDAO.getReferralsBySampleItemId(Integer.parseInt(sampleItem.getId()));
+                List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItem.getId());
 
                 for (Referral referral : referrals) {
                     // Check if this referral is assigned to this box

--- a/src/main/java/org/openelisglobal/shipment/service/ShippingBoxService.java
+++ b/src/main/java/org/openelisglobal/shipment/service/ShippingBoxService.java
@@ -111,13 +111,15 @@ public interface ShippingBoxService {
     ShippingBox changeBoxState(Integer id, BoxState newState, Integer systemUserId);
 
     /**
-     * Mark box as ready to send (validates box has at least one sample)
+     * Mark box as ready to send (validates the box holds at least one item of
+     * contents — a patient sample item or EQA panel material)
      *
-     * @param id Box ID
+     * @param id           Box ID
+     * @param systemUserId System user ID for audit trail
      * @return Updated ShippingBox
      * @throws IllegalStateException if box is empty
      */
-    ShippingBox markReadyToSend(Integer id);
+    ShippingBox markReadyToSend(Integer id, Integer systemUserId);
 
     /**
      * Get boxes for dashboard with sample counts and metadata Services MUST compile

--- a/src/main/java/org/openelisglobal/shipment/service/ShippingBoxServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/ShippingBoxServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.shipment.dao.BoxSampleItemDAO;
 import org.openelisglobal.shipment.dao.ShippingBoxDAO;
+import org.openelisglobal.shipment.fhir.ShipmentFhirImportService;
 import org.openelisglobal.shipment.fhir.ShippingBoxFhirTransform;
 import org.openelisglobal.shipment.valueholder.BoxState;
 import org.openelisglobal.shipment.valueholder.ShippingBox;
@@ -36,6 +37,9 @@ public class ShippingBoxServiceImpl implements ShippingBoxService {
 
     @Autowired
     private ShippingBoxFhirTransform shippingBoxFhirTransform;
+
+    @Autowired
+    private ShipmentFhirImportService shipmentFhirImportService;
 
     @Override
     @Transactional(readOnly = true)
@@ -258,6 +262,20 @@ public class ShippingBoxServiceImpl implements ShippingBoxService {
             // Sync state change to FHIR server asynchronously
             shippingBoxFhirTransform.syncToFhir(box, false);
 
+            // T-41: taking delivery of an imported box completes the origin store's
+            // SupplyDelivery, so the sender's monitor learns it arrived. Async and
+            // non-fatal, like the sync above; a locally-created box is a no-op there.
+            // The catch is not decoration: without @EnableAsync the call runs inline,
+            // and a backflow fault must never undo a completed state change.
+            if (newState == BoxState.RECEIVED) {
+                try {
+                    shipmentFhirImportService.completeRemoteSupplyDelivery(box);
+                } catch (Exception e) {
+                    logger.error("Delivery recorded but the origin store was not updated for box {}", box.getBoxId(),
+                            e);
+                }
+            }
+
             return box;
         } catch (IllegalStateException | IllegalArgumentException e) {
             logger.error("State transition error: {}", e.getMessage());
@@ -269,18 +287,23 @@ public class ShippingBoxServiceImpl implements ShippingBoxService {
     }
 
     @Override
-    public ShippingBox markReadyToSend(Integer id) {
+    public ShippingBox markReadyToSend(Integer id, Integer systemUserId) {
         try {
-            ShippingBox box = shippingBoxDAO.get(id)
-                    .orElseThrow(() -> new IllegalArgumentException("Box not found with ID: " + id));
+            shippingBoxDAO.get(id).orElseThrow(() -> new IllegalArgumentException("Box not found with ID: " + id));
 
-            // Validate box has at least one sample
-            int sampleCount = boxSampleItemDAO.countByShippingBoxId(id);
-            if (sampleCount == 0) {
+            // Validate box has at least one item of contents — a patient sample item or
+            // EQA panel material (T-40).
+            int contentsCount = boxSampleItemDAO.countByShippingBoxId(id);
+            if (contentsCount == 0) {
                 throw new IllegalStateException("Cannot mark empty box as ready to send");
             }
 
-            return changeBoxState(id, BoxState.READY_TO_SEND, null);
+            return changeBoxState(id, BoxState.READY_TO_SEND, systemUserId);
+        } catch (IllegalStateException | IllegalArgumentException e) {
+            // The empty-box refusal is the whole point of this method, so it must reach
+            // the caller as itself rather than as a wrapped runtime fault.
+            logger.error("Refused marking box ready to send: {}", e.getMessage());
+            throw e;
         } catch (Exception e) {
             logger.error("Error marking box as ready to send", e);
             throw new LIMSRuntimeException("Error marking box as ready to send", e);

--- a/src/main/java/org/openelisglobal/shipment/service/UnassignedSampleItemServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/UnassignedSampleItemServiceImpl.java
@@ -77,9 +77,7 @@ public class UnassignedSampleItemServiceImpl implements UnassignedSampleItemServ
     public SampleItemDTO getSampleItemById(String sampleItemId) {
         try {
             // Get all referrals for this sample item
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
 
             if (referrals.isEmpty()) {
                 logger.warn("No referrals found for sample item: {}", sampleItemId);
@@ -174,8 +172,7 @@ public class UnassignedSampleItemServiceImpl implements UnassignedSampleItemServ
                     collectionDate);
 
             // Get all referrals for this sample item
-            Integer sampleItemIdInt = Integer.parseInt(sampleItemId);
-            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemIdInt);
+            List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
 
             List<ReferralTestDTO> referralTests = new ArrayList<>();
             for (Referral referral : referrals) {

--- a/src/main/java/org/openelisglobal/shipment/valueholder/BoxSampleItem.java
+++ b/src/main/java/org/openelisglobal/shipment/valueholder/BoxSampleItem.java
@@ -15,6 +15,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import org.openelisglobal.common.valueholder.BaseObject;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 
 /**
@@ -42,9 +43,22 @@ public class BoxSampleItem extends BaseObject<Integer> {
     @JoinColumn(name = "shipping_box_id", nullable = false)
     private ShippingBox shippingBox;
 
+    /**
+     * Null for EQA panel material: qa/036's CHECK keeps exactly one of this and
+     * {@link #eqaPanelSample} set.
+     */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sample_item_id", nullable = false)
+    @JoinColumn(name = "sample_item_id")
     private SampleItem sampleItem;
+
+    /**
+     * Provider EQA panel material (T-40). It is not a specimen accessioned in this
+     * lab — it is going out to participant laboratories — so it cannot be a
+     * SampleItem, but it is genuinely what the box holds.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "eqa_panel_sample_id")
+    private EQAPanelSample eqaPanelSample;
 
     @Column(name = "added_date", nullable = false)
     private Timestamp addedDate;
@@ -90,6 +104,14 @@ public class BoxSampleItem extends BaseObject<Integer> {
 
     public void setSampleItem(SampleItem sampleItem) {
         this.sampleItem = sampleItem;
+    }
+
+    public EQAPanelSample getEqaPanelSample() {
+        return eqaPanelSample;
+    }
+
+    public void setEqaPanelSample(EQAPanelSample eqaPanelSample) {
+        this.eqaPanelSample = eqaPanelSample;
     }
 
     public Timestamp getAddedDate() {

--- a/src/main/java/org/openelisglobal/shipment/valueholder/ShippingBox.java
+++ b/src/main/java/org/openelisglobal/shipment/valueholder/ShippingBox.java
@@ -64,6 +64,16 @@ public class ShippingBox extends BaseObject<Integer> {
     @Column(name = "notes", columnDefinition = "TEXT")
     private String notes;
 
+    /**
+     * T-42: what an imported consignment says it holds — a JSON list of {label,
+     * type} captured from the SupplyDelivery at import time. Read-side only: an
+     * imported box has no box_sample_item rows (their FKs name rows only the sender
+     * has), so this is the manifest BoxDetails renders. Null on locally-created
+     * boxes.
+     */
+    @Column(name = "imported_contents", columnDefinition = "TEXT")
+    private String importedContents;
+
     @Column(name = "created_date", nullable = false)
     private Timestamp createdDate;
 
@@ -186,6 +196,14 @@ public class ShippingBox extends BaseObject<Integer> {
 
     public void setNotes(String notes) {
         this.notes = notes;
+    }
+
+    public String getImportedContents() {
+        return importedContents;
+    }
+
+    public void setImportedContents(String importedContents) {
+        this.importedContents = importedContents;
     }
 
     public Timestamp getCreatedDate() {

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -128,6 +128,11 @@
   <!-- EQA V2.5 — OGC-613: the cycle wizard's distribution method (qa-064/065) -->
   <include file="liquibase/qa/034-eqa-cycle-distribution-method.xml" />
 
+  <!-- EQA V2.5 T-40 — OGC-613: panel material as box contents (qa-068). Must follow
+       the shipment changelog that creates box_sample_item and qa/017's
+       eqa_panel_sample, both of which it references. -->
+  <include file="liquibase/qa/036-eqa-box-contents.xml" />
+
   <!-- EQA V2.3 — OGC-611: per-analyst capture opt-in on a scheme (qa-070) -->
   <include file="liquibase/qa/037-eqa-scheme-per-analyst.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/036-eqa-box-contents.xml
+++ b/src/main/resources/liquibase/qa/036-eqa-box-contents.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.5 (OGC-613) T-40: EQA panel material as real box contents.
+
+    box_sample_item keys on sample_item — a specimen accessioned into this lab
+    against a patient. Provider panel material is eqa_panel_sample and is going
+    out to other laboratories, so there was nothing legitimate to put in that
+    table and an EQA box shipped with zero contents rows: empty inside Sample
+    Shipment, no manifest source of truth, and a meaningless actual_sample_count.
+
+    One contents table, two kinds of content: sample_item_id becomes nullable,
+    eqa_panel_sample_id joins it, and a CHECK keeps exactly one of the pair set.
+    Keeping one table is what lets position_in_box, reception_status and the
+    box's own counts go on working untouched — a separate EQA-only contents
+    table would have forced every reader to union two shapes first.
+
+    uk_box_sample_item_sample_item stays as it is: PostgreSQL unique constraints
+    ignore NULLs, so any number of EQA rows can sit alongside it while a patient
+    sample item still cannot be packed into two boxes.
+
+    No backfill: boxes created before this changeset stay contentless. They are
+    dispatched history, their material is still derivable from the cycle's panel,
+    and inventing rows for them would date them to the migration rather than to
+    the dispatch.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-068-box-sample-item-eqa-panel-sample">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="clinlims" tableName="box_sample_item"
+                    columnName="eqa_panel_sample_id" />
+            </not>
+        </preConditions>
+        <comment>EQA panel material as box contents (FR-V2.5-13)</comment>
+
+        <addColumn schemaName="clinlims" tableName="box_sample_item">
+            <column name="eqa_panel_sample_id" type="numeric(10,0)" />
+        </addColumn>
+
+        <dropNotNullConstraint schemaName="clinlims" tableName="box_sample_item"
+            columnName="sample_item_id" columnDataType="int" />
+
+        <addForeignKeyConstraint baseTableSchemaName="clinlims" baseTableName="box_sample_item"
+            baseColumnNames="eqa_panel_sample_id"
+            constraintName="fk_box_sample_item_eqa_panel_sample"
+            referencedTableSchemaName="clinlims" referencedTableName="eqa_panel_sample"
+            referencedColumnNames="id" />
+
+        <createIndex schemaName="clinlims" tableName="box_sample_item"
+            indexName="idx_box_sample_item_eqa_panel_sample">
+            <column name="eqa_panel_sample_id" />
+        </createIndex>
+
+        <!-- Exactly one kind of content per row: a patient specimen or panel
+             material, never both and never neither. -->
+        <sql>
+            ALTER TABLE clinlims.box_sample_item
+            ADD CONSTRAINT box_sample_item_content_chk
+            CHECK ((sample_item_id IS NOT NULL) &lt;&gt; (eqa_panel_sample_id IS NOT NULL));
+        </sql>
+
+        <rollback>
+            <sql>ALTER TABLE clinlims.box_sample_item DROP CONSTRAINT box_sample_item_content_chk;</sql>
+            <dropIndex schemaName="clinlims" tableName="box_sample_item"
+                indexName="idx_box_sample_item_eqa_panel_sample" />
+            <dropForeignKeyConstraint baseTableSchemaName="clinlims" baseTableName="box_sample_item"
+                constraintName="fk_box_sample_item_eqa_panel_sample" />
+            <delete schemaName="clinlims" tableName="box_sample_item">
+                <where>eqa_panel_sample_id IS NOT NULL</where>
+            </delete>
+            <dropColumn schemaName="clinlims" tableName="box_sample_item"
+                columnName="eqa_panel_sample_id" />
+            <addNotNullConstraint schemaName="clinlims" tableName="box_sample_item"
+                columnName="sample_item_id" columnDataType="int" />
+        </rollback>
+    </changeSet>
+
+    <!-- T-42: an imported box's contents rows cannot exist locally (their FKs
+         name rows only the sender has), so what the consignment says it holds
+         is kept read-side: a JSON list of {label, type} captured from the
+         SupplyDelivery's content-item extensions at import time. Render-only —
+         never a source for per-item reception. -->
+    <changeSet author="openelisglobal" id="qa-069-shipping-box-imported-contents">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="clinlims" tableName="shipping_box"
+                    columnName="imported_contents" />
+            </not>
+        </preConditions>
+        <comment>Imported consignment contents as a read-side manifest (T-42)</comment>
+        <addColumn schemaName="clinlims" tableName="shipping_box">
+            <column name="imported_contents" type="TEXT" />
+        </addColumn>
+        <rollback>
+            <dropColumn schemaName="clinlims" tableName="shipping_box" columnName="imported_contents" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderCycleOversightIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderCycleOversightIntegrationTest.java
@@ -86,6 +86,8 @@ public class EQAProviderCycleOversightIntegrationTest extends EQASpineTestBase {
             // shipping_box.eqa_cycle_id is RESTRICT, so boxes go before their cycle.
             jdbc.update("DELETE FROM clinlims.shipment WHERE shipping_box_id IN"
                     + " (SELECT id FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%')");
+            jdbc.update("DELETE FROM clinlims.box_sample_item WHERE shipping_box_id IN"
+                    + " (SELECT id FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%')");
             jdbc.update("DELETE FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%'");
             jdbc.update("DELETE FROM clinlims.eqa_program_enrollment WHERE organization_id BETWEEN 9970 AND 9990");
         }
@@ -195,6 +197,13 @@ public class EQAProviderCycleOversightIntegrationTest extends EQASpineTestBase {
         assertEquals("2 samples for the original 2 participants plus 2 for the repeat", Integer.valueOf(6),
                 aliquots("aliquots_shipped"));
         assertEquals("the monitor now follows the repeat", repeat.get("boxCode"), receiptRow(ORG_A).get("boxCode"));
+        // T-40: a repeat box is packed like any other, so it does not go out empty.
+        assertEquals("the repeat box holds the panel material it replaces", Integer.valueOf(2),
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.box_sample_item bsi"
+                                + " JOIN clinlims.shipping_box b ON b.id = bsi.shipping_box_id"
+                                + " WHERE b.box_id = ? AND bsi.eqa_panel_sample_id IS NOT NULL",
+                        Integer.class, repeat.get("boxCode")));
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
@@ -9,8 +9,14 @@ import static org.junit.Assert.fail;
 import java.sql.Date;
 import java.util.List;
 import java.util.Map;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.SupplyDelivery;
 import org.junit.Before;
 import org.junit.Test;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
 import org.openelisglobal.eqa.service.EQAShipmentService;
@@ -23,7 +29,17 @@ import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
 import org.openelisglobal.eqa.valueholder.EQATriggerType;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.shipment.fhir.ShipmentFhirImportService;
+import org.openelisglobal.shipment.fhir.ShippingBoxFhirTransform;
+import org.openelisglobal.shipment.service.BoxSampleItemService;
+import org.openelisglobal.shipment.service.ShippingBoxService;
+import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * OGC-613 [EQA V2.5 / T-25] — the provider prep and shipment workbenches
@@ -44,6 +60,27 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
 
     @Autowired
     private EQACycleService cycleService;
+
+    @Autowired
+    private ShippingBoxService shippingBoxService;
+
+    @Autowired
+    private BoxSampleItemService boxSampleItemService;
+
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    @Autowired
+    private ShippingBoxFhirTransform boxFhirTransform;
+
+    @Autowired
+    private ShipmentFhirImportService shipmentFhirImportService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     private EQAProgram scheme;
     private EQACycle cycle;
@@ -73,6 +110,8 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         // shipping_box.eqa_cycle_id is RESTRICT, so boxes go before their cycle.
         if (jdbc != null) {
             jdbc.update("DELETE FROM clinlims.shipment WHERE shipping_box_id IN"
+                    + " (SELECT id FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%')");
+            jdbc.update("DELETE FROM clinlims.box_sample_item WHERE shipping_box_id IN"
                     + " (SELECT id FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%')");
             jdbc.update("DELETE FROM clinlims.shipping_box WHERE box_id LIKE 'EQA-C%'");
             jdbc.update("DELETE FROM clinlims.eqa_program_enrollment WHERE organization_id IN (9960, 9961, 9962)");
@@ -197,6 +236,131 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         assertEquals("the box knows its cycle", Long.valueOf(cycle.getId()),
                 jdbc.queryForObject("SELECT eqa_cycle_id FROM clinlims.shipping_box WHERE box_id = ?", Long.class,
                         "EQA-C" + cycle.getId() + "-" + ORG_A));
+    }
+
+    // ---- T-40: the box holds its panel material ----
+
+    @Test
+    public void savingDetailsPacksThePanelMaterialIntoTheBox() {
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-1", null, USER);
+
+        String boxCode = boxCode(ORG_A);
+        assertEquals("one contents row per panel sample, none of them a patient specimen", Integer.valueOf(2),
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.box_sample_item bsi"
+                                + " JOIN clinlims.shipping_box b ON b.id = bsi.shipping_box_id"
+                                + " JOIN clinlims.eqa_panel_sample ps ON ps.id = bsi.eqa_panel_sample_id"
+                                + " WHERE b.box_id = ? AND bsi.sample_item_id IS NULL AND ps.panel_id = ?",
+                        Integer.class, boxCode, panel.getId()));
+        assertEquals("the box counts what it holds", Integer.valueOf(2), jdbc.queryForObject(
+                "SELECT actual_sample_count FROM clinlims.shipping_box WHERE box_id = ?", Integer.class, boxCode));
+        assertEquals("packing order is recorded", Integer.valueOf(2),
+                jdbc.queryForObject(
+                        "SELECT max(bsi.position_in_box) FROM clinlims.box_sample_item bsi"
+                                + " JOIN clinlims.shipping_box b ON b.id = bsi.shipping_box_id WHERE b.box_id = ?",
+                        Integer.class, boxCode));
+    }
+
+    @Test
+    public void reSavingDetailsDoesNotPackTheMaterialTwice() {
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-1", null, USER);
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "FedEx", "TRK-2", null, USER);
+
+        assertEquals("courier details are edited, not re-packed", Integer.valueOf(2),
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.box_sample_item bsi"
+                                + " JOIN clinlims.shipping_box b ON b.id = bsi.shipping_box_id WHERE b.box_id = ?",
+                        Integer.class, boxCode(ORG_A)));
+    }
+
+    @Test
+    public void packingTheBoxDoesNotConsumeAliquotsByItself() {
+        clearTheGate();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+
+        assertEquals("contents say what is in the box; dispatch is what spends inventory", Integer.valueOf(0),
+                jdbc.queryForObject("SELECT aliquots_shipped FROM clinlims.eqa_panel WHERE id = ?", Integer.class,
+                        panel.getId()));
+
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A), USER);
+
+        assertEquals("2 samples for 1 participant, counted once", Integer.valueOf(2), jdbc.queryForObject(
+                "SELECT aliquots_shipped FROM clinlims.eqa_panel WHERE id = ?", Integer.class, panel.getId()));
+    }
+
+    @Test
+    public void aBoxWithNoContentsIsStillRefusedReadyToSend() {
+        ShippingBox empty = new ShippingBox();
+        empty.setBoxId("EQA-C" + cycle.getId() + "-EMPTY");
+        empty.setDestinationFacility(organizationService.getOrganizationById(String.valueOf(ORG_A)));
+        empty.setSystemUserId(Integer.valueOf(USER));
+        empty = shippingBoxService.createBox(empty);
+
+        try {
+            shippingBoxService.markReadyToSend(empty.getId(), Integer.valueOf(USER));
+            fail("an empty box must not be marked ready to send");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("empty box"));
+        }
+        assertEquals("DRAFT", jdbc.queryForObject("SELECT state FROM clinlims.shipping_box WHERE id = ?", String.class,
+                empty.getId()));
+
+        boxSampleItemService.addPanelSamplesToBox(empty.getId(),
+                eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId()), Integer.valueOf(USER));
+
+        assertEquals("the same check passes once the box holds panel material", BoxState.READY_TO_SEND,
+                shippingBoxService.markReadyToSend(empty.getId(), Integer.valueOf(USER)).getState());
+    }
+
+    @Test
+    public void aPatientSampleCannotBePackedIntoAnEqaBox() {
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        Integer boxId = jdbc.queryForObject("SELECT id FROM clinlims.shipping_box WHERE box_id = ?", Integer.class,
+                boxCode(ORG_A));
+
+        try {
+            // The EQA refusal comes before the sample item is even looked up, so no
+            // specimen has to exist for this to be the answer.
+            boxSampleItemService.addSampleItemToBox(boxId, "999999", Integer.valueOf(USER));
+            fail("a patient specimen must not be shipped to a participant lab in an EQA box");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("EQA panel material"));
+        }
+    }
+
+    @Test
+    public void aContentsRowMustCarryExactlyOneKindOfContent() {
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        Integer boxId = jdbc.queryForObject("SELECT id FROM clinlims.shipping_box WHERE box_id = ?", Integer.class,
+                boxCode(ORG_A));
+        Long panelSampleId = jdbc.queryForObject("SELECT min(id) FROM clinlims.eqa_panel_sample WHERE panel_id = ?",
+                Long.class, panel.getId());
+        String sampleItemId = jdbc.queryForObject("SELECT min(id) FROM clinlims.sample_item", String.class);
+
+        assertContentsRejected("neither a sample item nor panel material", boxId, null, null);
+        if (sampleItemId != null) {
+            assertContentsRejected("both at once", boxId, Integer.valueOf(sampleItemId), panelSampleId);
+        }
+    }
+
+    @Test
+    public void aCycleWithNoPanelMaterialHasNothingToPack() {
+        EQAProgram bare = insertScheme("Panel-less " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "This lab");
+        EQACycle bareCycle = readBack(insertCycle(bare, 1));
+        jdbc.update(
+                "INSERT INTO clinlims.eqa_program_enrollment (id, eqa_program_id, organization_id,"
+                        + " enrollment_date, status, sys_user_id, lastupdated)"
+                        + " VALUES (nextval('clinlims.eqa_enrollment_seq'), ?, ?, now(), 'Active', ?, now())",
+                bare.getId(), ORG_A, USER);
+
+        try {
+            shipmentService.saveShipmentDetails(bareCycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+            fail("a box that would go out empty must not be created at all");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("no panel material"));
+        }
+        assertEquals("no half-created box may survive the refusal", Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.shipping_box WHERE eqa_cycle_id = ?", Integer.class, bareCycle.getId()));
     }
 
     @Test
@@ -413,7 +577,210 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         assertEquals(1, cycles.get(2).get("cycleNumber"));
     }
 
+    // ---- T-41: delivery-status backflow ----
+
+    @Test
+    public void aRemoteReceiptDeliversTheCurrentShipmentLikeAManualConfirm() {
+        // Single-participant roster, so one delivery is "all delivered" and the
+        // cycle should walk to submissions on its own (AC-V2.5-13).
+        addToRoster(ORG_A);
+        clearTheGate();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A), USER);
+        Integer boxDbId = (Integer) shipmentService.getShipmentRows(cycle.getId()).get(0).get("boxId");
+
+        shipmentService.applyRemoteDelivery(boxDbId, USER);
+
+        Map<String, Object> row = shipmentService.getReceiptRows(cycle.getId()).get(0);
+        assertEquals("DELIVERED", row.get("receiptStatus"));
+        assertNotNull("the received date is stamped, as a manual confirm would", row.get("receivedDate"));
+        assertEquals("one delivered participant of one opens submissions", EQACycleStatus.SUBMISSIONS_OPEN,
+                readBack(cycle.getId()).getStatus());
+        assertEquals("RECEIVED",
+                jdbc.queryForObject("SELECT state FROM clinlims.shipping_box WHERE id = ?", String.class, boxDbId));
+    }
+
+    @Test
+    public void aRemoteReceiptForASupersededBoxDoesNotTouchTheCycle() {
+        addToRoster(ORG_A);
+        // Reserve covers the repeat, so the original can be superseded in-flight.
+        shipmentService.savePrep(panel.getId(), 8, 2, true, "Homogeneity CV 3%", USER);
+        toPrepInProgress();
+        readyToShip();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A), USER);
+        Integer originalBoxId = (Integer) shipmentService.getShipmentRows(cycle.getId()).get(0).get("boxId");
+        shipmentService.sendRepeat(cycle.getId(), ORG_A, null, USER);
+
+        // The stale original arrives after the repeat was dispatched.
+        shipmentService.applyRemoteDelivery(originalBoxId, USER);
+
+        assertEquals("the superseded box is closed off", "RECEIVED", jdbc
+                .queryForObject("SELECT state FROM clinlims.shipping_box WHERE id = ?", String.class, originalBoxId));
+        Map<String, Object> row = shipmentService.getReceiptRows(cycle.getId()).get(0);
+        assertEquals("the monitor still follows the repeat", boxCode(ORG_A) + "-R1", row.get("boxCode"));
+        assertEquals("IN_TRANSIT", row.get("receiptStatus"));
+        assertEquals("a stale arrival must not advance the cycle", EQACycleStatus.SHIPPED,
+                readBack(cycle.getId()).getStatus());
+    }
+
+    // ---- T-42: the consignment's manifest travels and survives import ----
+
+    @Test
+    public void theExportedConsignmentNamesEveryPanelSample() {
+        addToRoster(ORG_A);
+        clearTheGate();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        Integer boxDbId = (Integer) shipmentService.getShipmentRows(cycle.getId()).get(0).get("boxId");
+
+        // The transform walks lazy associations (panel sample → panel), so it runs
+        // inside a read-only transaction exactly as syncToFhir would run it.
+        SupplyDelivery delivery = new TransactionTemplate(transactionManager)
+                .execute(tx -> boxFhirTransform.transformToSupplyDelivery(shippingBoxService.getBoxById(boxDbId)));
+
+        List<Extension> contents = delivery.getExtensionsByUrl(ShippingBoxFhirTransform.EXT_CONTENT_ITEM);
+        assertEquals("one content item per panel sample", 2, contents.size());
+        List<String> labels = contents.stream()
+                .map(ext -> ((StringType) ext.getExtensionByUrl("label").getValue()).getValue()).sorted().toList();
+        assertEquals(List.of("PS-1", "PS-2"), labels);
+        for (Extension ext : contents) {
+            assertEquals("the panel name stands in for a specimen type", "Provider panel",
+                    ((StringType) ext.getExtensionByUrl("type").getValue()).getValue());
+        }
+    }
+
+    @Test
+    public void anImportedConsignmentKeepsItsManifestReadSide() {
+        String boxCode = "EQA-C-IMP-" + System.nanoTime();
+        SupplyDelivery delivery = importableDelivery(boxCode, new java.util.Date());
+        Extension item1 = new Extension(ShippingBoxFhirTransform.EXT_CONTENT_ITEM);
+        item1.addExtension(new Extension("label", new StringType("PS-1")));
+        item1.addExtension(new Extension("type", new StringType("Provider panel")));
+        delivery.addExtension(item1);
+        Extension item2 = new Extension(ShippingBoxFhirTransform.EXT_CONTENT_ITEM);
+        item2.addExtension(new Extension("label", new StringType("PS-2")));
+        item2.addExtension(new Extension("type", new StringType("Provider panel")));
+        delivery.addExtension(item2);
+
+        assertTrue("the consignment imports", shipmentFhirImportService.importSupplyDelivery(delivery));
+
+        String manifest = jdbc.queryForObject("SELECT imported_contents FROM clinlims.shipping_box WHERE box_id = ?",
+                String.class, boxCode);
+        assertNotNull("the manifest is kept read-side", manifest);
+        assertTrue(manifest, manifest.contains("\"label\":\"PS-1\"") && manifest.contains("\"label\":\"PS-2\"")
+                && manifest.contains("\"type\":\"Provider panel\""));
+    }
+
+    // ---- T-43: the staleness window ----
+
+    @Test
+    public void aStaleConsignmentIsNotResurrected() {
+        String boxCode = "EQA-C-STALE-" + System.nanoTime();
+        java.util.Date sixtyDaysAgo = java.util.Date
+                .from(java.time.Instant.now().minus(60, java.time.temporal.ChronoUnit.DAYS));
+
+        assertTrue("a 60-day-old consignment is skipped",
+                !shipmentFhirImportService.importSupplyDelivery(importableDelivery(boxCode, sixtyDaysAgo)));
+        assertEquals(Integer.valueOf(0), jdbc
+                .queryForObject("SELECT count(*) FROM clinlims.shipping_box WHERE box_id = ?", Integer.class, boxCode));
+    }
+
+    @Test
+    public void aConsignmentInsideTheWindowImportsNormally() {
+        String boxCode = "EQA-C-FRESH-" + System.nanoTime();
+        java.util.Date twentyNineDaysAgo = java.util.Date
+                .from(java.time.Instant.now().minus(29, java.time.temporal.ChronoUnit.DAYS));
+
+        assertTrue("a 29-day-old consignment imports",
+                shipmentFhirImportService.importSupplyDelivery(importableDelivery(boxCode, twentyNineDaysAgo)));
+        assertEquals("IN_TRANSIT",
+                jdbc.queryForObject("SELECT state FROM clinlims.shipping_box WHERE box_id = ?", String.class, boxCode));
+    }
+
+    // ---- T-46: opening submissions on a partial roster ----
+
+    @Test
+    public void aPartialRosterCanOpenSubmissionsByManualOverride() {
+        addToRoster(ORG_A);
+        addToRoster(ORG_B);
+        clearTheGate();
+        for (long org : new long[] { ORG_A, ORG_B }) {
+            shipmentService.saveShipmentDetails(cycle.getId(), org, "DHL", "TRK-" + org, null, USER);
+        }
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A, ORG_B), USER);
+        Integer boxA = (Integer) shipmentService.getShipmentRows(cycle.getId()).stream()
+                .filter(r -> Long.valueOf(ORG_A).equals(r.get("organizationId"))).findFirst().orElseThrow()
+                .get("boxId");
+
+        shipmentService.applyRemoteDelivery(boxA, USER);
+        assertEquals("one of two delivered does not auto-advance", EQACycleStatus.SHIPPED,
+                readBack(cycle.getId()).getStatus());
+
+        cycleService.transition(cycle.getId(), EQACycleStatus.SUBMISSIONS_OPEN, EQAStateMachine.PROVIDER,
+                EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID,
+                "Second lab dormant; opening for the lab that holds its panel", USER);
+
+        assertEquals(EQACycleStatus.SUBMISSIONS_OPEN, readBack(cycle.getId()).getStatus());
+        List<EQACycleStateTransition> audit = cycleService.getTransitions(cycle.getId());
+        EQACycleStateTransition last = audit.get(audit.size() - 1);
+        assertEquals("SUBMISSIONS_OPEN", last.getNewState());
+        assertEquals(EQATriggerType.MANUAL, last.getTriggerType());
+        assertTrue("the written reason is on the audit row", last.getReason().contains("dormant"));
+    }
+
+    @Test
+    public void openingSubmissionsWithoutAReasonIsRefused() {
+        addToRoster(ORG_A);
+        clearTheGate();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A), USER);
+
+        try {
+            cycleService.transition(cycle.getId(), EQACycleStatus.SUBMISSIONS_OPEN, EQAStateMachine.PROVIDER,
+                    EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, " ", USER);
+            fail("a manual open-submissions without a reason must be refused");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("reason"));
+        }
+        assertEquals(EQACycleStatus.SHIPPED, readBack(cycle.getId()).getStatus());
+    }
+
+    /**
+     * The smallest SupplyDelivery the importer accepts: a box identifier, an
+     * occurrence date, and a destination display that names a local organization
+     * (the by-UUID filter is off in the test DB — no siteOrganizationFhirUuid row).
+     */
+    private SupplyDelivery importableDelivery(String boxCode, java.util.Date occurrence) {
+        SupplyDelivery delivery = new SupplyDelivery();
+        delivery.setId(java.util.UUID.randomUUID().toString());
+        delivery.addIdentifier().setSystem("http://openelis.org/shipment/box-id").setValue(boxCode);
+        delivery.setOccurrence(new DateTimeType(occurrence));
+        delivery.setDestination(new Reference().setDisplay("Participant lab " + ORG_A));
+        return delivery;
+    }
+
     // ---- fixture helpers ----
+
+    private String boxCode(long organizationId) {
+        return "EQA-C" + cycle.getId() + "-" + organizationId;
+    }
+
+    /**
+     * qa/036's CHECK, exercised where it lives: Hibernate cannot express "exactly
+     * one of these two", so the guarantee is only worth what the database enforces.
+     */
+    private void assertContentsRejected(String why, Integer boxId, Integer sampleItemId, Long panelSampleId) {
+        try {
+            jdbc.update(
+                    "INSERT INTO clinlims.box_sample_item (id, shipping_box_id, sample_item_id,"
+                            + " eqa_panel_sample_id, added_date, sys_user_id, lastupdated)"
+                            + " VALUES (nextval('clinlims.box_sample_item_seq'), ?, ?, ?, now(), ?, now())",
+                    boxId, sampleItemId, panelSampleId, Integer.valueOf(USER));
+            fail("a contents row carrying " + why + " must be rejected");
+        } catch (DataIntegrityViolationException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("box_sample_item_content_chk"));
+        }
+    }
 
     private void seedOrganizations() {
         for (long id : new long[] { ORG_A, ORG_B, ORG_C }) {

--- a/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASpineTestBase.java
@@ -111,6 +111,8 @@ public abstract class EQASpineTestBase extends BaseWebContextSensitiveTest {
         jdbc.update("DELETE FROM clinlims.eqa_analyst_competency_event");
         jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
         jdbc.update("DELETE FROM clinlims.eqa_panel_receipt");
+        // T-40: box contents reference panel material, so they go first.
+        jdbc.update("DELETE FROM clinlims.box_sample_item WHERE eqa_panel_sample_id IS NOT NULL");
         jdbc.update("DELETE FROM clinlims.eqa_panel_sample");
         jdbc.update("DELETE FROM clinlims.eqa_panel");
         jdbc.update("DELETE FROM clinlims.eqa_scheme_analyst");

--- a/src/test/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransformNonConformityCodesTest.java
+++ b/src/test/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransformNonConformityCodesTest.java
@@ -1,0 +1,42 @@
+package org.openelisglobal.shipment.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * T-44: the fhirNonConformityCodes SiteInformation config must be parsed as
+ * real JSON, not scanned by indexOf — whitespace or formatting variations must
+ * not silently drop custom SNOMED codes.
+ */
+public class ShippingBoxFhirTransformNonConformityCodesTest {
+
+    @Test
+    public void compactJson_parsesAllEntries() {
+        Map<String, String> codes = ShippingBoxFhirTransform
+                .parseNonConformityCodes("{\"RECEIVED_DAMAGED\":\"12345\",\"MISSING\":\"67890\"}");
+        assertEquals("12345", codes.get("RECEIVED_DAMAGED"));
+        assertEquals("67890", codes.get("MISSING"));
+    }
+
+    @Test
+    public void spacedJson_parsesCorrectly() {
+        Map<String, String> codes = ShippingBoxFhirTransform
+                .parseNonConformityCodes("{ \"RECEIVED_DAMAGED\" : \"12345\" }");
+        assertEquals("12345", codes.get("RECEIVED_DAMAGED"));
+    }
+
+    @Test
+    public void malformedJson_yieldsEmptyMapSoDefaultsApply() {
+        Map<String, String> codes = ShippingBoxFhirTransform.parseNonConformityCodes("{'RECEIVED_DAMAGED': not json");
+        assertTrue(codes.isEmpty());
+    }
+
+    @Test
+    public void blankOrNull_yieldsEmptyMap() {
+        assertTrue(ShippingBoxFhirTransform.parseNonConformityCodes("").isEmpty());
+        assertTrue(ShippingBoxFhirTransform.parseNonConformityCodes(null).isEmpty());
+    }
+}

--- a/src/test/java/org/openelisglobal/shipment/service/BoxSampleItemServiceTest.java
+++ b/src/test/java/org/openelisglobal/shipment/service/BoxSampleItemServiceTest.java
@@ -109,6 +109,27 @@ public class BoxSampleItemServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals("Arrived in good condition", received.getReceptionNotes());
     }
 
+    /**
+     * The whole add path against a real DB — this is the call that used to die on
+     * every use, because the referral lookup inside it bound an Integer to
+     * SampleItem.id (a String property), which throws before the query runs even
+     * when the sample item has no referrals at all.
+     */
+    @Test
+    public void addSampleItemToBox_shouldCreateContentsRowForSampleItemWithoutReferrals() {
+        BoxSampleItem added = boxSampleItemService.addSampleItemToBox(2, "3", 1);
+
+        Assert.assertNotNull(added.getId());
+        Assert.assertEquals(Integer.valueOf(2), added.getShippingBox().getId());
+        Assert.assertEquals("3", added.getSampleItem().getId());
+        Assert.assertEquals(ReceptionStatus.PENDING, added.getReceptionStatus());
+        Assert.assertTrue(boxSampleItemService.isSampleItemInBox("3"));
+
+        // removal is the same referral lookup on the way out
+        boxSampleItemService.removeSampleItemFromBox(added.getId(), 1);
+        Assert.assertFalse(boxSampleItemService.isSampleItemInBox("3"));
+    }
+
     @Test
     public void isSampleItemInBox_shouldReturnTrueForAssignedItem() {
         Assert.assertTrue(boxSampleItemService.isSampleItemInBox("1"));


### PR DESCRIPTION
## What this delivers

The complete cross-site EQA shipping loop, built and verified live on a two-instance rig (provider Lab A + participant Lab B, each with its own OpenELIS + HAPI FHIR store):

dispatch → FHIR export → partner import (addressed-to-us filter) → reception → delivery backflow → provider Receipt Monitor DELIVERED → submissions open.

### T-40 — EQA panel material as real box contents
`box_sample_item` gains nullable `eqa_panel_sample_id` beside a now-nullable `sample_item_id` under an XOR CHECK (`qa/036`, changesets `qa-068`/`qa-069`). Provider boxes pack one contents row per panel sample at creation; the `markReadyToSend` empty-box bypass is deleted; patient samples are refused in EQA boxes.

### FHIR export/import fixes (found live on the rig)
- R4 types `SupplyDelivery.destination` as `Reference(Location)` — the old Organization reference was 422-rejected by HAPI on **every** box, so no consignment ever reached any store. The receiving lab now travels as a contained Location with `managingOrganization`.
- Sync always PUTs by the box's own FHIR UUID — the create path minted a random id per call, turning one box into N resources.
- `getReferralsBySampleItemId` now binds `String` (was Integer vs String `si.id` → 500 on every add-to-box).

### T-41 — delivery-status backflow
Receiver completes the origin store's SupplyDelivery on box RECEIVED; the sender's scheduled `reconcileDeliveredShipments` reads its own store and applies deliveries through the same path as a manual confirm (cycle auto-advance + audit included; superseded repeats closed quietly). Both directions guarded by `org.openelisglobal.remote.source.updateStatus`.

### T-42 — imported box shows its contents
Every contents row exports a `shipment-content-item` extension `{label, type}`; import keeps the manifest read-side on `shipping_box.imported_contents` and BoxDetails renders the labelled rows. Read-side by design — no per-item reception on imported boxes.

### T-43 — import staleness window
Deliveries older than `org.openelisglobal.shipment.import.maxAgeDays` (default 30) are skipped with box id + age in the poll log, so a fresh install cannot resurrect long-delivered consignments.

### T-44 — real JSON parsing for `fhirNonConformityCodes`
One Jackson parse per transform replaces an `indexOf` scan that silently fell back to default SNOMED codes on any whitespace.

### T-45 — site organization identity surfaced
Warning banner on Shipment Settings while `siteOrganizationFhirUuid` is unset, one accepting-all-consignments warn per import poll, one no-supplier warn per exported box.

### T-46 — open submissions on a partial roster
`SHIPPED → SUBMISSIONS_OPEN` becomes a legal PROVIDER edge; the Receipt Monitor gains an audited **Open submissions** action (MANUAL, written reason required) so one dormant lab cannot park submissions for labs that hold their panels. The all-delivered auto path is unchanged and covered by tests.

### Drive-by
`notification.success` / `notification.warning` were referenced by shipment and cold-storage toasts but missing from `en.json` (toasts rendered the raw key).

## Test plan
- **Backend:** 86 tests green — workbench integration suite grew T-40/T-41/T-42/T-43/T-46 cases (manifest export/import round-trip, staleness both sides of the window, partial-roster manual open + reason refusal, superseded-repeat delivery), plus Jackson-parse unit tests.
- **Frontend:** 21 vitest green.
- **Playwright:** three new foundational specs (`shipment-settings-fhir`, `shipment-imported-box-contents`, `eqa-open-submissions`) with a DB-seeded partial-delivery cycle helper; all green via `--project=core-app`.
- **Live UAT:** full-UI walkthrough of every card on the two-instance rig, including the complete A→B→A loop with zero provider clicks on the delivery leg.

## Notes for reviewers
- Liquibase: `qa/036` (`qa-068`, `qa-069`) per the slot registry.
- New config knobs: `org.openelisglobal.shipment.import.maxAgeDays` (default 30); backflow rides the existing `org.openelisglobal.remote.source.updateStatus`.
- Known cosmetic gap left out of scope: BoxDetails renders an IN_TRANSIT imported box's state tag as "Draft" (pre-existing tag mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)