### PR TITLE
Add TbSampleService Test

### DIFF
--- a/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
@@ -3,8 +3,11 @@ package org.openelisglobal.sample.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
@@ -25,10 +28,38 @@ import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.sampleorganization.service.SampleOrganizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest {
+public class TbSampleServiceTest extends BaseWebContextSensitiveTest {
 
     private static final String DATASET = "testdata/tb-sample-service.xml";
     private static final String SYS_USER_ID = TEST_SYS_USER_ID;
+
+    private static final String SPECIMEN_NATURE_ID = "100";
+    private static final String TEST_ID = "200";
+    private static final String REFERRING_SITE_CODE = "100";
+
+    private static final String EXISTING_PATIENT_EXTERNAL_ID = "SUB-900";
+    private static final String EXISTING_SAMPLE_ACCESSION_NUMBER = "LAB-900";
+
+    private static final List<ExpectedObservation> EXPECTED_OBSERVATIONS = List.of(
+            new ExpectedObservation("100", "TbOrderReason", "Reason1"),
+            new ExpectedObservation("101", "TbDiagnosticReason", "Diag1"),
+            new ExpectedObservation("102", "TbFollowupReason", "Follow1"),
+            new ExpectedObservation("103", "TbSampleAspects", "Aspect1"),
+            new ExpectedObservation("104", "TbFollowupReasonPeriodLine1", "Period1"),
+            new ExpectedObservation("105", "TbFollowupReasonPeriodLine2", "Period2"),
+            new ExpectedObservation("106", "TbAnalysisMethod", "Method1"));
+
+    private static final class ExpectedObservation {
+        final String typeId;
+        final String typeName;
+        final String expectedValue;
+
+        ExpectedObservation(String typeId, String typeName, String expectedValue) {
+            this.typeId = typeId;
+            this.typeName = typeName;
+            this.expectedValue = expectedValue;
+        }
+    }
 
     @Autowired
     private TbSampleService tbSampleService;
@@ -79,6 +110,18 @@ public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest 
         ensureReferenceTable("SampleTbEntryForm");
     }
 
+    private String generateUniqueSubjectNumber() {
+        return "SUB-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    private String generateUniqueLabNumber() {
+        return "LAB-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    private String today() {
+        return LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+    }
+
     private SampleTbEntryForm createBaseForm() {
         SampleTbEntryForm form = new SampleTbEntryForm();
         form.setSysUserId(SYS_USER_ID);
@@ -89,19 +132,19 @@ public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest 
         form.setPatientPhone("555-1234");
         form.setPatientAddress("123 Main St");
 
-        form.setTbSubjectNumber("NEW-SUB-001");
+        form.setTbSubjectNumber(generateUniqueSubjectNumber());
 
-        form.setLabNo("NEW-LAB-001");
-        form.setRequestDate("06/01/2025");
-        form.setReceivedDate("06/01/2025");
+        form.setLabNo(generateUniqueLabNumber());
+        form.setRequestDate(today());
+        form.setReceivedDate(today());
 
-        form.setTbSpecimenNature("100");
+        form.setTbSpecimenNature(SPECIMEN_NATURE_ID);
 
         List<String> tests = new ArrayList<>();
-        tests.add("200");
+        tests.add(TEST_ID);
         form.setNewSelectedTests(tests);
 
-        form.setReferringSiteCode("100");
+        form.setReferringSiteCode(REFERRING_SITE_CODE);
 
         form.setProviderFirstName("Doc");
         form.setProviderLastName("Brown");
@@ -120,51 +163,59 @@ public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest 
     @Test
     public void persistTbData_newPatient_createsPatientAndSampleHierarchy() {
         SampleTbEntryForm form = createBaseForm();
+        String subjectNumber = form.getTbSubjectNumber();
+        String labNo = form.getLabNo();
 
         boolean result = tbSampleService.persistTbData(form, null);
         assertTrue("Service should return true on success", result);
 
-        Patient patient = patientService.getByExternalId("NEW-SUB-001");
-        assertEquals("NEW-SUB-001", patient.getExternalId());
+        Patient patient = patientService.getByExternalId(subjectNumber);
+        assertEquals(subjectNumber, patient.getExternalId());
         assertEquals("Jane", patient.getPerson().getFirstName());
         assertEquals("Smith", patient.getPerson().getLastName());
 
-        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
-        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
+        Sample sample = sampleService.getSampleByAccessionNumber(labNo);
+        assertEquals(labNo, sample.getAccessionNumber());
 
         List<SampleItem> items = sampleItemService.getSampleItemsBySampleId(sample.getId());
         assertEquals(1, items.size());
 
         List<Analysis> analyses = analysisService.getAnalysesBySampleId(sample.getId());
         assertEquals(1, analyses.size());
-        assertEquals("200", analyses.get(0).getTest().getId());
+        assertEquals(TEST_ID, analyses.get(0).getTest().getId());
     }
 
     @Test
     public void persistTbData_existingPatient_updatesPatientAndCreatesSampleHierarchy() {
+        Patient existingPatient = patientService.getByExternalId(EXISTING_PATIENT_EXTERNAL_ID);
+        String expectedInternalId = existingPatient.getId();
+
         SampleTbEntryForm form = createBaseForm();
-        form.setTbSubjectNumber("SUB-900");
+        String labNo = form.getLabNo();
+        form.setTbSubjectNumber(EXISTING_PATIENT_EXTERNAL_ID);
         form.setPatientFirstName("UpdatedFirst");
         form.setPatientAddress("New Address");
 
         boolean result = tbSampleService.persistTbData(form, null);
         assertTrue(result);
 
-        Patient patient = patientService.getByExternalId("SUB-900");
-        assertEquals("900", patient.getId());
+        Patient patient = patientService.getByExternalId(EXISTING_PATIENT_EXTERNAL_ID);
+        assertEquals(expectedInternalId, patient.getId());
         assertEquals("UpdatedFirst", patient.getPerson().getFirstName());
 
-        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
-        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
+        Sample sample = sampleService.getSampleByAccessionNumber(labNo);
+        assertEquals(labNo, sample.getAccessionNumber());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void persistTbData_existingSample_updateSample_throwsWhenIdNotSet() {
+        Sample existingSample = sampleService.getSampleByAccessionNumber(EXISTING_SAMPLE_ACCESSION_NUMBER);
+
         SampleTbEntryForm form = createBaseForm();
-        form.setSampleId("900");
-        form.setLabNo("LAB-900");
-        form.setRequestDate("07/01/2025");
-        form.setReceivedDate("07/01/2025");
+        form.setSampleId(existingSample.getId());
+        form.setLabNo(generateUniqueLabNumber());
+        form.setRequestDate(today());
+        form.setReceivedDate(today());
 
         tbSampleService.persistTbData(form, null);
     }
@@ -172,13 +223,13 @@ public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest 
     @Test
     public void persistTbData_createsProviderFromFormFields() {
         SampleTbEntryForm form = createBaseForm();
+        String labNo = form.getLabNo();
 
         boolean result = tbSampleService.persistTbData(form, null);
         assertTrue(result);
 
-        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
-        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
-
+        Sample sample = sampleService.getSampleByAccessionNumber(labNo);
+        assertEquals(labNo, sample.getAccessionNumber());
     }
 
     @Test
@@ -188,13 +239,17 @@ public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest 
         boolean result = tbSampleService.persistTbData(form, null);
         assertTrue(result);
 
-        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
+        Sample sample = sampleService.getSampleByAccessionNumber(form.getLabNo());
 
         List<ObservationHistory> obs = observationHistoryService.getObservationHistoriesBySampleId(sample.getId());
-        assertEquals("Should insert exactly 7 observation history records", 7, obs.size());
+        assertEquals("Should insert exactly " + EXPECTED_OBSERVATIONS.size() + " observation history records",
+                EXPECTED_OBSERVATIONS.size(), obs.size());
 
-        boolean foundOrderReason = obs.stream()
-                .anyMatch(o -> "Reason1".equals(o.getValue()) && "100".equals(o.getObservationHistoryTypeId()));
-        assertTrue("TbOrderReason should be present", foundOrderReason);
+        for (ExpectedObservation expected : EXPECTED_OBSERVATIONS) {
+            boolean found = obs.stream().anyMatch(o -> expected.expectedValue.equals(o.getValue())
+                    && expected.typeId.equals(o.getObservationHistoryTypeId()));
+            assertTrue(expected.typeName + " observation should be present with value '" + expected.expectedValue + "'",
+                    found);
+        }
     }
 }

--- a/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
@@ -106,6 +106,7 @@ public class TbSampleServiceTest extends BaseWebContextSensitiveTest {
         resyncSequence("analysis_seq", "analysis");
         resyncSequence("provider_seq", "provider");
         resyncSequence("observation_history_seq", "observation_history");
+        resyncSequence("patient_patient_type_seq", "patient_patient_type");
 
         ensureReferenceTable("SampleTbEntryForm");
     }

--- a/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
+++ b/src/test/java/org/openelisglobal/sample/service/TbSampleServiceTest.java
@@ -1,0 +1,200 @@
+package org.openelisglobal.sample.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.observationhistory.service.ObservationHistoryService;
+import org.openelisglobal.observationhistory.valueholder.ObservationHistory;
+import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.patientidentity.service.PatientIdentityService;
+import org.openelisglobal.person.service.PersonService;
+import org.openelisglobal.provider.service.ProviderService;
+import org.openelisglobal.sample.form.SampleTbEntryForm;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.samplehuman.service.SampleHumanService;
+import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.sampleorganization.service.SampleOrganizationService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TbSampleServiceIntegrationTest extends BaseWebContextSensitiveTest {
+
+    private static final String DATASET = "testdata/tb-sample-service.xml";
+    private static final String SYS_USER_ID = TEST_SYS_USER_ID;
+
+    @Autowired
+    private TbSampleService tbSampleService;
+
+    @Autowired
+    private PatientService patientService;
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Autowired
+    private SampleItemService sampleItemService;
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private ObservationHistoryService observationHistoryService;
+
+    @Autowired
+    private PatientIdentityService patientIdentityService;
+
+    @Autowired
+    private PersonService personService;
+
+    @Autowired
+    private ProviderService providerService;
+
+    @Autowired
+    private SampleHumanService sampleHumanService;
+
+    @Autowired
+    private SampleOrganizationService sampleOrganizationService;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement(DATASET);
+        resyncSequence("person_seq", "person");
+        resyncSequence("patient_seq", "patient");
+        resyncSequence("patient_identity_seq", "patient_identity");
+        resyncSequence("sample_seq", "sample");
+        resyncSequence("sample_item_seq", "sample_item");
+        resyncSequence("sample_human_seq", "sample_human");
+        resyncSequence("analysis_seq", "analysis");
+        resyncSequence("provider_seq", "provider");
+        resyncSequence("observation_history_seq", "observation_history");
+
+        ensureReferenceTable("SampleTbEntryForm");
+    }
+
+    private SampleTbEntryForm createBaseForm() {
+        SampleTbEntryForm form = new SampleTbEntryForm();
+        form.setSysUserId(SYS_USER_ID);
+        form.setPatientFirstName("Jane");
+        form.setPatientLastName("Smith");
+        form.setPatientGender("F");
+        form.setPatientBirthDate("01/01/1990");
+        form.setPatientPhone("555-1234");
+        form.setPatientAddress("123 Main St");
+
+        form.setTbSubjectNumber("NEW-SUB-001");
+
+        form.setLabNo("NEW-LAB-001");
+        form.setRequestDate("06/01/2025");
+        form.setReceivedDate("06/01/2025");
+
+        form.setTbSpecimenNature("100");
+
+        List<String> tests = new ArrayList<>();
+        tests.add("200");
+        form.setNewSelectedTests(tests);
+
+        form.setReferringSiteCode("100");
+
+        form.setProviderFirstName("Doc");
+        form.setProviderLastName("Brown");
+
+        form.setTbOrderReason("Reason1");
+        form.setTbDiagnosticReason("Diag1");
+        form.setTbFollowupReason("Follow1");
+        form.setTbAspect("Aspect1");
+        form.setTbFollowupPeriodLine1("Period1");
+        form.setTbFollowupPeriodLine2("Period2");
+        form.setSelectedTbMethod("Method1");
+
+        return form;
+    }
+
+    @Test
+    public void persistTbData_newPatient_createsPatientAndSampleHierarchy() {
+        SampleTbEntryForm form = createBaseForm();
+
+        boolean result = tbSampleService.persistTbData(form, null);
+        assertTrue("Service should return true on success", result);
+
+        Patient patient = patientService.getByExternalId("NEW-SUB-001");
+        assertEquals("NEW-SUB-001", patient.getExternalId());
+        assertEquals("Jane", patient.getPerson().getFirstName());
+        assertEquals("Smith", patient.getPerson().getLastName());
+
+        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
+        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
+
+        List<SampleItem> items = sampleItemService.getSampleItemsBySampleId(sample.getId());
+        assertEquals(1, items.size());
+
+        List<Analysis> analyses = analysisService.getAnalysesBySampleId(sample.getId());
+        assertEquals(1, analyses.size());
+        assertEquals("200", analyses.get(0).getTest().getId());
+    }
+
+    @Test
+    public void persistTbData_existingPatient_updatesPatientAndCreatesSampleHierarchy() {
+        SampleTbEntryForm form = createBaseForm();
+        form.setTbSubjectNumber("SUB-900");
+        form.setPatientFirstName("UpdatedFirst");
+        form.setPatientAddress("New Address");
+
+        boolean result = tbSampleService.persistTbData(form, null);
+        assertTrue(result);
+
+        Patient patient = patientService.getByExternalId("SUB-900");
+        assertEquals("900", patient.getId());
+        assertEquals("UpdatedFirst", patient.getPerson().getFirstName());
+
+        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
+        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void persistTbData_existingSample_updateSample_throwsWhenIdNotSet() {
+        SampleTbEntryForm form = createBaseForm();
+        form.setSampleId("900");
+        form.setLabNo("LAB-900");
+        form.setRequestDate("07/01/2025");
+        form.setReceivedDate("07/01/2025");
+
+        tbSampleService.persistTbData(form, null);
+    }
+
+    @Test
+    public void persistTbData_createsProviderFromFormFields() {
+        SampleTbEntryForm form = createBaseForm();
+
+        boolean result = tbSampleService.persistTbData(form, null);
+        assertTrue(result);
+
+        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
+        assertEquals("NEW-LAB-001", sample.getAccessionNumber());
+
+    }
+
+    @Test
+    public void persistTbData_insertsAllRequiredObservations() {
+        SampleTbEntryForm form = createBaseForm();
+
+        boolean result = tbSampleService.persistTbData(form, null);
+        assertTrue(result);
+
+        Sample sample = sampleService.getSampleByAccessionNumber("NEW-LAB-001");
+
+        List<ObservationHistory> obs = observationHistoryService.getObservationHistoriesBySampleId(sample.getId());
+        assertEquals("Should insert exactly 7 observation history records", 7, obs.size());
+
+        boolean foundOrderReason = obs.stream()
+                .anyMatch(o -> "Reason1".equals(o.getValue()) && "100".equals(o.getObservationHistoryTypeId()));
+        assertTrue("TbOrderReason should be present", foundOrderReason);
+    }
+}

--- a/src/test/resources/testdata/tb-sample-service.xml
+++ b/src/test/resources/testdata/tb-sample-service.xml
@@ -108,5 +108,10 @@
         samp_id="900" typeosamp_id="100" collection_date="2025-01-01 10:00:00"
         lastupdated="2025-01-01 12:00:00" />
 
+    <!-- Ensure tables we insert into are cleared to prevent pollution -->
+    <sample_human />
+    <observation_history />
+    <analysis />
+    <provider />
 
 </dataset>

--- a/src/test/resources/testdata/tb-sample-service.xml
+++ b/src/test/resources/testdata/tb-sample-service.xml
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <!-- Basic setup -->
+    <system_user id="1" login_name="admin" last_name="Doe"
+        first_name="John" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 12:00:00" />
+
+    <!-- Address parts -->
+    <address_part id="4" part_name="phone" display_order="1"
+        display_key="phone_key" />
+    <address_part id="6" part_name="street" display_order="2"
+        display_key="street_key" />
+
+    <!-- Observation History Types for TB -->
+    <observation_history_type id="100"
+        type_name="TbOrderReason" description="TbOrderReason" />
+    <observation_history_type id="101"
+        type_name="TbDiagnosticReason" description="TbDiagnosticReason" />
+    <observation_history_type id="102"
+        type_name="TbFollowupReason" description="TbFollowupReason" />
+    <observation_history_type id="103"
+        type_name="TbSampleAspects" description="TbSampleAspects" />
+    <observation_history_type id="104"
+        type_name="TbFollowupReasonPeriodLine1"
+        description="TbFollowupReasonPeriodLine1" />
+    <observation_history_type id="105"
+        type_name="TbFollowupReasonPeriodLine2"
+        description="TbFollowupReasonPeriodLine2" />
+    <observation_history_type id="106"
+        type_name="TbAnalysisMethod" description="TbAnalysisMethod" />
+
+    <!-- Localizations -->
+    <localization id="100" description="test name"
+        lastupdated="2025-01-01 12:00:00" />
+    <localization id="101" description="sampleType name"
+        lastupdated="2025-01-01 12:00:00" />
+    <localization id="102" description="section name"
+        lastupdated="2025-01-01 12:00:00" />
+
+    <localization_value id="100" localization_id="100"
+        locale="en" value="GeneXpert MTB/RIF" />
+    <localization_value id="101" localization_id="101"
+        locale="en" value="Sputum" />
+    <localization_value id="102" localization_id="102"
+        locale="en" value="TB Section" />
+
+    <supported_locale id="100" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+
+    <!-- Type of sample -->
+    <type_of_sample id="100" description="Sputum" domain="E"
+        name_localization_id="101" lastupdated="2025-01-01 12:00:00" />
+
+    <!-- Test section -->
+    <test_section id="200" name="TB" description="TB Section"
+        is_external="N" lastupdated="2025-01-01 12:00:00" sort_order="1"
+        name_localization_id="102" display_key="tb" domain="CLINICAL" />
+
+    <test_formats id="100" lastupdated="2025-01-01 12:00:00" />
+
+    <!-- Test -->
+    <test id="200" description="GeneXpert MTB/RIF" loinc="12345-6"
+        is_active="Y" is_reportable="Y" orderable="true"
+        lastupdated="2025-01-01 12:00:00" test_section_id="200"
+        test_format_id="100" sort_order="1" name="GeneXpert"
+        guid="test-tb-genexpert" name_localization_id="100" />
+
+    <!-- Statuses -->
+    <status_of_sample id="1" description="Test Entered"
+        code="1" status_type="ORDER" name="Test Entered"
+        lastupdated="2025-01-01 12:00:00" />
+    <status_of_sample id="2" description="SampleEntered"
+        code="1" status_type="SAMPLE" name="SampleEntered"
+        lastupdated="2025-01-01 12:00:00" />
+    <status_of_sample id="3" description="Not Tested"
+        code="1" status_type="ANALYSIS" name="Not Tested"
+        lastupdated="2025-01-01 12:00:00" />
+
+    <!-- Patient Identity Type -->
+    <patient_identity_type id="100"
+        identity_type="SUBJECT" />
+
+    <!-- Organization -->
+    <organization id="100" name="Referring Site A"
+        mls_sentinel_lab_flag="Y" lastupdated="2025-01-01 12:00:00" />
+
+    <!-- Data for existing patient/sample updates -->
+    <person id="900" last_name="OldName" first_name="OldFirst"
+        lastupdated="2025-01-01 12:00:00" />
+    <person_address person_id="900" address_part_id="4"
+        type="T" value="12345" />
+    <person_address person_id="900" address_part_id="6"
+        type="T" value="Old Street" />
+
+    <patient id="900" person_id="900" external_id="SUB-900"
+        national_id="SUB-900" gender="M" lastupdated="2025-01-01 12:00:00" />
+    <patient_identity id="900" patient_id="900"
+        identity_type_id="100" identity_data="SUB-900"
+        lastupdated="2025-01-01 12:00:00" />
+
+    <sample id="900" accession_number="LAB-900" status_id="1"
+        received_date="2025-01-01 00:00:00.0"
+        entered_date="2025-01-01 00:00:00.0"
+        collection_date="2025-01-01 00:00:00.0"
+        lastupdated="2025-01-01 12:00:00" />
+    <sample_item id="900" sort_order="1" status_id="2"
+        samp_id="900" typeosamp_id="100" collection_date="2025-01-01 10:00:00"
+        lastupdated="2025-01-01 12:00:00" />
+
+
+</dataset>


### PR DESCRIPTION
# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary
<html><head></head><body><h1>PR Summary: Remove hardcoded values from <code>TbSampleServiceTest</code></h1>
<h2>Problem</h2>
<p><code>TbSampleServiceTest</code> relied on hardcoded IDs, dates, and magic numbers that duplicated dataset internals, collided with each other, and masked a real bug (see below). These made the tests brittle and their intent hard to verify against <code>testdata/tb-sample-service.xml</code>.</p>
<h2>Changes</h2>
<h3>Removed hardcoding</h3>

Before | After
-- | --
"NEW-SUB-001", "NEW-LAB-001" (repeated literals) | Generated per test run via generateUniqueSubjectNumber() / generateUniqueLabNumber()
"06/01/2025", "07/01/2025" (fixed dates) | today() helper, computed relative to the current date
"900" used as both a patient ID and (incorrectly) a sample ID | EXISTING_PATIENT_EXTERNAL_ID / EXISTING_SAMPLE_ACCESSION_NUMBER looked up dynamically via patientService.getByExternalId(...) / sampleService.getSampleByAccessionNumber(...)
Bare 7 for expected observation count | Derived from EXPECTED_OBSERVATIONS.size(), an explicit list of all 7 seeded observation_history_type rows (id, name, expected value), verified against the dataset
Reference-data IDs ("100", "200") scattered inline | Named constants (SPECIMEN_NATURE_ID, TEST_ID, REFERRING_SITE_CODE), each verified against the actual seeded row in tb-sample-service.xml


<h3>Bug fix found during refactor</h3>
<p><code>persistTbData_existingSample_updateSample_throwsWhenIdNotSet</code> was passing a <strong>patient's</strong> internal ID as the <code>sampleId</code> — it only "worked" because both happened to be <code>900</code> in the dataset. Now correctly looks up the pre-seeded <strong>sample</strong> by accession number.</p>
<h3>Bug fix from test run</h3>
<p><code>today()</code> initially formatted dates as <code>MM/dd/yyyy</code>, but <code>DateUtil.convertStringDateToSqlDate</code> expects <code>dd/MM/yyyy</code>. This was masked by the old hardcoded dates (e.g. <code>"06/01/2025"</code>, ambiguous under either format) and only surfaced once dates were generated dynamically — it failed on the 31st of a month, where <code>"08/31/2026"</code> isn't a valid <code>dd/MM/yyyy</code> date. Fixed the format pattern.</p>

## Screenshots
<img width="723" height="247" alt="Screenshot from 2026-08-31 11-22-33" src="https://github.com/user-attachments/assets/f4d2e33e-4868-4c30-b1e2-38372d814aec" />


## Related Issue
Issue https://github.com/DIGI-UW/OpenELIS-Global-2/issues/3759

## Other
