### PR TITLE
feat(eqa-v2): timeline actor + wizard participant defaults — T-35, T-36 (OGC-613)

### DIFF
--- a/frontend/src/components/eqa/CycleStateBanner.jsx
+++ b/frontend/src/components/eqa/CycleStateBanner.jsx
@@ -95,6 +95,9 @@ const CycleStateBanner = ({ cycleId, status, hint, distributionMethod }) => {
                     {t("eqa.cycle.history.trigger", "Trigger")}
                   </TableHeader>
                   <TableHeader>
+                    {t("eqa.cycle.history.actor", "Actor")}
+                  </TableHeader>
+                  <TableHeader>
                     {t("eqa.cycle.history.reason", "Reason")}
                   </TableHeader>
                 </TableRow>
@@ -110,6 +113,12 @@ const CycleStateBanner = ({ cycleId, status, hint, distributionMethod }) => {
                       {row.triggerType === "MANUAL"
                         ? t("eqa.cycle.history.manual", "Manual override")
                         : row.triggerEvent || row.triggerType}
+                    </TableCell>
+                    <TableCell>
+                      {/* FR-V2.5-16: timestamp + actor. AUTO rows carry no
+                          user, so they read as the system acting. */}
+                      {row.triggeredByName ||
+                        t("eqa.cycle.history.systemActor", "System")}
                     </TableCell>
                     <TableCell>{row.reason || "—"}</TableCell>
                   </TableRow>

--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -111,15 +111,19 @@ const CycleWizard = () => {
     fetchTests(setTests);
     getFromOpenElisServer(
       `/rest/eqa/programs/${schemeId}/enrollments`,
-      (data) =>
-        setOrganizations(
-          (data || [])
-            .filter((e) => e.status === "Active" && e.organizationId != null)
-            .map((e) => ({
-              id: String(e.organizationId),
-              name: e.organizationName || String(e.organizationId),
-            })),
-        ),
+      (data) => {
+        const active = (data || [])
+          .filter((e) => e.status === "Active" && e.organizationId != null)
+          .map((e) => ({
+            id: String(e.organizationId),
+            name: e.organizationName || String(e.organizationId),
+          }));
+        setOrganizations(active);
+        // FR-V2.5-02 step 3: default = all active, still editable. Step 5
+        // names every selected lab before the single write, which is what
+        // keeps the default safe.
+        setSelectedOrgs(active);
+      },
     );
   }, [schemeId]);
 
@@ -662,6 +666,7 @@ const CycleWizard = () => {
                   "Select participants",
                 )}
                 items={organizations}
+                initialSelectedItems={selectedOrgs}
                 itemToString={(item) => (item ? item.name || item.id : "")}
                 onChange={({ selectedItems }) => setSelectedOrgs(selectedItems)}
                 selectionFeedback="top-after-reopen"

--- a/frontend/src/components/eqa/Provider/Workbench/PrepWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/PrepWorkbench.jsx
@@ -190,6 +190,16 @@ const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
                   min={0}
                   value={draft.aliquotsReserved}
                   label={t("eqa.prep.reserved", "Aliquots reserved")}
+                  helperText={t(
+                    "eqa.prep.reserved.recommend",
+                    "{n} recommended: max(10% of participants, 5)",
+                    {
+                      n: Math.max(
+                        Math.ceil((prep.participantCount || 0) * 0.1),
+                        5,
+                      ),
+                    },
+                  )}
                   onChange={(_e, { value }) =>
                     setDraft(panel.panelId, {
                       aliquotsReserved: Number(value),

--- a/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
@@ -108,6 +108,11 @@ const ProviderWorkbenchPage = () => {
               "Prep must clear the inventory and QC gate before any panel can be dispatched.",
             )}
           />
+          {/* Deliberate divergence from FR-V2.5-16's "no in-page Tabs — use
+              sidebar children" (decided with the user, 2026-08-28): the four
+              workbench surfaces share one cycle banner and one state, so
+              sidebar child routes would multiply route plumbing for no
+              workflow gain. */}
           <Tabs>
             <TabList
               aria-label={t("eqa.provider.workbench.tabs", "Workbenches")}

--- a/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
@@ -27,7 +27,8 @@ vi.mock("../../../common/PageBreadCrumb", () => ({
 const ENROLLMENTS = [
   { organizationId: 100, organizationName: "District Lab A", status: "Active" },
   { organizationId: 101, organizationName: "District Lab B", status: "Active" },
-  { organizationId: 102, organizationName: "Lapsed Lab", status: "Withdrawn" },
+  { organizationId: 102, organizationName: "District Lab C", status: "Active" },
+  { organizationId: 103, organizationName: "Lapsed Lab", status: "Withdrawn" },
 ];
 
 const renderWizard = () => {
@@ -152,17 +153,35 @@ describe("CycleWizard", () => {
     expect(screen.queryByText("Lapsed Lab")).not.toBeInTheDocument();
   });
 
-  test("the participants step cannot be left with nobody chosen", async () => {
+  test("step 3 preselects exactly the active enrollments", () => {
+    // FR-V2.5-02 step 3: default = all active, still editable — a cycle must
+    // not be one forgotten click from shipping to nobody.
     renderWizard();
     throughPanelStep();
     next();
 
-    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+
+    // The confirm step names each preselected lab — the withdrawn one is not
+    // among them.
+    next();
+    next();
+    expect(
+      screen.getByText("District Lab A, District Lab B, District Lab C"),
+    ).toBeInTheDocument();
+  });
+
+  test("deselecting every lab disables Next", async () => {
+    renderWizard();
+    throughPanelStep();
+    next();
 
     await userEvent.click(screen.getByRole("combobox"));
     await userEvent.click(screen.getByText("District Lab A"));
+    await userEvent.click(screen.getByText("District Lab B"));
+    await userEvent.click(screen.getByText("District Lab C"));
 
-    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
   });
 
   test("the whole cycle is one POST, and it lands on the new cycle's workbench", async () => {
@@ -176,8 +195,7 @@ describe("CycleWizard", () => {
     });
     throughPanelStep();
     next();
-    await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.click(screen.getByText("District Lab A"));
+    // Step 3 preselects all active labs; the POST carries that default.
     next();
     fireEvent.click(screen.getByLabelText("CSV export"));
     next();
@@ -200,7 +218,7 @@ describe("CycleWizard", () => {
     expect(body.samples).toEqual([
       expect.objectContaining({ sampleCode: "PS-1", testId: "55" }),
     ]);
-    expect(body.participantOrganizationIds).toEqual([100]);
+    expect(body.participantOrganizationIds).toEqual([100, 101, 102]);
     // Nothing may be written before the last step.
     expect(body.aliquotsReserved).toBeUndefined();
 
@@ -220,8 +238,6 @@ describe("CycleWizard", () => {
 
     throughPanelStep();
     next();
-    await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.click(screen.getByText("District Lab A"));
     next();
     next();
     fireEvent.click(
@@ -244,8 +260,6 @@ describe("CycleWizard", () => {
 
     throughPanelStep();
     next();
-    await userEvent.click(screen.getByRole("combobox"));
-    await userEvent.click(screen.getByText("District Lab A"));
     next();
 
     // Step 4 is the method, not the cold chain: that moved to the panel step.

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8605,5 +8605,7 @@
   "eqa.provider.kpi.openCycles": "Open cycles",
   "eqa.provider.kpi.enrolled": "Enrolled participants",
   "eqa.provider.kpi.followupsOpen": "Follow-ups open",
-  "eqa.provider.schemes.discipline": "Discipline"
+  "eqa.provider.schemes.discipline": "Discipline",
+  "eqa.cycle.history.actor": "Actor",
+  "eqa.cycle.history.systemActor": "System"
 }

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8607,5 +8607,6 @@
   "eqa.provider.kpi.followupsOpen": "Follow-ups open",
   "eqa.provider.schemes.discipline": "Discipline",
   "eqa.cycle.history.actor": "Actor",
-  "eqa.cycle.history.systemActor": "System"
+  "eqa.cycle.history.systemActor": "System",
+  "eqa.prep.reserved.recommend": "{n} recommended: max(10% of participants, 5)"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -34,6 +34,8 @@ import org.openelisglobal.result.valueholder.Result;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.systemuser.service.SystemUserService;
+import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -69,10 +71,12 @@ public class EQACycleRestController extends BaseRestController {
     private final ResultService resultService;
     private final EQAPerformanceReportPDFService performanceReportService;
     private final EQAReportCommentService reportCommentService;
+    private final SystemUserService systemUserService;
 
     public EQACycleRestController(EQACycleService cycleService, SampleEQAService sampleEQAService,
             SampleService sampleService, AnalysisService analysisService, ResultService resultService,
-            EQAPerformanceReportPDFService performanceReportService, EQAReportCommentService reportCommentService) {
+            EQAPerformanceReportPDFService performanceReportService, EQAReportCommentService reportCommentService,
+            SystemUserService systemUserService) {
         this.cycleService = cycleService;
         this.sampleEQAService = sampleEQAService;
         this.sampleService = sampleService;
@@ -80,6 +84,7 @@ public class EQACycleRestController extends BaseRestController {
         this.resultService = resultService;
         this.performanceReportService = performanceReportService;
         this.reportCommentService = reportCommentService;
+        this.systemUserService = systemUserService;
     }
 
     /**
@@ -415,11 +420,29 @@ public class EQACycleRestController extends BaseRestController {
             dto.put("triggerType", t.getTriggerType() == null ? null : t.getTriggerType().name());
             dto.put("triggerEvent", t.getTriggerEvent() == null ? null : t.getTriggerEvent().name());
             dto.put("triggeredBy", t.getTriggeredBy());
+            dto.put("triggeredByName", resolveUserName(t.getTriggeredBy()));
             dto.put("reason", t.getReason());
             dto.put("occurredAt", t.getOccurredAt() == null ? null : t.getOccurredAt().toString());
             rows.add(dto);
         }
         return rows;
+    }
+
+    /**
+     * FR-V2.5-16: the timeline shows the actor, not a numeric user id. NULL for
+     * AUTO transitions — the client renders those as the system actor.
+     */
+    private String resolveUserName(Long triggeredBy) {
+        if (triggeredBy == null) {
+            return null;
+        }
+        SystemUser user = systemUserService.get(String.valueOf(triggeredBy));
+        if (user == null) {
+            return String.valueOf(triggeredBy);
+        }
+        String name = ((user.getFirstName() == null ? "" : user.getFirstName() + " ")
+                + (user.getLastName() == null ? "" : user.getLastName())).trim();
+        return name.isEmpty() ? String.valueOf(triggeredBy) : name;
     }
 
     /**

--- a/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
@@ -71,7 +71,7 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     public void setUp() throws Exception {
         super.setUp();
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, performanceReportService, reportCommentService);
+                resultService, performanceReportService, reportCommentService, systemUserService);
         ensureStatusRows();
         cleanupSeed();
     }

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -223,6 +223,33 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
     }
 
     @Test
+    public void theTransitionsEndpointNamesTheActorRatherThanNumberingThem() {
+        // FR-V2.5-16 (T-35): the timeline shows "timestamp + actor". A bare user
+        // id is not an actor to the person reading the page, so the endpoint
+        // resolves it; AUTO rows carry no user and resolve to null, which the
+        // client renders as the system actor.
+        long actorId = 9955L;
+        jdbc.update("INSERT INTO clinlims.system_user (id, external_id, login_name, last_name, first_name,"
+                + " initials, is_active, is_employee, lastupdated)"
+                + " SELECT ?, 'EQA_T35', 'eqa_t35_actor', 'Achieng', 'Grace', 'GA', 'Y', 'Y', now()"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.system_user WHERE id = ?)", actorId, actorId);
+
+        EQACycle cycle = newCycle();
+        cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, actorId, "Courier delivered early", USER);
+        cycleService.transition(cycle.getId(), EQACycleStatus.TESTING, EQAStateMachine.PARTICIPANT, EQATriggerType.AUTO,
+                EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
+
+        // AppTestConfig excludes eqa.controller.* from the scan, so the endpoint
+        // is exercised as a plain object over the real services it composes.
+        EQACycleRestController controller = new EQACycleRestController(cycleService, null, null, null, null, null, null,
+                systemUserService);
+        List<Map<String, Object>> rows = controller.transitions(cycle.getId());
+        assertEquals("Grace Achieng", rows.get(0).get("triggeredByName"));
+        assertNull("an automatic transition resolves to no actor name", rows.get(1).get("triggeredByName"));
+    }
+
+    @Test
     public void aManualTransitionWithoutAReasonIsRefused() {
         // AC-V2.1-19 requires a reason even on a happy-path manual move, which is
         // stricter than FR-V2.1-21's "off the happy path" wording.

--- a/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
@@ -135,7 +135,7 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
     @Before
     public void seedCycleWithScores() {
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, reportService, reportCommentService);
+                resultService, reportService, reportCommentService, systemUserService);
 
         jdbc.update("INSERT INTO clinlims.localization (id, description)"
                 + " SELECT ?, 'EQA Report Section' WHERE NOT EXISTS"


### PR DESCRIPTION
Two small FR-V2.5 completion cards from the EQA V2 delivery plan, one commit each.

## T-35 — FR-V2.5-16: the timeline names its actor
- `GET /rest/eqa/cycles/{id}/transitions` now returns `triggeredByName`, resolved from `system_user` (same lookup pattern as the analyst competency controller). AUTO rows resolve to null.
- Cycle history table gains an **Actor** column: manual overrides show the acting user's name; automatic transitions render as **System**.
- Integration test: the endpoint returns a name, not an id, for a row written by a known user, and no name for an AUTO row.
- The FR's "no in-page Tabs — use sidebar children" clause is recorded as a **deliberate divergence** (comment at the `Tabs` block in `ProviderWorkbenchPage.jsx`): the four workbench surfaces share one cycle banner and one state; sidebar child routes would multiply route plumbing for no workflow gain. Decided with the project owner 2026-08-28.

## T-36 — FR-V2.5-02 step 3: default = all active
- The cycle wizard preselects every active enrollment on the participants step (still editable) — a cycle is no longer one forgotten click from shipping to nobody. Step 5 still names every selected lab before the single write.
- The FRS reserve default `max(10% of participants, 5)` surfaces as helper text on the prep workbench's *Aliquots reserved* field — kept at prep (not the wizard) because `eqa_panel_aliquots_chk` enforces `produced >= reserved + shipped` and produced is 0 at creation.
- Jest: preselects exactly the active enrollments (withdrawn excluded); deselecting to none disables Next.

## UAT (live dev stack)
- Fresh wizard on a 6-lab scheme arrives at step 3 with all 6 preselected; confirm step lists all six names.
- Prep shows "5 recommended: max(10% of participants, 5)" for a 6-participant cycle.
- Cycle history: manual rows show "Open ELIS", a `FIRST_SHIPMENT_SENT` AUTO row shows "System"; both survive reload.
- `EQACycleStateMachineIntegrationTest` 18/18, EQA frontend suites 169/169, spotless + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)