### PR TITLE
fix(4050): support Log4j 2.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hibernate-search.version>6.1.8.Final</hibernate-search.version>
         <postgresql.version>42.7.12</postgresql.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <springframework.version>6.2.18</springframework.version>
         <springsecurity.version>6.2.8</springsecurity.version>
         <testContainersVersion>1.19.8</testContainersVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <hibernate-search.version>6.1.8.Final</hibernate-search.version>
         <postgresql.version>42.7.12</postgresql.version>
         <log4j.version>2.25.5</log4j.version>
+        <log4j-liquibase.version>2.19.0</log4j-liquibase.version>
         <springframework.version>6.2.18</springframework.version>
         <springsecurity.version>6.2.8</springsecurity.version>
         <testContainersVersion>1.19.8</testContainersVersion>
@@ -438,7 +439,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-liquibase</artifactId>
-            <version>${log4j.version}</version>
+            <version>${log4j-liquibase.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/org/openelisglobal/common/log/LogEvent.java
+++ b/src/main/java/org/openelisglobal/common/log/LogEvent.java
@@ -13,7 +13,7 @@
  */
 package org.openelisglobal.common.log;
 
-import org.apache.log4j.Category;
+import org.apache.log4j.Logger;
 import org.owasp.encoder.Encode;
 
 /**
@@ -213,8 +213,8 @@ public class LogEvent {
                 "Class: " + className + ", Method: " + methodName + ", Fatal:" + sanitizeLogMessage(fatalMessage));
     }
 
-    private static Category getLog() {
-        return Category.getInstance(LogEvent.class);
+    private static Logger getLog() {
+        return Logger.getLogger(LogEvent.class);
     }
 
     // for preventing log forging

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -5,18 +5,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern =%d{dd MMM yyyy HH:mm:ss} -- %p -- %m%n
 
-appender.rolling.type = RollingFile
-appender.rolling.name = RollingFile
-#appender.rolling.fileName=/var/lib/openelis-global/logs/openELIS.log
-appender.rolling.filePattern = /var/lib/openelis-global/logs/error-backup-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=%d{dd MMM yyyy HH:mm:ss} -- %p -- %m%n
-appender.rolling.policies.type = Policies
-appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-appender.rolling.policies.size.size=100KB
-appender.rolling.strategy.type = DefaultRolloverStrategy
-appender.rolling.strategy.max = 100
-
 loggers=rolling
 logger.rolling.name=org.openelisglobal
 logger.rolling.level = error


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [x] The PR includes a video showing the changes for the work done. N/A: this is a dependency compatibility change with no UI behavior.
- [x] The PR title follows conventional commit label standards.
- [x] The changes conform to the OpenELIS Global x3 Styleguide and Design documentation. N/A: no UI changes.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing Guidelines of this project.

## Summary

- retain the Dependabot upgrade of Log4j API/core to 2.25.5 while pinning the removed `log4j-liquibase` integration at its final release, 2.19.0
- use the Log4j 1.2 bridge `Logger` type in `LogEvent`, preserving the existing trace call under the newer bridge API
- remove an unused rolling-appender block from the test configuration that Log4j 2.25 now rejects because the appender is not declared

The change is limited to Log4j upgrade compatibility. It does not change the database schema, UI, FHIR behavior, or production logging destinations.

## Screenshots

N/A — no user-interface changes.

## Related Issue

Follow-up fix for the failed Dependabot upgrade in #4050. The fix was developed and verified from its exact head revision `8c0bc25c436c7182d40fd6ad1d94e086f5a855ea`.

## Other

Verification on Java 21:

- `mvn spotless:apply`
- `cd frontend && npm run format`
- `cd dataexport && mvn clean install`
- `mvn clean install -DskipTests -Dmaven.test.skip=true -Dspotless.check.skip=true`
- `mvn clean install -Dspotless.check.skip=true` — BUILD SUCCESS; 5,617 tests, 0 failures, 0 errors, 8 skipped; WAR, test JAR, and JaCoCo report produced

The complete commit diff was reviewed and `git diff --check` is clean. The commit includes a DCO sign-off.

JAIPilot workflows used: maintainer-intent, fast-execution, and review-diff.

Execution profile: `gpt-5.6-sol · xhigh · fast`.