### PR TITLE
feat(i18n): dynamic locale bundle loading + config-code matching in the language selector

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -117,7 +117,7 @@ import {
 } from "./components/resultPage/unified/routeGates";
 import { getFromOpenElisServer } from "./components/utils/Utils";
 import { loadAndApplyBranding } from "./components/utils/BrandingUtils";
-import { languages, languageMessages } from "./languages";
+import { resolveMessagesForLocale } from "./languages";
 import config from "./config.json";
 import { SecureRoute } from "./components/security";
 import "./index.scss";
@@ -204,13 +204,16 @@ import {
 } from "./components/vectorIdentification";
 
 export default function App() {
-  const defaultLocale =
-    localStorage.getItem("locale") || navigator.language.split(/[-_]/)[0];
+  // The stored preference, or the browser's full tag (region kept: fr-MG
+  // resolves to its own bundle, not just fr). The resolver accepts either
+  // spelling (fr_MG / fr-MG) and always returns usable messages, so a stale
+  // stored value can never break startup.
+  const initial = resolveMessagesForLocale(
+    localStorage.getItem("locale") || navigator.language,
+  );
 
-  const initialLocale = languages[defaultLocale] ? defaultLocale : "en";
-
-  const [locale, setLocale] = useState(initialLocale);
-  const [messages, setMessages] = useState(languages[initialLocale].messages);
+  const [locale, setLocale] = useState(initial.code);
+  const [messages, setMessages] = useState(initial.messages);
 
   const [userSessionDetails, setUserSessionDetails] = useState({});
   const [errorLoadingSessionDetails, setErrorLoadingSessionDetails] =
@@ -343,14 +346,14 @@ export default function App() {
   };
 
   const changeLanguageReact = (lang) => {
-    // Check if we have messages for this language
-    const messages = languageMessages[lang] || languages[lang]?.messages;
-    if (!messages) {
-      lang = "en";
-    }
-    setLocale(lang);
-    setMessages(languageMessages[lang] || languages["en"].messages);
-    localStorage.setItem("locale", lang);
+    // The selector hands over whatever code the locales config declared —
+    // underscore or hyphen, any casing. Resolve it to the canonical code and
+    // the best bundle (exact, then base language, then English) so a
+    // configured locale like fr_MG lands on its own translations.
+    const resolved = resolveMessagesForLocale(lang);
+    setLocale(resolved.code);
+    setMessages(resolved.messages);
+    localStorage.setItem("locale", resolved.code);
   };
 
   const changeLanguageBackend = async (lang) => {

--- a/frontend/src/languages/__tests__/languagesIndex.test.js
+++ b/frontend/src/languages/__tests__/languagesIndex.test.js
@@ -1,0 +1,164 @@
+import fs from "fs";
+import path from "path";
+import {
+  languageMessages,
+  languages,
+  normalizeLocaleCode,
+  resolveMessagesForLocale,
+  buildLanguagesFromConfig,
+  defaultLanguages,
+} from "../index";
+
+/**
+ * The languages registry is derived from the directory, not hand-maintained.
+ *
+ * Before this, every Transifex pull had to be wired into index.js by hand and
+ * a dozen bundles (fr_MG, en_US, ar, de, …) sat on disk unreachable: a locale
+ * configured in volume/configuration/backend/locales silently rendered
+ * English. The registry now loads every *.json in src/languages and any
+ * spelling of a code (fr_MG / fr-MG / FR_mg) lands on the same bundle.
+ */
+
+const languagesDir = path.join(__dirname, "..");
+const bundleFilesOnDisk = fs
+  .readdirSync(languagesDir)
+  .filter((f) => f.endsWith(".json"));
+
+describe("dynamic bundle loading", () => {
+  it("registers every locale file in the directory", () => {
+    for (const file of bundleFilesOnDisk) {
+      const code = normalizeLocaleCode(file.replace(/\.json$/, ""));
+      expect(
+        languageMessages[code],
+        `${file} is on disk but missing from languageMessages — the registry must not need manual wiring`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("registers nothing that is not a file (no phantom locales)", () => {
+    const codesFromDisk = new Set(
+      bundleFilesOnDisk.map((f) =>
+        normalizeLocaleCode(f.replace(/\.json$/, "")),
+      ),
+    );
+    for (const code of Object.keys(languageMessages)) {
+      expect(codesFromDisk.has(code), `${code} has no backing file`).toBe(true);
+    }
+  });
+
+  it("keeps the legacy languages export usable for every bundle", () => {
+    for (const [code, entry] of Object.entries(languages)) {
+      expect(entry.label && typeof entry.label === "string").toBe(true);
+      expect(entry.messages).toBe(languageMessages[code]);
+    }
+  });
+});
+
+describe("normalizeLocaleCode", () => {
+  it("maps the Java/Transifex underscore form onto BCP 47", () => {
+    expect(normalizeLocaleCode("fr_MG")).toBe("fr-MG");
+    expect(normalizeLocaleCode("FR_mg")).toBe("fr-MG");
+    expect(normalizeLocaleCode("fr-mg")).toBe("fr-MG");
+    expect(normalizeLocaleCode("en")).toBe("en");
+    expect(normalizeLocaleCode(" en_US ")).toBe("en-US");
+  });
+
+  it("is safe on garbage", () => {
+    expect(normalizeLocaleCode("")).toBe("");
+    expect(normalizeLocaleCode(null)).toBe("");
+    expect(normalizeLocaleCode(undefined)).toBe("");
+  });
+});
+
+describe("resolveMessagesForLocale", () => {
+  const en = JSON.parse(
+    fs.readFileSync(path.join(languagesDir, "en.json"), "utf8"),
+  );
+  const fr = JSON.parse(
+    fs.readFileSync(path.join(languagesDir, "fr.json"), "utf8"),
+  );
+  const frMG = JSON.parse(
+    fs.readFileSync(path.join(languagesDir, "fr_MG.json"), "utf8"),
+  );
+
+  it("matches a config-file code to its Transifex bundle whatever the spelling", () => {
+    const translatedKey = Object.keys(frMG).find((k) => frMG[k]);
+    expect(translatedKey, "fr_MG.json should not be empty").toBeTruthy();
+    for (const spelling of ["fr_MG", "fr-MG", "FR_mg"]) {
+      const { code, messages } = resolveMessagesForLocale(spelling);
+      expect(code).toBe("fr-MG");
+      expect(messages[translatedKey]).toBe(frMG[translatedKey]);
+    }
+  });
+
+  it("layers a regional variant over its base language before English", () => {
+    // Precedence contract for every key: the variant's own value wins, a key
+    // it lacks takes the base language's, and only then English. Asserted
+    // across all fr keys so it holds whether Transifex pulls fr_MG sparse or
+    // complete.
+    const { messages } = resolveMessagesForLocale("fr_MG");
+    for (const key of Object.keys(fr)) {
+      const expected = key in frMG ? frMG[key] : fr[key];
+      expect(messages[key], key).toBe(expected);
+    }
+    const enOnlyKey = Object.keys(en).find(
+      (key) => !(key in fr) && !(key in frMG),
+    );
+    if (enOnlyKey) {
+      expect(messages[enOnlyKey]).toBe(en[enOnlyKey]);
+    }
+  });
+
+  it("covers every English key so no locale renders raw message ids", () => {
+    const { messages } = resolveMessagesForLocale("fr_MG");
+    for (const key of Object.keys(en)) {
+      expect(key in messages, `missing ${key}`).toBe(true);
+    }
+  });
+
+  it("falls back to the base language for an unbundled regional code", () => {
+    const { code, messages } = resolveMessagesForLocale("fr_XX");
+    expect(code).toBe("fr-XX");
+    const frKey = Object.keys(fr).find((k) => fr[k] && fr[k] !== en[k]);
+    expect(messages[frKey]).toBe(fr[frKey]);
+  });
+
+  it("falls back to English for an unknown language and for garbage", () => {
+    expect(resolveMessagesForLocale("xx").messages).toBe(languageMessages.en);
+    expect(resolveMessagesForLocale("").code).toBe("en");
+    expect(resolveMessagesForLocale(undefined).messages).toBe(
+      languageMessages.en,
+    );
+  });
+});
+
+describe("buildLanguagesFromConfig", () => {
+  it("keys the result by canonical code so selector, intl and lookup agree", () => {
+    const built = buildLanguagesFromConfig([
+      { localeCode: "fr_MG", displayName: "French Madagascar" },
+      { localeCode: "en", displayName: "English", fallback: true },
+    ]);
+    expect(Object.keys(built)).toEqual(["fr-MG", "en"]);
+    expect(built["fr-MG"].label).toBe("French Madagascar");
+    expect(built["fr-MG"].messages).toBe(languageMessages["fr-MG"]);
+    expect(built["en"].fallback).toBe(true);
+  });
+
+  it("keeps a configured locale selectable even without a bundle", () => {
+    const built = buildLanguagesFromConfig([
+      { localeCode: "pt", displayName: "Português" },
+    ]);
+    expect(built["pt"].label).toBe("Português");
+    expect(built["pt"].messages).toBe(languageMessages.en);
+  });
+
+  it("skips rows without a code and falls back to defaults when empty", () => {
+    expect(buildLanguagesFromConfig([])).toBe(defaultLanguages);
+    expect(buildLanguagesFromConfig(null)).toBe(defaultLanguages);
+    const built = buildLanguagesFromConfig([
+      { localeCode: "", displayName: "nameless" },
+      { localeCode: "fr", displayName: "Français" },
+    ]);
+    expect(Object.keys(built)).toEqual(["fr"]);
+  });
+});

--- a/frontend/src/languages/index.js
+++ b/frontend/src/languages/index.js
@@ -1,49 +1,80 @@
 import en from "./en.json";
-import enGB from "./en_GB.json";
-import enLK from "./en_LK.json";
-import enUS from "./en_US.json";
-import es from "./es.json";
-import fr from "./fr.json";
-import id from "./id.json";
-import mg from "./mg.json";
-import ro from "./ro.json";
-import si from "./si.json";
-import siLK from "./si_LK.json";
-import ta from "./ta.json";
-import taLK from "./ta_LK.json";
-import amET from "./am_ET.json";
-import sw from "./sw.json";
 
 /**
- * A bundle layered over English, so a key a translation has not caught up with
- * yet renders its English text rather than the raw key id. New keys are added
- * to en.json only — Transifex is the source of truth for every other bundle —
- * so between an English release and its translation round every locale would
- * otherwise show identifiers like `label.patientHistory.filterByCategory` to
- * the user.
+ * Every locale bundle in this directory, loaded at build time. Dropping a new
+ * Transifex pull (e.g. fr_MG.json) here is all it takes — no manual import or
+ * registry edit. Vite statically analyzes the glob, so the bundles are part of
+ * the build exactly as the hand-written imports were.
  */
-const withEnglishFallback = (messages) => ({ ...en, ...messages });
+const bundleModules = import.meta.glob("./*.json", { eager: true });
 
 /**
- * All available language message bundles.
+ * Canonical form for a locale code: BCP 47 casing with hyphens. Accepts the
+ * Java/Transifex underscore form and any casing, so the code configured in
+ * volume/configuration/backend/locales and the filename Transifex pulls both
+ * land on the same key: "fr_MG", "fr-mg" and "FR_mg" all become "fr-MG".
+ */
+export const normalizeLocaleCode = (code) => {
+  if (typeof code !== "string" || !code.trim()) {
+    return "";
+  }
+  const [language, ...rest] = code.trim().replace(/_/g, "-").split("-");
+  return [
+    language.toLowerCase(),
+    ...rest.map((part) =>
+      part.length === 2 ? part.toUpperCase() : part.toLowerCase(),
+    ),
+  ].join("-");
+};
+
+/** Raw bundles keyed by canonical code, straight from the files. */
+const rawBundles = {};
+for (const [path, mod] of Object.entries(bundleModules)) {
+  const fileCode = path.replace(/^\.\//, "").replace(/\.json$/, "");
+  rawBundles[normalizeLocaleCode(fileCode)] = mod.default ?? mod;
+}
+
+/**
+ * A bundle layered over its base language and English, so a key a translation
+ * has not caught up with yet renders the most specific text available rather
+ * than the raw key id: a regional variant (fr-MG) falls back to its base
+ * language (fr) first, then to English. New keys are added to en.json only —
+ * Transifex is the source of truth for every other bundle — so between an
+ * English release and its translation round every locale would otherwise show
+ * identifiers like `label.patientHistory.filterByCategory` to the user.
+ */
+const withFallbacks = (code) => {
+  const base = code.split("-")[0];
+  return {
+    ...en,
+    ...(base !== code && base !== "en" ? rawBundles[base] : {}),
+    ...rawBundles[code],
+  };
+};
+
+/**
+ * All available language message bundles, keyed by canonical locale code.
  * These are bundled at build time and contain UI translations.
  */
-export const languageMessages = {
-  en: en,
-  "en-GB": withEnglishFallback(enGB),
-  "en-LK": withEnglishFallback(enLK),
-  "en-US": withEnglishFallback(enUS),
-  es: withEnglishFallback(es),
-  fr: withEnglishFallback(fr),
-  id: withEnglishFallback(id),
-  mg: withEnglishFallback(mg),
-  ro: withEnglishFallback(ro),
-  si: withEnglishFallback(si),
-  "si-LK": withEnglishFallback(siLK),
-  ta: withEnglishFallback(ta),
-  "ta-LK": withEnglishFallback(taLK),
-  sw: withEnglishFallback(sw),
-  "am-ET": withEnglishFallback(amET),
+export const languageMessages = Object.fromEntries(
+  Object.keys(rawBundles).map((code) => [
+    code,
+    code === "en" ? en : withFallbacks(code),
+  ]),
+);
+
+/**
+ * Best label we can produce without the backend: the language's own name for
+ * itself. The backend's displayName (from the locales config) wins wherever it
+ * is available; this only covers the static fallback list below.
+ */
+const labelFor = (code) => {
+  try {
+    const label = new Intl.DisplayNames([code], { type: "language" }).of(code);
+    return label ? label.charAt(0).toUpperCase() + label.slice(1) : code;
+  } catch {
+    return code;
+  }
 };
 
 /**
@@ -56,37 +87,50 @@ export const defaultLanguages = {
 };
 
 /**
- * Legacy export for backwards compatibility.
+ * Legacy export for backwards compatibility — now derived from whatever
+ * bundles exist instead of a hand-maintained list.
  * Components should migrate to using ConfigurationContext for dynamic locale list.
  * @deprecated Use ConfigurationContext.supportedLocales instead
  */
-export const languages = {
-  en: { label: "English", messages: languageMessages["en"] },
-  "en-GB": { label: "English (UK)", messages: languageMessages["en-GB"] },
-  "en-LK": {
-    label: "English (Sri Lanka)",
-    messages: languageMessages["en-LK"],
-  },
-  "en-US": { label: "English (US)", messages: languageMessages["en-US"] },
-  es: { label: "Español", messages: languageMessages["es"] },
-  fr: { label: "Français", messages: languageMessages["fr"] },
-  id: { label: "Indonesia", messages: languageMessages["id"] },
-  mg: { label: "Malagasy", messages: languageMessages["mg"] },
-  ro: { label: "Română", messages: languageMessages["ro"] },
-  si: { label: "සිංහල", messages: languageMessages["si"] },
-  "si-LK": { label: "සිංහල (Sri Lanka)", messages: languageMessages["si-LK"] },
-  ta: { label: "தமிழ்", messages: languageMessages["ta"] },
-  "ta-LK": { label: "தமிழ் (Sri Lanka)", messages: languageMessages["ta-LK"] },
-  sw: { label: "Swahili", messages: languageMessages["sw"] },
-  "am-ET": { label: "Amharic", messages: languageMessages["am-ET"] },
+export const languages = Object.fromEntries(
+  Object.keys(languageMessages)
+    .sort()
+    .map((code) => [
+      code,
+      { label: labelFor(code), messages: languageMessages[code] },
+    ]),
+);
+
+/**
+ * The message bundle for a locale code in any spelling: the exact bundle
+ * first, then the base language's, then English. The returned code is the
+ * canonical form of what was asked for (valid BCP 47, safe for react-intl and
+ * the Intl APIs), so a selector showing the configured locale stays in sync
+ * with intl.locale even when the messages had to fall back. Never returns
+ * undefined messages, so a stale localStorage value or an unconfigured
+ * navigator.language cannot break startup or a switch.
+ */
+export const resolveMessagesForLocale = (code) => {
+  const canonical = normalizeLocaleCode(code);
+  if (!canonical) {
+    return { code: "en", messages: languageMessages.en };
+  }
+  const messages =
+    languageMessages[canonical] ||
+    languageMessages[canonical.split("-")[0]] ||
+    languageMessages.en;
+  return { code: canonical, messages };
 };
 
 /**
- * Builds the languages object from backend-provided locales.
- * Falls back to default label if displayName not provided.
- * Falls back to English messages if no message bundle exists for a configured locale.
+ * Builds the languages object from backend-provided locales, keyed by the
+ * canonical code so the header selector, react-intl and the message lookup all
+ * agree — the config file may spell a code either way (fr_MG or fr-MG).
+ * Falls back to the code itself if displayName is not provided, and to the
+ * base language's (then English) messages if no bundle exists for a
+ * configured locale.
  * @param {Array} supportedLocales - Array of {localeCode, displayName, fallback} from backend
- * @returns {Object} Languages object with {[localeCode]: {label, messages, fallback}}
+ * @returns {Object} Languages object with {[canonicalCode]: {label, messages, fallback}}
  */
 export function buildLanguagesFromConfig(supportedLocales) {
   if (!supportedLocales || supportedLocales.length === 0) {
@@ -95,12 +139,13 @@ export function buildLanguagesFromConfig(supportedLocales) {
 
   const result = {};
   for (const locale of supportedLocales) {
-    const code = locale.localeCode;
-    const messages = languageMessages[code] || languageMessages["en"];
-
+    const code = normalizeLocaleCode(locale && locale.localeCode);
+    if (!code) {
+      continue;
+    }
     result[code] = {
       label: locale.displayName || code,
-      messages: messages,
+      messages: resolveMessagesForLocale(code).messages,
       fallback: locale.fallback || false,
     };
   }


### PR DESCRIPTION
## Problem

Adding a language took two registrations: Transifex pulls the bundle into `frontend/src/languages/`, and someone edits `index.js` by hand. The second step kept being skipped — **a dozen bundles on disk (`fr_MG`, `en_US`, `ar`, `de`, `ru`, `zh`, …) were unreachable**, so a locale declared in `volume/configuration/backend/locales` looked selected but silently rendered English.

The second half was spelling: the config file and the Java side write `fr_MG` while the registry keyed `fr-MG`, and both the header selector and `changeLanguageReact` looked codes up raw — so even a wired bundle could miss.

## Implementation

- **`languages/index.js` is now derived from the directory**: a Vite `import.meta.glob` loads every `*.json` at build time. Dropping a Transifex pull into the folder is the whole job — no registry edit.
- Every bundle is **layered variant → base language → English**, so a key a regional variant lacks shows the base translation, and no locale can render raw message ids.
- **`normalizeLocaleCode` / `resolveMessagesForLocale`**: any spelling (`fr_MG`, `fr-mg`, `FR_mg`) lands on the canonical BCP 47 code; lookup falls back exact → base → English. `buildLanguagesFromConfig` keys its result canonically, so the selector's values, `intl.locale`, `localStorage` and the message lookup always agree.
- `changeLanguageReact` and the **boot path** use the resolver — a stale stored locale or unconfigured `navigator.language` can no longer boot into English silently (or, pre-guard, a TypeError). Boot now honors the browser's full tag (`fr-MG` resolves to its own bundle, not just `fr`).
- The deployment translation-override feature is untouched: `overrideFilesFor` already normalizes hyphen→underscore for its file names, so canonical codes flow through it correctly.

## Testing

- **13 new vitest cases** (`languagesIndex.test.js`): every file on disk registered / no phantom locales; normalization incl. garbage; spelling-independent matching; full precedence contract across all `fr` keys (holds whether Transifex pulls `fr_MG` sparse or complete); English-key coverage; base fallback for unbundled variants; `buildLanguagesFromConfig` canonical keying, bundle-less locale, empty/invalid rows.
- **Inversion-verified**: narrowing the glob back to a hand-picked set fails 3 tests; removing normalization fails 4; restored → 13/13.
- Full frontend suite: **1,258 passed / 179 files**. Prettier clean.

## Live verification (local dev stack, locales CSV with `fr_MG` + `en_US` active)

7/7: header lists *French Madagascar* and *English (US)* from the backend config → selecting French Madagascar renders French (previously English), stores `fr-MG`, selector stays in sync with `intl.locale`, **survives reload through the boot resolver**, `en_US` round-trips as `en-US`, zero JS errors.

## Limitations / notes

- The example locales CSV in this repo still lists only the original locales; the `fr_MG`/`en_US` rows used for live testing were a local configuration. Deployments enable languages purely via their own locales config now — which is the point.
- Legacy `languages` export labels are now derived via `Intl.DisplayNames` (backend `displayName` remains the real label source in the UI).
- Backend `?lang=` continues to receive the canonical hyphen form — the same form the previous hand-written registry already sent for `si-LK`/`ta-LK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
