### PR TITLE
fix(order): stop panels leaking tests not configured for the sample type (OGC-1189)

### DIFF
--- a/frontend/src/components/order/steps/sections/SampleTestSection.jsx
+++ b/frontend/src/components/order/steps/sections/SampleTestSection.jsx
@@ -310,10 +310,14 @@ const SampleTestSection = ({
         { id: panel.id, name: panel.name, testIds: panel.testIds },
       ];
       const testsToAdd = panelTestIds
-        .filter((testId) => !currentTests.some((t) => t.id === testId))
+        .filter(
+          (testId) =>
+            availableTests.some((t) => t.id === testId) &&
+            !currentTests.some((t) => t.id === testId),
+        )
         .map((testId) => {
           const test = availableTests.find((t) => t.id === testId);
-          return { id: testId, name: test?.name || testId };
+          return { id: testId, name: test.name };
         });
       updated[sampleIndex].tests = [...currentTests, ...testsToAdd];
     } else {

--- a/frontend/src/components/order/steps/sections/SampleTestSection.test.jsx
+++ b/frontend/src/components/order/steps/sections/SampleTestSection.test.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../../languages/en.json";
+import SampleTestSection from "./SampleTestSection";
+
+const { getFromOpenElisServerMock } = vi.hoisted(() => ({
+  getFromOpenElisServerMock: vi.fn(),
+}));
+
+vi.mock("../../../utils/Utils", () => ({
+  getFromOpenElisServer: (...args) => getFromOpenElisServerMock(...args),
+}));
+
+// The sample-type-filtered catalogue the server returns for ST1: only T1 is
+// configured for the sample type; the panel P1 additionally lists T2, which is
+// NOT valid for ST1 (the OGC-1189 leak).
+function mockServer() {
+  getFromOpenElisServerMock.mockImplementation((url, cb) => {
+    if (url.startsWith("/rest/user-sample-types")) {
+      cb([{ id: "ST1", value: "Serum" }]);
+    } else if (url.startsWith("/rest/sample-type-tests")) {
+      cb({
+        tests: [{ id: "T1", name: "Alpha" }],
+        panels: [{ id: "P1", name: "Panel One", testIds: "T1,T2" }],
+      });
+    }
+  });
+}
+
+function renderSection({ samples, setSamples }) {
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <SampleTestSection
+        samples={samples}
+        setSamples={setSamples}
+        orderData={{}}
+        setOrderData={vi.fn()}
+        isReadOnly={false}
+        workflowType="clinical"
+      />
+    </IntlProvider>,
+  );
+}
+
+describe("SampleTestSection — panel selection (OGC-1189)", () => {
+  beforeEach(() => {
+    getFromOpenElisServerMock.mockReset();
+    mockServer();
+  });
+
+  it("adds only panel members configured for the sample type, dropping foreign ones", async () => {
+    const setSamples = vi.fn();
+    renderSection({
+      samples: [{ sampleTypeId: "ST1", tests: [], panels: [] }],
+      setSamples,
+    });
+
+    const panelCheckbox = await screen.findByLabelText("Panel One");
+    fireEvent.click(panelCheckbox);
+
+    expect(setSamples).toHaveBeenCalled();
+    const updatedSamples = setSamples.mock.calls.at(-1)[0];
+    const addedTestIds = updatedSamples[0].tests.map((t) => t.id);
+
+    expect(addedTestIds).toContain("T1"); // valid member added
+    expect(addedTestIds).not.toContain("T2"); // foreign member dropped (the leak)
+    // No raw-id-as-name fallback: every added test carries its catalogue name.
+    expect(updatedSamples[0].tests).toEqual([{ id: "T1", name: "Alpha" }]);
+  });
+});

--- a/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
+++ b/src/main/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderRestController.java
@@ -247,7 +247,12 @@ public class SampleEntryTestsForTypeProviderRestController extends BaseRestContr
         return samplePanelService.getTypeOfSamplePanelsForSampleType(sampleType);
     }
 
-    private List<PanelTestMap> linkTestsToPanels(List<TypeOfSamplePanel> panelList, List<Test> tests) {
+    /**
+     * Package-private (not {@code private}) so the same-package test can exercise
+     * the sample-type panel-member filter without a full {@code /rest} session
+     * (OGC-1189).
+     */
+    List<PanelTestMap> linkTestsToPanels(List<TypeOfSamplePanel> panelList, List<Test> tests) {
         List<PanelTestMap> selected = new ArrayList<>();
 
         Map<String, Integer> testNameOrderMap = new HashMap<>();
@@ -280,7 +285,7 @@ public class SampleEntryTestsForTypeProviderRestController extends BaseRestContr
 
         for (PanelItem item : items) {
             String derivedNameFromPanel = getDerivedNameFromPanel(item);
-            if (derivedNameFromPanel != null) {
+            if (derivedNameFromPanel != null && testIdOrderMap.get(derivedNameFromPanel) != null) {
                 String ItemId = item.getTest().getId();
 
                 if (ItemId != null) {

--- a/src/test/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderPanelFilterTest.java
+++ b/src/test/java/org/openelisglobal/common/rest/provider/SampleEntryTestsForTypeProviderPanelFilterTest.java
@@ -1,0 +1,69 @@
+package org.openelisglobal.common.rest.provider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.rest.provider.SampleEntryTestsForTypeProviderRestController.PanelTestMap;
+import org.openelisglobal.test.service.TestService;
+import org.openelisglobal.test.service.TestServiceImpl;
+import org.openelisglobal.typeofsample.valueholder.TypeOfSamplePanel;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * OGC-1189: a panel offered during sample entry must not leak tests that are
+ * not configured for the chosen sample type. {@code linkTestsToPanels} builds
+ * the per-panel test-id string from only the members whose localized name is
+ * present in the sample-type-filtered {@code tests} list; a member outside that
+ * list is dropped.
+ *
+ * <p>
+ * This exercises the controller method directly (it lives in this package and
+ * is package-private) rather than through the {@code /rest/sample-type-tests}
+ * endpoint, which would need a full authenticated session. The panel list is
+ * built in code so no {@code type_of_sample}/{@code sampletype_test} wiring is
+ * needed — the fixture only has to make panel P and its two members resolvable.
+ */
+public class SampleEntryTestsForTypeProviderPanelFilterTest extends BaseWebContextSensitiveTest {
+
+    private static final String PANEL_P_ID = "4001";
+    private static final String TEST_IN_ID = "3001";
+    private static final String TEST_OUT_ID = "3002";
+
+    @Autowired
+    private TestService testService;
+
+    private SampleEntryTestsForTypeProviderRestController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/sample-entry-panel-filter.xml");
+        controller = new SampleEntryTestsForTypeProviderRestController();
+    }
+
+    @Test
+    public void linkTestsToPanels_dropsPanelMemberNotConfiguredForSampleType() {
+        org.openelisglobal.test.valueholder.Test testIn = testService.get(TEST_IN_ID);
+        assertNotNull("fixture must load T_IN", testIn);
+
+        List<org.openelisglobal.test.valueholder.Test> sampleTypeFilteredTests = List.of(testIn);
+
+        TypeOfSamplePanel samplePanel = new TypeOfSamplePanel();
+        samplePanel.setPanelId(PANEL_P_ID);
+
+        List<PanelTestMap> result = controller.linkTestsToPanels(List.of(samplePanel), sampleTypeFilteredTests);
+
+        assertEquals("panel P must be selected because T_IN is in-type", 1, result.size());
+        PanelTestMap panelMap = result.get(0);
+        assertEquals(PANEL_P_ID, panelMap.getId());
+        assertEquals("T_OUT (not configured for the sample type) must be dropped from the panel", TEST_IN_ID,
+                panelMap.getTestIds());
+
+        assertEquals("Test In", TestServiceImpl.getUserLocalizedTestName(testIn));
+        assertEquals("Test Out", TestServiceImpl.getUserLocalizedTestName(testService.get(TEST_OUT_ID)));
+    }
+}

--- a/src/test/resources/testdata/sample-entry-panel-filter.xml
+++ b/src/test/resources/testdata/sample-entry-panel-filter.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Fixture for SampleEntryTestsForTypeProviderPanelFilterTest (OGC-1189).
+    Panel P (4001) contains two tests: T_IN (3001) and T_OUT (3002). Only T_IN
+    is in the sample-type-filtered list handed to linkTestsToPanels, so the panel's
+    test-id string for P must resolve to T_IN's id ONLY — T_OUT must be dropped
+    because its localized name is not in the filtered map. Each localization
+    carries an English value so getUserLocalizedTestName / Panel.getLocalizedName
+    resolve to distinct, non-blank names regardless of the test locale. A test_section
+    named "user" is required because the controller constructor resolves USER_TEST_SECTION_ID
+    via getTestSectionByName("user"). -->
+<dataset>
+    <supported_locale id="1" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+    <supported_locale id="2" locale_code="fr"
+        display_name="Français" is_active="true" is_fallback="false"
+        sort_order="2" />
+
+    <localization id="10" description="user section name" />
+    <localization id="11" description="filter panel name" />
+    <localization id="12" description="test in name" />
+    <localization id="13" description="test out name" />
+
+    <localization_value id="10" localization_id="10"
+        locale="en" value="User Section" />
+    <localization_value id="11" localization_id="11"
+        locale="en" value="Filter Panel" />
+    <localization_value id="12" localization_id="12"
+        locale="en" value="Test In" />
+    <localization_value id="13" localization_id="13"
+        locale="en" value="Test Out" />
+
+    <test_section id="900" name="user"
+        description="Bench section for the current user" is_external="N"
+        is_active="Y" sort_order="1" name_localization_id="10"
+        lastupdated="2025-03-20 12:00:00.0" />
+
+    <test id="3001" description="Test In" loinc="300001"
+        reporting_description="Test In" sticker_req_flag="N" is_active="Y"
+        active_begin="2025-01-01 12:00:00" active_end="2025-12-31 12:00:00"
+        is_reportable="N" time_holding="30" time_wait="15"
+        time_ta_average="60" time_ta_warning="90" time_ta_max="120"
+        label_qty="1" lastupdated="2025-03-20 12:00:00" local_code="TIN"
+        sort_order="1" name="Test In" orderable="true" guid="tin-3001"
+        name_localization_id="12" antimicrobial_resistance="false" />
+
+    <test id="3002" description="Test Out" loinc="300002"
+        reporting_description="Test Out" sticker_req_flag="N" is_active="Y"
+        active_begin="2025-01-01 12:00:00" active_end="2025-12-31 12:00:00"
+        is_reportable="N" time_holding="30" time_wait="15"
+        time_ta_average="60" time_ta_warning="90" time_ta_max="120"
+        label_qty="1" lastupdated="2025-03-20 12:00:00" local_code="TOUT"
+        sort_order="2" name="Test Out" orderable="true" guid="tout-3002"
+        name_localization_id="13" antimicrobial_resistance="false" />
+
+    <panel id="4001" name="Filter Panel"
+        description="Panel with one in-type and one out-of-type test"
+        is_active="Y" sort_order="1" name_localization_id="11" />
+
+    <panel_item id="5001" panel_id="4001" sort_order="1"
+        test_id="3001" lastupdated="2025-03-26 10:00:00" />
+    <panel_item id="5002" panel_id="4001" sort_order="2"
+        test_id="3002" lastupdated="2025-03-26 10:00:00" />
+</dataset>


### PR DESCRIPTION
## Problem (OGC-1189)

Ordering **any** panel in the clinical order wizard created analyses for **every** panel member — including tests not configured for the sample type being ordered. Measured across the instance, **15 of 15 panel offerings leaked** (e.g. `Bilan Biochimique` on a Serum tube produced immunohistochemistry-only analyses like `AMACR (p504 s)` and `Actin Smooth Muscle`). Those analyses are indistinguishable from legitimate ones — they reach worklists, accept results, and can be validated against a specimen they cannot be run on.

## Root cause

A sample-type filter present in the legacy path was dropped in the REST/React rewrite, in **two independent layers** (either alone reproduces the defect):

1. **Backend** — `SampleEntryTestsForTypeProviderRestController.getTestIndexesForPanels` received `testIdOrderMap` (built from the **sample-type-filtered** test list, keyed by localized test name) but never consulted it — it appended every panel member's test id. The legacy XML provider `SampleEntryTestsForTypeProvider` still guards with `testIdOrderMap.get(name) != null`; the rewrite switched from emitting indexes to real test ids and lost the lookup. So `GET /rest/sample-type-tests`'s `panels[].testIds` was not filtered.
2. **Frontend** — `SampleTestSection.handlePanelToggle` consulted the sample-type-filtered `availableTests` only for a display name; an id absent from it was still pushed into the sample's test list (with the raw id as a fallback name), then serialized into the save payload.

## Implementation

Restored the filter at both layers, mirroring the still-correct legacy code:

- **Backend** (`SampleEntryTestsForTypeProviderRestController.java`): the panel loop now keeps a member only when `testIdOrderMap.get(derivedNameFromPanel) != null` — i.e. its localized name is in the sample type's test list. This alone fixes the reported behaviour.
- **Frontend** (`SampleTestSection.jsx`): `handlePanelToggle` now filters `panel.testIds` to ids present in `availableTests` before adding them (defence in depth), which also removes the raw-id-as-name fallback.

## Tests

- **Backend integration test** — `SampleEntryTestsForTypeProviderPanelFilterTest` with DBUnit fixture `sample-entry-panel-filter.xml`: a panel with one in-type member and one foreign member; asserts `linkTestsToPanels` returns only the in-type member. Inversion-verified (reverting the guard leaks the foreign member). `linkTestsToPanels` was relaxed `private → package-private` for the same-package test (avoids a full authenticated `/rest` session).
- **Frontend test** — `SampleTestSection.test.jsx`: selecting a panel whose `testIds` include a foreign member adds only the valid member. Inversion-verified: without the fix, `expected [ 'T1', 'T2' ] to not include 'T2'`.
- Full frontend suite: **1273 passed / 13 skipped / 0 failed**. Full backend suite (isolated copy): **5663 run / 0 failures / 0 errors / 8 skipped — BUILD SUCCESS**.

## Verification

The observable proof of the backend behaviour is the inversion-verified integration test, which runs `linkTestsToPanels` against a **real Postgres 14.4** (testcontainers) with a fixture panel that mixes an in-type and an out-of-type member:

- guard in place → `Tests run: 1, Failures: 0` (out-of-type member dropped, `testIds == "3001"`);
- guard reverted → `ComparisonFailure … expected:<3001[]> but was:<3001[,3002]>` (leak reproduced);
- restored → pass.

A local docker "before/after" probe was deliberately not used as the primary evidence: the leak's visibility depends on a deployment's specific panel/sample-type data (the ticket measured it on `testing.openelis-global.org`), so a fixture-controlled test is the deterministic check. The frontend fix is served live by the dev HMR stack and is covered by the inversion-verified component test above.

## Assumptions / limitations / follow-ups

- Suggestion #3 in the ticket — a server-side backstop in `populateAnalysis` asserting the test is valid for the sample item's type of sample — is **not** included here. The two client-facing filters fully close the reported leak; the save-path assertion is broader hardening against any future client and carries more regression risk (legitimately cross-type tests), so it is left as a follow-up.
- The QA regression suite `tests/panel-sample-type-leak.spec.ts` (TC-PANEL-LEAK-3) lives in DIGI-UW/OpenELIS-QA and is not runnable from this repo; the in-repo tests above cover both fixed layers.
- Not established (per the ticket) whether this is a regression vs 3.2.1 or always-true of the REST path — not needed to fix, and not asserted here.
