### PR TITLE
feat(eqa-v2): provider cycle round 1 carries the distribution date and step 1 says what it collects — T-34 (OGC-613)

### DIFF
--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -296,16 +296,16 @@ const CycleWizard = () => {
                   <DatePickerInput
                     id="cycle-planned-start"
                     labelText={t(
-                      "eqa.provider.wizard.plannedStart",
-                      "Planned start",
+                      "eqa.provider.wizard.distributionDate",
+                      "Distribution date",
                     )}
                     placeholder="dd/mm/yyyy"
                   />
                   <DatePickerInput
                     id="cycle-planned-end"
                     labelText={t(
-                      "eqa.provider.wizard.plannedEnd",
-                      "Planned end",
+                      "eqa.provider.wizard.submissionDeadline",
+                      "Submission deadline",
                     )}
                     placeholder="dd/mm/yyyy"
                   />

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8329,8 +8329,6 @@
   "eqa.provider.wizard.cycleName": "Cycle name",
   "eqa.provider.wizard.cycleNumber": "Cycle number",
   "eqa.provider.wizard.cycleNumber.hint": "Left blank, the next unused number for this scheme is used.",
-  "eqa.provider.wizard.plannedStart": "Planned start",
-  "eqa.provider.wizard.plannedEnd": "Planned end",
   "eqa.provider.wizard.panelName": "Panel name",
   "eqa.provider.wizard.source": "Material source",
   "eqa.provider.wizard.lot": "Lot number",
@@ -8600,5 +8598,7 @@
   "eqa.receipt.submissionsOpenFailed": "Could not open submissions.",
   "notification.success": "Success",
   "notification.warning": "Warning",
-  "eqa.provider.schemes.lastDistribution": "Last distribution"
+  "eqa.provider.schemes.lastDistribution": "Last distribution",
+  "eqa.provider.wizard.distributionDate": "Distribution date",
+  "eqa.provider.wizard.submissionDeadline": "Submission deadline"
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -395,6 +395,12 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
             round.setFhirUuid(UUID.randomUUID());
             round.setCycle(cycle);
             round.setRoundNumber(1);
+            // Step 1's date pair IS the FRS's "distribution date, submission deadline"
+            // (FR-V2.5-02); the cycle keeps them as planned_start/planned_end, the
+            // round carries them under their real names for the digest and reports.
+            if (request.plannedStartDate() != null) {
+                round.setDistributionDate(new Timestamp(request.plannedStartDate().getTime()));
+            }
             round.setSubmissionDeadline(new Timestamp(request.plannedEndDate().getTime()));
             round.setSysUserId(sysUserId);
             eqaRoundDAO.insert(round);

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
@@ -319,6 +319,11 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
         assertEquals(Timestamp.valueOf("2026-10-01 00:00:00"),
                 jdbc.queryForObject("SELECT submission_deadline FROM clinlims.eqa_round WHERE cycle_id = ?",
                         Timestamp.class, created.getId()));
+        // FR-V2.5-02 step 1 collects "distribution date, submission deadline" — the
+        // round must carry both, not just the one the digest reads.
+        assertEquals(Timestamp.valueOf("2026-09-01 00:00:00"),
+                jdbc.queryForObject("SELECT distribution_date FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        Timestamp.class, created.getId()));
 
         List<Long> visibleToDigest = eqaRoundDAO
                 .findWithSubmissionDeadlineBetween(Timestamp.valueOf("2026-09-30 00:00:00"),
@@ -339,6 +344,26 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
 
         assertEquals(Integer.valueOf(0), jdbc.queryForObject(
                 "SELECT count(*) FROM clinlims.eqa_round WHERE cycle_id = ?", Integer.class, created.getId()));
+    }
+
+    /**
+     * The deadline alone is enough for a round — a missing distribution date must
+     * not cost the digest its reminder, and must not invent a date either.
+     */
+    @Test
+    public void aDeadlineWithoutADistributionDateStillWritesTheRound() {
+        EQACycle created = cycleService
+                .createProviderCycle(
+                        new ProviderCycleRequest(scheme.getId(), 12, "2026 Round", null, Date.valueOf("2026-10-01"),
+                                "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null, null,
+                                twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR),
+                        USER);
+
+        assertEquals(Timestamp.valueOf("2026-10-01 00:00:00"),
+                jdbc.queryForObject("SELECT submission_deadline FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        Timestamp.class, created.getId()));
+        assertNull(jdbc.queryForObject("SELECT distribution_date FROM clinlims.eqa_round WHERE cycle_id = ?",
+                Timestamp.class, created.getId()));
     }
 
     private ProviderCycleRequest request(List<Long> participants) {


### PR DESCRIPTION
## What

Completes **T-34 — provider cycle deadlines that actually fire**. The M-half shipped inside #4107 (round 1 + `submission_deadline` written by `createProviderCycle`); this PR closes the remainder:

- **`eqa_round.distribution_date` is written** from step 1's first date, inside the wizard's existing transaction (null-guarded — a deadline alone still writes the round, and a missing distribution date invents nothing).
- **Step 1 relabeled** from "Planned start / Planned end" to **"Distribution date / Submission deadline"** (FR-V2.5-02 step 1: "distribution date, submission deadline") — the labels now promise exactly the behaviour that exists. Two new i18n keys appended to `en.json`; the two orphaned `plannedStart`/`plannedEnd` keys deleted (this wizard was their only consumer).
- **`planned_*` keep-or-drop decision recorded: keep.** `eqa_cycle.planned_start_date`/`planned_end_date` stay as the stored pair — My Cycles (`cyclesApi.js`) already reads `plannedEndDate` as the deadline — and round 1 carries the same dates under their real names for the digest and reports. No schema change, no new liquibase slot.

## Tests

- `EQAProviderCycleWizardIntegrationTest` 18/18 — two new: round 1 carries both dates exactly as entered; deadline-without-distribution-date still writes the round with a NULL distribution date.
- `EQACycleDeadlineDigestIntegrationTest` + `EQADeadlineAlertSchedulerTest` 17/17 unchanged and green.
- Vitest `CycleWizard.test.jsx` 8/8.

## Live UAT (dev stack)

Wizard cycle on "Verify PT 2026": step 1 shows the new labels → distribution 26/08/2026, deadline 29/08/2026 → `eqa_round` row has both dates with no off-by-one → next scheduler pass wrote exactly one `EQA_DEADLINE` alert with `thresholdDays: 3`, rendered on /Alerts as *"EQA cycle 'Verify PT 2026' #10 round 1: submission deadline in 3 day(s)"*.

Noted, not fixed (pre-existing, out of scope): /Alerts "Created" column renders dates as `21/01/1970` — epoch mis-render in the FE date formatting; worth its own card.

Refs: OGC-613 · FR-V2.5-02 step 1 · FR-V2.2-14 / T-16 digest · follows #4107

🤖 Generated with [Claude Code](https://claude.com/claude-code)