### PR TITLE
feat(eqa-v2): provider scheme list — active cycles, last distribution, shared header keys (OGC-613)

### DIFF
--- a/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
+++ b/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
@@ -101,20 +101,22 @@ const ProviderSchemeList = () => {
               <TableHead>
                 <TableRow>
                   <TableExpandHeader />
-                  <TableHeader>
-                    {t("eqa.provider.scheme", "Scheme")}
-                  </TableHeader>
+                  <TableHeader>{t("eqa.col.scheme", "Scheme")}</TableHeader>
                   <TableHeader>
                     {t("eqa.provider.schemes.provider", "Provider")}
                   </TableHeader>
-                  <TableHeader>
-                    {t("eqa.provider.schemes.type", "Type")}
-                  </TableHeader>
+                  <TableHeader>{t("eqa.col.type", "Type")}</TableHeader>
                   <TableHeader>
                     {t("eqa.provider.schemes.enrolled", "Enrolled labs")}
                   </TableHeader>
                   <TableHeader>
-                    {t("eqa.provider.schemes.cycles", "Cycles")}
+                    {t("eqa.kpi.active", "Active cycles")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t(
+                      "eqa.provider.schemes.lastDistribution",
+                      "Last distribution",
+                    )}
                   </TableHeader>
                   <TableHeader />
                 </TableRow>
@@ -168,7 +170,10 @@ const SchemeRows = ({ scheme, t, onNewCycle }) => {
             : "—"}
         </TableCell>
         <TableCell>{scheme.enrolledParticipantCount}</TableCell>
-        <TableCell>{cycles.length}</TableCell>
+        <TableCell>{scheme.activeCycleCount}</TableCell>
+        <TableCell>
+          {scheme.lastDistribution ? scheme.lastDistribution.slice(0, 10) : "—"}
+        </TableCell>
         <TableCell>
           <Button kind="tertiary" size="sm" onClick={onNewCycle}>
             {t("eqa.provider.schemes.newCycle", "New cycle")}
@@ -179,7 +184,7 @@ const SchemeRows = ({ scheme, t, onNewCycle }) => {
           inner container at max-height 0, and the cycle table then paints over
           the scheme row above it — covering its own links. */}
       {expanded && (
-        <TableExpandedRow colSpan={7}>
+        <TableExpandedRow colSpan={8}>
           {cycles.length === 0 ? (
             <span style={hintStyle}>
               {t(
@@ -191,7 +196,7 @@ const SchemeRows = ({ scheme, t, onNewCycle }) => {
             <Table size="sm">
               <TableHead>
                 <TableRow>
-                  <TableHeader>{t("eqa.provider.cycle", "Cycle")}</TableHeader>
+                  <TableHeader>{t("eqa.col.cycle", "Cycle")}</TableHeader>
                   <TableHeader>{t("label.status", "Status")}</TableHeader>
                   <TableHeader>
                     {t("eqa.prep.participants", "Participants")}

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8170,8 +8170,6 @@
   "eqa.provider.workbench.forCycle": "Prep & shipping — {name}",
   "eqa.provider.workbench.tabs": "Workbenches",
   "eqa.provider.workbench.stateHint": "Prep must clear the inventory and QC gate before any panel can be dispatched.",
-  "eqa.provider.cycle": "Cycle",
-  "eqa.provider.scheme": "Scheme",
   "eqa.prep.tab": "Prep",
   "eqa.prep.participants": "Participants",
   "eqa.prep.panels": "Panels",
@@ -8306,7 +8304,6 @@
   "eqa.provider.schemes.none.title": "No schemes to provide yet",
   "eqa.provider.schemes.none.body": "A scheme appears here once another laboratory is actively enrolled in it.",
   "eqa.provider.schemes.provider": "Provider",
-  "eqa.provider.schemes.type": "Type",
   "eqa.provider.schemes.enrolled": "Enrolled labs",
   "eqa.provider.schemes.cycles": "Cycles",
   "eqa.provider.schemes.expand": "Show cycles",
@@ -8602,5 +8599,6 @@
   "eqa.receipt.submissionsOpened": "Submissions are open.",
   "eqa.receipt.submissionsOpenFailed": "Could not open submissions.",
   "notification.success": "Success",
-  "notification.warning": "Warning"
+  "notification.warning": "Warning",
+  "eqa.provider.schemes.lastDistribution": "Last distribution"
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
@@ -114,6 +114,12 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         for (EQACycleParticipant participant : eqaCycleParticipantDAO.findActiveByCycleIds(cycleIds)) {
             rosterCounts.merge(participant.getCycle().getId(), 1, Integer::sum);
         }
+        // FR-V2.5-01 "Last distribution": the newest shipped date across the scheme's
+        // cycles, one aggregate query for the whole list.
+        Map<Long, Timestamp> lastShippedByCycle = new LinkedHashMap<>();
+        for (Object[] row : shipmentService.getLatestShippedDatesByEqaCycleIds(cycleIds)) {
+            lastShippedByCycle.put(((Number) row[0]).longValue(), (Timestamp) row[1]);
+        }
 
         List<Map<String, Object>> schemes = new ArrayList<>();
         for (Object[] row : schemeRows) {
@@ -121,7 +127,16 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
             int enrolled = ((Number) row[4]).intValue();
 
             List<Map<String, Object>> cycleDtos = new ArrayList<>();
+            int activeCycleCount = 0;
+            Timestamp lastDistribution = null;
             for (EQACycle cycle : cyclesByScheme.getOrDefault(schemeId, List.of())) {
+                if (cycle.getStatus() != EQACycleStatus.CLOSED) {
+                    activeCycleCount++;
+                }
+                Timestamp shipped = lastShippedByCycle.get(cycle.getId());
+                if (shipped != null && (lastDistribution == null || shipped.after(lastDistribution))) {
+                    lastDistribution = shipped;
+                }
                 Map<String, Object> dto = new LinkedHashMap<>();
                 dto.put("id", cycle.getId());
                 dto.put("cycleNumber", cycle.getCycleNumber());
@@ -143,6 +158,9 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
             scheme.put("provider", row[2]);
             scheme.put("schemeType", row[3] == null ? null : ((EQASchemeType) row[3]).name());
             scheme.put("enrolledParticipantCount", enrolled);
+            // FR-V2.5-01: a dormant scheme must read 0, not its lifetime cycle total.
+            scheme.put("activeCycleCount", activeCycleCount);
+            scheme.put("lastDistribution", lastDistribution == null ? null : lastDistribution.toString());
             scheme.put("cycles", cycleDtos);
             schemes.add(scheme);
         }

--- a/src/main/java/org/openelisglobal/shipment/dao/ShipmentDAO.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/ShipmentDAO.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.shipment.dao;
 
+import java.util.Collection;
 import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.shipment.valueholder.Shipment;
@@ -38,4 +39,13 @@ public interface ShipmentDAO extends BaseDAO<Shipment, Integer> {
      * @return List of shipments
      */
     List<Shipment> findByCourier(String courier);
+
+    /**
+     * Newest shipped date per EQA cycle, one aggregate row per cycle that has
+     * shipped at least once
+     *
+     * @param eqaCycleIds EQA cycle ids
+     * @return rows of (eqaCycleId, max shippedDate)
+     */
+    List<Object[]> findLatestShippedDatesByEqaCycleIds(Collection<Long> eqaCycleIds);
 }

--- a/src/main/java/org/openelisglobal/shipment/dao/ShipmentDAOImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/ShipmentDAOImpl.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.shipment.dao;
 
+import java.util.Collection;
 import java.util.List;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -73,6 +74,23 @@ public class ShipmentDAOImpl extends BaseDAOImpl<Shipment, Integer> implements S
         } catch (Exception e) {
             logger.error("Error finding Shipments by courier", e);
             throw new LIMSRuntimeException("Error finding Shipments by courier", e);
+        }
+    }
+
+    @Override
+    public List<Object[]> findLatestShippedDatesByEqaCycleIds(Collection<Long> eqaCycleIds) {
+        if (eqaCycleIds == null || eqaCycleIds.isEmpty()) {
+            return List.of();
+        }
+        try {
+            String hql = "SELECT b.eqaCycleId, MAX(s.shippedDate) FROM Shipment s JOIN s.shippingBox b"
+                    + " WHERE b.eqaCycleId IN :eqaCycleIds AND s.shippedDate IS NOT NULL GROUP BY b.eqaCycleId";
+            Query<Object[]> query = entityManager.unwrap(Session.class).createQuery(hql, Object[].class);
+            query.setParameterList("eqaCycleIds", eqaCycleIds);
+            return query.list();
+        } catch (Exception e) {
+            logger.error("Error finding latest shipped dates by EQA cycle ids", e);
+            throw new LIMSRuntimeException("Error finding latest shipped dates by EQA cycle ids", e);
         }
     }
 }

--- a/src/main/java/org/openelisglobal/shipment/service/ShipmentService.java
+++ b/src/main/java/org/openelisglobal/shipment/service/ShipmentService.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.shipment.service;
 
+import java.util.Collection;
 import java.util.List;
 import org.openelisglobal.shipment.valueholder.Shipment;
 import org.openelisglobal.shipment.valueholder.ShipmentStatus;
@@ -45,6 +46,14 @@ public interface ShipmentService {
      * @return List of shipments
      */
     List<Shipment> getShipmentsByCourier(String courier);
+
+    /**
+     * Newest shipped date per EQA cycle
+     *
+     * @param eqaCycleIds EQA cycle ids
+     * @return rows of (eqaCycleId, max shippedDate) for cycles that shipped
+     */
+    List<Object[]> getLatestShippedDatesByEqaCycleIds(Collection<Long> eqaCycleIds);
 
     /**
      * Create a new shipment

--- a/src/main/java/org/openelisglobal/shipment/service/ShipmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/ShipmentServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.shipment.service;
 
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.List;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.shipment.dao.ShipmentDAO;
@@ -77,6 +78,12 @@ public class ShipmentServiceImpl implements ShipmentService {
             logger.error("Error getting shipments by courier", e);
             throw new LIMSRuntimeException("Error getting shipments by courier", e);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Object[]> getLatestShippedDatesByEqaCycleIds(Collection<Long> eqaCycleIds) {
+        return shipmentDAO.findLatestShippedDatesByEqaCycleIds(eqaCycleIds);
     }
 
     @Override

--- a/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
@@ -577,6 +577,41 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         assertEquals(1, cycles.get(2).get("cycleNumber"));
     }
 
+    @Test
+    public void providerSchemeListCountsOnlyOpenCyclesAsActive() {
+        // The fixture cycle is the scheme's only one; closing it must zero the
+        // count while the expansion still lists the cycle (FR-V2.5-01).
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
+
+        Map<String, Object> scheme = shipmentService.getProviderSchemes().get(0);
+
+        assertEquals("a scheme whose only cycle is closed is dormant, not busy", 0, scheme.get("activeCycleCount"));
+        List<Map<String, Object>> cycles = cycles(scheme);
+        assertEquals("the closed cycle still shows on expansion", 1, cycles.size());
+        assertEquals("CLOSED", cycles.get(0).get("status"));
+    }
+
+    @Test
+    public void providerSchemeListLastDistributionIsTheNewestShippedDate() {
+        assertNull("a scheme that never shipped has no last distribution",
+                shipmentService.getProviderSchemes().get(0).get("lastDistribution"));
+
+        addToRoster(ORG_A);
+        clearTheGate();
+        shipmentService.saveShipmentDetails(cycle.getId(), ORG_A, "DHL", "TRK-A", null, USER);
+        shipmentService.markShipped(cycle.getId(), List.of(ORG_A), USER);
+
+        Map<String, Object> scheme = shipmentService.getProviderSchemes().get(0);
+        java.sql.Timestamp shippedDate = jdbc.queryForObject(
+                "SELECT s.shipped_date FROM clinlims.shipment s"
+                        + " JOIN clinlims.shipping_box b ON s.shipping_box_id = b.id WHERE b.eqa_cycle_id = ?",
+                java.sql.Timestamp.class, cycle.getId());
+        assertNotNull(shippedDate);
+        assertEquals("last distribution is the dispatch's own shipped date", shippedDate.toString(),
+                scheme.get("lastDistribution"));
+        assertEquals("dispatching does not close the cycle", 1, scheme.get("activeCycleCount"));
+    }
+
     // ---- T-41: delivery-status backflow ----
 
     @Test


### PR DESCRIPTION
## Summary

FR-V2.5-01 names six provider scheme list columns, including **Active cycles** and **Last distribution**. The shipped list rendered a lifetime cycle total (a dormant scheme with 8 closed cycles read "Cycles: 8") and had no distribution date column.

- `getProviderSchemes` now emits `activeCycleCount` (non-`CLOSED` cycles) and `lastDistribution` — the newest `shipment.shipped_date` across the scheme's cycles, fetched with one `GROUP BY` through `shipping_box.eqa_cycle_id` in the same read (no N+1).
- `ProviderSchemeList` renders **Active cycles** and **Last distribution**; closed cycles still list on row expansion.
- The Scheme/Type/Cycle headers reuse the existing `eqa.col.*` keys and **Active cycles** reuses `eqa.kpi.active`; the three byte-identical `eqa.provider.*` duplicates are deleted per constitution Principle VII. Net i18n change: one key added, three removed.

No liquibase changes, no new dependencies.

## Testing

- `EQAShipmentWorkbenchIntegrationTest`: 38 run, 0 failures, including two new tests — a scheme whose only cycle is `CLOSED` reports `activeCycleCount = 0` while the cycle still lists on expansion, and `lastDistribution` equals the dispatch's own `shipped_date` (null before any shipping).
- Live UAT on the dev stack: a real dispatch through the shipment workbench (courier → mark shipped) flipped **Last distribution** from `—` to the dispatch date; closing a cycle dropped **Active cycles** 7 → 6 with the closed cycle still visible on expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)