### PR TITLE
feat(eqa-v2): role-conditional scheme board — T-39 (OGC-613)

### DIFF
--- a/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
+++ b/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   Button,
   Column,
@@ -21,6 +21,8 @@ import {
 import { useIntl } from "react-intl";
 import { Link as RouterLink, useHistory } from "react-router-dom";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
+import UserSessionDetailsContext from "../../../UserSessionDetailsContext";
+import { hasQaPermission } from "../../utils/Utils";
 import {
   CycleStatusTag,
   hintStyle,
@@ -53,17 +55,73 @@ const ProviderSchemeList = () => {
   const t = (id, defaultMessage, values) =>
     intl.formatMessage({ id, defaultMessage }, values);
 
+  // FR-V2.5-01 role-conditional composition (T-39): the provider panel only
+  // renders for the provider grant; a participant-only viewer gets links to
+  // the participant surfaces instead of a blank page. The menu row itself is
+  // visible to every EQA viewer today (menu reads are not permission-filtered)
+  // — hiding it and the FR's sidebar hint are deferred to OGC-1151, which will
+  // also need a system_module_url mapping for this route; until then this
+  // fallback is what an ungranted click lands on.
+  const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  const isProvider = hasQaPermission(userSessionDetails, "qa.eqa.provider");
+
   const [board, setBoard] = useState({ kpis: {}, schemes: [] });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!isProvider) {
+      return;
+    }
     fetchProviderSchemes((data) => {
       setBoard(data);
       setLoading(false);
     });
-  }, []);
+  }, [isProvider]);
 
   const { kpis, schemes } = board;
+
+  if (!isProvider) {
+    return (
+      <>
+        <PageBreadCrumb breadcrumbs={breadcrumbs} />
+        <Grid fullWidth>
+          <Column lg={16} md={8} sm={4}>
+            <InlineNotification
+              kind="info"
+              lowContrast
+              hideCloseButton
+              title={t(
+                "eqa.provider.schemes.participantOnly.title",
+                "Participant view only",
+              )}
+              subtitle={t(
+                "eqa.provider.schemes.participantOnly.body",
+                "Provider scheme administration needs the provider grant. Your lab's participation lives on the pages below.",
+              )}
+            />
+            <ul style={{ marginTop: "0.75rem" }}>
+              <li>
+                <RouterLink to="/qa/eqa/my-programs">
+                  {t(
+                    "eqa.provider.schemes.link.myPrograms",
+                    "My enrollments — schemes this lab takes part in",
+                  )}
+                </RouterLink>
+              </li>
+              <li>
+                <RouterLink to="/qa/eqa/my-cycles">
+                  {t(
+                    "eqa.provider.schemes.link.myCycles",
+                    "My Cycles — panels, results and deadlines",
+                  )}
+                </RouterLink>
+              </li>
+            </ul>
+          </Column>
+        </Grid>
+      </>
+    );
+  }
 
   if (loading) {
     return <Loading />;

--- a/frontend/src/components/eqa/Provider/__tests__/ProviderSchemeList.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/ProviderSchemeList.test.jsx
@@ -5,9 +5,14 @@ import { IntlProvider } from "react-intl";
 import { MemoryRouter, Route } from "react-router-dom";
 import messages from "../../../../languages/en.json";
 import ProviderSchemeList from "../ProviderSchemeList";
+import UserSessionDetailsContext from "../../../../UserSessionDetailsContext";
 import { getFromOpenElisServer } from "../../../utils/Utils";
 
-vi.mock("../../../utils/Utils", () => ({
+// Keep the real hasQaPermission (incl. its Global Administrator fallback) —
+// mocking it would let the composition tests stay green while the production
+// predicate regresses. Same pattern as EQAParticipantsPage.test.jsx.
+vi.mock("../../../utils/Utils", async (importOriginal) => ({
+  ...(await importOriginal()),
   getFromOpenElisServer: vi.fn(),
 }));
 
@@ -48,25 +53,36 @@ const KPIS = {
   followupsOpen: 0,
 };
 
-const renderList = (schemes = SCHEMES, kpis = KPIS) => {
+const renderList = (
+  schemes = SCHEMES,
+  kpis = KPIS,
+  permissions = ["qa.eqa.provider"],
+  roles = [],
+) => {
   getFromOpenElisServer.mockImplementation((url, cb) =>
     url === "/rest/eqa/provider/schemes" ? cb({ kpis, schemes }) : cb([]),
   );
   const history = [];
   const view = render(
     <IntlProvider locale="en" messages={messages}>
-      <MemoryRouter initialEntries={["/qa/eqa/provider/schemes"]}>
-        <Route path="/qa/eqa/provider/schemes" exact>
-          <ProviderSchemeList />
-        </Route>
-        <Route
-          path="/qa/eqa/provider/schemes/:schemeId/cycles/new"
-          render={({ match }) => {
-            history.push(match.url);
-            return <div>wizard</div>;
-          }}
-        />
-      </MemoryRouter>
+      <UserSessionDetailsContext.Provider
+        value={{
+          userSessionDetails: { authenticated: true, roles, permissions },
+        }}
+      >
+        <MemoryRouter initialEntries={["/qa/eqa/provider/schemes"]}>
+          <Route path="/qa/eqa/provider/schemes" exact>
+            <ProviderSchemeList />
+          </Route>
+          <Route
+            path="/qa/eqa/provider/schemes/:schemeId/cycles/new"
+            render={({ match }) => {
+              history.push(match.url);
+              return <div>wizard</div>;
+            }}
+          />
+        </MemoryRouter>
+      </UserSessionDetailsContext.Provider>
     </IntlProvider>,
   );
   return { ...view, history };
@@ -147,6 +163,40 @@ describe("ProviderSchemeList", () => {
     renderList([]);
 
     expect(screen.getByText("No schemes to provide yet")).toBeInTheDocument();
+  });
+
+  // FR-V2.5-01 role-conditional composition (T-39)
+  test("a participant-only viewer gets the participant links, not the provider table", () => {
+    renderList(SCHEMES, KPIS, ["qa.view.eqa"]);
+
+    expect(screen.getByText("Participant view only")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /My enrollments/ }),
+    ).toHaveAttribute("href", "/qa/eqa/my-programs");
+    expect(screen.getByRole("link", { name: /My Cycles/ })).toHaveAttribute(
+      "href",
+      "/qa/eqa/my-cycles",
+    );
+    // No provider surface, and no provider fetch either — the hiding is UI
+    // composition (FR-V2.5-01); the endpoint stays read-guarded like every
+    // provider GET (EQARestGuardMatrixTest).
+    expect(screen.queryByText("National HIV VL PT")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("kpi-active-schemes")).not.toBeInTheDocument();
+    expect(getFromOpenElisServer).not.toHaveBeenCalled();
+  });
+
+  test("the provider grant renders the scheme table, not the participant hint", () => {
+    renderList();
+
+    expect(screen.queryByText("Participant view only")).not.toBeInTheDocument();
+    expect(screen.getByText("National HIV VL PT")).toBeInTheDocument();
+  });
+
+  test("Global Administrator passes the gate without the explicit permission", () => {
+    renderList(SCHEMES, KPIS, [], ["Global Administrator"]);
+
+    expect(screen.queryByText("Participant view only")).not.toBeInTheDocument();
+    expect(screen.getByText("National HIV VL PT")).toBeInTheDocument();
   });
 
   test("a scheme with no cycle yet says so instead of rendering an empty table", () => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8608,5 +8608,9 @@
   "eqa.provider.schemes.discipline": "Discipline",
   "eqa.cycle.history.actor": "Actor",
   "eqa.cycle.history.systemActor": "System",
-  "eqa.prep.reserved.recommend": "{n} recommended: max(10% of participants, 5)"
+  "eqa.prep.reserved.recommend": "{n} recommended: max(10% of participants, 5)",
+  "eqa.provider.schemes.participantOnly.title": "Participant view only",
+  "eqa.provider.schemes.participantOnly.body": "Provider scheme administration needs the provider grant. Your lab's participation lives on the pages below.",
+  "eqa.provider.schemes.link.myPrograms": "My enrollments — schemes this lab takes part in",
+  "eqa.provider.schemes.link.myCycles": "My Cycles — panels, results and deadlines"
 }


### PR DESCRIPTION
FR-V2.5-01 role-conditional composition — the last follow-up card in the provider lane. Frontend-only.

## What
- **Frontend gate:** `ProviderSchemeList` renders the provider board only for the `qa.eqa.provider` grant (real `hasQaPermission`, Global Administrator fallback included). A participant-only viewer gets a "Participant view only" notification with links to *My enrollments* (`/qa/eqa/my-programs`) and *My Cycles* (`/qa/eqa/my-cycles`) — the provider fetch is never issued, so no blank page.
- The hiding is **UI composition**: the endpoint keeps the class-level read guard, per `EQARestGuardMatrixTest`'s rule that EQA reads inherit the class guard. (First push guarded the endpoint; the guard matrix correctly refused it.)
- **Menu-row hiding and the FR's sidebar hint are deferred to OGC-1151** — menu reads are not permission-filtered today, and OGC-1151 will also need a `system_module_url` mapping for this route. Until then, an ungranted click lands on the participant fallback rather than a blank page. Recorded in the component comment.

## Review feedback addressed
- Dropped the `/qa/eqa/participants` link — that page is provider-side enrollment administration, not a participant surface.
- Test uses the real `hasQaPermission` via `importActual` (only network mocked), plus a Global Administrator case — same pattern as `EQAParticipantsPage.test.jsx`.
- Backend file untouched (comment bloat removed; PR is now frontend-only).
- OGC-1151 claim corrected from "rides visibility filtering" to an explicit deferral with the missing-mapping note.

## Tests
- Jest 11/11 — participant-only viewer sees the two links, no provider table, **zero** fetches; provider grant sees the table; Global Administrator passes the gate without the explicit permission.

## Live UAT (two logins, dev stack)
- `participant1` (Results + Reception → `qa.view.eqa` only): `/qa/eqa/provider/schemes` shows the participant hint + working links.
- `admin`: full scheme board with KPI tiles and cycle expansion, no hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
