### PR TITLE
feat(eqa): participant cycles from consignments and from My Cycles; scope My Cycles to this lab (OGC-610)

### DIFF
--- a/docs/workplan/eqa-interaction.md
+++ b/docs/workplan/eqa-interaction.md
@@ -5,8 +5,8 @@ Workplan, and the one rule that keeps blinding intact.
 
 ## What the Workplan shows
 
-An in-house blinded panel (EQA V2.4, OGC-612) is distributed as standard
-orders. Each order's accession number is the panel sample's blind code
+An in-house blinded panel (EQA V2.4, OGC-612) is distributed as standard orders.
+Each order's accession number is the panel sample's blind code
 (`IH-{panel}-{nn}`), so the Workplan lists the order under that code in the
 sample column, exactly as it lists any other order. Nothing about the row
 reveals the panel, the analyte's target value, or the acceptance range: those
@@ -17,24 +17,23 @@ result-entry page renders). The badge marks the row as proficiency-testing
 material; it does not say which panel or scheme it belongs to.
 
 The analyst assigned to a blinded sample sees it in the Workplan and on the
-result-entry page like any other work and enters the result through the
-standard pipeline. Scoring happens later, at unblind, against the sealed
-target (see `docs/eqa/analyst-competency-rules.md` for what a scored result
-means for the analyst).
+result-entry page like any other work and enters the result through the standard
+pipeline. Scoring happens later, at unblind, against the sealed target (see
+`docs/eqa/analyst-competency-rules.md` for what a scored result means for the
+analyst).
 
 ## The rule: never add an "exclude EQA" filter
 
-FR-V2.4-15 requires blinded orders to sit among routine work. The Workplan
-must not grow a filter, tab, or default that hides EQA rows: an analyst who
-could tell a proficiency sample from a patient sample by where it appears
-would defeat the blinding. Filters that already exist (test section, priority,
-date) apply to EQA rows the same way they apply to everything else.
+FR-V2.4-15 requires blinded orders to sit among routine work. The Workplan must
+not grow a filter, tab, or default that hides EQA rows: an analyst who could
+tell a proficiency sample from a patient sample by where it appears would defeat
+the blinding. Filters that already exist (test section, priority, date) apply to
+EQA rows the same way they apply to everything else.
 
 The EQA badge is deliberately the only EQA-specific element on the row. It
-exists so a supervisor reviewing the Workplan can account for the material;
-it stays acceptable because the analyst working the row is also the one who
-will be scored on it, so knowing it is EQA material grants no advantage on
-the value.
+exists so a supervisor reviewing the Workplan can account for the material; it
+stays acceptable because the analyst working the row is also the one who will be
+scored on it, so knowing it is EQA material grants no advantage on the value.
 
 ## Unblinding and timing
 
@@ -43,9 +42,8 @@ distributed panel on its first pass after midnight of that date, or a holder of
 `qa.eqa.inhouse.unblind` does it earlier with **Unblind now**. Results entered
 after the unblind are still scored, but the participant result is flagged
 `MISSED_DEADLINE` and the analyst receives an `IN_HOUSE_MISSED_DEADLINE`
-competency event. The Workplan does not change at unblind; the orders stay
-where they are until they finish through the normal result and validation
-steps.
+competency event. The Workplan does not change at unblind; the orders stay where
+they are until they finish through the normal result and validation steps.
 
 ## Where to look
 

--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -19,8 +19,10 @@ import {
   TableBody,
   TableCell,
   Loading,
+  Modal,
+  TextInput,
 } from "@carbon/react";
-import { ChevronDown, ChevronUp, Download } from "@carbon/react/icons";
+import { Add, ChevronDown, ChevronUp, Download } from "@carbon/react/icons";
 import { useIntl } from "react-intl";
 import { Link as RouterLink, useHistory } from "react-router-dom";
 import config from "../../../config.json";
@@ -32,7 +34,12 @@ import {
   kpiLabelStyle,
   kpiValueStyle,
 } from "../eqaCommon";
-import { fetchMyCycles, submitCycle } from "./cyclesApi";
+import {
+  createMyCycle,
+  fetchMyCycles,
+  fetchMyPrograms,
+  submitCycle,
+} from "./cyclesApi";
 
 const breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -135,6 +142,52 @@ const MyCyclesPage = () => {
   const [typeFilter, setTypeFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [submitNotice, setSubmitNotice] = useState(null);
+
+  // "New cycle": a participant records a cycle for a provider that does not
+  // send consignments to this OpenELIS (FR-V2.2-09). Consignments from an
+  // OpenELIS provider open their cycle on import, so this is the fallback.
+  const EMPTY_NEW_CYCLE = {
+    schemeName: "",
+    cycleName: "",
+    distributionDate: "",
+    submissionDeadline: "",
+  };
+  const [newCycleOpen, setNewCycleOpen] = useState(false);
+  const [newCycle, setNewCycle] = useState(EMPTY_NEW_CYCLE);
+  const [myPrograms, setMyPrograms] = useState([]);
+  const [newCycleError, setNewCycleError] = useState(null);
+  const [newCycleNotice, setNewCycleNotice] = useState(null);
+  const [savingCycle, setSavingCycle] = useState(false);
+
+  const openNewCycle = () => {
+    setNewCycleError(null);
+    setNewCycle(EMPTY_NEW_CYCLE);
+    fetchMyPrograms(setMyPrograms);
+    setNewCycleOpen(true);
+  };
+
+  const handleCreateCycle = () => {
+    setSavingCycle(true);
+    setNewCycleError(null);
+    createMyCycle(newCycle, (result) => {
+      setSavingCycle(false);
+      if (!result.ok) {
+        setNewCycleError(
+          result.error ||
+            t("eqa.cycle.new.error", "Could not create the cycle"),
+        );
+        return;
+      }
+      setNewCycleOpen(false);
+      setNewCycleNotice(
+        t(
+          "eqa.cycle.new.created",
+          'Cycle created. It is listed as Planned; use "Receive panel" when the panel arrives.',
+        ),
+      );
+      fetchMyCycles(setCycles);
+    });
+  };
 
   useEffect(() => {
     fetchMyCycles((data) => {
@@ -444,6 +497,24 @@ const MyCyclesPage = () => {
                 "Cycles your lab is participating in. Result entry and validation happen in the standard OpenELIS result pipeline — this page tracks progress and routes you there.",
               )}
             </p>
+            <Button
+              kind="tertiary"
+              size="sm"
+              renderIcon={Add}
+              onClick={openNewCycle}
+              style={{ marginBottom: "1rem" }}
+            >
+              {t("eqa.btn.newCycle", "New cycle")}
+            </Button>
+            {newCycleNotice && (
+              <InlineNotification
+                kind="success"
+                lowContrast
+                title={newCycleNotice}
+                onCloseButtonClick={() => setNewCycleNotice(null)}
+                style={{ marginBottom: "1rem" }}
+              />
+            )}
           </Section>
 
           <Grid condensed style={{ marginBottom: "1.5rem" }}>
@@ -740,6 +811,98 @@ const MyCyclesPage = () => {
           )}
         </Column>
       </Grid>
+
+      {newCycleOpen && (
+        <Modal
+          open
+          size="sm"
+          modalHeading={t("eqa.cycle.new.heading", "New EQA cycle")}
+          primaryButtonText={t("eqa.cycle.new.create", "Create cycle")}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={
+            savingCycle ||
+            !newCycle.schemeName ||
+            !newCycle.cycleName.trim() ||
+            !newCycle.submissionDeadline
+          }
+          onRequestClose={() => setNewCycleOpen(false)}
+          onSecondarySubmit={() => setNewCycleOpen(false)}
+          onRequestSubmit={handleCreateCycle}
+        >
+          <p style={{ color: "#525252", marginBottom: "1rem" }}>
+            {t(
+              "eqa.cycle.new.help",
+              'For a provider that does not send consignments to this OpenELIS: record the cycle the panel belongs to so it appears here with "Receive panel". Consignments from an OpenELIS provider open their cycle on import.',
+            )}
+          </p>
+          {newCycleError && (
+            <InlineNotification
+              kind="error"
+              lowContrast
+              hideCloseButton
+              title={newCycleError}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          <Select
+            id="new-cycle-scheme"
+            labelText={t(
+              "eqa.cycle.new.scheme",
+              "Programme (from My Programs)",
+            )}
+            helperText={
+              myPrograms.length === 0
+                ? t(
+                    "eqa.cycle.new.noPrograms",
+                    "Enroll in a programme under My Programs first.",
+                  )
+                : undefined
+            }
+            value={newCycle.schemeName}
+            onChange={(e) =>
+              setNewCycle({ ...newCycle, schemeName: e.target.value })
+            }
+          >
+            <SelectItem value="" text="" />
+            {myPrograms.map((prog) => (
+              <SelectItem
+                key={prog.id}
+                value={prog.programName}
+                text={prog.programName}
+              />
+            ))}
+          </Select>
+          <TextInput
+            id="new-cycle-name"
+            labelText={t("eqa.cycle.new.name", "Cycle name")}
+            value={newCycle.cycleName}
+            onChange={(e) =>
+              setNewCycle({ ...newCycle, cycleName: e.target.value })
+            }
+            style={{ marginTop: "1rem" }}
+          />
+          <TextInput
+            id="new-cycle-distribution"
+            type="date"
+            labelText={t("eqa.cycle.new.distributionDate", "Distribution date")}
+            value={newCycle.distributionDate}
+            onChange={(e) =>
+              setNewCycle({ ...newCycle, distributionDate: e.target.value })
+            }
+            style={{ marginTop: "1rem" }}
+          />
+          <TextInput
+            id="new-cycle-deadline"
+            type="date"
+            labelText={t("eqa.cycle.new.deadline", "Submission deadline")}
+            value={newCycle.submissionDeadline}
+            onChange={(e) =>
+              setNewCycle({ ...newCycle, submissionDeadline: e.target.value })
+            }
+            style={{ marginTop: "1rem" }}
+          />
+        </Modal>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
+++ b/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
@@ -10,11 +10,13 @@ import { MOCK_CYCLES } from "../mockCycles";
 import {
   getFromOpenElisServer,
   patchToOpenElisServerJsonResponse,
+  postToOpenElisServerFullResponse,
 } from "../../../utils/Utils";
 
 vi.mock("../../../utils/Utils", () => ({
   getFromOpenElisServer: vi.fn(),
   patchToOpenElisServerJsonResponse: vi.fn(),
+  postToOpenElisServerFullResponse: vi.fn(),
 }));
 
 vi.mock("../../../common/PageBreadCrumb", () => ({
@@ -37,6 +39,8 @@ const renderPage = (orders = UNCYCLED_ORDERS, cycles = MOCK_CYCLES) => {
   getFromOpenElisServer.mockImplementation((url, cb) => {
     if (url.startsWith("/rest/eqa/cycles/mine")) cb(cycles);
     if (url.startsWith("/rest/eqa/orders")) cb(orders);
+    if (url.startsWith("/rest/eqa/my-programs"))
+      cb([{ id: 7, programName: "CPHL National HIV Viral Load EQA" }]);
   });
   return render(
     <IntlProvider locale="en" messages={messages}>
@@ -101,6 +105,65 @@ describe("MyCyclesPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /Receive panel/i }));
     expect(history.location.pathname).toBe("/SamplePatientEntry");
     expect(history.location.search).toBe("?isEQA=true&cycleId=9");
+  });
+
+  test("New cycle posts the enrolled programme, name and deadline, then confirms", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /New cycle/i }));
+    fireEvent.change(screen.getByLabelText("Programme (from My Programs)"), {
+      target: { value: "CPHL National HIV Viral Load EQA" },
+    });
+    fireEvent.change(screen.getByLabelText("Cycle name"), {
+      target: { value: "Round 9" },
+    });
+    fireEvent.change(screen.getByLabelText("Submission deadline"), {
+      target: { value: "2026-09-30" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create cycle" }));
+
+    expect(postToOpenElisServerFullResponse).toHaveBeenCalledTimes(1);
+    const [url, body, callback] =
+      postToOpenElisServerFullResponse.mock.calls[0];
+    expect(url).toBe("/rest/eqa/cycles/mine");
+    expect(JSON.parse(body)).toEqual({
+      schemeName: "CPHL National HIV Viral Load EQA",
+      cycleName: "Round 9",
+      distributionDate: "",
+      submissionDeadline: "2026-09-30",
+    });
+
+    callback({
+      ok: true,
+      json: () =>
+        Promise.resolve({ id: 99, cycleName: "Round 9", status: "PLANNED" }),
+    });
+    expect(await screen.findByText(/Cycle created/)).toBeInTheDocument();
+  });
+
+  test("New cycle shows the server's refusal instead of a false success", async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /New cycle/i }));
+    fireEvent.change(screen.getByLabelText("Programme (from My Programs)"), {
+      target: { value: "CPHL National HIV Viral Load EQA" },
+    });
+    fireEvent.change(screen.getByLabelText("Cycle name"), {
+      target: { value: "Round 9" },
+    });
+    fireEvent.change(screen.getByLabelText("Submission deadline"), {
+      target: { value: "2026-09-30" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create cycle" }));
+    const callback = postToOpenElisServerFullResponse.mock.calls[0][2];
+    callback({
+      ok: false,
+      statusText: "Unprocessable Entity",
+      json: () =>
+        Promise.resolve({ error: "This laboratory is not enrolled in X" }),
+    });
+    expect(
+      await screen.findByText("This laboratory is not enrolled in X"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Cycle created/)).toBeNull();
   });
 
   test("row expansion reveals sample progress with result-entry deep links", () => {

--- a/frontend/src/components/eqa/MyCycles/cyclesApi.js
+++ b/frontend/src/components/eqa/MyCycles/cyclesApi.js
@@ -7,6 +7,7 @@
 import {
   getFromOpenElisServer,
   patchToOpenElisServerJsonResponse,
+  postToOpenElisServerFullResponse,
 } from "../../utils/Utils";
 
 const toViewModel = (dto) => ({
@@ -42,5 +43,40 @@ export const submitCycle = (cycleId, callback) => {
       reason: "Participant review & submit from My Cycles",
     }),
     (response) => callback(response ? toViewModel(response) : null),
+  );
+};
+
+// Programmes this lab has enrolled in (My Programs); the "New cycle" form
+// offers exactly these, by name, because the participant-created cycle is
+// matched to a local programme of the same name on the server.
+export const fetchMyPrograms = (callback) => {
+  getFromOpenElisServer("/rest/eqa/my-programs", (data) =>
+    callback(Array.isArray(data) ? data : []),
+  );
+};
+
+// Participant-created cycle for a provider that is not an OpenELIS instance
+// (FR-V2.2-09). The server answers 4xx with an {error} body when the lab is
+// not enrolled or no local programme carries the name, so the raw response
+// is inspected rather than trusting any JSON as success.
+export const createMyCycle = (body, callback) => {
+  postToOpenElisServerFullResponse(
+    "/rest/eqa/cycles/mine",
+    JSON.stringify(body),
+    (response) => {
+      response
+        .json()
+        .catch(() => ({}))
+        .then((payload) => {
+          if (response.ok) {
+            callback({ ok: true, cycle: toViewModel(payload) });
+          } else {
+            callback({
+              ok: false,
+              error: payload?.error || payload?.message || response.statusText,
+            });
+          }
+        });
+    },
   );
 };

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8523,5 +8523,16 @@
   "eqa.provider.schemes.participantOnly.title": "Participant view only",
   "eqa.provider.schemes.participantOnly.body": "Provider scheme administration needs the provider grant. Your lab's participation lives on the pages below.",
   "eqa.provider.schemes.link.myPrograms": "My enrollments — schemes this lab takes part in",
-  "eqa.provider.schemes.link.myCycles": "My Cycles — panels, results and deadlines"
+  "eqa.provider.schemes.link.myCycles": "My Cycles — panels, results and deadlines",
+  "eqa.btn.newCycle": "New cycle",
+  "eqa.cycle.new.heading": "New EQA cycle",
+  "eqa.cycle.new.help": "For a provider that does not send consignments to this OpenELIS: record the cycle the panel belongs to so it appears here with \"Receive panel\". Consignments from an OpenELIS provider open their cycle on import.",
+  "eqa.cycle.new.scheme": "Programme (from My Programs)",
+  "eqa.cycle.new.name": "Cycle name",
+  "eqa.cycle.new.distributionDate": "Distribution date",
+  "eqa.cycle.new.deadline": "Submission deadline",
+  "eqa.cycle.new.create": "Create cycle",
+  "eqa.cycle.new.created": "Cycle created. It is listed as Planned; use \"Receive panel\" when the panel arrives.",
+  "eqa.cycle.new.error": "Could not create the cycle",
+  "eqa.cycle.new.noPrograms": "Enroll in a programme under My Programs first."
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -3,9 +3,11 @@ package org.openelisglobal.eqa.controller.rest;
 import jakarta.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
@@ -16,6 +18,7 @@ import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQACycleService.PanelSampleRequest;
 import org.openelisglobal.eqa.service.EQACycleService.ProviderCycleRequest;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
 import org.openelisglobal.eqa.service.EQAReportCommentService;
 import org.openelisglobal.eqa.service.SampleEQAService;
@@ -23,7 +26,10 @@ import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQADistributionMethod;
+import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQAPanelSourceType;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQAStorageTemp;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
@@ -72,11 +78,12 @@ public class EQACycleRestController extends BaseRestController {
     private final EQAPerformanceReportPDFService performanceReportService;
     private final EQAReportCommentService reportCommentService;
     private final SystemUserService systemUserService;
+    private final EQALabProgramEnrollmentService enrollmentService;
 
     public EQACycleRestController(EQACycleService cycleService, SampleEQAService sampleEQAService,
             SampleService sampleService, AnalysisService analysisService, ResultService resultService,
             EQAPerformanceReportPDFService performanceReportService, EQAReportCommentService reportCommentService,
-            SystemUserService systemUserService) {
+            SystemUserService systemUserService, EQALabProgramEnrollmentService enrollmentService) {
         this.cycleService = cycleService;
         this.sampleEQAService = sampleEQAService;
         this.sampleService = sampleService;
@@ -85,6 +92,7 @@ public class EQACycleRestController extends BaseRestController {
         this.performanceReportService = performanceReportService;
         this.reportCommentService = reportCommentService;
         this.systemUserService = systemUserService;
+        this.enrollmentService = enrollmentService;
     }
 
     /**
@@ -182,16 +190,68 @@ public class EQACycleRestController extends BaseRestController {
      */
     @GetMapping(value = "/cycles/mine", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Map<String, Object>> myCycles(@RequestParam(required = false) Long labEnrollmentId) {
+        // FR-V2.2-09: the cycles this laboratory takes part in — programmes it has
+        // enrolled in (My Programs), its own in-house cycles, and any cycle that
+        // already carries one of its EQA orders. A provider's outbound cycles have
+        // their own board and are not "mine".
+        Set<String> enrolledNames = new HashSet<>();
+        for (EQALabProgramEnrollment enrollment : enrollmentService.findActiveEnrollments()) {
+            if (enrollment.getProgramName() != null) {
+                enrolledNames.add(enrollment.getProgramName().trim().toLowerCase());
+            }
+        }
         List<Map<String, Object>> rows = new ArrayList<>();
         for (EQACycle cycle : cycleService.getAll()) {
             Map<String, Object> dto = toCycleDto(cycle);
             addSampleProgress(dto, cycle.getId());
+            if (!participatesIn(cycle, enrolledNames, dto)) {
+                continue;
+            }
             if (labEnrollmentId != null) {
                 dto.put("participantState", cycleService.deriveParticipantState(cycle, labEnrollmentId).name());
             }
             rows.add(dto);
         }
         return rows;
+    }
+
+    private static boolean participatesIn(EQACycle cycle, Set<String> enrolledNames, Map<String, Object> dto) {
+        EQAProgram scheme = cycle.getScheme();
+        if (scheme != null && scheme.getSchemeType() == EQASchemeType.IN_HOUSE) {
+            return true;
+        }
+        if (scheme != null && scheme.getName() != null
+                && enrolledNames.contains(scheme.getName().trim().toLowerCase())) {
+            return true;
+        }
+        Object samples = dto.get("samples");
+        return samples instanceof List<?> linked && !linked.isEmpty();
+    }
+
+    /**
+     * FR-V2.2-09, the participant's own way in: a cycle for a programme this lab
+     * has enrolled in, for a provider that does not send consignments to an
+     * OpenELIS. The programme is named, not numbered, because that is all an
+     * enrollment carries; it must exist locally under the same name.
+     */
+    @PostMapping(value = "/cycles/mine", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PARTICIPANT)
+    @ResponseStatus(HttpStatus.CREATED)
+    public Map<String, Object> createMyCycle(HttpServletRequest request, @RequestBody Map<String, Object> body) {
+        String schemeName = stringField(body, "schemeName");
+        if (schemeName == null) {
+            throw new IllegalArgumentException("A cycle needs a programme");
+        }
+        boolean enrolled = enrollmentService.findActiveEnrollments().stream()
+                .anyMatch(e -> e.getProgramName() != null && e.getProgramName().trim().equalsIgnoreCase(schemeName));
+        if (!enrolled) {
+            throw new IllegalArgumentException("This laboratory is not enrolled in " + schemeName);
+        }
+        EQACycle cycle = cycleService.ensureParticipantCycle(schemeName, null, stringField(body, "cycleName"),
+                dateField(body, "distributionDate"), dateField(body, "submissionDeadline"), getSysUserId(request))
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No programme named '" + schemeName + "' exists on this instance; add it under EQA Programs"));
+        return toCycleDto(cycle);
     }
 
     /**

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleService.java
@@ -3,6 +3,7 @@ package org.openelisglobal.eqa.service;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.util.List;
+import java.util.Optional;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
@@ -94,6 +95,18 @@ public interface EQACycleService extends BaseObjectService<EQACycle, Long> {
      *                                  repeats
      */
     EQACycle createProviderCycle(ProviderCycleRequest request, String sysUserId);
+
+    /**
+     * Participant side of a cycle: the local cycle that a consignment from an
+     * OpenELIS provider, or a lab user filling the My Cycles form, names by scheme
+     * name. Matched to a local programme of that exact name; when
+     * {@code cycleNumber} is given and that cycle already exists it is returned
+     * unchanged, so an import poll can run repeatedly. A new cycle is PLANNED and,
+     * when a deadline is known, carries round 1 with it so the 7/3/1-day digest and
+     * the reports see it. Empty when no local programme carries the name.
+     */
+    Optional<EQACycle> ensureParticipantCycle(String schemeName, Integer cycleNumber, String cycleName,
+            Date distributionDate, Date submissionDeadline, String sysUserId);
 
     /**
      * What the wizard collects, in step order: 1 cycle details, 2 panel samples +

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.validator.GenericValidator;
@@ -177,6 +178,42 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         cycle.setSysUserId(sysUserId);
         cycle.setId(eqaCycleDAO.insert(cycle));
         return cycle;
+    }
+
+    @Override
+    @Transactional
+    public Optional<EQACycle> ensureParticipantCycle(String schemeName, Integer cycleNumber, String cycleName,
+            Date distributionDate, Date submissionDeadline, String sysUserId) {
+        if (GenericValidator.isBlankOrNull(schemeName)) {
+            return Optional.empty();
+        }
+        EQAProgram scheme = eqaProgramService.getAllMatching("name", schemeName.trim()).stream().findFirst()
+                .orElse(null);
+        if (scheme == null) {
+            return Optional.empty();
+        }
+        if (cycleNumber != null) {
+            for (EQACycle existing : eqaCycleDAO.getAllMatching("scheme.id", scheme.getId())) {
+                if (cycleNumber.equals(existing.getCycleNumber())) {
+                    return Optional.of(existing);
+                }
+            }
+        }
+        EQACycle cycle = create(scheme.getId(), cycleNumber, cycleName, distributionDate, submissionDeadline, null,
+                sysUserId);
+        if (submissionDeadline != null) {
+            EQARound round = new EQARound();
+            round.setFhirUuid(UUID.randomUUID());
+            round.setCycle(cycle);
+            round.setRoundNumber(1);
+            if (distributionDate != null) {
+                round.setDistributionDate(new Timestamp(distributionDate.getTime()));
+            }
+            round.setSubmissionDeadline(new Timestamp(submissionDeadline.getTime()));
+            round.setSysUserId(sysUserId);
+            eqaRoundDAO.insert(round);
+        }
+        return Optional.of(cycle);
     }
 
     private static Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {

--- a/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShipmentFhirImportService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.r4.model.BaseDateTimeType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IntegerType;
@@ -23,7 +24,9 @@ import org.hl7.fhir.r4.model.SupplyDelivery.SupplyDeliveryStatus;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAShipmentService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.shipment.dao.ShippingBoxDAO;
@@ -330,6 +333,8 @@ public class ShipmentFhirImportService {
                 return false;
             }
 
+            linkParticipantCycle(box, delivery);
+
             shippingBoxDAO.insert(box);
             LogEvent.logInfo(this.getClass().getSimpleName(), "importSupplyDelivery",
                     "Imported shipment box: " + boxId + " with state IN_TRANSIT");
@@ -584,6 +589,58 @@ public class ShipmentFhirImportService {
                     "Could not serialise imported contents: " + e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * A consignment from an OpenELIS provider names the EQA cycle it belongs to.
+     * Open (or find) the local cycle of the same scheme name and number and link
+     * the box to it, so My Cycles offers "Receive panel" and the Add Order receipt
+     * can point at this consignment. A lab that has no programme of that name gets
+     * the box without a cycle, and a failure here never blocks the import.
+     */
+    private void linkParticipantCycle(ShippingBox box, SupplyDelivery delivery) {
+        Extension ext = delivery.getExtensionByUrl(ShippingBoxFhirTransform.EXT_EQA_CYCLE);
+        if (ext == null) {
+            return;
+        }
+        try {
+            String schemeName = subExtensionString(ext, "scheme");
+            Integer number = subExtensionInteger(ext, "number");
+            java.sql.Date distribution = subExtensionDate(ext, "distributionDate");
+            java.sql.Date deadline = subExtensionDate(ext, "submissionDeadline");
+            Optional<EQACycle> cycle = SpringContext.getBean(EQACycleService.class).ensureParticipantCycle(schemeName,
+                    number, subExtensionString(ext, "name"), distribution, deadline,
+                    String.valueOf(getAutomatedImportUserId()));
+            if (cycle.isPresent()) {
+                box.setEqaCycleId(cycle.get().getId());
+                LogEvent.logInfo(this.getClass().getSimpleName(), "linkParticipantCycle", "Consignment "
+                        + box.getBoxId() + " belongs to EQA cycle " + cycle.get().getId() + " (" + schemeName + ")");
+            } else {
+                LogEvent.logWarn(this.getClass().getSimpleName(), "linkParticipantCycle",
+                        "Consignment " + box.getBoxId() + " names EQA programme '" + schemeName
+                                + "' but this laboratory has no programme of that name — imported without a cycle");
+            }
+        } catch (Exception e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "linkParticipantCycle",
+                    "Consignment " + box.getBoxId() + " imported without its EQA cycle: " + e.getMessage());
+        }
+    }
+
+    private static String subExtensionString(Extension parent, String url) {
+        Extension ext = parent.getExtensionByUrl(url);
+        return ext != null && ext.getValue() instanceof StringType st ? st.getValue() : null;
+    }
+
+    private static Integer subExtensionInteger(Extension parent, String url) {
+        Extension ext = parent.getExtensionByUrl(url);
+        return ext != null && ext.getValue() instanceof IntegerType it ? it.getValue() : null;
+    }
+
+    private static java.sql.Date subExtensionDate(Extension parent, String url) {
+        Extension ext = parent.getExtensionByUrl(url);
+        return ext != null && ext.getValue() instanceof BaseDateTimeType dt && dt.getValue() != null
+                ? new java.sql.Date(dt.getValue().getTime())
+                : null;
     }
 
     private String extractExtensionString(SupplyDelivery delivery, String url) {

--- a/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DateType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
@@ -21,6 +22,8 @@ import org.hl7.fhir.r4.model.SupplyDelivery.SupplyDeliverySuppliedItemComponent;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
 import org.openelisglobal.shipment.dao.BoxSampleItemDAO;
 import org.openelisglobal.shipment.valueholder.BoxSampleItem;
@@ -56,6 +59,13 @@ public class ShippingBoxFhirTransform {
      * panel material too, which has no Specimen resource and so no EXT_SPECIMEN.
      */
     public static final String EXT_CONTENT_ITEM = "http://openelis.org/fhir/extension/shipment-content-item";
+    /**
+     * The EQA cycle a provider consignment belongs to — scheme name, cycle number
+     * and name, distribution date, submission deadline — so a participant OpenELIS
+     * can open the matching local cycle on import instead of waiting for a REST
+     * call.
+     */
+    public static final String EXT_EQA_CYCLE = "http://openelis.org/fhir/extension/eqa-cycle";
     /** Anchor for the contained Location the destination reference points at. */
     static final String CONTAINED_DESTINATION_ID = "destination-facility";
 
@@ -190,7 +200,34 @@ public class ShippingBoxFhirTransform {
         // Extensions — specimen references and type summary
         addSpecimenExtensions(supplyDelivery, boxSampleItems);
 
+        addEqaCycleExtension(supplyDelivery, box);
+
         return supplyDelivery;
+    }
+
+    private void addEqaCycleExtension(SupplyDelivery supplyDelivery, ShippingBox box) {
+        if (box.getEqaCycleId() == null) {
+            return;
+        }
+        EQACycle cycle = SpringContext.getBean(EQACycleService.class).get(box.getEqaCycleId());
+        if (cycle == null || cycle.getScheme() == null) {
+            return;
+        }
+        Extension ext = new Extension(EXT_EQA_CYCLE);
+        ext.addExtension(new Extension("scheme", new StringType(cycle.getScheme().getName())));
+        if (cycle.getCycleNumber() != null) {
+            ext.addExtension(new Extension("number", new IntegerType(cycle.getCycleNumber())));
+        }
+        if (cycle.getCycleName() != null) {
+            ext.addExtension(new Extension("name", new StringType(cycle.getCycleName())));
+        }
+        if (cycle.getPlannedStartDate() != null) {
+            ext.addExtension(new Extension("distributionDate", new DateType(cycle.getPlannedStartDate())));
+        }
+        if (cycle.getPlannedEndDate() != null) {
+            ext.addExtension(new Extension("submissionDeadline", new DateType(cycle.getPlannedEndDate())));
+        }
+        supplyDelivery.addExtension(ext);
     }
 
     /**

--- a/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
@@ -14,6 +14,7 @@ import org.openelisglobal.common.services.IStatusService;
 import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
 import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
 import org.openelisglobal.eqa.service.EQAReportCommentService;
 import org.openelisglobal.eqa.service.SampleEQAService;
@@ -62,6 +63,8 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
 
     @Autowired
     private EQAReportCommentService reportCommentService;
+    @Autowired
+    private EQALabProgramEnrollmentService enrollmentService;
 
     // eqa.controller.* is excluded from the test component scan — construct it
     private EQACycleRestController controller;
@@ -71,7 +74,7 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     public void setUp() throws Exception {
         super.setUp();
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, performanceReportService, reportCommentService, systemUserService);
+                resultService, performanceReportService, reportCommentService, systemUserService, enrollmentService);
         ensureStatusRows();
         cleanupSeed();
     }
@@ -110,6 +113,8 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     @Test
     public void myCyclesCarriesSchemeDisplayFieldsAndEmptyProgress() {
         EQAProgram scheme = insertScheme("Enrichment scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "NHRL");
+        // An external cycle is "mine" only for a programme this lab has enrolled in.
+        seedEnrollment(9951, scheme.getName());
         Long cycleId = insertCycle(scheme, 3);
 
         Map<String, Object> row = findCycleRow(cycleId);
@@ -131,6 +136,8 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     @Test
     public void reviewGatedSchemeCarriesReportedValueAndValidationTime() {
         EQAProgram scheme = insertScheme("Gated scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "NHRL");
+        // An external cycle is "mine" only for a programme this lab has enrolled in.
+        seedEnrollment(9952, scheme.getName());
         scheme.setRequiresCycleReview(true);
         scheme.setSysUserId(USER);
         eqaProgramService.update(scheme);

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -243,7 +243,7 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
         // AppTestConfig excludes eqa.controller.* from the scan, so the endpoint
         // is exercised as a plain object over the real services it composes.
         EQACycleRestController controller = new EQACycleRestController(cycleService, null, null, null, null, null, null,
-                systemUserService);
+                systemUserService, null);
         List<Map<String, Object>> rows = controller.transitions(cycle.getId());
         assertEquals("Grace Achieng", rows.get(0).get("triggeredByName"));
         assertNull("an automatic transition resolves to no actor name", rows.get(1).get("triggeredByName"));

--- a/src/test/java/org/openelisglobal/eqa/EQAParticipantCycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAParticipantCycleIntegrationTest.java
@@ -1,0 +1,276 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.SupplyDelivery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.analysis.service.AnalysisService;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
+import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
+import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
+import org.openelisglobal.eqa.service.EQAReportCommentService;
+import org.openelisglobal.eqa.service.SampleEQAService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.result.service.ResultService;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.shipment.fhir.ShipmentFhirImportService;
+import org.openelisglobal.shipment.fhir.ShippingBoxFhirTransform;
+import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * The participant side of a cycle (OGC-610): a consignment from an OpenELIS
+ * provider names its cycle and the import opens the matching local one; a lab
+ * whose provider is not an OpenELIS records the cycle itself from My Cycles;
+ * and My Cycles lists only the cycles this laboratory takes part in.
+ */
+public class EQAParticipantCycleIntegrationTest extends EQASpineTestBase {
+
+    private static final long ORG_ID = 9970L;
+    private static final String ORG_NAME = "Participant lab 9970";
+
+    @Autowired
+    private EQACycleService cycleService;
+    @Autowired
+    private EQALabProgramEnrollmentService enrollmentService;
+    @Autowired
+    private ShipmentFhirImportService importService;
+    @Autowired
+    private ShippingBoxFhirTransform transform;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @Autowired
+    private SampleEQAService sampleEQAService;
+    @Autowired
+    private SampleService sampleService;
+    @Autowired
+    private AnalysisService analysisService;
+    @Autowired
+    private ResultService resultService;
+    @Autowired
+    private EQAPerformanceReportPDFService reportService;
+    @Autowired
+    private EQAReportCommentService reportCommentService;
+
+    @Before
+    public void seedOrganization() {
+        jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                + " VALUES (?, ?, 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING", ORG_ID, ORG_NAME);
+    }
+
+    @After
+    public void cleanConsignments() {
+        // Imported boxes reference the cycles the base class clears afterwards.
+        jdbc.update("DELETE FROM clinlims.shipping_box WHERE box_id LIKE 'PCYC-%'");
+        jdbc.update("DELETE FROM clinlims.organization WHERE id = ?", ORG_ID);
+    }
+
+    @Test
+    public void aNamedConsignmentCycleIsOpenedOnceWithItsDeadline() {
+        EQAProgram scheme = insertScheme("Participant scheme A", EQASchemeType.REGIONAL_PT, "CPHL");
+        Date distribution = Date.valueOf("2026-09-01");
+        Date deadline = Date.valueOf("2026-09-15");
+
+        EQACycle cycle = cycleService
+                .ensureParticipantCycle("Participant scheme A", 7, "Round 7", distribution, deadline, USER)
+                .orElseThrow(AssertionError::new);
+
+        assertEquals(Integer.valueOf(7), cycle.getCycleNumber());
+        assertEquals("Round 7", cycle.getCycleName());
+        assertEquals(EQACycleStatus.PLANNED, cycle.getStatus());
+        assertEquals(scheme.getId(), cycle.getScheme().getId());
+        assertEquals("2026-09-15",
+                jdbc.queryForObject("SELECT submission_deadline::date::text FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        String.class, cycle.getId()));
+        assertEquals("2026-09-01",
+                jdbc.queryForObject("SELECT distribution_date::date::text FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        String.class, cycle.getId()));
+
+        // The import poll runs every few minutes: the same consignment must land on
+        // the same cycle, and a second round must not appear.
+        EQACycle again = cycleService
+                .ensureParticipantCycle("Participant scheme A", 7, "Round 7 (repeat)", distribution, deadline, USER)
+                .orElseThrow(AssertionError::new);
+        assertEquals(cycle.getId(), again.getId());
+        assertEquals(Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_cycle WHERE scheme_id = ?", Integer.class, scheme.getId()));
+        assertEquals(Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_round WHERE cycle_id = ?", Integer.class, cycle.getId()));
+
+        assertFalse("a programme this instance does not know opens nothing",
+                cycleService.ensureParticipantCycle("No such programme", 1, null, null, deadline, USER).isPresent());
+    }
+
+    @Test
+    public void anImportedConsignmentThatNamesItsCycleLinksTheBoxToTheLocalCycle() {
+        insertScheme("Participant scheme B", EQASchemeType.REGIONAL_PT, "CPHL");
+        String boxCode = "PCYC-" + System.nanoTime();
+        SupplyDelivery delivery = deliveryFor(boxCode);
+        delivery.addExtension(cycleExtension("Participant scheme B", 3, "Round 3"));
+
+        assertTrue("the consignment imports", importService.importSupplyDelivery(delivery));
+
+        Long linked = jdbc.queryForObject("SELECT eqa_cycle_id FROM clinlims.shipping_box WHERE box_id = ?", Long.class,
+                boxCode);
+        assertNotNull("the imported box is linked to a cycle", linked);
+        Map<String, Object> cycle = jdbc
+                .queryForMap("SELECT cycle_number, cycle_name, status FROM clinlims.eqa_cycle WHERE id = ?", linked);
+        assertEquals(3, ((Number) cycle.get("cycle_number")).intValue());
+        assertEquals("Round 3", cycle.get("cycle_name"));
+        assertEquals("PLANNED", cycle.get("status"));
+        assertEquals("2026-09-15",
+                jdbc.queryForObject("SELECT submission_deadline::date::text FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        String.class, linked));
+    }
+
+    @Test
+    public void aConsignmentForAnUnknownProgrammeStillImportsWithoutACycle() {
+        String boxCode = "PCYC-" + System.nanoTime();
+        SupplyDelivery delivery = deliveryFor(boxCode);
+        delivery.addExtension(cycleExtension("Programme nobody here runs", 1, "Ghost round"));
+
+        assertTrue(importService.importSupplyDelivery(delivery));
+
+        assertNull(jdbc.queryForObject("SELECT eqa_cycle_id FROM clinlims.shipping_box WHERE box_id = ?", Long.class,
+                boxCode));
+        assertEquals(Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_cycle WHERE cycle_name = 'Ghost round'", Integer.class));
+    }
+
+    @Test
+    public void anEqaBoxExportsTheCycleItBelongsTo() {
+        EQAProgram scheme = insertScheme("Provider scheme C", EQASchemeType.REGIONAL_PT, "CPHL");
+        Long cycleId = insertCycle(scheme, 2);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET cycle_name = 'Round 2', planned_start_date = '2026-09-01',"
+                + " planned_end_date = '2026-09-15' WHERE id = ?", cycleId);
+        ShippingBox box = new ShippingBox();
+        box.setBoxId("PCYC-EXPORT");
+        box.setState(BoxState.SENT);
+        box.setEqaCycleId(cycleId);
+        box.setCreatedDate(new Timestamp(System.currentTimeMillis()));
+
+        SupplyDelivery delivery = new TransactionTemplate(transactionManager)
+                .execute(tx -> transform.transformToSupplyDelivery(box));
+
+        Extension ext = delivery.getExtensionByUrl(ShippingBoxFhirTransform.EXT_EQA_CYCLE);
+        assertNotNull("an EQA box names its cycle", ext);
+        assertEquals("Provider scheme C", ((StringType) ext.getExtensionByUrl("scheme").getValue()).getValue());
+        assertEquals(2, ((IntegerType) ext.getExtensionByUrl("number").getValue()).getValue().intValue());
+        assertEquals("Round 2", ((StringType) ext.getExtensionByUrl("name").getValue()).getValue());
+        assertEquals("2026-09-01",
+                ((DateType) ext.getExtensionByUrl("distributionDate").getValue()).getValueAsString());
+        assertEquals("2026-09-15",
+                ((DateType) ext.getExtensionByUrl("submissionDeadline").getValue()).getValueAsString());
+    }
+
+    @Test
+    public void myCyclesListsEnrolledInHouseAndNotProviderOnlyCycles() {
+        EQAProgram enrolled = insertScheme("Enrolled scheme D", EQASchemeType.REGIONAL_PT, "CPHL");
+        seedEnrollment(9953, "Enrolled scheme D");
+        EQAProgram inHouse = insertScheme("Own in-house scheme E", EQASchemeType.IN_HOUSE, null);
+        EQAProgram foreign = insertScheme("Provider-only scheme F", EQASchemeType.REGIONAL_PT, "CPHL");
+        Long mine = insertCycle(enrolled, 1);
+        Long ours = insertCycle(inHouse, 1);
+        Long theirs = insertCycle(foreign, 1);
+
+        Set<Long> listed = controller().myCycles(null).stream().map(row -> ((Number) row.get("id")).longValue())
+                .collect(Collectors.toSet());
+
+        assertTrue("an enrolled programme's cycle is mine", listed.contains(mine));
+        assertTrue("our own in-house cycle is mine", listed.contains(ours));
+        assertFalse("a cycle of a programme this lab has not enrolled in is not", listed.contains(theirs));
+    }
+
+    @Test
+    public void aParticipantCreatesACycleOnlyForAProgrammeItHasEnrolledIn() {
+        insertScheme("Enrolled scheme G", EQASchemeType.REGIONAL_PT, "CPHL");
+        seedEnrollment(9954, "Enrolled scheme G");
+        insertScheme("Not enrolled scheme H", EQASchemeType.REGIONAL_PT, "CPHL");
+
+        Map<String, Object> dto = controller().createMyCycle(requestForUser(),
+                Map.of("schemeName", "Enrolled scheme G", "cycleName", "Round 1", "submissionDeadline", "2026-09-30"));
+
+        assertEquals("PLANNED", dto.get("status"));
+        assertEquals("Round 1", dto.get("cycleName"));
+        Long cycleId = ((Number) dto.get("id")).longValue();
+        assertEquals("2026-09-30",
+                jdbc.queryForObject("SELECT submission_deadline::date::text FROM clinlims.eqa_round WHERE cycle_id = ?",
+                        String.class, cycleId));
+        assertTrue("the new cycle is listed on My Cycles", controller().myCycles(null).stream()
+                .anyMatch(row -> cycleId.equals(((Number) row.get("id")).longValue())));
+
+        try {
+            controller().createMyCycle(requestForUser(), Map.of("schemeName", "Not enrolled scheme H", "cycleName",
+                    "Round 1", "submissionDeadline", "2026-09-30"));
+            fail("a programme the lab has not enrolled in must be refused");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("not enrolled"));
+        }
+        assertEquals(Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_cycle c"
+                        + " JOIN clinlims.eqa_program p ON p.id = c.scheme_id WHERE p.name = 'Not enrolled scheme H'",
+                        Integer.class));
+    }
+
+    // ---- helpers ----
+
+    private EQACycleRestController controller() {
+        return new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService, resultService,
+                reportService, reportCommentService, systemUserService, enrollmentService);
+    }
+
+    private MockHttpServletRequest requestForUser() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId(Integer.parseInt(USER));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession(true).setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
+        return request;
+    }
+
+    private SupplyDelivery deliveryFor(String boxCode) {
+        SupplyDelivery delivery = new SupplyDelivery();
+        delivery.setId(java.util.UUID.randomUUID().toString());
+        delivery.addIdentifier().setSystem("http://openelis.org/shipment/box-id").setValue(boxCode);
+        delivery.setOccurrence(new DateTimeType(new java.util.Date()));
+        delivery.setDestination(new Reference().setDisplay(ORG_NAME));
+        return delivery;
+    }
+
+    private Extension cycleExtension(String schemeName, int number, String name) {
+        Extension ext = new Extension(ShippingBoxFhirTransform.EXT_EQA_CYCLE);
+        ext.addExtension(new Extension("scheme", new StringType(schemeName)));
+        ext.addExtension(new Extension("number", new IntegerType(number)));
+        ext.addExtension(new Extension("name", new StringType(name)));
+        ext.addExtension(new Extension("distributionDate", new DateType(Date.valueOf("2026-09-01"))));
+        ext.addExtension(new Extension("submissionDeadline", new DateType(Date.valueOf("2026-09-15"))));
+        return ext;
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPerformanceReportIntegrationTest.java
@@ -22,6 +22,7 @@ import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.service.EQACycleService;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
 import org.openelisglobal.eqa.service.EQAParticipantResultService;
 import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
 import org.openelisglobal.eqa.service.EQAReportCommentService;
@@ -102,6 +103,8 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
 
     @Autowired
     private EQAReportCommentService reportCommentService;
+    @Autowired
+    private EQALabProgramEnrollmentService enrollmentService;
 
     @Autowired
     private SystemUserService systemUserService;
@@ -135,7 +138,7 @@ public class EQAPerformanceReportIntegrationTest extends EQASpineTestBase {
     @Before
     public void seedCycleWithScores() {
         controller = new EQACycleRestController(cycleService, sampleEQAService, sampleService, analysisService,
-                resultService, reportService, reportCommentService, systemUserService);
+                resultService, reportService, reportCommentService, systemUserService, enrollmentService);
 
         jdbc.update("INSERT INTO clinlims.localization (id, description)"
                 + " SELECT ?, 'EQA Report Section' WHERE NOT EXISTS"

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -69,6 +69,7 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQAAlertRestController#acknowledgeAlert", EQAGuards.LAB_WIDE_ALERTS);
         // Cycle lifecycle
         WRITE_GUARDS.put("EQACycleRestController#createCycle", EQAGuards.MANAGE);
+        WRITE_GUARDS.put("EQACycleRestController#createMyCycle", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQACycleRestController#transition", EQAGuards.MANAGE);
         // OGC-934: commentary on a signed report is a scoring-lane act.
         WRITE_GUARDS.put("EQACycleRestController#attachReportComments", EQAGuards.MANAGE);

--- a/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedMalformedInputTest.java
+++ b/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedMalformedInputTest.java
@@ -71,13 +71,11 @@ public class SystemPresetSeedMalformedInputTest extends BaseWebContextSensitiveT
 
     @After
     public void restoreCanonicalSeed() throws Exception {
-        // Restore the pristine baseline for sibling tests: canonical presets + their
-        // LAB_NUMBER field rows (031 re-run, since clearSystemPresets cascade-deletes
-        // them) + no fixture keys. Shared committed Testcontainer (NOT_SUPPORTED).
-        SystemPresetSeedTest.clearSystemPresets(dataSource);
+        // Restore the pristine baseline for sibling tests: canonical presets, their
+        // LAB_NUMBER field rows, the universality backfill, and no fixture keys.
+        // Shared committed Testcontainer (NOT_SUPPORTED).
         SystemPresetSeedTest.clearBarcodeSiteInformation(dataSource);
-        SystemPresetSeedTest.executeSeedSql(dataSource, SEED_CHANGESET);
-        SystemPresetSeedTest.executeSeedSql(dataSource, SystemPresetSeedTest.FIELD_SEED_CHANGESET);
+        SystemPresetSeedTest.restoreCanonicalSeed(dataSource);
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedTest.java
+++ b/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedTest.java
@@ -72,7 +72,7 @@ import org.w3c.dom.NodeList;
  */
 public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
 
-    private static final String SEED_CHANGESET = "liquibase/3.3.x.x/030-seed-system-presets.xml";
+    static final String SEED_CHANGESET = "liquibase/3.3.x.x/030-seed-system-presets.xml";
     /**
      * Field-seed changeset (031). The Liquibase init run executes 030 THEN 031, so
      * the pristine baseline has every system preset carrying its {@code LAB_NUMBER}
@@ -82,6 +82,14 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
      * {@code label_preset_field}.
      */
     static final String FIELD_SEED_CHANGESET = "liquibase/3.3.x.x/031-seed-system-preset-fields.xml";
+    /**
+     * Universality backfill changeset (032). The seed SQL in 030 inserts every
+     * system preset with {@code is_universal} at its column default of false; 032
+     * is what marks Specimen Label universal. Re-running 030 alone therefore
+     * restores the presets in a state the pristine baseline never had, and every
+     * later reader of the seeded Specimen Label sees a non-universal preset.
+     */
+    static final String UNIVERSAL_BACKFILL_CHANGESET = "liquibase/3.3.x.x/032-label-preset-is-universal.xml";
     private static final String FIXTURE = "fixtures/v1-barcode-config.sql";
 
     /**
@@ -104,18 +112,8 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
 
     @After
     public void restoreCanonicalSeed() throws Exception {
-        // Leave the DB the way the rest of the suite expects: canonical system presets
-        // (built from fallbacks, since no barcode.* keys remain), their LAB_NUMBER
-        // field
-        // rows (re-seeded via 031, since clearSystemPresets cascade-deleted them), and
-        // no
-        // fixture keys. The Testcontainer is shared + committed (NOT_SUPPORTED), so
-        // this
-        // restore protects sibling tests that read label_preset / label_preset_field.
-        clearSystemPresets();
         clearBarcodeSiteInformation();
-        runRealSeedChangesetSql();
-        executeSeedSql(dataSource, FIELD_SEED_CHANGESET);
+        restoreCanonicalSeed(dataSource);
     }
 
     @Test
@@ -147,6 +145,44 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
                 "seed must read fixture dimensions, not fallbacks — "
                         + "Specimen Label width should not equal the canonical fallback " + FALLBACK_WIDTH,
                 isWidthEqual("Specimen Label", FALLBACK_WIDTH));
+    }
+
+    /**
+     * The restore this class runs after every test is what sibling classes read for
+     * the rest of the suite, so it must reproduce the whole init run and not just
+     * the insert half. Re-running 030 alone leaves Specimen Label at the column
+     * default of false, and the aggregation tests that assert the universal column
+     * then fail depending only on surefire ordering.
+     */
+    @Test
+    public void restoreCanonicalSeed_leavesSpecimenLabelUniversal() throws Exception {
+        clearSystemPresets();
+
+        restoreCanonicalSeed(dataSource);
+
+        assertEquals("restore must re-apply the universality backfill, not only the preset insert", Boolean.TRUE,
+                isSpecimenLabelUniversal());
+        assertEquals("restore must leave exactly one seeded Specimen Label", 1, countSeededSpecimenLabels());
+    }
+
+    private Boolean isSpecimenLabelUniversal() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement("SELECT is_universal FROM clinlims.label_preset"
+                        + " WHERE is_system = true AND name = 'Specimen Label'");
+                ResultSet rs = stmt.executeQuery()) {
+            assertTrue("the seeded Specimen Label preset must exist after a restore", rs.next());
+            return rs.getBoolean(1);
+        }
+    }
+
+    private int countSeededSpecimenLabels() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement("SELECT COUNT(*) FROM clinlims.label_preset"
+                        + " WHERE is_system = true AND name = 'Specimen Label'");
+                ResultSet rs = stmt.executeQuery()) {
+            rs.next();
+            return rs.getInt(1);
+        }
     }
 
     @Test
@@ -246,38 +282,75 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
     // ----------------------------------------------------------------------------------------------
 
     static void executeSeedSql(DataSource dataSource, String changesetPath) throws Exception {
-        String seedSql = extractSeedSql(changesetPath);
+        executeChangesetSql(dataSource, changesetPath, "INSERT INTO");
+    }
+
+    /** Runs the {@code UPDATE} block of a changeset, such as 032's backfill. */
+    static void executeUpdateSql(DataSource dataSource, String changesetPath) throws Exception {
+        executeChangesetSql(dataSource, changesetPath, "UPDATE CLINLIMS.LABEL_PRESET");
+    }
+
+    private static void executeChangesetSql(DataSource dataSource, String changesetPath, String statementKeyword)
+            throws Exception {
+        String sql = extractChangesetSql(changesetPath, statementKeyword);
         try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.execute(seedSql);
+            stmt.execute(sql);
         }
     }
 
-    /**
-     * Parses the changeset XML and returns the text of its (single) {@code <sql>}
-     * child. Reads the production artifact so the executed SQL is never a copy.
-     */
     static String extractSeedSql(String changesetPath) throws Exception {
+        return extractChangesetSql(changesetPath, "INSERT INTO");
+    }
+
+    /**
+     * Parses the changeset XML and returns the text of the top-level {@code <sql>}
+     * block containing {@code statementKeyword}. Reads the production artifact so
+     * the executed SQL is never a copy. Only {@code <sql>} elements whose parent is
+     * a {@code <changeSet>} are considered, so a {@code <rollback>} carrying the
+     * inverse statement never matches.
+     */
+    static String extractChangesetSql(String changesetPath, String statementKeyword) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         ClassPathResource resource = new ClassPathResource(changesetPath);
         try (InputStream in = resource.getInputStream()) {
             NodeList sqlNodes = builder.parse(in).getElementsByTagNameNS("*", "sql");
-            // The seed changeset contains exactly one top-level <sql> insert block;
-            // <rollback>
-            // wraps its own <sql>, so filter to the element whose parent is a <changeSet>.
+            // <rollback> wraps its own <sql> and carries the inverse statement, so
+            // filter to the elements whose parent is a <changeSet> before matching on
+            // the keyword.
             for (int i = 0; i < sqlNodes.getLength(); i++) {
                 Element sql = (Element) sqlNodes.item(i);
                 String parentLocal = sql.getParentNode().getLocalName();
                 if (parentLocal != null && parentLocal.equals("changeSet")) {
                     String text = sql.getTextContent();
-                    if (text != null && text.toUpperCase().contains("INSERT INTO")) {
+                    if (text != null && text.toUpperCase().contains(statementKeyword)) {
                         return text;
                     }
                 }
             }
-            throw new IllegalStateException("No top-level <sql> INSERT block found in changeset " + changesetPath);
+            throw new IllegalStateException(
+                    "No top-level <sql> " + statementKeyword + " block found in changeset " + changesetPath);
         }
+    }
+
+    /**
+     * Rebuilds the canonical system presets the way the Liquibase init run leaves
+     * them, for a test that cleared them: 030 re-inserts the presets, 031 re-adds
+     * the LAB_NUMBER field rows {@link #clearSystemPresets(DataSource)}
+     * cascade-deleted, and 032 re-marks Specimen Label universal.
+     *
+     * <p>
+     * The Testcontainer is shared and committed ({@code NOT_SUPPORTED}), so an
+     * incomplete restore is not local damage — it is the state every later test
+     * class in the run reads. Add the matching call here whenever a new changeset
+     * conditions the seeded presets.
+     */
+    static void restoreCanonicalSeed(DataSource dataSource) throws Exception {
+        clearSystemPresets(dataSource);
+        executeSeedSql(dataSource, SEED_CHANGESET);
+        executeSeedSql(dataSource, FIELD_SEED_CHANGESET);
+        executeUpdateSql(dataSource, UNIVERSAL_BACKFILL_CHANGESET);
     }
 
     static void clearSystemPresets(DataSource dataSource) throws Exception {

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorRangesIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorRangesIntegrationTest.java
@@ -247,8 +247,14 @@ public class TestCatalogEditorRangesIntegrationTest extends BaseWebContextSensit
     public void saveRanges_preservesDictionaryLimitsAndReportingBounds() {
         // The Ranges editor manages only NUMERIC ranges. Seed a non-numeric
         // (dictionary) limit via the service — it must survive a ranges save.
-        Long dictTypeId = jdbc
-                .queryForObject("SELECT id FROM clinlims.type_of_test_result WHERE test_result_type = 'D'", Long.class);
+        // MIN(id), not a bare lookup by code: the Testcontainer is shared across the
+        // suite, and a fixture that remaps this vocabulary to ids of its own
+        // (result-limit.xml loads Dictionary as id 203) leaves the canonical seed row
+        // alongside the fixture's, so a bare lookup returns two rows and this test
+        // fails on surefire ordering alone. The canonical seed always holds the lower
+        // id, and it is the row ResultLimitServiceImpl cached at startup.
+        Long dictTypeId = jdbc.queryForObject(
+                "SELECT MIN(id) FROM clinlims.type_of_test_result WHERE test_result_type = 'D'", Long.class);
         org.openelisglobal.resultlimits.valueholder.ResultLimit dict = new org.openelisglobal.resultlimits.valueholder.ResultLimit();
         dict.setTestId(testId());
         dict.setResultTypeId(String.valueOf(dictTypeId));


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

A participant laboratory had no way to get an external programme's cycle onto My Cycles except a REST call, and My Cycles listed every cycle on the instance, including a provider's outbound ones.

- **Consignments carry their cycle.** The SupplyDelivery export gains an extension (scheme name, cycle number and name, distribution date, submission deadline) when the box belongs to an EQA cycle. On import the participant opens the matching local cycle by programme name — once; the poll repeats — with round 1 carrying the deadline, and links the imported box to it (`shipping_box.eqa_cycle_id`). A lab with no programme of that name imports the box without a cycle, logged.
- **New cycle form.** `POST /rest/eqa/cycles/mine` (participant grant, registered in the guard matrix) takes a programme *name* from My Programs and refuses one the lab has not enrolled in; My Cycles gains a "New cycle" modal for providers that are not an OpenELIS instance. A dedicated route rather than loosening `POST /rest/eqa/cycles`, so a bench user cannot open cycles on provider schemes.
- **Scope.** `GET /rest/eqa/cycles/mine` lists cycles of enrolled programmes, the lab's own in-house cycles, and any cycle already carrying one of its EQA orders.

No schema change.

## Tests

- New `EQAParticipantCycleIntegrationTest` (6): create-once with deadline and round; import links the box; unknown programme imports without a cycle; export carries the cycle; scoping; participant create refuses an un-enrolled programme.
- Jest: the modal posts the body and shows the server's refusal instead of a false success.
- Enrichment, state-machine, performance-report, guard-matrix, security-slice and shipment-workbench suites green (103). Two enrichment tests now enroll the lab in the scheme they read, which is the real precondition.
- Live on the dev stack with the instance's own HAPI as the "remote": My Cycles dropped provider-only cycles; the form created a planned cycle offering **Receive panel**; a SupplyDelivery placed in the store with the extension was imported as a box linked to a newly opened cycle that appeared on My Cycles after the lab enrolled in that programme.

## Related Issue

[OGC-610](https://uwdigi.atlassian.net/browse/OGC-610)

## Other

Merge before the FHIR-exchange PR (it appends to the same `base-changelog.xml` and `en.json` tails; the conflicts are trivial).


[OGC-610]: https://uwdigi.atlassian.net/browse/OGC-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ