### PR TITLE
feat(eqa): preselect the cycle and enrollment when Add Order opens from My Cycles (OGC-610)

### DIFF
--- a/frontend/src/components/eqa/EQAOrderForm.jsx
+++ b/frontend/src/components/eqa/EQAOrderForm.jsx
@@ -18,6 +18,8 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
   const [myPrograms, setMyPrograms] = useState([]);
   const [cycles, setCycles] = useState([]);
   const [existingReceipt, setExistingReceipt] = useState(null);
+  // Both lists have answered; the deep link below waits for that.
+  const [listsLoaded, setListsLoaded] = useState(0);
 
   const sampleOrder = orderFormValues?.sampleOrderItems || {};
   const cycleId = sampleOrder.eqaCycleId || "";
@@ -31,18 +33,54 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
       if (componentMounted.current && Array.isArray(response)) {
         setMyPrograms(response);
       }
+      if (componentMounted.current) setListsLoaded((n) => n + 1);
     });
 
     getFromOpenElisServer("/rest/eqa/cycles/mine", (response) => {
       if (componentMounted.current && Array.isArray(response)) {
         setCycles(response);
       }
+      if (componentMounted.current) setListsLoaded((n) => n + 1);
     });
 
     return () => {
       componentMounted.current = false;
     };
   }, []);
+
+  // "Receive panel" on My Cycles deep-links here with the cycle in the query
+  // string. Once both lists have answered, preselect that cycle and the
+  // enrollment whose programme name matches the cycle's scheme; an explicit
+  // enrollmentId in the link wins over the name match. Fields the user has
+  // already filled are left alone.
+  useEffect(() => {
+    if (listsLoaded < 2) {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const linkedCycleId = params.get("cycleId");
+    if (!linkedCycleId) {
+      return;
+    }
+    const cycle = cycles.find((c) => String(c.id) === linkedCycleId);
+    if (!cycle) {
+      return;
+    }
+    const linkedEnrollmentId = params.get("enrollmentId");
+    const enrollment = linkedEnrollmentId
+      ? myPrograms.find((prog) => String(prog.id) === linkedEnrollmentId)
+      : myPrograms.find((prog) => prog.programName === cycle.schemeName);
+    setOrderFormValues((prev) => ({
+      ...prev,
+      sampleOrderItems: {
+        ...prev?.sampleOrderItems,
+        eqaCycleId: prev?.sampleOrderItems?.eqaCycleId || String(cycle.id),
+        eqaProgramId:
+          prev?.sampleOrderItems?.eqaProgramId ||
+          (enrollment ? String(enrollment.id) : ""),
+      },
+    }));
+  }, [listsLoaded]);
 
   // A receipt already on file makes this a read-only view: saving again is a
   // no-op server-side, so re-offering the fields would only mislead.

--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -407,7 +407,11 @@ const MyCyclesPage = () => {
               <Button
                 size="sm"
                 kind="tertiary"
-                onClick={() => history.push("/SamplePatientEntry?isEQA=true")}
+                onClick={() =>
+                  history.push(
+                    `/SamplePatientEntry?isEQA=true&cycleId=${cycle.id}`,
+                  )
+                }
               >
                 {t("eqa.btn.receivePanel", "Receive panel — open Add Order")}
               </Button>

--- a/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
+++ b/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
@@ -2,7 +2,8 @@ import React from "react";
 import { render, screen, within, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
 import messages from "../../../../languages/en.json";
 import MyCyclesPage from "../MyCyclesPage";
 import { MOCK_CYCLES } from "../mockCycles";
@@ -74,6 +75,32 @@ describe("MyCyclesPage", () => {
     // submitted / scored / closed stay out of the Active bucket
     expect(screen.queryByTestId("cycle-row-3")).not.toBeInTheDocument();
     expect(screen.queryByTestId("cycle-row-4")).not.toBeInTheDocument();
+  });
+
+  test("Receive panel deep-links to Add Order with the cycle in the query string", () => {
+    const planned = {
+      ...MOCK_CYCLES[0],
+      id: 9,
+      status: "PLANNED",
+      participantState: "PLANNED",
+      samples: [],
+    };
+    const history = createMemoryHistory();
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url.startsWith("/rest/eqa/cycles/mine")) cb([planned]);
+      if (url.startsWith("/rest/eqa/orders")) cb([]);
+    });
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <Router history={history}>
+          <MyCyclesPage />
+        </Router>
+      </IntlProvider>,
+    );
+    fireEvent.click(screen.getByTestId("cycle-row-9"));
+    fireEvent.click(screen.getByRole("button", { name: /Receive panel/i }));
+    expect(history.location.pathname).toBe("/SamplePatientEntry");
+    expect(history.location.search).toBe("?isEQA=true&cycleId=9");
   });
 
   test("row expansion reveals sample progress with result-entry deep links", () => {

--- a/frontend/src/components/eqa/__tests__/EQAOrderForm.test.jsx
+++ b/frontend/src/components/eqa/__tests__/EQAOrderForm.test.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../languages/en.json";
+import EQAOrderForm from "../EQAOrderForm";
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+vi.mock("../../utils/Utils", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getFromOpenElisServer: vi.fn() };
+});
+vi.mock("../../common/CustomDatePicker", () => ({
+  default: function MockDatePicker() {
+    return <div data-testid="datepicker" />;
+  },
+}));
+
+const PROGRAMS = [
+  { id: 7, programName: "CPHL National HIV Viral Load EQA" },
+  { id: 8, programName: "CPHL National HIV Serology EQA" },
+];
+const CYCLES = [
+  {
+    id: 12,
+    cycleName: "Round 1",
+    schemeName: "CPHL National HIV Viral Load EQA",
+  },
+  {
+    id: 13,
+    cycleName: "Round 2",
+    schemeName: "CPHL National HIV Serology EQA",
+  },
+];
+
+const Harness = () => {
+  const [orderFormValues, setOrderFormValues] = useState({
+    sampleOrderItems: {},
+  });
+  return (
+    <EQAOrderForm
+      orderFormValues={orderFormValues}
+      setOrderFormValues={setOrderFormValues}
+    />
+  );
+};
+
+const renderForm = (search) => {
+  window.history.pushState({}, "", `/SamplePatientEntry${search}`);
+  getFromOpenElisServer.mockImplementation((url, cb) => {
+    if (url.startsWith("/rest/eqa/my-programs")) cb(PROGRAMS);
+    else if (url.startsWith("/rest/eqa/cycles/mine")) cb(CYCLES);
+  });
+  return render(
+    <IntlProvider locale="en" messages={messages}>
+      <Harness />
+    </IntlProvider>,
+  );
+};
+
+const cycleSelect = () => screen.findByLabelText(messages["eqa.order.cycle"]);
+const programmeSelect = () =>
+  screen.findByLabelText(messages["eqa.order.programme"]);
+
+describe("EQAOrderForm deep link from My Cycles", () => {
+  test("preselects the linked cycle and the enrollment whose programme matches its scheme", async () => {
+    renderForm("?isEQA=true&cycleId=12");
+    expect(await cycleSelect()).toHaveValue("12");
+    expect(await programmeSelect()).toHaveValue("7");
+  });
+
+  test("an explicit enrollmentId on the link wins over the name match", async () => {
+    renderForm("?isEQA=true&cycleId=12&enrollmentId=8");
+    expect(await cycleSelect()).toHaveValue("12");
+    expect(await programmeSelect()).toHaveValue("8");
+  });
+
+  test("without a linked cycle both selects start empty", async () => {
+    renderForm("?isEQA=true");
+    expect(await cycleSelect()).toHaveValue("");
+    expect(await programmeSelect()).toHaveValue("");
+  });
+});


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

The **Receive panel** action on My Cycles opened Add Order with only the EQA flag set, so the receiving technician had to find the programme and the cycle again by hand. The link now carries the cycle id; on the programme step the EQA order section preselects that cycle and the enrollment whose programme name matches the cycle's scheme, once both lists have loaded. An explicit `enrollmentId` on the link takes precedence, and fields the user has already filled are left alone.

## Tests

- New `EQAOrderForm.test.jsx` (3): preselect by name, explicit enrollment wins, nothing preselected without a link. Inversion run against the unchanged form fails exactly the two preselect tests.
- `MyCyclesPage.test.jsx` gains a test asserting the pushed URL. 15 tests green.
- Live on the dev stack: a planned cycle → **Receive panel** → Add Order at `?isEQA=true&cycleId=…`, programme step shows cycle and programme preselected.

## Related Issue

[OGC-610](https://uwdigi.atlassian.net/browse/OGC-610)

## Other

Frontend only. Independent of the other EQA UAT-fix PRs.


[OGC-610]: https://uwdigi.atlassian.net/browse/OGC-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ