### PR TITLE
feat(shipment): optional scheduled poll for inbound FHIR consignments (OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
@@ -40,6 +40,7 @@ import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -93,6 +94,22 @@ public class ShipmentFhirImportService {
      */
     @Value("${org.openelisglobal.shipment.import.maxAgeDays:30}")
     private int importMaxAgeDays;
+
+    /**
+     * Off by default: the consignment import stays a button on the Reception screen
+     * unless the deployment turns the poll on. It then runs on the same cadence as
+     * the delivery reconcile below.
+     */
+    @Value("${org.openelisglobal.shipment.import.scheduled:false}")
+    private boolean importScheduled;
+
+    /**
+     * The scheduled poll goes through the proxy so pollAndImportShipments keeps
+     * its @Async and @Transactional behaviour; a plain self-call would bypass both.
+     */
+    @Autowired
+    @Lazy
+    private ShipmentFhirImportService self;
 
     private boolean statusBackflowEnabled() {
         return remoteStoreUpdateStatus.isPresent() && remoteStoreUpdateStatus.get();
@@ -434,6 +451,20 @@ public class ShipmentFhirImportService {
      * transaction, so a fault mid-loop keeps every box already applied and the next
      * run picks up the rest.
      */
+    /**
+     * Scheduled counterpart of the Reception screen's Import from FHIR button,
+     * enabled by {@code org.openelisglobal.shipment.import.scheduled=true}. A
+     * participant laboratory then sees a dispatched consignment within one poll
+     * with nobody clicking; with the property unset nothing changes.
+     */
+    @Scheduled(initialDelay = 45 * 1000, fixedRateString = "${org.openelisglobal.remote.poll.frequency:120000}")
+    public void importShipmentsOnSchedule() {
+        if (!importScheduled) {
+            return;
+        }
+        self.pollAndImportShipments();
+    }
+
     @Scheduled(initialDelay = 30 * 1000, fixedRateString = "${org.openelisglobal.remote.poll.frequency:120000}")
     public void reconcileDeliveredShipments() {
         if (!statusBackflowEnabled()) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,8 @@ facilitylist.schedule.fixedRate=864000000
 #org.openelisglobal.remote.source.uri=http://185.218.126.190:5001/fhir/
 #org.openelisglobal.remote.source.identifier=Practitioner/738185ba-eac9-11e5-8f4d-e06995eac916
 #org.openelisglobal.remote.poll.frequency=120000
+# Poll the remote store for inbound consignments on the same cadence (default: manual import only)
+#org.openelisglobal.shipment.import.scheduled=false
 #org.openelisglobal.remote.source.updateStatus=false
 #org.openelisglobal.task.useBasedOn=true
 #org.openelisglobal.fhirstore.username=openelis

--- a/src/test/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportScheduleTest.java
+++ b/src/test/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportScheduleTest.java
@@ -1,0 +1,34 @@
+package org.openelisglobal.shipment.fhir;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The scheduled consignment import is a deployment choice: unset, the poll must
+ * not run at all; set, each pass hands off to the same import the Reception
+ * screen's button uses.
+ */
+public class ShipmentFhirImportScheduleTest {
+
+    @Test
+    public void scheduledImportStaysOffUnlessTheDeploymentTurnsItOn() {
+        ShipmentFhirImportService service = spy(new ShipmentFhirImportService());
+        ReflectionTestUtils.setField(service, "self", service);
+        doNothing().when(service).pollAndImportShipments();
+
+        ReflectionTestUtils.setField(service, "importScheduled", false);
+        service.importShipmentsOnSchedule();
+        verify(service, never()).pollAndImportShipments();
+
+        ReflectionTestUtils.setField(service, "importScheduled", true);
+        service.importShipmentsOnSchedule();
+        service.importShipmentsOnSchedule();
+        verify(service, times(2)).pollAndImportShipments();
+    }
+}


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

Importing a consignment from the remote FHIR store was only ever a button on the Reception screen, so a participant laboratory saw a dispatched box only when someone remembered to click. With `org.openelisglobal.shipment.import.scheduled=true` the same import also runs on the delivery-reconcile cadence (`org.openelisglobal.remote.poll.frequency`); left unset, nothing changes. The scheduled call goes through the bean proxy so the import keeps its asynchronous, transactional behaviour. A boolean on the existing cadence was chosen over a millisecond property because a zero `fixedDelay` would spin.

## Tests

- `ShipmentFhirImportScheduleTest`: off → the import is never called; on → called per pass.
- `EQAShipmentWorkbenchIntegrationTest` 43 green, which also boots the lazy self-injection without a bean cycle.
- Live on the dev stack with the property set: the poll ran at boot and every 120 s with nobody clicking (log lines against the configured remote).

## Related Issue

[OGC-613](https://uwdigi.atlassian.net/browse/OGC-613)

## Other

Documented beside `remote.poll.frequency` in `application.properties`. Independent of the other EQA UAT-fix PRs.


[OGC-613]: https://uwdigi.atlassian.net/browse/OGC-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ