### PR TITLE
fix(eqa): render panel DTOs after the producing transaction has ended (OGC-612)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -241,6 +241,14 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
     @Override
     @Transactional(readOnly = true)
     public Map<String, Object> toPanelDto(EQAPanel panel) {
+        // Callers such as the unblind endpoint and GET /panels/{id} map the DTO
+        // after the transaction that produced the panel has ended, so the lazy
+        // cycle on the instance they hold cannot load. Re-read by id: inside a
+        // transaction this is a first-level-cache hit, outside it is the one query
+        // that keeps the mapping from failing with the work already committed.
+        if (panel.getId() != null) {
+            panel = eqaPanelDAO.get(panel.getId()).orElse(panel);
+        }
         Map<String, Object> dto = new LinkedHashMap<>();
         dto.put("id", panel.getId());
         dto.put("panelName", panel.getPanelName());

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -27,6 +27,7 @@ import org.openelisglobal.eqa.scheduler.EQADeadlineAlertScheduler;
 import org.openelisglobal.eqa.service.EQABlindingService;
 import org.openelisglobal.eqa.service.EQABlindingService.BlindOrderSpec;
 import org.openelisglobal.eqa.service.EQALabelPDFService;
+import org.openelisglobal.eqa.service.EQAPanelService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
@@ -63,6 +64,8 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
     private EQAPanelSampleDAO panelSampleDAO;
     @Autowired
     private IStatusService statusService;
+    @Autowired
+    private EQAPanelService panelService;
 
     /**
      * The eqa.scheduler package is deliberately excluded from the test component
@@ -141,6 +144,33 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
     }
 
     // ---- fixture builders ----
+
+    /**
+     * The unblind endpoint maps its response after the scoring transaction has
+     * committed, so the panel it holds is detached. The DTO must still resolve the
+     * lazily loaded cycle, or the call answers 500 with the work already done. GET
+     * /panels/{id} reads and maps in two transactions the same way.
+     */
+    @Test
+    public void unblind_returnsAPanelTheEndpointCanRenderAfterTheTransactionEnds() {
+        EQAProgram scheme = inHouseScheme("IH Detached Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        insertPanelSample(panel, "IH-01", "IHBLIND-D1", NUMERIC_ANALYTE, "100", "95", "105");
+
+        Map<String, Object> dto = panelService
+                .toPanelDto(blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL));
+
+        assertEquals("SCORED", dto.get("status"));
+        assertEquals("MANUAL", dto.get("unblindMethod"));
+        assertEquals(cycle.getId(), dto.get("cycleId"));
+        assertEquals(cycle.getCycleNumber(), dto.get("cycleNumber"));
+        assertEquals(cycle.getCycleName(), dto.get("cycleName"));
+
+        Map<String, Object> read = panelService.toPanelDto(panelService.get(panel.getId()));
+        assertEquals("SCORED", read.get("status"));
+        assertEquals(cycle.getCycleNumber(), read.get("cycleNumber"));
+    }
 
     private EQAProgram inHouseScheme(String name) {
         return insertScheme(name, EQASchemeType.IN_HOUSE, null);


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

Unblinding an in-house panel could answer HTTP 500 with the unblind already persisted, and `GET /rest/eqa/panels/{id}` answered 500 for any panel bound to a cycle. Both endpoints map the panel to its DTO in the controller, after the transaction that loaded or updated the panel has committed; the cycle association is lazy, so the mapping hit a detached proxy (`LazyInitializationException: could not initialize proxy [EQACycle#…] - no Session`). `sealAndDistribute` never showed it because it maps inside its own transaction.

`toPanelDto` now re-reads the panel by id inside its own read-only transaction: a first-level-cache hit when the caller is still in a transaction, one query otherwise. No schema or controller changes.

Found while planning the two-instance EQA UAT (the Playwright unblind spec in #4157 carries a `test.fixme` for this; it can be un-skipped once this merges).

## Tests

- New `EQABlindingIntegrationTest.unblind_returnsAPanelTheEndpointCanRenderAfterTheTransactionEnds` drives the endpoint's exact sequence (unblind, then map outside the transaction) and the plain read path. Red before the fix, green after.
- `EQABlindingIntegrationTest` 12, `EQAPanelLifecycleIntegrationTest` 9, `EQAInHouseWizardIntegrationTest` 5, `EQAPanelRestControllerTest` 5 — all green.
- Live on the dev stack: `GET /panels/10` 500 → 200 after the swap; a fresh panel walked seal-and-distribute → read → unblind (SCORED, MANUAL) → 409 on repeat → read.

## Related Issue

[OGC-612](https://uwdigi.atlassian.net/browse/OGC-612)

## Other

Independent of the other EQA UAT-fix PRs; can merge in any order.


[OGC-612]: https://uwdigi.atlassian.net/browse/OGC-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ