### PR TITLE
feat(eqa): provider result intake and cross-instance exchange over the provider's FHIR store (OGC-610, OGC-613)

### DIFF
--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -182,7 +182,7 @@ const MyCyclesPage = () => {
   };
 
   // "New cycle": a participant records a cycle for a provider that does not
-  // send consignments to this OpenELIS (FR-V2.2-09). Consignments from an
+  // send consignments to this OpenELIS. Consignments from an
   // OpenELIS provider open their cycle on import, so this is the fallback.
   const EMPTY_NEW_CYCLE = {
     schemeName: "",

--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -20,6 +20,7 @@ import {
   TableCell,
   Loading,
   Modal,
+  TextArea,
   TextInput,
 } from "@carbon/react";
 import { Add, ChevronDown, ChevronUp, Download } from "@carbon/react/icons";
@@ -38,6 +39,7 @@ import {
   createMyCycle,
   fetchMyCycles,
   fetchMyPrograms,
+  importScoresCsv,
   submitCycle,
 } from "./cyclesApi";
 
@@ -142,6 +144,42 @@ const MyCyclesPage = () => {
   const [typeFilter, setTypeFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [submitNotice, setSubmitNotice] = useState(null);
+
+  // Scores from a provider that is not an OpenELIS arrive as a file; a provider
+  // OpenELIS delivers them through the FHIR store on its own.
+  const [scoreImport, setScoreImport] = useState(null);
+  const [importNotice, setImportNotice] = useState(null);
+
+  const handleImportScores = () => {
+    setScoreImport({ ...scoreImport, busy: true, error: null });
+    importScoresCsv(scoreImport.cycle.id, scoreImport.csv, (result) => {
+      if (!result.ok) {
+        setScoreImport({
+          ...scoreImport,
+          busy: false,
+          error:
+            result.error ||
+            t("eqa.cycle.importScores.failed", "Could not import the scores"),
+        });
+        return;
+      }
+      setScoreImport(null);
+      setImportNotice(
+        t("eqa.cycle.importScores.imported", "{count} scores recorded.", {
+          count: result.scored,
+        }) +
+          (result.unmapped.length
+            ? " " +
+              t(
+                "eqa.cycle.importScores.unmapped",
+                "Not recognised here: {names}",
+                { names: result.unmapped.join(", ") },
+              )
+            : ""),
+      );
+      fetchMyCycles(setCycles);
+    });
+  };
 
   // "New cycle": a participant records a cycle for a provider that does not
   // send consignments to this OpenELIS (FR-V2.2-09). Consignments from an
@@ -269,7 +307,20 @@ const MyCyclesPage = () => {
 
   const renderExpanded = (cycle) => (
     <div style={{ padding: "0.5rem 0" }}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}
+      >
+        {cycle.status === "submitted" && (
+          <Button
+            kind="ghost"
+            size="sm"
+            onClick={() =>
+              setScoreImport({ cycle, csv: "", error: null, busy: false })
+            }
+          >
+            {t("eqa.cycle.importScores", "Import scores (CSV)")}
+          </Button>
+        )}
         <Button
           kind="ghost"
           size="sm"
@@ -491,6 +542,15 @@ const MyCyclesPage = () => {
             <Heading>
               {t("eqa.participant.myCycles.title", "My EQA Cycles")}
             </Heading>
+            {importNotice && (
+              <InlineNotification
+                kind="success"
+                lowContrast
+                title={importNotice}
+                onCloseButtonClick={() => setImportNotice(null)}
+                style={{ marginBottom: "1rem" }}
+              />
+            )}
             <p style={{ color: "#525252", marginBottom: "1rem" }}>
               {t(
                 "eqa.participant.myCycles.subtitle",
@@ -900,6 +960,50 @@ const MyCyclesPage = () => {
               setNewCycle({ ...newCycle, submissionDeadline: e.target.value })
             }
             style={{ marginTop: "1rem" }}
+          />
+        </Modal>
+      )}
+      {scoreImport && (
+        <Modal
+          open
+          size="sm"
+          modalHeading={t(
+            "eqa.cycle.importScores.heading",
+            "Import the provider's scores",
+          )}
+          primaryButtonText={t(
+            "eqa.cycle.importScores.import",
+            "Import scores",
+          )}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={scoreImport.busy || !scoreImport.csv.trim()}
+          onRequestClose={() => setScoreImport(null)}
+          onSecondarySubmit={() => setScoreImport(null)}
+          onRequestSubmit={handleImportScores}
+        >
+          <p style={{ color: "#525252", marginBottom: "1rem" }}>
+            {t(
+              "eqa.cycle.importScores.help",
+              "Paste the scores CSV the provider sent (analyte_name and performance_status columns). Scores from a provider OpenELIS arrive on their own through the FHIR store.",
+            )}
+          </p>
+          {scoreImport.error && (
+            <InlineNotification
+              kind="error"
+              lowContrast
+              hideCloseButton
+              title={scoreImport.error}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          <TextArea
+            id="score-import-csv"
+            labelText={t("eqa.cycle.importScores.csv", "Scores CSV")}
+            value={scoreImport.csv}
+            onChange={(e) =>
+              setScoreImport({ ...scoreImport, csv: e.target.value })
+            }
+            rows={5}
           />
         </Modal>
       )}

--- a/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
+++ b/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
@@ -166,6 +166,44 @@ describe("MyCyclesPage", () => {
     expect(screen.queryByText(/Cycle created/)).toBeNull();
   });
 
+  test("Import scores (CSV) posts the pasted file for a submitted cycle and reports the outcome", async () => {
+    const submitted = {
+      ...MOCK_CYCLES[0],
+      id: 9,
+      status: "SUBMITTED",
+      participantState: "SUBMITTED",
+      samples: [],
+    };
+    renderPage(UNCYCLED_ORDERS, [submitted]);
+    // A submitted cycle sits outside the default in-flight bucket.
+    fireEvent.change(document.getElementById("cycle-bucket-filter"), {
+      target: { value: "all" },
+    });
+    fireEvent.click(screen.getByTestId("cycle-row-9"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Import scores (CSV)" }),
+    );
+    fireEvent.change(screen.getByLabelText("Scores CSV"), {
+      target: { value: "analyte_name,performance_status\nHIV VL,ACCEPTABLE" },
+    });
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb({
+        ok: true,
+        json: () => Promise.resolve({ scored: 1, unmapped: ["Ghost"] }),
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Import scores" }));
+
+    const [url, body] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(url).toBe("/rest/eqa/cycles/9/score-intake/csv");
+    expect(JSON.parse(body)).toEqual({
+      csv: "analyte_name,performance_status\nHIV VL,ACCEPTABLE",
+    });
+    expect(
+      await screen.findByText(/1 scores recorded\. Not recognised here: Ghost/),
+    ).toBeInTheDocument();
+  });
+
   test("row expansion reveals sample progress with result-entry deep links", () => {
     renderPage();
     fireEvent.click(screen.getByTestId("cycle-row-1"));

--- a/frontend/src/components/eqa/MyCycles/cyclesApi.js
+++ b/frontend/src/components/eqa/MyCycles/cyclesApi.js
@@ -55,10 +55,10 @@ export const fetchMyPrograms = (callback) => {
   );
 };
 
-// Participant-created cycle for a provider that is not an OpenELIS instance
-// (FR-V2.2-09). The server answers 4xx with an {error} body when the lab is
-// not enrolled or no local programme carries the name, so the raw response
-// is inspected rather than trusting any JSON as success.
+// Participant-created cycle for a provider that is not an OpenELIS instance.
+// The server answers 4xx with an {error} body when the lab is not enrolled or
+// no local programme carries the name, so the raw response is inspected rather
+// than trusting any JSON as success.
 export const createMyCycle = (body, callback) => {
   postToOpenElisServerFullResponse(
     "/rest/eqa/cycles/mine",
@@ -77,6 +77,29 @@ export const createMyCycle = (body, callback) => {
             });
           }
         });
+    },
+  );
+};
+
+// The provider's scores as a file, for a provider that is not an OpenELIS
+// instance. 400 means the file is unusable and 409 means nothing is left to
+// score, so the raw response is read and neither is mistaken for success.
+export const importScoresCsv = (cycleId, csv, callback) => {
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/score-intake/csv`,
+    JSON.stringify({ csv }),
+    (response) => {
+      response
+        .json()
+        .catch(() => ({}))
+        .then((payload) =>
+          callback({
+            ok: response.ok,
+            scored: payload?.scored,
+            unmapped: payload?.unmapped || [],
+            error: payload?.error || (response.ok ? null : response.statusText),
+          }),
+        );
     },
   );
 };

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -274,7 +274,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
       report(
         response,
         "eqa.score.distributed",
-        "Scores returned over FHIR.",
+        "Scores placed in the FHIR store for the participant to collect.",
         "eqa.score.distributeFailed",
       ),
     );

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -11,6 +11,7 @@ import {
   TableRow,
   Tag,
   TextArea,
+  TextInput,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import { Link as RouterLink } from "react-router-dom";
@@ -18,10 +19,13 @@ import { formatDateOnly, resolveApiErrorMessage } from "../../../utils/Utils";
 import { hintStyle } from "../../eqaCommon";
 import {
   distributeScores,
+  fetchIntake,
   fetchReceiptRows,
   fetchScoreRows,
+  importIntakeCsv,
   markDelivered,
   openSubmissions,
+  saveIntake,
   scoreCycle,
   scoresCsvUrl,
   sendRepeat,
@@ -147,6 +151,109 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.submissionsOpenFailed",
       );
     });
+  };
+
+  // FR-V2.5-03: the provider keys what a participant phoned or emailed, or
+  // pastes the participant's export bundle. Values are kept as reported —
+  // numbers or words such as "Reactive" — and saving overwrites what is on file.
+  const [intake, setIntake] = useState(null);
+
+  const openIntake = (row) => {
+    setBusy(row.organizationId);
+    fetchIntake(cycleId, row.organizationId, (grid) => {
+      setBusy(null);
+      const tests = grid?.tests || [];
+      setIntake({
+        row,
+        tests,
+        values: Object.fromEntries(
+          tests.map((test) => [
+            test.testId,
+            test.reported === null || test.reported === undefined
+              ? ""
+              : String(test.reported),
+          ]),
+        ),
+        csv: "",
+        error: null,
+        imported: null,
+      });
+    });
+  };
+
+  const reportedRows = () =>
+    intake.tests
+      .map((test) => ({
+        testId: test.testId,
+        value: intake.values[test.testId] ?? "",
+      }))
+      .filter((entry) => String(entry.value).trim() !== "");
+
+  const handleSaveIntake = () => {
+    setBusy("intake");
+    saveIntake(
+      cycleId,
+      intake.row.organizationId,
+      reportedRows(),
+      ({ ok, body }) => {
+        setBusy(null);
+        if (!ok) {
+          setIntake({
+            ...intake,
+            error:
+              body?.error ||
+              t("eqa.intake.failed", "Could not record the results"),
+          });
+          return;
+        }
+        setIntake(null);
+        refresh();
+        onNotice({
+          kind: "success",
+          text: t("eqa.intake.saved", "Results recorded for {lab}.", {
+            lab: intake.row.organizationName,
+          }),
+        });
+      },
+    );
+  };
+
+  const handleImportCsv = () => {
+    setBusy("intake");
+    importIntakeCsv(
+      cycleId,
+      intake.row.organizationId,
+      intake.csv,
+      ({ ok, body }) => {
+        setBusy(null);
+        if (!ok) {
+          setIntake({
+            ...intake,
+            error:
+              body?.error ||
+              t("eqa.intake.failed", "Could not record the results"),
+          });
+          return;
+        }
+        const tests = body?.tests || intake.tests;
+        setIntake({
+          ...intake,
+          tests,
+          values: Object.fromEntries(
+            tests.map((test) => [
+              test.testId,
+              test.reported === null || test.reported === undefined
+                ? ""
+                : String(test.reported),
+            ]),
+          ),
+          csv: "",
+          error: (body?.errors || []).length ? body.errors.join(" ") : null,
+          imported: body?.imported ?? 0,
+        });
+        refresh();
+      },
+    );
   };
 
   const handleScore = () => {
@@ -335,6 +442,14 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                           {t("eqa.receipt.sendRepeat", "Send repeat")}
                         </Button>
                       )}
+                      <Button
+                        kind="ghost"
+                        size="sm"
+                        disabled={busy !== null}
+                        onClick={() => openIntake(row)}
+                      >
+                        {t("eqa.intake.enterResults", "Enter results")}
+                      </Button>
                       {score && score.resultCount > 0 && (
                         <>
                           <Button
@@ -361,6 +476,120 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
             </TableBody>
           </Table>
         </>
+      )}
+
+      {intake && (
+        <Modal
+          open
+          size="md"
+          modalHeading={t("eqa.intake.heading", "Results from {lab}", {
+            lab: intake.row.organizationName,
+          })}
+          primaryButtonText={t("eqa.intake.save", "Save results")}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={busy !== null || reportedRows().length === 0}
+          onRequestClose={() => setIntake(null)}
+          onSecondarySubmit={() => setIntake(null)}
+          onRequestSubmit={handleSaveIntake}
+        >
+          <p style={{ ...hintStyle, marginBottom: "1rem" }}>
+            {t(
+              "eqa.intake.help",
+              "Key the values as the participant reported them — numbers, or words such as Reactive. Saving overwrites what is on file for that test.",
+            )}
+          </p>
+          {intake.error && (
+            <InlineNotification
+              kind="error"
+              lowContrast
+              hideCloseButton
+              title={intake.error}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          {intake.imported !== null && (
+            <InlineNotification
+              kind="success"
+              lowContrast
+              hideCloseButton
+              title={t("eqa.intake.imported", "{count} values imported.", {
+                count: intake.imported,
+              })}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          {intake.tests.length === 0 ? (
+            <p style={hintStyle}>
+              {t(
+                "eqa.intake.noTests",
+                "This scheme has no tests assigned yet.",
+              )}
+            </p>
+          ) : (
+            <Table size="sm" data-testid="intake-grid">
+              <TableHead>
+                <TableRow>
+                  <TableHeader>{t("eqa.intake.test", "Test")}</TableHeader>
+                  <TableHeader>
+                    {t("eqa.intake.value", "Reported value")}
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {intake.tests.map((test) => (
+                  <TableRow key={test.testId}>
+                    <TableCell>
+                      {test.testName}
+                      {test.analyteName && (
+                        <div style={hintStyle}>{test.analyteName}</div>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <TextInput
+                        id={`intake-${test.testId}`}
+                        labelText={test.testName}
+                        hideLabel
+                        size="sm"
+                        value={intake.values[test.testId] ?? ""}
+                        onChange={(event) =>
+                          setIntake({
+                            ...intake,
+                            values: {
+                              ...intake.values,
+                              [test.testId]: event.target.value,
+                            },
+                          })
+                        }
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          <TextArea
+            id="intake-csv"
+            labelText={t(
+              "eqa.intake.csv",
+              "Or paste the participant's export bundle (CSV)",
+            )}
+            value={intake.csv}
+            onChange={(event) =>
+              setIntake({ ...intake, csv: event.target.value })
+            }
+            rows={3}
+            style={{ marginTop: "1rem" }}
+          />
+          <Button
+            kind="tertiary"
+            size="sm"
+            disabled={busy !== null || !intake.csv.trim()}
+            onClick={handleImportCsv}
+            style={{ marginTop: "0.5rem" }}
+          >
+            {t("eqa.intake.import", "Import CSV")}
+          </Button>
+        </Modal>
       )}
 
       {openingSubmissions && (

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -153,7 +153,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
     });
   };
 
-  // FR-V2.5-03: the provider keys what a participant phoned or emailed, or
+  // The provider keys what a participant phoned or emailed, or
   // pastes the participant's export bundle. Values are kept as reported —
   // numbers or words such as "Reactive" — and saving overwrites what is on file.
   const [intake, setIntake] = useState(null);

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { waitFor } from "@testing-library/dom";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
@@ -197,5 +197,105 @@ describe("ReceiptMonitor", () => {
         expect.any(Function),
       ),
     );
+  });
+
+  test("Enter results keys a participant's reported values and posts them per test", async () => {
+    renderTab();
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url.includes("/results?organizationId=550")) {
+        cb({
+          cycleId: 9,
+          organizationId: 550,
+          tests: [
+            {
+              testId: 7,
+              testName: "HIV viral load",
+              analyteName: "HIV VL",
+              reported: null,
+            },
+            {
+              testId: 8,
+              testName: "HIV serology",
+              analyteName: "HIV Ab",
+              reported: "Reactive",
+            },
+          ],
+        });
+      } else if (url.includes("/receipts")) cb(RECEIPTS);
+      else if (url.includes("/scores")) cb(SCORES);
+    });
+
+    const mbeya = (await screen.findByText("Mbeya Regional Lab")).closest("tr");
+    fireEvent.click(
+      within(mbeya).getByRole("button", { name: "Enter results" }),
+    );
+
+    expect(
+      await screen.findByText("Results from Mbeya Regional Lab"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("HIV serology")).toHaveValue("Reactive");
+    fireEvent.change(screen.getByLabelText("HIV viral load"), {
+      target: { value: "250" },
+    });
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb(jsonResponse(true, { tests: [] })),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save results" }));
+
+    const [url, body] = postToOpenElisServerFullResponse.mock.calls.at(-1);
+    expect(url).toBe("/rest/eqa/cycles/9/results");
+    expect(JSON.parse(body)).toEqual({
+      organizationId: 550,
+      results: [
+        { testId: 7, value: "250" },
+        { testId: 8, value: "Reactive" },
+      ],
+    });
+  });
+
+  test("Import CSV posts the pasted export bundle and reports what did not map", async () => {
+    renderTab();
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url.includes("/results?organizationId=550")) {
+        cb({
+          tests: [{ testId: 7, testName: "HIV viral load", reported: null }],
+        });
+      } else if (url.includes("/receipts")) cb(RECEIPTS);
+      else if (url.includes("/scores")) cb(SCORES);
+    });
+    const mbeya = (await screen.findByText("Mbeya Regional Lab")).closest("tr");
+    fireEvent.click(
+      within(mbeya).getByRole("button", { name: "Enter results" }),
+    );
+    await screen.findByText("Results from Mbeya Regional Lab");
+
+    fireEvent.change(
+      screen.getByLabelText("Or paste the participant's export bundle (CSV)"),
+      {
+        target: { value: "analyte_name,result_value\nHIV VL,250\nGhost,1" },
+      },
+    );
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb(
+        jsonResponse(true, {
+          imported: 1,
+          errors: ["Row 3: no test in this scheme reports 'Ghost'"],
+          tests: [{ testId: 7, testName: "HIV viral load", reported: 250 }],
+        }),
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+
+    const [url, body] = postToOpenElisServerFullResponse.mock.calls.at(-1);
+    expect(url).toBe("/rest/eqa/cycles/9/results/import");
+    expect(JSON.parse(body)).toEqual({
+      organizationId: 550,
+      csv: "analyte_name,result_value\nHIV VL,250\nGhost,1",
+    });
+    expect(await screen.findByText("1 values imported.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Row 3: no test in this scheme reports 'Ghost'"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("HIV viral load")).toHaveValue("250");
   });
 });

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -184,6 +184,29 @@ export const distributeScores = (cycleId, organizationId, callback) =>
 export const scoresCsvUrl = (cycleId, organizationId) =>
   `${config.serverBaseUrl}/rest/eqa/cycles/${cycleId}/scores/${organizationId}/csv`;
 
+// --- FR-V2.5-03 provider-side result intake (phoned/emailed results, export bundles) ---
+
+/** The scheme's tests with what this participant has reported so far. */
+export const fetchIntake = (cycleId, organizationId, callback) =>
+  getFromOpenElisServer(
+    `/rest/eqa/cycles/${cycleId}/results?organizationId=${organizationId}`,
+    (data) => callback(data || null),
+  );
+
+export const saveIntake = (cycleId, organizationId, results, callback) =>
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/results`,
+    JSON.stringify({ organizationId, results }),
+    withBody(callback),
+  );
+
+export const importIntakeCsv = (cycleId, organizationId, csv, callback) =>
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/results/import`,
+    JSON.stringify({ organizationId, csv }),
+    withBody(callback),
+  );
+
 // --- OGC-934 report comments ---
 
 /** The pre-approved library the picker offers. */

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -184,7 +184,7 @@ export const distributeScores = (cycleId, organizationId, callback) =>
 export const scoresCsvUrl = (cycleId, organizationId) =>
   `${config.serverBaseUrl}/rest/eqa/cycles/${cycleId}/scores/${organizationId}/csv`;
 
-// --- FR-V2.5-03 provider-side result intake (phoned/emailed results, export bundles) ---
+// --- Provider-side result intake (phoned/emailed results, export bundles) ---
 
 /** The scheme's tests with what this participant has reported so far. */
 export const fetchIntake = (cycleId, organizationId, callback) =>

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8540,5 +8540,17 @@
   "eqa.order.receipt.consignment.thisCycle": "this cycle",
   "eqa.order.receipt.consignment.help": "Choosing the consignment takes delivery of it and tells the provider the panel arrived.",
   "eqa.order.receipt.reference": "Shipment reference",
-  "eqa.order.receipt.referenceRecorded": "Consignment {code} received."
+  "eqa.order.receipt.referenceRecorded": "Consignment {code} received.",
+  "eqa.intake.enterResults": "Enter results",
+  "eqa.intake.heading": "Results from {lab}",
+  "eqa.intake.help": "Key the values as the participant reported them — numbers, or words such as Reactive. Saving overwrites what is on file for that test.",
+  "eqa.intake.test": "Test",
+  "eqa.intake.value": "Reported value",
+  "eqa.intake.save": "Save results",
+  "eqa.intake.saved": "Results recorded for {lab}.",
+  "eqa.intake.failed": "Could not record the results",
+  "eqa.intake.csv": "Or paste the participant's export bundle (CSV)",
+  "eqa.intake.import": "Import CSV",
+  "eqa.intake.imported": "{count} values imported.",
+  "eqa.intake.noTests": "This scheme has no tests assigned yet."
 }

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8417,7 +8417,7 @@
   "eqa.score.verdicts": "Scores",
   "eqa.score.counts": "{unacceptable} unacceptable of {total}",
   "eqa.score.sendScores": "Send scores",
-  "eqa.score.distributed": "Scores returned over FHIR.",
+  "eqa.score.distributed": "Scores placed in the FHIR store for the participant to collect.",
   "eqa.score.distributeFailed": "The scores could not be returned.",
   "eqa.score.downloadCsv": "Scores CSV",
   "eqa.provider.followups.title": "Participant follow-up",
@@ -8552,5 +8552,13 @@
   "eqa.intake.csv": "Or paste the participant's export bundle (CSV)",
   "eqa.intake.import": "Import CSV",
   "eqa.intake.imported": "{count} values imported.",
-  "eqa.intake.noTests": "This scheme has no tests assigned yet."
+  "eqa.intake.noTests": "This scheme has no tests assigned yet.",
+  "eqa.cycle.importScores": "Import scores (CSV)",
+  "eqa.cycle.importScores.heading": "Import the provider's scores",
+  "eqa.cycle.importScores.help": "Paste the scores CSV the provider sent (analyte_name and performance_status columns). Scores from a provider OpenELIS arrive on their own through the FHIR store.",
+  "eqa.cycle.importScores.csv": "Scores CSV",
+  "eqa.cycle.importScores.import": "Import scores",
+  "eqa.cycle.importScores.imported": "{count} scores recorded.",
+  "eqa.cycle.importScores.unmapped": "Not recognised here: {names}",
+  "eqa.cycle.importScores.failed": "Could not import the scores"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -190,7 +190,7 @@ public class EQACycleRestController extends BaseRestController {
      */
     @GetMapping(value = "/cycles/mine", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Map<String, Object>> myCycles(@RequestParam(required = false) Long labEnrollmentId) {
-        // FR-V2.2-09: the cycles this laboratory takes part in — programmes it has
+        // The cycles this laboratory takes part in — programmes it has
         // enrolled in (My Programs), its own in-house cycles, and any cycle that
         // already carries one of its EQA orders. A provider's outbound cycles have
         // their own board and are not "mine".
@@ -229,10 +229,10 @@ public class EQACycleRestController extends BaseRestController {
     }
 
     /**
-     * FR-V2.2-09, the participant's own way in: a cycle for a programme this lab
-     * has enrolled in, for a provider that does not send consignments to an
-     * OpenELIS. The programme is named, not numbered, because that is all an
-     * enrollment carries; it must exist locally under the same name.
+     * The participant's own way in: a cycle for a programme this lab has enrolled
+     * in, for a provider that does not send consignments to an OpenELIS. The
+     * programme is named, not numbered, because that is all an enrollment carries;
+     * it must exist locally under the same name.
      */
     @PostMapping(value = "/cycles/mine", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PARTICIPANT)

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAPanelReceiptRestController.java
@@ -109,7 +109,7 @@ public class EQAPanelReceiptRestController extends BaseRestController {
         dto.put("labEnrollmentId", receipt.getLabEnrollmentId());
         dto.put("shipmentId", receipt.getShipmentId());
         dto.put("shippingBoxId", receipt.getShippingBoxId());
-        // The box code is the receipt's shipment reference (FR-V2.2-12).
+        // The box code is the receipt's shipment reference.
         ShippingBox box = receipt.getShippingBoxId() == null ? null
                 : shippingBoxService.getBoxById(receipt.getShippingBoxId());
         dto.put("boxCode", box == null ? null : box.getBoxId());

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAResultRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAResultRestController.java
@@ -40,7 +40,7 @@ public class EQAResultRestController extends BaseRestController {
     private EQAProviderScoringService scoringService;
 
     /**
-     * FR-V2.5-03: what a participant has reported so far, per test of the scheme.
+     * What a participant has reported so far, per test of the scheme.
      */
     @GetMapping(value = "/cycles/{cycleId}/results", produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<String, Object> cycleResults(@PathVariable Long cycleId, @RequestParam Long organizationId) {
@@ -48,8 +48,8 @@ public class EQAResultRestController extends BaseRestController {
     }
 
     /**
-     * FR-V2.5-03: provider-side entry of a participant's phoned or emailed results
-     * — {@code {"organizationId": 12, "results": [{"testId": 7, "value":
+     * Provider-side entry of a participant's phoned or emailed results —
+     * {@code {"organizationId": 12, "results": [{"testId": 7, "value":
      * "Reactive"}]}}. Numbers and qualitative words alike; a blank value leaves the
      * test untouched.
      */
@@ -75,8 +75,8 @@ public class EQAResultRestController extends BaseRestController {
     }
 
     /**
-     * FR-V2.5-03: import the participant's export bundle CSV as pasted or uploaded
-     * — {@code {"organizationId": 12, "csv":
+     * Import the participant's export bundle CSV as pasted or uploaded —
+     * {@code {"organizationId": 12, "csv":
      * "cycle_id,...,analyte_name,result_value,..."}}.
      */
     @PostMapping(value = "/cycles/{cycleId}/results/import", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAResultRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAResultRestController.java
@@ -1,10 +1,14 @@
 package org.openelisglobal.eqa.controller.rest;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.openelisglobal.common.rest.BaseRestController;
+import org.openelisglobal.eqa.service.EQAProviderScoringService;
 import org.openelisglobal.eqa.service.EQAResultService;
 import org.openelisglobal.eqa.service.EQAStatisticsService;
 import org.openelisglobal.eqa.valueholder.EQAResult;
@@ -18,12 +22,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/rest/eqa")
 @PreAuthorize(EQAGuards.READ)
-public class EQAResultRestController {
+public class EQAResultRestController extends BaseRestController {
 
     @Autowired
     private EQAResultService resultService;
@@ -31,9 +36,65 @@ public class EQAResultRestController {
     @Autowired
     private EQAStatisticsService statisticsService;
 
+    @Autowired
+    private EQAProviderScoringService scoringService;
+
+    /**
+     * FR-V2.5-03: what a participant has reported so far, per test of the scheme.
+     */
+    @GetMapping(value = "/cycles/{cycleId}/results", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, Object> cycleResults(@PathVariable Long cycleId, @RequestParam Long organizationId) {
+        return scoringService.intakeGrid(cycleId, organizationId);
+    }
+
+    /**
+     * FR-V2.5-03: provider-side entry of a participant's phoned or emailed results
+     * — {@code {"organizationId": 12, "results": [{"testId": 7, "value":
+     * "Reactive"}]}}. Numbers and qualitative words alike; a blank value leaves the
+     * test untouched.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/results", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PROVIDER)
+    public Map<String, Object> takeInCycleResults(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestBody Map<String, Object> body) {
+        Long organizationId = longField(body, "organizationId");
+        if (organizationId == null) {
+            throw new IllegalArgumentException("organizationId is required");
+        }
+        Map<Long, String> reported = new LinkedHashMap<>();
+        if (body.get("results") instanceof List<?> rows) {
+            for (Object row : rows) {
+                if (row instanceof Map<?, ?> cell && cell.get("testId") != null) {
+                    reported.put(Long.valueOf(String.valueOf(cell.get("testId"))),
+                            cell.get("value") == null ? null : String.valueOf(cell.get("value")));
+                }
+            }
+        }
+        return scoringService.takeIn(cycleId, organizationId, reported, EQASubmissionMethod.MANUAL,
+                getSysUserId(request));
+    }
+
+    /**
+     * FR-V2.5-03: import the participant's export bundle CSV as pasted or uploaded
+     * — {@code {"organizationId": 12, "csv":
+     * "cycle_id,...,analyte_name,result_value,..."}}.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/results/import", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PROVIDER)
+    public Map<String, Object> importCycleResultsCsv(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestBody Map<String, Object> body) {
+        Long organizationId = longField(body, "organizationId");
+        if (organizationId == null) {
+            throw new IllegalArgumentException("organizationId is required");
+        }
+        return scoringService.importReportedCsv(cycleId, organizationId, stringField(body, "csv"),
+                getSysUserId(request));
+    }
+
     @PostMapping(value = "/distributions/{distributionId}/results", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PARTICIPANT)
-    public ResponseEntity<?> submitResult(@PathVariable Long distributionId, @RequestBody Map<String, Object> body) {
+    public ResponseEntity<?> submitResult(HttpServletRequest request, @PathVariable Long distributionId,
+            @RequestBody Map<String, Object> body) {
         try {
             Number orgId = (Number) body.get("organizationId");
             Number testId = (Number) body.get("testId");
@@ -45,7 +106,7 @@ public class EQAResultRestController {
             }
 
             EQAResult result = resultService.submitResult(distributionId, orgId.longValue(), testId.longValue(),
-                    new BigDecimal(value.toString()), EQASubmissionMethod.MANUAL);
+                    new BigDecimal(value.toString()), EQASubmissionMethod.MANUAL, getSysUserId(request));
 
             return ResponseEntity.ok(toResultDto(result));
         } catch (Exception e) {
@@ -55,7 +116,7 @@ public class EQAResultRestController {
 
     @PostMapping(value = "/distributions/{distributionId}/results/import", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PARTICIPANT)
-    public ResponseEntity<?> batchImportResults(@PathVariable Long distributionId,
+    public ResponseEntity<?> batchImportResults(HttpServletRequest request, @PathVariable Long distributionId,
             @RequestBody List<Map<String, Object>> rows) {
         try {
             int successCount = 0;
@@ -76,7 +137,7 @@ public class EQAResultRestController {
                     }
 
                     resultService.submitResult(distributionId, orgId.longValue(), testId.longValue(),
-                            new BigDecimal(value.toString()), EQASubmissionMethod.FILE_UPLOAD);
+                            new BigDecimal(value.toString()), EQASubmissionMethod.FILE_UPLOAD, getSysUserId(request));
                     successCount++;
                 } catch (Exception e) {
                     errors.put(i, e.getMessage());

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
@@ -85,8 +85,8 @@ public class EQASubmissionRestController extends BaseRestController {
      * FR-V2.3-01 tiers read. Provider act, so it takes the manage grant.
      */
     /**
-     * FR-V2.2-08 by file: the provider's scores CSV pasted or uploaded from My
-     * Cycles — {@code {"csv": "test,analyte_name,...", "labEnrollmentId": 3}}.
+     * Scores by file: the provider's scores CSV pasted or uploaded from My Cycles —
+     * {@code {"csv": "test,analyte_name,...", "labEnrollmentId": 3}}.
      */
     @PostMapping(value = "/cycles/{cycleId}/score-intake/csv", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.MANAGE)

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
@@ -84,6 +84,24 @@ public class EQASubmissionRestController extends BaseRestController {
      * FR-V2.2-08 score intake: the provider's verdicts, with the Z-score the
      * FR-V2.3-01 tiers read. Provider act, so it takes the manage grant.
      */
+    /**
+     * FR-V2.2-08 by file: the provider's scores CSV pasted or uploaded from My
+     * Cycles — {@code {"csv": "test,analyte_name,...", "labEnrollmentId": 3}}.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/score-intake/csv", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.MANAGE)
+    public ResponseEntity<?> intakeScoresCsv(HttpServletRequest request, @PathVariable Long cycleId,
+            @RequestBody Map<String, Object> body) {
+        try {
+            return ResponseEntity.ok(cycleSubmissionService.intakeScoresCsv(cycleId, longField(body, "labEnrollmentId"),
+                    stringField(body, "csv"), getSysUserId(request)));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
     @PostMapping(value = "/cycles/{cycleId}/score-intake", produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.MANAGE)
     public ResponseEntity<?> intakeScores(HttpServletRequest request, @PathVariable Long cycleId,

--- a/src/main/java/org/openelisglobal/eqa/scheduler/EQAFhirExchangeScheduler.java
+++ b/src/main/java/org/openelisglobal/eqa/scheduler/EQAFhirExchangeScheduler.java
@@ -1,0 +1,47 @@
+package org.openelisglobal.eqa.scheduler;
+
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.eqa.service.EQAFhirExchangeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs the provider↔participant FHIR exchange on the delivery-reconcile
+ * cadence: a provider takes in participant reports from its own store, a
+ * participant takes in score reports from its provider's store. Both passes are
+ * no-ops when the store they read is not configured, so a single-instance
+ * deployment sees nothing new.
+ */
+@Component
+public class EQAFhirExchangeScheduler {
+
+    @Autowired
+    private EQAFhirExchangeService exchangeService;
+
+    @Scheduled(initialDelay = 90 * 1000, fixedRateString = "${org.openelisglobal.remote.poll.frequency:120000}")
+    public void takeInParticipantReports() {
+        try {
+            int applied = exchangeService.pollParticipantReports();
+            if (applied > 0) {
+                LogEvent.logInfo(getClass().getSimpleName(), "takeInParticipantReports",
+                        applied + " participant report(s) taken in from the store");
+            }
+        } catch (RuntimeException e) {
+            LogEvent.logError(getClass().getSimpleName(), "takeInParticipantReports", e.getMessage());
+        }
+    }
+
+    @Scheduled(initialDelay = 105 * 1000, fixedRateString = "${org.openelisglobal.remote.poll.frequency:120000}")
+    public void takeInScoreReports() {
+        try {
+            int applied = exchangeService.pollScoreReports();
+            if (applied > 0) {
+                LogEvent.logInfo(getClass().getSimpleName(), "takeInScoreReports",
+                        applied + " score report(s) taken in from the provider's store");
+            }
+        } catch (RuntimeException e) {
+            LogEvent.logError(getClass().getSimpleName(), "takeInScoreReports", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
@@ -76,4 +76,13 @@ public interface EQACycleSubmissionService {
     boolean assignAnalyst(Analysis analysis, Long analystId, String sysUserId);
 
     int intakeScores(Long cycleId, Long labEnrollmentId, List<Map<String, Object>> scores, String sysUserId);
+
+    /**
+     * FR-V2.2-08 by file: the provider's score CSV (columns analyte_name,
+     * performance_status, z_score; the rest is ignored) applied through
+     * {@link #intakeScores}. Analytes are matched by name — the provider's ids are
+     * its own. Answers {@code scored} and the {@code unmapped} analyte names this
+     * laboratory does not know.
+     */
+    Map<String, Object> intakeScoresCsv(Long cycleId, Long labEnrollmentId, String csv, String sysUserId);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
@@ -78,7 +78,7 @@ public interface EQACycleSubmissionService {
     int intakeScores(Long cycleId, Long labEnrollmentId, List<Map<String, Object>> scores, String sysUserId);
 
     /**
-     * FR-V2.2-08 by file: the provider's score CSV (columns analyte_name,
+     * Scores by file: the provider's score CSV (columns analyte_name,
      * performance_status, z_score; the rest is ignored) applied through
      * {@link #intakeScores}. Analytes are matched by name — the provider's ids are
      * its own. Answers {@code scored} and the {@code unmapped} analyte names this

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -659,6 +660,61 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             advanceTo(cycle, SCORED, EQATriggerType.AUTO, EQATriggerEvent.SCORE_INTAKE, null, null, sysUserId);
         }
         return scored;
+    }
+
+    @Override
+    public Map<String, Object> intakeScoresCsv(Long cycleId, Long labEnrollmentId, String csv, String sysUserId) {
+        if (csv == null || csv.isBlank()) {
+            throw new IllegalArgumentException("The CSV is empty");
+        }
+        String[] lines = EqaCsv.lines(csv);
+        List<String> header = EqaCsv.split(lines[0]);
+        int nameColumn = EqaCsv.indexOf(header, "analyte_name");
+        int verdictColumn = EqaCsv.indexOf(header, "performance_status");
+        int zColumn = EqaCsv.indexOf(header, "z_score");
+        if (nameColumn < 0 || verdictColumn < 0) {
+            throw new IllegalArgumentException(
+                    "The CSV needs analyte_name and performance_status columns (the provider's scores CSV)");
+        }
+        AnalyteService analyteService = SpringContext.getBean(AnalyteService.class);
+        List<Map<String, Object>> scores = new ArrayList<>();
+        List<String> unmapped = new ArrayList<>();
+        for (int i = 1; i < lines.length; i++) {
+            if (lines[i].isBlank()) {
+                continue;
+            }
+            List<String> cells = EqaCsv.split(lines[i]);
+            String name = EqaCsv.cell(cells, nameColumn);
+            String verdict = EqaCsv.cell(cells, verdictColumn);
+            if (name.isEmpty() || verdict.isEmpty()) {
+                continue;
+            }
+            Analyte probe = new Analyte();
+            probe.setAnalyteName(name);
+            Analyte analyte = analyteService.getAnalyteByName(probe, true);
+            if (analyte == null) {
+                unmapped.add(name);
+                continue;
+            }
+            Map<String, Object> score = new LinkedHashMap<>();
+            score.put("analyteId", Long.valueOf(analyte.getId()));
+            score.put("performance", verdict);
+            String z = EqaCsv.cell(cells, zColumn);
+            if (!z.isEmpty()) {
+                score.put("zScore", z);
+            }
+            scores.add(score);
+        }
+        if (scores.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No row names an analyte this laboratory knows" + (unmapped.isEmpty() ? "" : ": " + unmapped));
+        }
+        int scored = intakeScores(cycleId, labEnrollmentId, scores, sysUserId);
+        Map<String, Object> outcome = new LinkedHashMap<>();
+        outcome.put("cycleId", cycleId);
+        outcome.put("scored", scored);
+        outcome.put("unmapped", unmapped);
+        return outcome;
     }
 
     private EQAParticipantResult resolveScoredRow(Long cycleId, Long labEnrollmentId, Map<String, Object> entry) {

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -26,6 +26,7 @@ import org.openelisglobal.alert.valueholder.AlertSeverity;
 import org.openelisglobal.alert.valueholder.AlertType;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.analyte.service.AnalyteService;
 import org.openelisglobal.analyte.valueholder.Analyte;
 import org.openelisglobal.common.services.IStatusService;
 import org.openelisglobal.common.services.StatusService.AnalysisStatus;
@@ -52,6 +53,7 @@ import org.openelisglobal.eqa.valueholder.EQATriggerType;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.openelisglobal.result.service.ResultService;
 import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.testanalyte.service.TestAnalyteService;
 import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
 import org.slf4j.Logger;
@@ -593,8 +595,10 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
     @Override
     @Transactional(readOnly = true)
     public String exportBundleCsv(Long cycleId, Long labEnrollmentId) {
-        StringBuilder csv = new StringBuilder(
-                "cycle_id,cycle_name,round_number,analyte_id,result_value,result_unit,submission_status,entered_at\n");
+        // analyte_name travels with the id: the provider that imports this bundle is
+        // another instance whose analyte ids differ, so the name is what it matches on.
+        StringBuilder csv = new StringBuilder("cycle_id,cycle_name,round_number,analyte_id,analyte_name,"
+                + "result_value,result_unit,submission_status,entered_at\n");
         for (EQAParticipantResult result : results(cycleId, labEnrollmentId)) {
             if (!SUBMITTABLE.contains(result.getSubmissionStatus())) {
                 continue;
@@ -603,11 +607,20 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             EQARound round = result.getRound();
             csv.append(cycleId).append(',').append(csvField(cycle == null ? null : cycle.getCycleName())).append(',')
                     .append(round == null || round.getRoundNumber() == null ? "" : round.getRoundNumber()).append(',')
-                    .append(result.getAnalyteId()).append(',').append(csvField(result.getResultValue())).append(',')
+                    .append(result.getAnalyteId()).append(',').append(csvField(analyteName(result.getAnalyteId())))
+                    .append(',').append(csvField(result.getResultValue())).append(',')
                     .append(csvField(result.getResultUnit())).append(',').append(result.getSubmissionStatus().name())
                     .append(',').append(result.getEnteredAt() == null ? "" : result.getEnteredAt()).append('\n');
         }
         return csv.toString();
+    }
+
+    private String analyteName(Long analyteId) {
+        if (analyteId == null) {
+            return null;
+        }
+        Analyte analyte = SpringContext.getBean(AnalyteService.class).get(String.valueOf(analyteId));
+        return analyte == null ? null : analyte.getAnalyteName();
     }
 
     /** RFC 4180 quoting: a value carrying a comma, quote or newline is quoted. */

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirExchangeService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirExchangeService.java
@@ -1,0 +1,41 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.List;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Observation;
+
+/**
+ * The provider↔participant exchange over the provider's FHIR store (OGC-610 /
+ * OGC-613): the participant pushes its DiagnosticReport bundle to the
+ * provider's store and later reads score reports from it; the provider reads
+ * participant reports from its own store and writes score reports there. The
+ * consignment's SupplyDelivery uuid — held by both instances since the shipment
+ * loop — is the identity that places every resource; analytes are matched by
+ * name because catalog ids differ per install.
+ */
+public interface EQAFhirExchangeService {
+
+    /**
+     * Provider side: apply every participant report in this instance's own store.
+     */
+    int pollParticipantReports();
+
+    /**
+     * Participant side: apply every score report addressed to this lab's
+     * consignments.
+     */
+    int pollScoreReports();
+
+    /**
+     * Provider side: take in one participant report. Idempotent — values already on
+     * file are left alone and the call answers false.
+     */
+    boolean applyParticipantReport(DiagnosticReport report, List<Observation> observations);
+
+    /**
+     * Participant side: apply one score report to the local cycle its consignment
+     * belongs to. Answers false when the cycle is already scored or nothing
+     * matched.
+     */
+    boolean applyScoreReport(DiagnosticReport report, List<Observation> observations);
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirExchangeServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirExchangeServiceImpl.java
@@ -1,0 +1,340 @@
+package org.openelisglobal.eqa.service;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Quantity;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
+import org.openelisglobal.shipment.dao.ShippingBoxDAO;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EQAFhirExchangeServiceImpl implements EQAFhirExchangeService {
+
+    /**
+     * System actor for exchange-initiated writes (admin user id, as the schedulers
+     * use).
+     */
+    private static final String EXCHANGE_USER = "1";
+
+    @Autowired
+    private FhirConfig fhirConfig;
+    @Autowired
+    private FhirUtil fhirUtil;
+    @Autowired
+    private ShippingBoxDAO shippingBoxDAO;
+    @Autowired
+    private EQAProviderScoringService scoringService;
+    @Autowired
+    private EQACycleSubmissionService cycleSubmissionService;
+    @Autowired
+    private AnalyteService analyteService;
+
+    @Override
+    public int pollParticipantReports() {
+        if (fhirConfig.getLocalFhirStorePath() == null || fhirConfig.getLocalFhirStorePath().isBlank()) {
+            return 0;
+        }
+        IGenericClient client = fhirUtil.getLocalFhirClient();
+        int applied = 0;
+        for (DiagnosticReport report : reportsWithIdentifierSystem(client,
+                fhirConfig.getOeFhirSystem() + EQAFhirSubmissionService.CONSIGNMENT_SUFFIX)) {
+            // Score reports carry the consignment identifier too; they are this
+            // provider's own writes, not inbound results.
+            if (identifierValue(report, EQAFhirSubmissionService.SCORES_SUFFIX) != null) {
+                continue;
+            }
+            try {
+                if (applyParticipantReport(report, observationsOf(client, report))) {
+                    applied++;
+                }
+            } catch (RuntimeException e) {
+                LogEvent.logError(this.getClass().getSimpleName(), "pollParticipantReports",
+                        "Participant report " + report.getIdElement().getIdPart() + " not applied: " + e.getMessage());
+            }
+        }
+        return applied;
+    }
+
+    @Override
+    public int pollScoreReports() {
+        int applied = 0;
+        for (String remoteStorePath : remoteStorePaths()) {
+            IGenericClient client = fhirUtil.getFhirClient(remoteStorePath);
+            for (DiagnosticReport report : reportsWithIdentifierSystem(client,
+                    fhirConfig.getOeFhirSystem() + EQAFhirSubmissionService.SCORES_SUFFIX)) {
+                try {
+                    if (applyScoreReport(report, observationsOf(client, report))) {
+                        applied++;
+                    }
+                } catch (RuntimeException e) {
+                    LogEvent.logError(this.getClass().getSimpleName(), "pollScoreReports",
+                            "Score report " + report.getIdElement().getIdPart() + " not applied: " + e.getMessage());
+                }
+            }
+        }
+        return applied;
+    }
+
+    @Override
+    public boolean applyParticipantReport(DiagnosticReport report, List<Observation> observations) {
+        ShippingBox box = boxFor(report);
+        if (box == null || box.getEqaCycleId() == null || box.getDestinationFacility() == null) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "applyParticipantReport",
+                    "Participant report " + report.getIdElement().getIdPart()
+                            + " names no consignment this instance dispatched for a cycle — not applied");
+            return false;
+        }
+        Long organizationId = Long.valueOf(box.getDestinationFacility().getId());
+        Map<String, String> byAnalyteName = new LinkedHashMap<>();
+        for (Observation observation : observations) {
+            String name = analyteNameOf(observation);
+            String value = reportedValueOf(observation);
+            if (name != null && value != null) {
+                byAnalyteName.put(name, value);
+            }
+        }
+        if (byAnalyteName.isEmpty()) {
+            return false;
+        }
+        // The poll repeats: a report whose values are already on file is a read.
+        if (alreadyOnFile(box.getEqaCycleId(), organizationId, byAnalyteName)) {
+            return false;
+        }
+        Map<String, Object> grid = scoringService.takeInByAnalyteName(box.getEqaCycleId(), organizationId,
+                byAnalyteName, EQASubmissionMethod.FHIR, EXCHANGE_USER);
+        List<?> unmapped = (List<?>) grid.get("unmapped");
+        if (!unmapped.isEmpty()) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "applyParticipantReport", "Consignment " + box.getBoxId()
+                    + ": no test in the scheme reports " + unmapped + " — those values were skipped");
+        }
+        LogEvent.logInfo(this.getClass().getSimpleName(), "applyParticipantReport", "Consignment " + box.getBoxId()
+                + ": " + (byAnalyteName.size() - unmapped.size()) + " participant result(s) taken in from the store");
+        return byAnalyteName.size() > unmapped.size();
+    }
+
+    @Override
+    public boolean applyScoreReport(DiagnosticReport report, List<Observation> observations) {
+        ShippingBox box = boxFor(report);
+        if (box == null || box.getEqaCycleId() == null) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "applyScoreReport",
+                    "Score report " + report.getIdElement().getIdPart()
+                            + " names no consignment this laboratory imported — not applied");
+            return false;
+        }
+        List<Map<String, Object>> scores = new ArrayList<>();
+        for (Observation observation : observations) {
+            String name = analyteNameOf(observation);
+            String performance = performanceOf(observation);
+            if (name == null || performance == null) {
+                continue;
+            }
+            Analyte probe = new Analyte();
+            probe.setAnalyteName(name);
+            Analyte analyte = analyteService.getAnalyteByName(probe, true);
+            if (analyte == null) {
+                LogEvent.logWarn(this.getClass().getSimpleName(), "applyScoreReport",
+                        "Score for analyte '" + name + "' skipped: this laboratory has no analyte of that name");
+                continue;
+            }
+            Map<String, Object> score = new LinkedHashMap<>();
+            score.put("analyteId", Long.valueOf(analyte.getId()));
+            score.put("performance", performance);
+            BigDecimal z = zScoreOf(observation);
+            if (z != null) {
+                score.put("zScore", z);
+            }
+            scores.add(score);
+        }
+        if (scores.isEmpty()) {
+            return false;
+        }
+        try {
+            int scored = cycleSubmissionService.intakeScores(box.getEqaCycleId(), null, scores, EXCHANGE_USER);
+            LogEvent.logInfo(this.getClass().getSimpleName(), "applyScoreReport",
+                    "Consignment " + box.getBoxId() + ": " + scored + " score(s) taken in from the provider's store");
+            return scored > 0;
+        } catch (IllegalStateException alreadyScored) {
+            // Replay of a report the lab has already taken in — the intake's 409 case.
+            return false;
+        } catch (IllegalArgumentException noMatch) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), "applyScoreReport",
+                    "Consignment " + box.getBoxId() + ": scores not applied — " + noMatch.getMessage());
+            return false;
+        }
+    }
+
+    // ---- helpers ----
+
+    private ShippingBox boxFor(DiagnosticReport report) {
+        String consignment = identifierValue(report, EQAFhirSubmissionService.CONSIGNMENT_SUFFIX);
+        if (consignment == null) {
+            return null;
+        }
+        try {
+            return shippingBoxDAO.findByFhirUuid(UUID.fromString(consignment));
+        } catch (IllegalArgumentException notAUuid) {
+            return null;
+        }
+    }
+
+    private String identifierValue(DiagnosticReport report, String systemSuffix) {
+        String system = fhirConfig.getOeFhirSystem() + systemSuffix;
+        for (Identifier identifier : report.getIdentifier()) {
+            if (system.equals(identifier.getSystem()) && identifier.hasValue()) {
+                return identifier.getValue();
+            }
+        }
+        return null;
+    }
+
+    private boolean alreadyOnFile(Long cycleId, Long organizationId, Map<String, String> byAnalyteName) {
+        Map<String, Object> grid = scoringService.intakeGrid(cycleId, organizationId);
+        Map<String, String> onFile = new LinkedHashMap<>();
+        for (Object row : (List<?>) grid.get("tests")) {
+            Map<?, ?> test = (Map<?, ?>) row;
+            if (test.get("analyteName") != null && test.get("reported") != null) {
+                onFile.put(String.valueOf(test.get("analyteName")).trim().toLowerCase(),
+                        normalise(String.valueOf(test.get("reported"))));
+            }
+        }
+        for (Map.Entry<String, String> entry : byAnalyteName.entrySet()) {
+            String current = onFile.get(entry.getKey().trim().toLowerCase());
+            if (current == null || !current.equals(normalise(entry.getValue()))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String normalise(String value) {
+        try {
+            return new BigDecimal(value.trim()).stripTrailingZeros().toPlainString();
+        } catch (NumberFormatException e) {
+            return value.trim().toLowerCase();
+        }
+    }
+
+    private static String analyteNameOf(Observation observation) {
+        if (observation.getCode() == null) {
+            return null;
+        }
+        if (observation.getCode().hasText()) {
+            return observation.getCode().getText();
+        }
+        for (Coding coding : observation.getCode().getCoding()) {
+            if (coding.hasDisplay()) {
+                return coding.getDisplay();
+            }
+        }
+        return null;
+    }
+
+    private static String reportedValueOf(Observation observation) {
+        if (observation.hasValueQuantity() && observation.getValueQuantity().hasValue()) {
+            return observation.getValueQuantity().getValue().toPlainString();
+        }
+        if (observation.hasValueStringType()) {
+            return ((StringType) observation.getValue()).getValue();
+        }
+        return null;
+    }
+
+    private String performanceOf(Observation observation) {
+        String system = fhirConfig.getOeFhirSystem() + "/eqa/performance";
+        for (CodeableConcept concept : observation.getInterpretation()) {
+            for (Coding coding : concept.getCoding()) {
+                if (system.equals(coding.getSystem()) && coding.hasCode()) {
+                    return coding.getCode();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static BigDecimal zScoreOf(Observation observation) {
+        for (Observation.ObservationComponentComponent component : observation.getComponent()) {
+            for (Coding coding : component.getCode().getCoding()) {
+                if ("z-score".equals(coding.getCode()) && component.hasValueQuantity()) {
+                    Quantity quantity = component.getValueQuantity();
+                    return quantity.hasValue() ? quantity.getValue() : null;
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<String> remoteStorePaths() {
+        List<String> remotes = new ArrayList<>();
+        if (fhirConfig.getRemoteStorePaths() == null) {
+            return remotes;
+        }
+        for (String path : fhirConfig.getRemoteStorePaths()) {
+            if (path != null && !path.isBlank() && !path.equals(fhirConfig.getLocalFhirStorePath())) {
+                remotes.add(path);
+            }
+        }
+        return remotes;
+    }
+
+    private static List<DiagnosticReport> reportsWithIdentifierSystem(IGenericClient client, String system) {
+        List<DiagnosticReport> reports = new ArrayList<>();
+        Bundle bundle = client.search().forResource(DiagnosticReport.class)
+                .where(DiagnosticReport.IDENTIFIER.hasSystemWithAnyCode(system)).returnBundle(Bundle.class).execute();
+        collect(bundle, reports);
+        while (bundle.getLink(IBaseBundle.LINK_NEXT) != null) {
+            bundle = client.loadPage().next(bundle).execute();
+            collect(bundle, reports);
+        }
+        return reports;
+    }
+
+    private static void collect(Bundle bundle, List<DiagnosticReport> target) {
+        if (bundle == null || !bundle.hasEntry()) {
+            return;
+        }
+        for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+            if (entry.hasResource() && entry.getResource() instanceof DiagnosticReport report) {
+                target.add(report);
+            }
+        }
+    }
+
+    private static List<Observation> observationsOf(IGenericClient client, DiagnosticReport report) {
+        List<Observation> observations = new ArrayList<>();
+        for (Reference reference : report.getResult()) {
+            if (!reference.hasReference()) {
+                continue;
+            }
+            String id = reference.getReferenceElement().getIdPart();
+            try {
+                observations.add(client.read().resource(Observation.class).withId(id).execute());
+            } catch (RuntimeException e) {
+                LogEvent.logWarn(EQAFhirExchangeServiceImpl.class.getSimpleName(), "observationsOf",
+                        "Observation " + id + " referenced by report " + report.getIdElement().getIdPart()
+                                + " could not be read: " + e.getMessage());
+            }
+        }
+        return observations;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionService.java
@@ -1,8 +1,36 @@
 package org.openelisglobal.eqa.service;
 
 import java.util.Map;
+import org.hl7.fhir.r4.model.Resource;
 
 public interface EQAFhirSubmissionService {
+
+    /**
+     * Identifier system suffixes (appended to the instance's FHIR system) that
+     * route resources between a provider and a participant through the provider's
+     * store: {@code CONSIGNMENT} carries the SupplyDelivery uuid of the box the
+     * panel travelled in — the one identity both instances hold — on a participant
+     * report and on a score report; {@code SCORES} marks a score report so a
+     * participant can search for the scores addressed to its box.
+     */
+    String CONSIGNMENT_SUFFIX = "/eqa/consignment";
+    String SCORES_SUFFIX = "/eqa/scores";
+    String SCHEME_NAME_SUFFIX = "/eqa/scheme_name";
+    String CYCLE_NUMBER_SUFFIX = "/eqa/cycle_number";
+
+    /**
+     * The DiagnosticReport + Observations a participant sends for a cycle: the
+     * report names the consignment, scheme and cycle number, each observation names
+     * its analyte by name, so a provider on another instance can place it.
+     */
+    Map<String, Resource> participantSubmissionResources(Long cycleId, Long labEnrollmentId);
+
+    /**
+     * The DiagnosticReport + Observations a provider returns to one participant:
+     * marked as scores for the consignment the panel travelled in, observations
+     * named by analyte, each with its Z and verdict.
+     */
+    Map<String, Resource> scoreReturnResources(Long distributionId, Long organizationId);
 
     Map<String, Object> submitResultsViaFhir(Long distributionId, Long organizationId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa.service;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,8 +19,11 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r4.model.StringType;
+import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
@@ -33,6 +37,9 @@ import org.openelisglobal.eqa.valueholder.EQAResult;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.shipment.dao.ShippingBoxDAO;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
+import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +76,12 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
     @Autowired
     private SystemUserService systemUserService;
 
+    @Autowired
+    private ShippingBoxDAO shippingBoxDAO;
+
+    @Autowired
+    private FhirUtil fhirUtil;
+
     @Override
     public Map<String, Object> submitResultsViaFhir(Long distributionId, Long organizationId) {
         EQADistribution distribution = distributionDAO.get(distributionId)
@@ -82,15 +95,7 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
                     "No results found for organization " + organizationId + " in distribution " + distributionId);
         }
 
-        Map<String, Resource> fhirResources = new HashMap<>();
-
-        DiagnosticReport report = buildDiagnosticReport(distribution, organizationId, results);
-        fhirResources.put(report.getId(), report);
-
-        for (EQAResult result : results) {
-            Observation observation = buildObservation(result, distribution);
-            fhirResources.put(observation.getId(), observation);
-        }
+        Map<String, Resource> fhirResources = scoreResources(distribution, organizationId, results);
 
         Map<String, Object> response = new HashMap<>();
         try {
@@ -114,16 +119,37 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
     }
 
     @Override
-    public boolean submitCycleViaFhir(Long cycleId, Long labEnrollmentId) {
+    @Transactional(readOnly = true)
+    public Map<String, Resource> scoreReturnResources(Long distributionId, Long organizationId) {
+        EQADistribution distribution = distributionDAO.get(distributionId)
+                .orElseThrow(() -> new IllegalArgumentException("Distribution not found: " + distributionId));
+        List<EQAResult> results = resultDAO.findByDistributionId(distributionId).stream()
+                .filter(r -> r.getParticipantOrganizationId().equals(organizationId)).collect(Collectors.toList());
+        return scoreResources(distribution, organizationId, results);
+    }
+
+    private Map<String, Resource> scoreResources(EQADistribution distribution, Long organizationId,
+            List<EQAResult> results) {
+        Map<String, Resource> fhirResources = new HashMap<>();
+        DiagnosticReport report = buildDiagnosticReport(distribution, organizationId, results);
+        fhirResources.put(report.getId(), report);
+        for (EQAResult result : results) {
+            Observation observation = buildObservation(result, distribution);
+            fhirResources.put(observation.getId(), observation);
+        }
+        return fhirResources;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Resource> participantSubmissionResources(Long cycleId, Long labEnrollmentId) {
         EQACycle cycle = cycleDAO.get(cycleId)
                 .orElseThrow(() -> new IllegalArgumentException("Cycle not found: " + cycleId));
-
         List<EQAParticipantResult> results = submittableResults(cycleId, labEnrollmentId);
         if (results.isEmpty()) {
             throw new IllegalArgumentException(
                     "No submittable result for cycle " + cycleId + " and enrollment " + labEnrollmentId);
         }
-
         Map<String, Resource> fhirResources = new HashMap<>();
         DiagnosticReport report = buildCycleReport(cycle, labEnrollmentId, results);
         fhirResources.put(report.getId(), report);
@@ -131,13 +157,23 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
             Observation observation = buildParticipantObservation(result);
             fhirResources.put(observation.getId(), observation);
         }
+        return fhirResources;
+    }
+
+    @Override
+    public boolean submitCycleViaFhir(Long cycleId, Long labEnrollmentId) {
+        Map<String, Resource> fhirResources = participantSubmissionResources(cycleId, labEnrollmentId);
 
         try {
             Bundle responseBundle = fhirPersistanceService.createFhirResourcesInFhirStore(fhirResources);
             LogEvent.logInfo(this.getClass().getSimpleName(), "submitCycleViaFhir",
                     "EQA cycle submission successful: cycle=" + cycleId + ", enrollment=" + labEnrollmentId
                             + ", resources=" + fhirResources.size() + ", bundle=" + responseBundle.getId());
-            return true;
+            // The provider is another instance: the same bundle goes to every remote
+            // store this lab is configured to exchange with (the shipment loop's
+            // hub). A remote it cannot reach is a failed attempt, so the sweep's
+            // backoff and alert apply, exactly as for the local store.
+            return pushToRemoteStores(fhirResources, cycleId);
         } catch (FhirLocalPersistingException | RuntimeException e) {
             // Any transport or serialization failure is a failed attempt, not a
             // crash: the caller counts it and retries under FR-V2.2-05 backoff.
@@ -145,6 +181,82 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
                     "EQA cycle submission failed: cycle=" + cycleId + ", enrollment=" + labEnrollmentId + ": "
                             + e.getMessage());
             return false;
+        }
+    }
+
+    private boolean pushToRemoteStores(Map<String, Resource> fhirResources, Long cycleId) {
+        boolean allSent = true;
+        for (String remoteStorePath : remoteStorePaths()) {
+            try {
+                Bundle bundle = new Bundle();
+                bundle.setType(Bundle.BundleType.TRANSACTION);
+                for (Resource resource : fhirResources.values()) {
+                    String url = resource.fhirType() + "/" + resource.getIdElement().getIdPart();
+                    Bundle.BundleEntryComponent entry = bundle.addEntry();
+                    entry.setFullUrl(url);
+                    entry.setResource(resource);
+                    entry.getRequest().setMethod(Bundle.HTTPVerb.PUT).setUrl(url);
+                }
+                fhirUtil.getFhirClient(remoteStorePath).transaction().withBundle(bundle).execute();
+                LogEvent.logInfo(this.getClass().getSimpleName(), "pushToRemoteStores",
+                        "EQA cycle " + cycleId + " submission sent to " + remoteStorePath);
+            } catch (RuntimeException e) {
+                allSent = false;
+                LogEvent.logError(this.getClass().getSimpleName(), "pushToRemoteStores", "EQA cycle " + cycleId
+                        + " submission did not reach " + remoteStorePath + ": " + e.getMessage());
+            }
+        }
+        return allSent;
+    }
+
+    /** Remote stores other than this lab's own; empty when none is configured. */
+    private List<String> remoteStorePaths() {
+        List<String> remotes = new ArrayList<>();
+        if (fhirConfig.getRemoteStorePaths() == null) {
+            return remotes;
+        }
+        for (String path : fhirConfig.getRemoteStorePaths()) {
+            if (path != null && !path.isBlank() && !path.equals(fhirConfig.getLocalFhirStorePath())) {
+                remotes.add(path);
+            }
+        }
+        return remotes;
+    }
+
+    /**
+     * The consignment the participant's panel travelled in, by the SupplyDelivery
+     * uuid both instances hold: the provider exported it, the participant imported
+     * it, and either side can find its own box by it. Null when the cycle was not
+     * created from a consignment.
+     */
+    private String consignmentUuidFor(Long cycleId, Long participantOrganizationId) {
+        for (ShippingBox box : shippingBoxDAO.findByEqaCycleId(cycleId)) {
+            if (box.getFhirUuid() == null) {
+                continue;
+            }
+            if (participantOrganizationId == null || box.getDestinationFacility() == null
+                    || participantOrganizationId.toString().equals(box.getDestinationFacility().getId())) {
+                return box.getFhirUuid().toString();
+            }
+        }
+        return null;
+    }
+
+    private String analyteNameFor(Long analyteId) {
+        if (analyteId == null) {
+            return null;
+        }
+        Analyte analyte = SpringContext.getBean(AnalyteService.class).get(String.valueOf(analyteId));
+        return analyte == null ? null : analyte.getAnalyteName();
+    }
+
+    private String analyteNameForTest(Long testId) {
+        try {
+            Long analyteId = testId == null ? null
+                    : SpringContext.getBean(EQAPanelService.class).analyteIdForTest(String.valueOf(testId));
+            return analyteNameFor(analyteId);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 
@@ -177,6 +289,20 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
                 createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/cycle_id", cycle.getId().toString()));
         report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/lab_enrollment_id",
                 labEnrollmentId.toString()));
+        // Routing for a provider on another instance: the consignment the panel came
+        // in, and the scheme name + cycle number as the human-readable fallback.
+        String consignment = consignmentUuidFor(cycle.getId(), null);
+        if (consignment != null) {
+            report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + CONSIGNMENT_SUFFIX, consignment));
+        }
+        if (cycle.getScheme() != null && cycle.getScheme().getName() != null) {
+            report.addIdentifier(
+                    createIdentifier(fhirConfig.getOeFhirSystem() + SCHEME_NAME_SUFFIX, cycle.getScheme().getName()));
+        }
+        if (cycle.getCycleNumber() != null) {
+            report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + CYCLE_NUMBER_SUFFIX,
+                    cycle.getCycleNumber().toString()));
+        }
         report.setStatus(DiagnosticReportStatus.FINAL);
 
         CodeableConcept category = new CodeableConcept();
@@ -214,6 +340,9 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
         CodeableConcept code = new CodeableConcept();
         code.addCoding(new Coding(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/analyte",
                 String.valueOf(result.getAnalyteId()), "EQA analyte " + result.getAnalyteId()));
+        // The analyte's name is what another instance can match on; ids differ per
+        // install.
+        code.setText(analyteNameFor(result.getAnalyteId()));
         observation.setCode(code);
 
         String value = result.getResultValue();
@@ -296,6 +425,15 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
 
         report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/distribution_id",
                 distribution.getId().toString()));
+        // Addressed to the participant by the consignment its panel travelled in, so
+        // the participant instance can search its provider's store for scores that
+        // are its own.
+        String consignment = distribution.getCycleId() == null ? null
+                : consignmentUuidFor(distribution.getCycleId(), organizationId);
+        if (consignment != null) {
+            report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + CONSIGNMENT_SUFFIX, consignment));
+            report.addIdentifier(createIdentifier(fhirConfig.getOeFhirSystem() + SCORES_SUFFIX, consignment));
+        }
 
         report.setStatus(DiagnosticReportStatus.FINAL);
 
@@ -355,12 +493,15 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
         CodeableConcept code = new CodeableConcept();
         code.addCoding(new Coding(fhirConfig.getOeFhirSystem() + EQA_SYSTEM + "/test", result.getTestId().toString(),
                 "EQA Test " + result.getTestId()));
+        code.setText(analyteNameForTest(result.getTestId()));
         observation.setCode(code);
 
         if (result.getResultValue() != null) {
             Quantity quantity = new Quantity();
             quantity.setValue(result.getResultValue());
             observation.setValue(quantity);
+        } else if (result.getResultText() != null) {
+            observation.setValue(new StringType(result.getResultText()));
         }
 
         // The participating laboratory is the performer, not the subject: FHIR R4

--- a/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAFhirSubmissionServiceImpl.java
@@ -251,13 +251,9 @@ public class EQAFhirSubmissionServiceImpl implements EQAFhirSubmissionService {
     }
 
     private String analyteNameForTest(Long testId) {
-        try {
-            Long analyteId = testId == null ? null
-                    : SpringContext.getBean(EQAPanelService.class).analyteIdForTest(String.valueOf(testId));
-            return analyteNameFor(analyteId);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        Long analyteId = testId == null ? null
+                : SpringContext.getBean(EQAPanelService.class).findAnalyteIdForTest(String.valueOf(testId));
+        return analyteNameFor(analyteId);
     }
 
     /**

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptService.java
@@ -21,10 +21,10 @@ public interface EQAPanelReceiptService extends BaseObjectService<EQAPanelReceip
 
     /**
      * As above, also taking delivery of the imported consignment
-     * {@code shippingBoxId} (FR-V2.2-12): the box goes RECEIVED in the same
-     * transaction, which completes the provider's SupplyDelivery so its monitor
-     * learns the panel arrived, and the receipt records the box as its shipment
-     * reference. A box already received stays as it is.
+     * {@code shippingBoxId}: the box goes RECEIVED in the same transaction, which
+     * completes the provider's SupplyDelivery so its monitor learns the panel
+     * arrived, and the receipt records the box as its shipment reference. A box
+     * already received stays as it is.
      */
     EQAPanelReceipt recordReceipt(Long cycleId, Long labEnrollmentId, Integer shipmentId, Integer shippingBoxId,
             BigDecimal receivedTempC, Boolean integrityOk, String integrityNotes, Long receivedBy, String sysUserId);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
@@ -115,7 +115,7 @@ public class EQAPanelReceiptServiceImpl extends BaseObjectServiceImpl<EQAPanelRe
             shipmentService.updateShipment(shipment);
         }
 
-        // FR-V2.2-12: taking the panel in IS receiving the consignment. Walking the
+        // Taking the panel in IS receiving the consignment. Walking the
         // imported box to RECEIVED here is what completes the provider's
         // SupplyDelivery (the delivery backflow), so the sender's monitor turns
         // DELIVERED without a second act on the Reception screen. A box someone

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelService.java
@@ -48,6 +48,19 @@ public interface EQAPanelService extends BaseObjectService<EQAPanel, Long> {
     Long analyteIdForTest(String testId);
 
     /**
+     * The same resolution as {@link #analyteIdForTest(String)}, returning null
+     * instead of throwing when the test is unknown or carries no analyte.
+     *
+     * <p>
+     * Callers that resolve an analyte only to label an export row or a FHIR
+     * observation must use this one. A throw would join the caller's transaction
+     * and mark it rollback-only, so catching it around the call is not enough — the
+     * caller's own commit then fails with UnexpectedRollback even though it handled
+     * the miss.
+     */
+    Long findAnalyteIdForTest(String testId);
+
+    /**
      * PREPARING → SEALED (FR-V2.1-11). Refuses a panel with no samples, any sample
      * with a blank target (the encryption converter passes blanks through
      * unencrypted, so blanks must never reach the column), and an in-house panel

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -212,7 +212,7 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
         if (GenericValidator.isBlankOrNull(testId)) {
             return null;
         }
-        Test test = SpringContext.getBean(TestService.class).get(testId);
+        Test test = loadTest(testId);
         if (test == null) {
             throw new IllegalArgumentException("Unknown test " + testId);
         }
@@ -222,6 +222,33 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
                     "Test " + test.getName() + " has no analyte, so it cannot carry a panel target");
         }
         return Long.valueOf(analytes.get(0).getAnalyte().getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Long findAnalyteIdForTest(String testId) {
+        if (GenericValidator.isBlankOrNull(testId)) {
+            return null;
+        }
+        Test test = loadTest(testId);
+        if (test == null) {
+            return null;
+        }
+        List<TestAnalyte> analytes = testAnalyteService.getAllTestAnalytesPerTest(test);
+        return analytes.isEmpty() ? null : Long.valueOf(analytes.get(0).getAnalyte().getId());
+    }
+
+    /**
+     * Returns null for a test id with no row behind it. Deliberately
+     * {@code getTestById}, which runs a query, rather than {@code get}, which hands
+     * back a lazy proxy and throws ObjectNotFoundException on the first dereference
+     * of an id that is not there. That throw crosses TestService's own transaction
+     * proxy, which marks the shared transaction rollback-only before either caller
+     * below can catch it, and the caller's commit then fails with
+     * UnexpectedRollback even though it handled the miss.
+     */
+    private Test loadTest(String testId) {
+        return SpringContext.getBean(TestService.class).getTestById(testId);
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
@@ -42,9 +42,9 @@ public interface EQAProviderScoringService {
     String buildScoreCsv(Long cycleId, Long organizationId);
 
     /**
-     * The intake grid for one participant (FR-V2.5-03): the scheme's tests with the
-     * value already on file for each, so phoned and emailed results can be keyed on
-     * the provider side.
+     * The intake grid for one participant: the scheme's tests with the value
+     * already on file for each, so phoned and emailed results can be keyed on the
+     * provider side.
      */
     Map<String, Object> intakeGrid(Long cycleId, Long organizationId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
@@ -64,6 +64,14 @@ public interface EQAProviderScoringService {
      */
     Map<String, Object> importReportedCsv(Long cycleId, Long organizationId, String csv, String sysUserId);
 
+    /**
+     * Take in values keyed by analyte <i>name</i> — the identity another instance
+     * shares — resolving each to the scheme's test. The answer is the grid plus an
+     * {@code unmapped} list naming analytes this scheme does not run.
+     */
+    Map<String, Object> takeInByAnalyteName(Long cycleId, Long organizationId,
+            Map<String, String> reportedByAnalyteName, EQASubmissionMethod method, String sysUserId);
+
     /** One participant's scores returned over FHIR (FR-V2.5-04). */
     Map<String, Object> distributeScores(Long cycleId, Long organizationId);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
@@ -2,6 +2,7 @@ package org.openelisglobal.eqa.service;
 
 import java.util.List;
 import java.util.Map;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
 
 /**
  * Provider-side scoring and score return for a V2 cycle (T-26, FR-V2.5-03 /
@@ -39,6 +40,29 @@ public interface EQAProviderScoringService {
 
     /** One participant's scores as CSV (FR-V2.5-04 manual return channel). */
     String buildScoreCsv(Long cycleId, Long organizationId);
+
+    /**
+     * The intake grid for one participant (FR-V2.5-03): the scheme's tests with the
+     * value already on file for each, so phoned and emailed results can be keyed on
+     * the provider side.
+     */
+    Map<String, Object> intakeGrid(Long cycleId, Long organizationId);
+
+    /**
+     * Provider-side intake of a participant's reported values, keyed by test id.
+     * Numbers and qualitative words alike; the cycle's distribution is opened on
+     * demand. Answers the refreshed grid.
+     */
+    Map<String, Object> takeIn(Long cycleId, Long organizationId, Map<Long, String> reportedByTest,
+            EQASubmissionMethod method, String sysUserId);
+
+    /**
+     * Import a participant's export bundle CSV (columns analyte_name and
+     * result_value; the rest is ignored). Analytes are matched by name to the
+     * scheme's tests, because the two instances do not share ids. Rows naming an
+     * analyte this scheme does not run are reported back, not dropped silently.
+     */
+    Map<String, Object> importReportedCsv(Long cycleId, Long organizationId, String csv, String sysUserId);
 
     /** One participant's scores returned over FHIR (FR-V2.5-04). */
     Map<String, Object> distributeScores(Long cycleId, Long organizationId);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -3,25 +3,37 @@ package org.openelisglobal.eqa.service;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.ObjectNotFoundException;
+import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
 import org.openelisglobal.common.util.StringUtil;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQADistributionDAO;
+import org.openelisglobal.eqa.dao.EQAPanelDAO;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.dao.EQAResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQADistribution;
 import org.openelisglobal.eqa.valueholder.EQADistributionStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQAResult;
 import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQAStateMachine;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
 import org.openelisglobal.eqa.valueholder.EQATriggerType;
 import org.openelisglobal.organization.service.OrganizationService;
@@ -79,6 +91,16 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
 
     @Autowired
     private SystemUserService systemUserService;
+    @Autowired
+    private EQAResultService eqaResultService;
+    @Autowired
+    private EQAProgramService eqaProgramService;
+    @Autowired
+    private EQAPanelDAO eqaPanelDAO;
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+    @Autowired
+    private EQAPanelService eqaPanelService;
 
     @Override
     @Transactional(readOnly = true)
@@ -114,7 +136,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
 
         EQADistribution distribution = findOrOpenDistribution(cycle, sysUserId);
         long reported = eqaResultDAO.findByDistributionId(distribution.getId()).stream()
-                .filter(result -> result.getResultValue() != null).count();
+                .filter(result -> result.getResultValue() != null || result.getResultText() != null).count();
         // Refused rather than silently half-scored: below this the peer mean and SD
         // describe nothing, and the statistics service would leave every verdict null.
         if (reported < EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS) {
@@ -123,6 +145,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         }
 
         eqaStatisticsService.calculateAndUpdateStatistics(distribution.getId());
+        judgeReportedText(cycle, distribution.getId());
         advanceToScored(cycle, sysUserId);
 
         int followups = 0;
@@ -154,8 +177,10 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             // decimal through csvEscape would quote a negative Z as a formula and
             // print it as '-0.28 (found driving the download, 2026-08-24).
             csv.append(StringUtil.csvEscape(testName(result.getTestId()))).append(',')
-                    .append(number(result.getResultValue())).append(',').append(number(result.getTargetValue()))
-                    .append(',').append(number(result.getZScore())).append(',')
+                    .append(result.getResultText() != null ? StringUtil.csvEscape(result.getResultText())
+                            : number(result.getResultValue()))
+                    .append(',').append(number(result.getTargetValue())).append(',').append(number(result.getZScore()))
+                    .append(',')
                     .append(result.getPerformanceStatus() == null ? "" : result.getPerformanceStatus().name())
                     .append(',').append(result.getSubmissionDate() == null ? "" : result.getSubmissionDate())
                     .append('\n');
@@ -170,6 +195,221 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             throw new IllegalArgumentException("This cycle has no distribution, so there are no scores to return");
         }
         return eqaFhirSubmissionService.submitResultsViaFhir(distribution.getId(), organizationId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> intakeGrid(Long cycleId, Long organizationId) {
+        EQACycle cycle = cycle(cycleId);
+        EQADistribution distribution = distributionOf(cycle);
+        Map<Long, EQAResult> onFile = new HashMap<>();
+        if (distribution != null) {
+            for (EQAResult result : eqaResultDAO.findByDistributionId(distribution.getId())) {
+                if (organizationId.equals(result.getParticipantOrganizationId())) {
+                    onFile.put(result.getTestId(), result);
+                }
+            }
+        }
+        List<Map<String, Object>> tests = new ArrayList<>();
+        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
+            if (!Boolean.TRUE.equals(assignment.getIsActive())) {
+                continue;
+            }
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("testId", assignment.getTestId());
+            row.put("testName", testName(assignment.getTestId()));
+            Long analyteId = analyteIdOrNull(assignment.getTestId());
+            row.put("analyteId", analyteId);
+            row.put("analyteName", analyteName(analyteId));
+            EQAResult result = onFile.get(assignment.getTestId());
+            row.put("reported", result == null ? null : reportedOf(result));
+            row.put("performanceStatus", result == null || result.getPerformanceStatus() == null ? null
+                    : result.getPerformanceStatus().name());
+            tests.add(row);
+        }
+        Map<String, Object> grid = new LinkedHashMap<>();
+        grid.put("cycleId", cycleId);
+        grid.put("organizationId", organizationId);
+        grid.put("distributionId", distribution == null ? null : distribution.getId());
+        grid.put("tests", tests);
+        return grid;
+    }
+
+    private static final Set<EQACycleStatus> INTAKE_STATES = EnumSet.of(EQACycleStatus.SHIPPED,
+            EQACycleStatus.DELIVERED, EQACycleStatus.SUBMISSIONS_OPEN, EQACycleStatus.SUBMISSIONS_CLOSED,
+            EQACycleStatus.SCORING);
+
+    @Override
+    public Map<String, Object> takeIn(Long cycleId, Long organizationId, Map<Long, String> reportedByTest,
+            EQASubmissionMethod method, String sysUserId) {
+        EQACycle cycle = cycle(cycleId);
+        if (!INTAKE_STATES.contains(cycle.getStatus())) {
+            throw new IllegalStateException(
+                    "Results are taken in between shipping and scoring; this cycle is " + cycle.getStatus());
+        }
+        Set<Long> assigned = new HashSet<>();
+        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
+            if (Boolean.TRUE.equals(assignment.getIsActive())) {
+                assigned.add(assignment.getTestId());
+            }
+        }
+        for (Long testId : reportedByTest.keySet()) {
+            if (!assigned.contains(testId)) {
+                // Named by id: the test may not exist at all, and resolving its name would
+                // turn a clean refusal into a not-found error.
+                throw new IllegalArgumentException(
+                        "Test " + testId + " is not part of scheme " + cycle.getScheme().getName());
+            }
+        }
+        EQADistribution distribution = findOrOpenDistribution(cycle, sysUserId);
+        for (Map.Entry<Long, String> entry : reportedByTest.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().isBlank()) {
+                continue;
+            }
+            eqaResultService.submitReportedValue(distribution.getId(), organizationId, entry.getKey(), entry.getValue(),
+                    method, sysUserId);
+        }
+        return intakeGrid(cycleId, organizationId);
+    }
+
+    @Override
+    public Map<String, Object> importReportedCsv(Long cycleId, Long organizationId, String csv, String sysUserId) {
+        if (csv == null || csv.isBlank()) {
+            throw new IllegalArgumentException("The CSV is empty");
+        }
+        String[] lines = csv.split("\\r?\\n");
+        List<String> header = splitCsv(lines[0]);
+        int nameColumn = indexOfHeader(header, "analyte_name");
+        int valueColumn = indexOfHeader(header, "result_value");
+        if (nameColumn < 0 || valueColumn < 0) {
+            throw new IllegalArgumentException(
+                    "The CSV needs analyte_name and result_value columns (the participant's export bundle)");
+        }
+        EQACycle cycle = cycle(cycleId);
+        Map<String, Long> testByAnalyteName = new HashMap<>();
+        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
+            String name = analyteName(analyteIdOrNull(assignment.getTestId()));
+            if (Boolean.TRUE.equals(assignment.getIsActive()) && name != null) {
+                testByAnalyteName.put(name.trim().toLowerCase(), assignment.getTestId());
+            }
+        }
+        Map<Long, String> reported = new LinkedHashMap<>();
+        List<String> errors = new ArrayList<>();
+        for (int i = 1; i < lines.length; i++) {
+            if (lines[i].isBlank()) {
+                continue;
+            }
+            List<String> cells = splitCsv(lines[i]);
+            String name = nameColumn < cells.size() ? cells.get(nameColumn).trim() : "";
+            String value = valueColumn < cells.size() ? cells.get(valueColumn).trim() : "";
+            if (value.isEmpty()) {
+                continue;
+            }
+            Long testId = testByAnalyteName.get(name.toLowerCase());
+            if (testId == null) {
+                errors.add("Row " + (i + 1) + ": no test in this scheme reports '" + name + "'");
+                continue;
+            }
+            reported.put(testId, value);
+        }
+        Map<String, Object> grid = takeIn(cycleId, organizationId, reported, EQASubmissionMethod.FILE_UPLOAD,
+                sysUserId);
+        grid.put("imported", reported.size());
+        grid.put("errors", errors);
+        return grid;
+    }
+
+    /**
+     * Qualitative results have no peer mean: the verdict is an exact,
+     * case-insensitive match against the panel's sealed target for the test's
+     * analyte (the same rule in-house scoring applies). A test with no sealed
+     * target leaves the verdict blank rather than guessing.
+     */
+    private void judgeReportedText(EQACycle cycle, Long distributionId) {
+        Map<Long, String> targetByAnalyte = new HashMap<>();
+        for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycle.getId())) {
+            for (EQAPanelSample sample : eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId())) {
+                if (sample.getAnalyteId() != null && sample.getTargetValue() != null) {
+                    targetByAnalyte.put(sample.getAnalyteId(), sample.getTargetValue().trim());
+                }
+            }
+        }
+        for (EQAResult result : eqaResultDAO.findByDistributionId(distributionId)) {
+            if (result.getResultText() == null || result.getResultValue() != null) {
+                continue;
+            }
+            Long analyteId = analyteIdOrNull(result.getTestId());
+            String target = analyteId == null ? null : targetByAnalyte.get(analyteId);
+            if (target == null) {
+                continue;
+            }
+            result.setZScore(null);
+            result.setPerformanceStatus(
+                    target.equalsIgnoreCase(result.getResultText().trim()) ? EQAPerformanceStatus.ACCEPTABLE
+                            : EQAPerformanceStatus.UNACCEPTABLE);
+            eqaResultDAO.update(result);
+        }
+    }
+
+    private static Object reportedOf(EQAResult result) {
+        return result.getResultText() != null ? result.getResultText() : result.getResultValue();
+    }
+
+    private Long analyteIdOrNull(Long testId) {
+        try {
+            return testId == null ? null : eqaPanelService.analyteIdForTest(String.valueOf(testId));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private String analyteName(Long analyteId) {
+        if (analyteId == null) {
+            return null;
+        }
+        Analyte analyte = SpringContext.getBean(AnalyteService.class).get(String.valueOf(analyteId));
+        return analyte == null ? null : analyte.getAnalyteName();
+    }
+
+    private static int indexOfHeader(List<String> header, String name) {
+        for (int i = 0; i < header.size(); i++) {
+            if (name.equalsIgnoreCase(header.get(i).trim())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * RFC 4180 enough for an export bundle: quoted cells may carry commas and
+     * doubled quotes.
+     */
+    private static List<String> splitCsv(String line) {
+        List<String> cells = new ArrayList<>();
+        StringBuilder cell = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (quoted) {
+                if (c == '"' && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                    cell.append('"');
+                    i++;
+                } else if (c == '"') {
+                    quoted = false;
+                } else {
+                    cell.append(c);
+                }
+            } else if (c == '"') {
+                quoted = true;
+            } else if (c == ',') {
+                cells.add(cell.toString());
+                cell.setLength(0);
+            } else {
+                cell.append(c);
+            }
+        }
+        cells.add(cell.toString());
+        return cells;
     }
 
     // ---- helpers ----
@@ -286,7 +526,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             Map<String, Object> row = new LinkedHashMap<>();
             row.put("testId", result.getTestId());
             row.put("testName", testName(result.getTestId()));
-            row.put("reported", result.getResultValue());
+            row.put("reported", reportedOf(result));
             row.put("target", result.getTargetValue());
             row.put("zScore", result.getZScore());
             row.put("performanceStatus", result.getPerformanceStatus().name());

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -381,11 +381,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     }
 
     private Long analyteIdOrNull(Long testId) {
-        try {
-            return testId == null ? null : eqaPanelService.analyteIdForTest(String.valueOf(testId));
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        return testId == null ? null : eqaPanelService.findAnalyteIdForTest(String.valueOf(testId));
     }
 
     private String analyteName(Long analyteId) {

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -171,12 +171,17 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     @Override
     @Transactional(readOnly = true)
     public String buildScoreCsv(Long cycleId, Long organizationId) {
-        StringBuilder csv = new StringBuilder("test,result_value,target_value,z_score,performance_status,scored_on\n");
+        // analyte_name is what a participant on another instance matches on when it
+        // imports these scores: test ids and names are the provider's own.
+        StringBuilder csv = new StringBuilder(
+                "test,analyte_name,result_value,target_value,z_score,performance_status,scored_on\n");
         for (EQAResult result : resultsFor(cycleId, organizationId)) {
-            // Only the test name is escaped: it is the one free-text cell. Running a
-            // decimal through csvEscape would quote a negative Z as a formula and
-            // print it as '-0.28 (found driving the download, 2026-08-24).
+            // Only the free-text cells are escaped. Running a decimal through csvEscape
+            // would quote a negative Z as a formula and print it as '-0.28 (found
+            // driving the download, 2026-08-24).
+            String analyte = analyteName(analyteIdOrNull(result.getTestId()));
             csv.append(StringUtil.csvEscape(testName(result.getTestId()))).append(',')
+                    .append(analyte == null ? "" : StringUtil.csvEscape(analyte)).append(',')
                     .append(result.getResultText() != null ? StringUtil.csvEscape(result.getResultText())
                             : number(result.getResultValue()))
                     .append(',').append(number(result.getTargetValue())).append(',').append(number(result.getZScore()))
@@ -277,10 +282,10 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         if (csv == null || csv.isBlank()) {
             throw new IllegalArgumentException("The CSV is empty");
         }
-        String[] lines = csv.split("\\r?\\n");
-        List<String> header = splitCsv(lines[0]);
-        int nameColumn = indexOfHeader(header, "analyte_name");
-        int valueColumn = indexOfHeader(header, "result_value");
+        String[] lines = EqaCsv.lines(csv);
+        List<String> header = EqaCsv.split(lines[0]);
+        int nameColumn = EqaCsv.indexOf(header, "analyte_name");
+        int valueColumn = EqaCsv.indexOf(header, "result_value");
         if (nameColumn < 0 || valueColumn < 0) {
             throw new IllegalArgumentException(
                     "The CSV needs analyte_name and result_value columns (the participant's export bundle)");
@@ -291,9 +296,9 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             if (lines[i].isBlank()) {
                 continue;
             }
-            List<String> cells = splitCsv(lines[i]);
-            String name = nameColumn < cells.size() ? cells.get(nameColumn).trim() : "";
-            String value = valueColumn < cells.size() ? cells.get(valueColumn).trim() : "";
+            List<String> cells = EqaCsv.split(lines[i]);
+            String name = EqaCsv.cell(cells, nameColumn);
+            String value = EqaCsv.cell(cells, valueColumn);
             if (value.isEmpty()) {
                 continue;
             }
@@ -389,47 +394,6 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         }
         Analyte analyte = SpringContext.getBean(AnalyteService.class).get(String.valueOf(analyteId));
         return analyte == null ? null : analyte.getAnalyteName();
-    }
-
-    private static int indexOfHeader(List<String> header, String name) {
-        for (int i = 0; i < header.size(); i++) {
-            if (name.equalsIgnoreCase(header.get(i).trim())) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * RFC 4180 enough for an export bundle: quoted cells may carry commas and
-     * doubled quotes.
-     */
-    private static List<String> splitCsv(String line) {
-        List<String> cells = new ArrayList<>();
-        StringBuilder cell = new StringBuilder();
-        boolean quoted = false;
-        for (int i = 0; i < line.length(); i++) {
-            char c = line.charAt(i);
-            if (quoted) {
-                if (c == '"' && i + 1 < line.length() && line.charAt(i + 1) == '"') {
-                    cell.append('"');
-                    i++;
-                } else if (c == '"') {
-                    quoted = false;
-                } else {
-                    cell.append(c);
-                }
-            } else if (c == '"') {
-                quoted = true;
-            } else if (c == ',') {
-                cells.add(cell.toString());
-                cell.setLength(0);
-            } else {
-                cell.append(c);
-            }
-        }
-        cells.add(cell.toString());
-        return cells;
     }
 
     // ---- helpers ----

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -285,16 +285,8 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             throw new IllegalArgumentException(
                     "The CSV needs analyte_name and result_value columns (the participant's export bundle)");
         }
-        EQACycle cycle = cycle(cycleId);
-        Map<String, Long> testByAnalyteName = new HashMap<>();
-        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
-            String name = analyteName(analyteIdOrNull(assignment.getTestId()));
-            if (Boolean.TRUE.equals(assignment.getIsActive()) && name != null) {
-                testByAnalyteName.put(name.trim().toLowerCase(), assignment.getTestId());
-            }
-        }
-        Map<Long, String> reported = new LinkedHashMap<>();
-        List<String> errors = new ArrayList<>();
+        Map<String, String> byAnalyteName = new LinkedHashMap<>();
+        Map<String, Integer> rowOf = new HashMap<>();
         for (int i = 1; i < lines.length; i++) {
             if (lines[i].isBlank()) {
                 continue;
@@ -305,17 +297,45 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             if (value.isEmpty()) {
                 continue;
             }
+            byAnalyteName.put(name, value);
+            rowOf.put(name, i + 1);
+        }
+        Map<String, Object> grid = takeInByAnalyteName(cycleId, organizationId, byAnalyteName,
+                EQASubmissionMethod.FILE_UPLOAD, sysUserId);
+        List<String> errors = new ArrayList<>();
+        for (Object unmapped : (List<?>) grid.get("unmapped")) {
+            errors.add("Row " + rowOf.get(String.valueOf(unmapped)) + ": no test in this scheme reports '" + unmapped
+                    + "'");
+        }
+        grid.put("imported", byAnalyteName.size() - errors.size());
+        grid.put("errors", errors);
+        return grid;
+    }
+
+    @Override
+    public Map<String, Object> takeInByAnalyteName(Long cycleId, Long organizationId,
+            Map<String, String> reportedByAnalyteName, EQASubmissionMethod method, String sysUserId) {
+        EQACycle cycle = cycle(cycleId);
+        Map<String, Long> testByAnalyteName = new HashMap<>();
+        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
+            String name = analyteName(analyteIdOrNull(assignment.getTestId()));
+            if (Boolean.TRUE.equals(assignment.getIsActive()) && name != null) {
+                testByAnalyteName.put(name.trim().toLowerCase(), assignment.getTestId());
+            }
+        }
+        Map<Long, String> reported = new LinkedHashMap<>();
+        List<String> unmapped = new ArrayList<>();
+        for (Map.Entry<String, String> entry : reportedByAnalyteName.entrySet()) {
+            String name = entry.getKey() == null ? "" : entry.getKey().trim();
             Long testId = testByAnalyteName.get(name.toLowerCase());
             if (testId == null) {
-                errors.add("Row " + (i + 1) + ": no test in this scheme reports '" + name + "'");
+                unmapped.add(name);
                 continue;
             }
-            reported.put(testId, value);
+            reported.put(testId, entry.getValue());
         }
-        Map<String, Object> grid = takeIn(cycleId, organizationId, reported, EQASubmissionMethod.FILE_UPLOAD,
-                sysUserId);
-        grid.put("imported", reported.size());
-        grid.put("errors", errors);
+        Map<String, Object> grid = takeIn(cycleId, organizationId, reported, method, sysUserId);
+        grid.put("unmapped", unmapped);
         return grid;
     }
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAResultService.java
@@ -8,7 +8,16 @@ import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
 public interface EQAResultService extends BaseObjectService<EQAResult, Long> {
 
     EQAResult submitResult(Long distributionId, Long organizationId, Long testId, java.math.BigDecimal resultValue,
-            EQASubmissionMethod method);
+            EQASubmissionMethod method, String sysUserId);
+
+    /**
+     * Provider-side intake of a value as the participant reported it: a number
+     * lands in result_value, anything else ("Reactive", "Scanty") in result_text.
+     * The provider is the authority on what arrived, so a value after the deadline
+     * is recorded as late rather than refused.
+     */
+    EQAResult submitReportedValue(Long distributionId, Long organizationId, Long testId, String reported,
+            EQASubmissionMethod method, String sysUserId);
 
     List<EQAResult> findByDistributionId(Long distributionId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAResultServiceImpl.java
@@ -38,7 +38,7 @@ public class EQAResultServiceImpl extends BaseObjectServiceImpl<EQAResult, Long>
 
     @Override
     public EQAResult submitResult(Long distributionId, Long organizationId, Long testId, BigDecimal resultValue,
-            EQASubmissionMethod method) {
+            EQASubmissionMethod method, String sysUserId) {
 
         EQADistribution distribution = eqaDistributionDAO.get(distributionId)
                 .orElseThrow(() -> new IllegalArgumentException("Distribution not found: " + distributionId));
@@ -51,11 +51,44 @@ public class EQAResultServiceImpl extends BaseObjectServiceImpl<EQAResult, Long>
                     "Submission deadline has passed. Supervisor approval is required for late submissions.");
         }
 
-        // T115: Result value validation — reject biologically implausible values
+        requirePlausible(resultValue);
+        return upsert(distribution, organizationId, testId, resultValue, null, method, sysUserId);
+    }
+
+    @Override
+    public EQAResult submitReportedValue(Long distributionId, Long organizationId, Long testId, String reported,
+            EQASubmissionMethod method, String sysUserId) {
+        if (reported == null || reported.isBlank()) {
+            throw new IllegalArgumentException("A reported value is required");
+        }
+        EQADistribution distribution = eqaDistributionDAO.get(distributionId)
+                .orElseThrow(() -> new IllegalArgumentException("Distribution not found: " + distributionId));
+        String trimmed = reported.trim();
+        BigDecimal numeric;
+        try {
+            numeric = new BigDecimal(trimmed);
+        } catch (NumberFormatException e) {
+            numeric = null;
+        }
+        if (numeric != null) {
+            requirePlausible(numeric);
+        }
+        return upsert(distribution, organizationId, testId, numeric, numeric == null ? trimmed : null, method,
+                sysUserId);
+    }
+
+    // T115: Result value validation — reject biologically implausible values
+    private static void requirePlausible(BigDecimal resultValue) {
         if (resultValue != null && (resultValue.compareTo(BigDecimal.ZERO) < 0
                 || resultValue.compareTo(new BigDecimal("999999")) > 0)) {
             throw new IllegalArgumentException("Result value out of plausible range: " + resultValue);
         }
+    }
+
+    private EQAResult upsert(EQADistribution distribution, Long organizationId, Long testId, BigDecimal resultValue,
+            String resultText, EQASubmissionMethod method, String sysUserId) {
+        Long distributionId = distribution.getId();
+        Timestamp now = new Timestamp(System.currentTimeMillis());
 
         // Check for existing result (duplicate handling with overwrite)
         Optional<EQAResult> existing = eqaResultDAO.findByDistributionAndOrgAndTest(distributionId, organizationId,
@@ -70,8 +103,10 @@ public class EQAResultServiceImpl extends BaseObjectServiceImpl<EQAResult, Long>
             result.setPreviousSubmissionMethod(result.getSubmissionMethod());
             // Update with new values
             result.setResultValue(resultValue);
+            result.setResultText(resultText);
             result.setSubmissionMethod(method);
-            result.setSubmissionDate(new Timestamp(System.currentTimeMillis()));
+            result.setSubmissionDate(now);
+            result.setSysUserId(sysUserId);
             result = eqaResultDAO.update(result);
         } else {
             result = new EQAResult();
@@ -79,8 +114,12 @@ public class EQAResultServiceImpl extends BaseObjectServiceImpl<EQAResult, Long>
             result.setParticipantOrganizationId(organizationId);
             result.setTestId(testId);
             result.setResultValue(resultValue);
+            result.setResultText(resultText);
             result.setSubmissionMethod(method);
-            result.setSubmissionDate(new Timestamp(System.currentTimeMillis()));
+            result.setSubmissionDate(now);
+            // sys_user_id is NOT NULL; the V1 path never set it, so no row had ever been
+            // written through this entity (the oversight suites seeded results in SQL).
+            result.setSysUserId(sysUserId);
 
             // Check if late submission (for approved late submissions that bypass deadline
             // check)

--- a/src/main/java/org/openelisglobal/eqa/service/EQAStatisticsServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAStatisticsServiceImpl.java
@@ -3,7 +3,10 @@ package org.openelisglobal.eqa.service;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.openelisglobal.eqa.dao.EQAResultDAO;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
@@ -25,24 +28,35 @@ public class EQAStatisticsServiceImpl implements EQAStatisticsService {
     @Autowired
     private EQAResultDAO eqaResultDAO;
 
+    /**
+     * Peer statistics are per test: a cycle's panel carries several analytes, and
+     * pooling a viral load with a CD4 count would score every participant against a
+     * mean that describes nothing. A test with fewer numeric results than the floor
+     * keeps its Z and verdict blank; qualitative results (result_text) are judged
+     * elsewhere, against the panel target.
+     */
     @Override
     public void calculateAndUpdateStatistics(Long distributionId) {
-        List<EQAResult> results = eqaResultDAO.findByDistributionId(distributionId);
-
-        List<BigDecimal> values = results.stream().map(EQAResult::getResultValue).filter(v -> v != null)
-                .collect(Collectors.toList());
-
-        if (values.size() < MIN_PARTICIPANTS_FOR_STATS) {
-            logger.info("Distribution {} has only {} results, minimum {} required for statistics", distributionId,
-                    values.size(), MIN_PARTICIPANTS_FOR_STATS);
-            return;
+        Map<Long, List<EQAResult>> byTest = new LinkedHashMap<>();
+        for (EQAResult result : eqaResultDAO.findByDistributionId(distributionId)) {
+            if (result.getResultValue() != null) {
+                byTest.computeIfAbsent(result.getTestId(), key -> new ArrayList<>()).add(result);
+            }
         }
 
-        BigDecimal mean = calculateMean(values);
-        BigDecimal sd = calculateStandardDeviation(values, mean);
+        for (Map.Entry<Long, List<EQAResult>> group : byTest.entrySet()) {
+            List<BigDecimal> values = group.getValue().stream().map(EQAResult::getResultValue)
+                    .collect(Collectors.toList());
+            if (values.size() < MIN_PARTICIPANTS_FOR_STATS) {
+                logger.info("Distribution {} test {} has only {} numeric results, minimum {} required for statistics",
+                        distributionId, group.getKey(), values.size(), MIN_PARTICIPANTS_FOR_STATS);
+                continue;
+            }
 
-        for (EQAResult result : results) {
-            if (result.getResultValue() != null) {
+            BigDecimal mean = calculateMean(values);
+            BigDecimal sd = calculateStandardDeviation(values, mean);
+
+            for (EQAResult result : group.getValue()) {
                 BigDecimal zScore = calculateZScore(result.getResultValue(), mean, sd);
                 result.setZScore(zScore);
                 result.setPerformanceStatus(classifyPerformance(zScore));

--- a/src/main/java/org/openelisglobal/eqa/service/EqaCsv.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EqaCsv.java
@@ -1,0 +1,60 @@
+package org.openelisglobal.eqa.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * RFC 4180 enough for the EQA exchange files (export bundles, score CSVs):
+ * quoted cells may carry commas and doubled quotes; headers match by name,
+ * case-insensitively.
+ */
+final class EqaCsv {
+
+    private EqaCsv() {
+    }
+
+    static String[] lines(String csv) {
+        return csv.split("\\r?\\n");
+    }
+
+    static int indexOf(List<String> header, String name) {
+        for (int i = 0; i < header.size(); i++) {
+            if (name.equalsIgnoreCase(header.get(i).trim())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static String cell(List<String> cells, int index) {
+        return index >= 0 && index < cells.size() ? cells.get(index).trim() : "";
+    }
+
+    static List<String> split(String line) {
+        List<String> cells = new ArrayList<>();
+        StringBuilder cell = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (quoted) {
+                if (c == '"' && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                    cell.append('"');
+                    i++;
+                } else if (c == '"') {
+                    quoted = false;
+                } else {
+                    cell.append(c);
+                }
+            } else if (c == '"') {
+                quoted = true;
+            } else if (c == ',') {
+                cells.add(cell.toString());
+                cell.setLength(0);
+            } else {
+                cell.append(c);
+            }
+        }
+        cells.add(cell.toString());
+        return cells;
+    }
+}

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQAResult.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQAResult.java
@@ -53,6 +53,12 @@ public class EQAResult extends BaseObject<Long> {
     @Column(name = "result_value", precision = 15, scale = 5)
     private BigDecimal resultValue;
 
+    /**
+     * A qualitative reported value ("Reactive"); filled when result_value is not.
+     */
+    @Column(name = "result_text", length = 255)
+    private String resultText;
+
     @Column(name = "target_value", precision = 15, scale = 5)
     private BigDecimal targetValue;
 

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -144,4 +144,6 @@
   <!-- EQA V2.2 — OGC-610: the imported consignment a panel receipt took delivery
        of (qa-077). Must follow the shipment changelog that creates shipping_box. -->
   <include file="liquibase/qa/038-eqa-panel-receipt-shipping-box.xml" />
+  <!-- EQA V2.5 — OGC-613: qualitative participant results on the provider side (qa-078) -->
+  <include file="liquibase/qa/039-eqa-result-text.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/038-eqa-panel-receipt-shipping-box.xml
+++ b/src/main/resources/liquibase/qa/038-eqa-panel-receipt-shipping-box.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    EQA V2.2 (OGC-610, FR-V2.2-12): the inbound consignment a panel receipt was
+    EQA V2.2 (OGC-610): the inbound consignment a panel receipt was
     taken from. A participant receives a provider's panel as an imported shipping
     box; recording that box on the receipt lets the Add Order receipt take
     delivery of the consignment itself — which is what completes the provider's
@@ -19,7 +19,7 @@
                 <columnExists schemaName="clinlims" tableName="eqa_panel_receipt" columnName="shipping_box_id" />
             </not>
         </preConditions>
-        <comment>FR-V2.2-12: the imported consignment a panel receipt took delivery of</comment>
+        <comment>The imported consignment a panel receipt took delivery of</comment>
         <addColumn schemaName="clinlims" tableName="eqa_panel_receipt">
             <column name="shipping_box_id" type="INTEGER" />
         </addColumn>

--- a/src/main/resources/liquibase/qa/039-eqa-result-text.xml
+++ b/src/main/resources/liquibase/qa/039-eqa-result-text.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.5 (OGC-613, FR-V2.5-03): a participant's reported value that is not a
+    number. Four of the six CPHL domains are qualitative (HIV serology, EID, TB
+    microscopy, recency), and the V1 result row only had DECIMAL(15,5) for the
+    value, so a provider could not take those results in at all. Exactly one of
+    result_value / result_text is filled per row; a textual result is judged by
+    exact match against the panel's sealed target and carries no Z.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-078-eqa-result-text">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="clinlims" tableName="eqa_result" columnName="result_text" />
+            </not>
+        </preConditions>
+        <comment>FR-V2.5-03: qualitative participant results on the provider side</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_result">
+            <column name="result_text" type="VARCHAR(255)" />
+        </addColumn>
+        <rollback>
+            <dropColumn schemaName="clinlims" tableName="eqa_result" columnName="result_text" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/qa/039-eqa-result-text.xml
+++ b/src/main/resources/liquibase/qa/039-eqa-result-text.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    EQA V2.5 (OGC-613, FR-V2.5-03): a participant's reported value that is not a
+    EQA V2.5 (OGC-613): a participant's reported value that is not a
     number. Four of the six CPHL domains are qualitative (HIV serology, EID, TB
     microscopy, recency), and the V1 result row only had DECIMAL(15,5) for the
     value, so a provider could not take those results in at all. Exactly one of
@@ -18,7 +18,7 @@
                 <columnExists schemaName="clinlims" tableName="eqa_result" columnName="result_text" />
             </not>
         </preConditions>
-        <comment>FR-V2.5-03: qualitative participant results on the provider side</comment>
+        <comment>Qualitative participant results on the provider side</comment>
         <addColumn schemaName="clinlims" tableName="eqa_result">
             <column name="result_text" type="VARCHAR(255)" />
         </addColumn>

--- a/src/test/java/org/openelisglobal/eqa/EQAFhirExchangeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAFhirExchangeIntegrationTest.java
@@ -1,0 +1,254 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.eqa.service.EQAFhirExchangeService;
+import org.openelisglobal.eqa.service.EQAFhirSubmissionService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * The provider↔participant exchange over the provider's store (OGC-610 /
+ * OGC-613), driven on one database standing in for both instances: the
+ * participant's report is built from its cycle and imported box, re-addressed
+ * to the provider's box (the consignment uuid both hold) and taken in; the
+ * provider's score report is built and taken in the other way. Analytes travel
+ * by name, ids differ per install.
+ */
+public class EQAFhirExchangeIntegrationTest extends EQASpineTestBase {
+
+    private static final long ORG = 9990L;
+    private static final long ENROLLMENT = 9905L;
+    private static final long ANALYTE = 9821L;
+    private static final String ANALYTE_NAME = "Exchange HIV VL";
+    private static final long TEST = 9991L;
+    private static final int PROVIDER_BOX = 9960;
+    private static final int PARTICIPANT_BOX = 9961;
+
+    @Autowired
+    private EQAFhirSubmissionService submissionService;
+    @Autowired
+    private EQAFhirExchangeService exchangeService;
+    @Autowired
+    private FhirConfig fhirConfig;
+
+    private EQAProgram scheme;
+    private EQACycle providerCycle;
+    private EQACycle participantCycle;
+    private UUID providerConsignment;
+    private UUID participantConsignment;
+
+    @Before
+    public void seed() {
+        jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                + " VALUES (?, 'Exchange participant lab', 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING", ORG);
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE, ANALYTE_NAME);
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, 'Exchange HIV VL test', 'Exchange HIV VL test', 'Y', ?, now()"
+                        + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                TEST, UUID.randomUUID().toString(), TEST);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = 99821");
+        jdbc.update(
+                "INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (99821, ?, ?, now())",
+                TEST, ANALYTE);
+        seedEnrollment(ENROLLMENT, "Exchange programme");
+
+        scheme = insertScheme("Exchange scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+        eqaProgramService.assignTest(scheme.getId(), TEST);
+        providerCycle = readBack(insertCycle(scheme, 1));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", providerCycle.getId());
+        participantCycle = readBack(insertCycle(scheme, 2));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMITTED' WHERE id = ?", participantCycle.getId());
+        Long roundId = insertRound(participantCycle, 1, "OPEN");
+        insertParticipantResult(participantCycle, readBackRound(roundId), ENROLLMENT, ANALYTE,
+                EQASubmissionStatus.SUBMITTED, "105.5");
+
+        providerConsignment = UUID.randomUUID();
+        participantConsignment = UUID.randomUUID();
+        box(PROVIDER_BOX, "EXCH-P", providerConsignment, "SENT", providerCycle.getId());
+        box(PARTICIPANT_BOX, "EXCH-Q", participantConsignment, "RECEIVED", participantCycle.getId());
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.eqa_result");
+            jdbc.update("DELETE FROM clinlims.eqa_distribution WHERE cycle_id IS NOT NULL");
+            jdbc.update("DELETE FROM clinlims.shipping_box WHERE id IN (?, ?)", PROVIDER_BOX, PARTICIPANT_BOX);
+        }
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = 99821");
+            jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE);
+            jdbc.update("DELETE FROM clinlims.organization WHERE id = ?", ORG);
+        }
+    }
+
+    @Test
+    public void aParticipantReportNamesItsConsignmentSchemeAndAnalytes() {
+        Map<String, Resource> resources = submissionService.participantSubmissionResources(participantCycle.getId(),
+                ENROLLMENT);
+
+        DiagnosticReport report = report(resources);
+        assertEquals(participantConsignment.toString(),
+                identifier(report, EQAFhirSubmissionService.CONSIGNMENT_SUFFIX));
+        assertEquals(scheme.getName(), identifier(report, EQAFhirSubmissionService.SCHEME_NAME_SUFFIX));
+        assertEquals("2", identifier(report, EQAFhirSubmissionService.CYCLE_NUMBER_SUFFIX));
+        List<Observation> observations = observations(resources);
+        assertEquals(1, observations.size());
+        assertEquals("the analyte travels by name", ANALYTE_NAME, observations.get(0).getCode().getText());
+        assertEquals(0, new BigDecimal("105.5").compareTo(observations.get(0).getValueQuantity().getValue()));
+    }
+
+    @Test
+    public void theProviderTakesInAParticipantReportOnce() {
+        Map<String, Resource> resources = submissionService.participantSubmissionResources(participantCycle.getId(),
+                ENROLLMENT);
+        DiagnosticReport report = report(resources);
+        // On the provider instance the same consignment is its own dispatched box.
+        readdress(report, providerConsignment);
+
+        assertTrue("the report is taken in", exchangeService.applyParticipantReport(report, observations(resources)));
+
+        Long distributionId = jdbc.queryForObject("SELECT id FROM clinlims.eqa_distribution WHERE cycle_id = ?",
+                Long.class, providerCycle.getId());
+        assertNotNull("the provider's distribution is opened on demand", distributionId);
+        Map<String, Object> row = jdbc.queryForMap(
+                "SELECT result_value, submission_method FROM clinlims.eqa_result"
+                        + " WHERE eqa_distribution_id = ? AND participant_organization_id = ? AND test_id = ?",
+                distributionId, ORG, TEST);
+        assertEquals(0, new BigDecimal("105.5").compareTo((BigDecimal) row.get("result_value")));
+        assertEquals("FHIR", row.get("submission_method"));
+
+        assertFalse("a replay of the same report changes nothing",
+                exchangeService.applyParticipantReport(report, observations(resources)));
+        assertEquals(Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_result WHERE eqa_distribution_id = ?",
+                        Integer.class, distributionId));
+    }
+
+    @Test
+    public void aScoreReportIsAddressedToTheConsignmentAndTheParticipantTakesItInOnce() {
+        Map<String, Resource> inbound = submissionService.participantSubmissionResources(participantCycle.getId(),
+                ENROLLMENT);
+        readdress(report(inbound), providerConsignment);
+        exchangeService.applyParticipantReport(report(inbound), observations(inbound));
+        Long distributionId = jdbc.queryForObject("SELECT id FROM clinlims.eqa_distribution WHERE cycle_id = ?",
+                Long.class, providerCycle.getId());
+        jdbc.update("UPDATE clinlims.eqa_result SET z_score = 1.2, performance_status = 'ACCEPTABLE'"
+                + " WHERE eqa_distribution_id = ?", distributionId);
+
+        Map<String, Resource> scores = submissionService.scoreReturnResources(distributionId, ORG);
+        DiagnosticReport scoreReport = report(scores);
+        assertEquals(providerConsignment.toString(), identifier(scoreReport, EQAFhirSubmissionService.SCORES_SUFFIX));
+        assertEquals(providerConsignment.toString(),
+                identifier(scoreReport, EQAFhirSubmissionService.CONSIGNMENT_SUFFIX));
+        Observation scored = observations(scores).get(0);
+        assertEquals(ANALYTE_NAME, scored.getCode().getText());
+        assertEquals("ACCEPTABLE", scored.getInterpretationFirstRep().getCodingFirstRep().getCode());
+
+        // On the participant instance the same consignment is the box it imported.
+        readdress(scoreReport, participantConsignment);
+        assertTrue(exchangeService.applyScoreReport(scoreReport, observations(scores)));
+
+        Map<String, Object> result = jdbc.queryForMap("SELECT submission_status, performance_status, z_score"
+                + " FROM clinlims.eqa_participant_result WHERE cycle_id = ?", participantCycle.getId());
+        assertEquals("SCORED", result.get("submission_status"));
+        assertEquals("ACCEPTABLE", result.get("performance_status"));
+        assertEquals(0, new BigDecimal("1.2").compareTo((BigDecimal) result.get("z_score")));
+        assertEquals("SCORED", jdbc.queryForObject("SELECT status FROM clinlims.eqa_cycle WHERE id = ?", String.class,
+                participantCycle.getId()));
+
+        assertFalse("a replayed score report is a no-op, not a second scoring",
+                exchangeService.applyScoreReport(scoreReport, observations(scores)));
+    }
+
+    @Test
+    public void aReportForAnUnknownConsignmentIsNotApplied() {
+        Map<String, Resource> resources = submissionService.participantSubmissionResources(participantCycle.getId(),
+                ENROLLMENT);
+        DiagnosticReport report = report(resources);
+        readdress(report, UUID.randomUUID());
+
+        assertFalse(exchangeService.applyParticipantReport(report, observations(resources)));
+        assertEquals(Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_result", Integer.class));
+    }
+
+    // ---- helpers ----
+
+    private void box(int id, String code, UUID fhirUuid, String state, Long cycleId) {
+        jdbc.update(
+                "INSERT INTO clinlims.shipping_box (id, box_id, fhir_uuid, destination_facility_id, state,"
+                        + " created_date, archived, sys_user_id, lastupdated, eqa_cycle_id)"
+                        + " VALUES (?, ?, ?, ?, ?, now(), false, ?, now(), ?)",
+                id, code, fhirUuid, ORG, state, Integer.parseInt(USER), cycleId);
+    }
+
+    private org.openelisglobal.eqa.valueholder.EQARound readBackRound(Long roundId) {
+        return eqaRoundDAO.get(roundId).orElseThrow(AssertionError::new);
+    }
+
+    private static DiagnosticReport report(Map<String, Resource> resources) {
+        for (Resource resource : resources.values()) {
+            if (resource instanceof DiagnosticReport report) {
+                return report;
+            }
+        }
+        throw new AssertionError("no DiagnosticReport in the bundle");
+    }
+
+    private static List<Observation> observations(Map<String, Resource> resources) {
+        List<Observation> observations = new ArrayList<>();
+        for (Resource resource : resources.values()) {
+            if (resource instanceof Observation observation) {
+                observations.add(observation);
+            }
+        }
+        return observations;
+    }
+
+    private String identifier(DiagnosticReport report, String suffix) {
+        String system = fhirConfig.getOeFhirSystem() + suffix;
+        for (Identifier identifier : report.getIdentifier()) {
+            if (system.equals(identifier.getSystem())) {
+                return identifier.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * What the other instance sees: the same consignment under its own box's uuid.
+     */
+    private void readdress(DiagnosticReport report, UUID consignment) {
+        String consignmentSystem = fhirConfig.getOeFhirSystem() + EQAFhirSubmissionService.CONSIGNMENT_SUFFIX;
+        String scoresSystem = fhirConfig.getOeFhirSystem() + EQAFhirSubmissionService.SCORES_SUFFIX;
+        for (Identifier identifier : report.getIdentifier()) {
+            if (consignmentSystem.equals(identifier.getSystem()) || scoresSystem.equals(identifier.getSystem())) {
+                identifier.setValue(consignment.toString());
+            }
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelLifecycleIntegrationTest.java
@@ -2,6 +2,8 @@ package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
@@ -188,5 +190,39 @@ public class EQAPanelLifecycleIntegrationTest extends EQASpineTestBase {
 
         assertEquals("4.52", dto.get("targetValue"));
         assertEquals(Boolean.TRUE, dto.get("targetsRevealed"));
+    }
+
+    /**
+     * Exports and FHIR observations label a row with its analyte name, and the row
+     * may name a test that no longer exists. The strict lookup throws for that, and
+     * a throw joins the caller's transaction and marks it rollback-only, so the
+     * caller's own commit fails even when it catches. The lenient lookup must
+     * answer null and leave the transaction usable.
+     */
+    @Test
+    public void findAnalyteIdForTest_answersNullForATestThatDoesNotExist() {
+        assertNull("an id with no test row behind it resolves to no analyte",
+                panelService.findAnalyteIdForTest("99999999"));
+        assertNull("a blank test id resolves to no analyte", panelService.findAnalyteIdForTest(null));
+
+        // The transaction still works: a read after the miss must succeed rather
+        // than fail with UnexpectedRollback.
+        EQAProgram scheme = insertScheme("Lenient analyte lookup", EQASchemeType.IN_HOUSE, null);
+        EQAPanel panel = insertPanel(scheme, p -> {
+            p.setPanelName("Lenient");
+            p.setUnblindDate(Date.valueOf("2026-12-01"));
+        });
+        insertSample(panel, "A01", "1.00");
+
+        assertEquals(EQAPanelStatus.SEALED, panelService.seal(panel.getId(), USER).getStatus());
+    }
+
+    @Test
+    public void analyteIdForTest_stillRefusesATestThatDoesNotExist() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> panelService.analyteIdForTest("99999999"));
+
+        assertTrue("the refusal must name the test it could not resolve: " + thrown.getMessage(),
+                thrown.getMessage().contains("99999999"));
     }
 }

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
@@ -22,8 +22,8 @@ import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Provider-side intake of participant results (OGC-613, FR-V2.5-03): phoned and
- * emailed values keyed on the provider, numbers and qualitative words alike, a
+ * Provider-side intake of participant results (OGC-613): phoned and emailed
+ * values keyed on the provider, numbers and qualitative words alike, a
  * participant's export bundle imported by analyte name, peer statistics per
  * test, and qualitative verdicts judged against the panel's sealed target.
  */

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
@@ -1,0 +1,251 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.service.EQAProviderScoringService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Provider-side intake of participant results (OGC-613, FR-V2.5-03): phoned and
+ * emailed values keyed on the provider, numbers and qualitative words alike, a
+ * participant's export bundle imported by analyte name, peer statistics per
+ * test, and qualitative verdicts judged against the panel's sealed target.
+ */
+public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
+
+    private static final long FIRST_ORG = 9975L;
+    private static final int ORGS = 12;
+    private static final long TEST_VL = 9987L;
+    private static final long TEST_SERO = 9988L;
+    private static final long TEST_CD4 = 9989L;
+    private static final long ANALYTE_VL = 9811L;
+    private static final long ANALYTE_SERO = 9812L;
+    private static final long ANALYTE_CD4 = 9813L;
+
+    @Autowired
+    private EQAProviderScoringService scoringService;
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    private EQAProgram scheme;
+    private EQACycle cycle;
+
+    @Before
+    public void seed() {
+        for (long id = FIRST_ORG; id < FIRST_ORG + ORGS; id++) {
+            jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                    + " VALUES (?, ?, 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING", id, "Intake lab " + id);
+        }
+        analyte(ANALYTE_VL, "Intake HIV VL");
+        analyte(ANALYTE_SERO, "Intake HIV serology");
+        analyte(ANALYTE_CD4, "Intake CD4");
+        test(TEST_VL, "Intake HIV VL test", ANALYTE_VL, 99811);
+        test(TEST_SERO, "Intake HIV serology test", ANALYTE_SERO, 99812);
+        test(TEST_CD4, "Intake CD4 test", ANALYTE_CD4, 99813);
+
+        scheme = insertScheme("Intake scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+        eqaProgramService.assignTest(scheme.getId(), TEST_VL);
+        eqaProgramService.assignTest(scheme.getId(), TEST_SERO);
+        eqaProgramService.assignTest(scheme.getId(), TEST_CD4);
+        cycle = readBack(insertCycle(scheme, 1));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
+
+        EQAPanel panel = insertPanel(scheme, p -> {
+            p.setCycle(cycle);
+            p.setPanelName("Intake panel");
+        });
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode("S01");
+        sample.setAnalyteId(ANALYTE_SERO);
+        sample.setTargetValue("Reactive");
+        sample.setSysUserId(USER);
+        eqaPanelSampleDAO.insert(sample);
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.eqa_result");
+            jdbc.update("DELETE FROM clinlims.eqa_distribution WHERE cycle_id IS NOT NULL");
+        }
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id IN (99811, 99812, 99813)");
+            jdbc.update("DELETE FROM clinlims.test WHERE id IN (?, ?, ?)", TEST_VL, TEST_SERO, TEST_CD4);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id IN (?, ?, ?)", ANALYTE_VL, ANALYTE_SERO, ANALYTE_CD4);
+            jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_ORG, FIRST_ORG + ORGS);
+        }
+    }
+
+    @Test
+    public void reportedValuesLandAsNumbersOrWordsAndAreEchoedBack() {
+        Map<String, Object> grid = scoringService.takeIn(cycle.getId(), FIRST_ORG,
+                Map.of(TEST_VL, "105.5", TEST_SERO, "Reactive"), EQASubmissionMethod.MANUAL, USER);
+
+        assertEquals(new BigDecimal("105.50000"), resultValue(FIRST_ORG, TEST_VL));
+        assertNull(resultText(FIRST_ORG, TEST_VL));
+        assertEquals("Reactive", resultText(FIRST_ORG, TEST_SERO));
+        assertNull(resultValue(FIRST_ORG, TEST_SERO));
+        assertEquals("Reactive", reportedInGrid(grid, TEST_SERO));
+        assertEquals(0, new BigDecimal("105.5").compareTo((BigDecimal) reportedInGrid(grid, TEST_VL)));
+        assertNull("nothing reported for CD4 yet", reportedInGrid(grid, TEST_CD4));
+
+        scoringService.takeIn(cycle.getId(), FIRST_ORG, Map.of(TEST_SERO, "Non-reactive"), EQASubmissionMethod.MANUAL,
+                USER);
+        assertEquals("a second entry overwrites, it does not duplicate", "Non-reactive",
+                resultText(FIRST_ORG, TEST_SERO));
+        assertEquals(Integer.valueOf(2),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_result WHERE participant_organization_id = ?",
+                        Integer.class, FIRST_ORG));
+    }
+
+    @Test
+    public void peerStatisticsAreComputedPerTestNotAcrossThePanel() {
+        for (int i = 0; i < ORGS; i++) {
+            long org = FIRST_ORG + i;
+            String viralLoad = i == ORGS - 1 ? "400" : "100";
+            String cd4 = String.valueOf(1000 + i);
+            scoringService.takeIn(cycle.getId(), org, Map.of(TEST_VL, viralLoad, TEST_CD4, cd4),
+                    EQASubmissionMethod.MANUAL, USER);
+        }
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("the viral-load outlier is judged against viral loads", "UNACCEPTABLE",
+                verdict(FIRST_ORG + ORGS - 1, TEST_VL));
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG, TEST_VL));
+        // Pooled across the panel, every CD4 (~1000) would sit far above a mean pulled
+        // down by the viral loads and read as positive Z; per test, the lowest CD4 is
+        // below its own peers and the highest above.
+        assertTrue("lowest CD4 sits below its peers", zScore(FIRST_ORG, TEST_CD4).signum() < 0);
+        assertTrue("highest CD4 sits above its peers", zScore(FIRST_ORG + ORGS - 1, TEST_CD4).signum() > 0);
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG + ORGS - 1, TEST_CD4));
+    }
+
+    @Test
+    public void qualitativeResultsAreJudgedAgainstThePanelTarget() {
+        for (int i = 0; i < ORGS; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i,
+                    Map.of(TEST_SERO, i == ORGS - 1 ? "Non-reactive" : "reactive"), EQASubmissionMethod.MANUAL, USER);
+        }
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG, TEST_SERO));
+        assertEquals("UNACCEPTABLE", verdict(FIRST_ORG + ORGS - 1, TEST_SERO));
+        assertNull("a word has no Z", zScore(FIRST_ORG + ORGS - 1, TEST_SERO));
+        assertEquals("the failing participant reaches the follow-up register", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_participant_followup WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()));
+    }
+
+    @Test
+    public void aParticipantExportBundleImportsByAnalyteName() {
+        String csv = "cycle_id,cycle_name,round_number,analyte_id,analyte_name,result_value,result_unit,"
+                + "submission_status,entered_at\n" + "9,,1,4711,Intake HIV serology,Reactive,,SUBMITTED,\n"
+                + "9,,1,4712,intake hiv vl,250,copies/mL,SUBMITTED,\n"
+                + "9,,1,4713,Something this scheme does not run,5,,SUBMITTED,\n";
+
+        Map<String, Object> outcome = scoringService.importReportedCsv(cycle.getId(), FIRST_ORG, csv, USER);
+
+        assertEquals(2, outcome.get("imported"));
+        List<?> errors = (List<?>) outcome.get("errors");
+        assertEquals(1, errors.size());
+        assertTrue(String.valueOf(errors.get(0)), String.valueOf(errors.get(0)).contains("Something this scheme"));
+        assertEquals("Reactive", resultText(FIRST_ORG, TEST_SERO));
+        assertEquals(0, new BigDecimal("250").compareTo(resultValue(FIRST_ORG, TEST_VL)));
+        assertEquals("FILE_UPLOAD", jdbc.queryForObject(
+                "SELECT submission_method FROM clinlims.eqa_result WHERE participant_organization_id = ? AND test_id = ?",
+                String.class, FIRST_ORG, TEST_VL));
+    }
+
+    @Test
+    public void intakeRefusesATestOutsideTheSchemeAndACycleNotYetShipped() {
+        try {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG, Map.of(424242L, "1"), EQASubmissionMethod.MANUAL, USER);
+            fail("a test the scheme does not run must be refused");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("not part of scheme"));
+        }
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'PLANNED' WHERE id = ?", cycle.getId());
+        try {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG, Map.of(TEST_VL, "1"), EQASubmissionMethod.MANUAL, USER);
+            fail("a cycle that has not shipped has no results to take in");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("PLANNED"));
+        }
+        assertEquals(Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_result", Integer.class));
+    }
+
+    // ---- helpers ----
+
+    private void analyte(long id, String name) {
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", id, name);
+    }
+
+    private void test(long id, String name, long analyteId, int linkId) {
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                id, name, name, UUID.randomUUID().toString(), id);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", linkId);
+        jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
+                linkId, id, analyteId);
+    }
+
+    private BigDecimal resultValue(long organizationId, long testId) {
+        return jdbc.queryForObject(
+                "SELECT result_value FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, testId);
+    }
+
+    private String resultText(long organizationId, long testId) {
+        return jdbc.queryForObject(
+                "SELECT result_text FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                String.class, organizationId, testId);
+    }
+
+    private String verdict(long organizationId, long testId) {
+        return jdbc.queryForObject(
+                "SELECT performance_status FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                String.class, organizationId, testId);
+    }
+
+    private BigDecimal zScore(long organizationId, long testId) {
+        return jdbc.queryForObject(
+                "SELECT z_score FROM clinlims.eqa_result" + " WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, testId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object reportedInGrid(Map<String, Object> grid, long testId) {
+        for (Map<String, Object> row : (List<Map<String, Object>>) grid.get("tests")) {
+            if (Long.valueOf(testId).equals(row.get("testId"))) {
+                return row.get("reported");
+            }
+        }
+        throw new AssertionError("test " + testId + " missing from the grid");
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAScoreCsvIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAScoreCsvIntakeIntegrationTest.java
@@ -18,8 +18,8 @@ import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * FR-V2.2-08 by file (OGC-610): a participant pastes the provider's scores CSV
- * and its submitted results are scored, matched by analyte name; rows naming an
+ * Scores by file (OGC-610): a participant pastes the provider's scores CSV and
+ * its submitted results are scored, matched by analyte name; rows naming an
  * analyte this laboratory does not know are reported, and a second paste has
  * nothing left to score.
  */

--- a/src/test/java/org/openelisglobal/eqa/EQAScoreCsvIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAScoreCsvIntakeIntegrationTest.java
@@ -1,0 +1,96 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQACycleSubmissionService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * FR-V2.2-08 by file (OGC-610): a participant pastes the provider's scores CSV
+ * and its submitted results are scored, matched by analyte name; rows naming an
+ * analyte this laboratory does not know are reported, and a second paste has
+ * nothing left to score.
+ */
+public class EQAScoreCsvIntakeIntegrationTest extends EQASpineTestBase {
+
+    private static final long ENROLLMENT = 9906L;
+    private static final long ANALYTE = 9831L;
+    private static final String ANALYTE_NAME = "Csv intake analyte";
+
+    @Autowired
+    private EQACycleSubmissionService cycleSubmissionService;
+
+    private EQACycle cycle;
+
+    @Before
+    public void seed() {
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE, ANALYTE_NAME);
+        seedEnrollment(ENROLLMENT, "Csv intake programme");
+        EQAProgram scheme = insertScheme("Csv intake scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+        cycle = readBack(insertCycle(scheme, 1));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMITTED' WHERE id = ?", cycle.getId());
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQARound round = eqaRoundDAO.get(roundId).orElseThrow(AssertionError::new);
+        insertParticipantResult(cycle, round, ENROLLMENT, ANALYTE, EQASubmissionStatus.SUBMITTED, "105");
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE);
+        }
+    }
+
+    @Test
+    public void theProviderScoresCsvScoresTheSubmittedResultsByAnalyteName() {
+        String csv = "test,analyte_name,result_value,target_value,z_score,performance_status,scored_on\n"
+                + "HIV VL (provider's name),csv intake analyte,105,100,1.2,ACCEPTABLE,2026-09-03\n"
+                + "Other,An analyte nobody here runs,1,,,UNACCEPTABLE,2026-09-03\n";
+
+        Map<String, Object> outcome = cycleSubmissionService.intakeScoresCsv(cycle.getId(), ENROLLMENT, csv, USER);
+
+        assertEquals(1, outcome.get("scored"));
+        assertEquals(List.of("An analyte nobody here runs"), outcome.get("unmapped"));
+        Map<String, Object> result = jdbc.queryForMap("SELECT submission_status, performance_status, z_score"
+                + " FROM clinlims.eqa_participant_result WHERE cycle_id = ?", cycle.getId());
+        assertEquals("SCORED", result.get("submission_status"));
+        assertEquals("ACCEPTABLE", result.get("performance_status"));
+        assertEquals(0, new BigDecimal("1.2").compareTo((BigDecimal) result.get("z_score")));
+        assertEquals("SCORED",
+                jdbc.queryForObject("SELECT status FROM clinlims.eqa_cycle WHERE id = ?", String.class, cycle.getId()));
+
+        try {
+            cycleSubmissionService.intakeScoresCsv(cycle.getId(), ENROLLMENT, csv, USER);
+            fail("a second paste has no submitted result left to score");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("No submitted result"));
+        }
+    }
+
+    @Test
+    public void aCsvWithoutTheScoreColumnsIsRefused() {
+        try {
+            cycleSubmissionService.intakeScoresCsv(cycle.getId(), ENROLLMENT, "a,b\n1,2\n", USER);
+            fail("the header must name analyte_name and performance_status");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("analyte_name"));
+        }
+        assertEquals("SUBMITTED",
+                jdbc.queryForObject("SELECT submission_status FROM clinlims.eqa_participant_result WHERE cycle_id = ?",
+                        String.class, cycle.getId()));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -90,6 +90,7 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQASubmissionRestController#approveLateSubmission", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQACycleRestController#createProviderCycle", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAResultRestController#takeInCycleResults", EQAGuards.PROVIDER);
+        WRITE_GUARDS.put("EQASubmissionRestController#intakeScoresCsv", EQAGuards.MANAGE);
         WRITE_GUARDS.put("EQAResultRestController#importCycleResultsCsv", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#savePrep", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#saveShipment", EQAGuards.PROVIDER);

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -89,6 +89,8 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQAProgramRestController#updateAnalysts", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQASubmissionRestController#approveLateSubmission", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQACycleRestController#createProviderCycle", EQAGuards.PROVIDER);
+        WRITE_GUARDS.put("EQAResultRestController#takeInCycleResults", EQAGuards.PROVIDER);
+        WRITE_GUARDS.put("EQAResultRestController#importCycleResultsCsv", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#savePrep", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#saveShipment", EQAGuards.PROVIDER);
         WRITE_GUARDS.put("EQAShipmentRestController#ship", EQAGuards.PROVIDER);

--- a/src/test/java/org/openelisglobal/eqa/controller/rest/EQAResultRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/rest/EQAResultRestControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -20,13 +21,16 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.eqa.service.EQAResultService;
 import org.openelisglobal.eqa.service.EQAStatisticsService;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
 import org.openelisglobal.eqa.valueholder.EQAResult;
 import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
+import org.openelisglobal.login.valueholder.UserSessionData;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EQAResultRestControllerTest {
@@ -43,15 +47,15 @@ public class EQAResultRestControllerTest {
     @Test
     public void testSubmitResult_ValidData_ReturnsOk() {
         EQAResult result = createResult(1L, 10L, 20L, new BigDecimal("5.5"));
-        when(resultService.submitResult(eq(1L), eq(10L), eq(20L), any(BigDecimal.class),
-                eq(EQASubmissionMethod.MANUAL))).thenReturn(result);
+        when(resultService.submitResult(eq(1L), eq(10L), eq(20L), any(BigDecimal.class), eq(EQASubmissionMethod.MANUAL),
+                anyString())).thenReturn(result);
 
         Map<String, Object> body = new HashMap<>();
         body.put("organizationId", 10);
         body.put("testId", 20);
         body.put("resultValue", 5.5);
 
-        ResponseEntity<?> response = controller.submitResult(1L, body);
+        ResponseEntity<?> response = controller.submitResult(request(), 1L, body);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         Map<?, ?> responseBody = (Map<?, ?>) response.getBody();
@@ -64,7 +68,7 @@ public class EQAResultRestControllerTest {
         Map<String, Object> body = new HashMap<>();
         body.put("organizationId", 10);
 
-        ResponseEntity<?> response = controller.submitResult(1L, body);
+        ResponseEntity<?> response = controller.submitResult(request(), 1L, body);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
     }
@@ -73,11 +77,11 @@ public class EQAResultRestControllerTest {
     public void testBatchImport_AllValid_ReturnsSuccessCount() {
         EQAResult result = createResult(1L, 10L, 20L, new BigDecimal("5.5"));
         when(resultService.submitResult(anyLong(), anyLong(), anyLong(), any(BigDecimal.class),
-                eq(EQASubmissionMethod.FILE_UPLOAD))).thenReturn(result);
+                eq(EQASubmissionMethod.FILE_UPLOAD), anyString())).thenReturn(result);
 
         List<Map<String, Object>> rows = Arrays.asList(createRow(10, 20, 5.5), createRow(11, 20, 6.0));
 
-        ResponseEntity<?> response = controller.batchImportResults(1L, rows);
+        ResponseEntity<?> response = controller.batchImportResults(request(), 1L, rows);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         Map<?, ?> body = (Map<?, ?>) response.getBody();
@@ -90,7 +94,7 @@ public class EQAResultRestControllerTest {
     public void testBatchImport_SomeInvalid_ReportsErrors() {
         EQAResult result = createResult(1L, 10L, 20L, new BigDecimal("5.5"));
         when(resultService.submitResult(anyLong(), anyLong(), anyLong(), any(BigDecimal.class),
-                eq(EQASubmissionMethod.FILE_UPLOAD))).thenReturn(result);
+                eq(EQASubmissionMethod.FILE_UPLOAD), anyString())).thenReturn(result);
 
         Map<String, Object> invalidRow = new HashMap<>();
         invalidRow.put("organizationId", 10);
@@ -98,7 +102,7 @@ public class EQAResultRestControllerTest {
 
         List<Map<String, Object>> rows = Arrays.asList(createRow(10, 20, 5.5), invalidRow);
 
-        ResponseEntity<?> response = controller.batchImportResults(1L, rows);
+        ResponseEntity<?> response = controller.batchImportResults(request(), 1L, rows);
 
         Map<?, ?> body = (Map<?, ?>) response.getBody();
         assertNotNull(body);
@@ -186,5 +190,13 @@ public class EQAResultRestControllerTest {
         row.put("testId", testId);
         row.put("resultValue", value);
         return row;
+    }
+
+    private static MockHttpServletRequest request() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId(1);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession(true).setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
+        return request;
     }
 }

--- a/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
@@ -605,8 +605,8 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
 
         String[] lines = csv.split("\n");
         assertEquals("header plus one row", 2, lines.length);
-        assertEquals("cycle_id,cycle_name,round_number,analyte_id,result_value,result_unit,submission_status,"
-                + "entered_at", lines[0]);
+        assertEquals("cycle_id,cycle_name,round_number,analyte_id,analyte_name,result_value,result_unit,"
+                + "submission_status,entered_at", lines[0]);
         assertTrue("a value with a comma must be quoted, or the column count shifts: " + lines[1],
                 lines[1].contains("\"Positive, weak\""));
         assertTrue(lines[1].startsWith(cycle.getId() + ",,1," + VL_ANALYTE + ","));

--- a/src/test/java/org/openelisglobal/eqa/service/EQAResultServiceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAResultServiceTest.java
@@ -51,7 +51,8 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.insert(any(EQAResult.class))).thenReturn(1L);
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(Collections.emptyList());
 
-        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL,
+                "1");
 
         assertNotNull("Result should not be null", result);
         assertEquals("Organization ID should match", Long.valueOf(10L), result.getParticipantOrganizationId());
@@ -81,7 +82,8 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.update(any(EQAResult.class))).thenAnswer(i -> i.getArgument(0));
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(Collections.emptyList());
 
-        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL,
+                "1");
 
         assertEquals("Result value should be updated", new BigDecimal("5.5"), result.getResultValue());
         // T116: Verify audit trail fields
@@ -101,7 +103,7 @@ public class EQAResultServiceTest {
 
         when(eqaDistributionDAO.get(1L)).thenReturn(Optional.of(distribution));
 
-        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL, "1");
     }
 
     @Test
@@ -115,7 +117,8 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.insert(any(EQAResult.class))).thenReturn(1L);
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(Collections.emptyList());
 
-        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        EQAResult result = resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL,
+                "1");
 
         assertNotNull("Result should not be null", result);
     }
@@ -128,7 +131,7 @@ public class EQAResultServiceTest {
 
         when(eqaDistributionDAO.get(1L)).thenReturn(Optional.of(distribution));
 
-        resultService.submitResult(1L, 10L, 20L, new BigDecimal("-1"), EQASubmissionMethod.MANUAL);
+        resultService.submitResult(1L, 10L, 20L, new BigDecimal("-1"), EQASubmissionMethod.MANUAL, "1");
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -139,7 +142,7 @@ public class EQAResultServiceTest {
 
         when(eqaDistributionDAO.get(1L)).thenReturn(Optional.of(distribution));
 
-        resultService.submitResult(1L, 10L, 20L, new BigDecimal("1000000"), EQASubmissionMethod.MANUAL);
+        resultService.submitResult(1L, 10L, 20L, new BigDecimal("1000000"), EQASubmissionMethod.MANUAL, "1");
     }
 
     @Test
@@ -153,7 +156,7 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.insert(any(EQAResult.class))).thenReturn(1L);
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(Collections.emptyList());
 
-        EQAResult result = resultService.submitResult(1L, 10L, 20L, null, EQASubmissionMethod.MANUAL);
+        EQAResult result = resultService.submitResult(1L, 10L, 20L, null, EQASubmissionMethod.MANUAL, "1");
 
         assertNotNull("Result should not be null", result);
     }
@@ -172,7 +175,7 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(
                 Arrays.asList(new EQAResult(), new EQAResult(), new EQAResult(), new EQAResult(), new EQAResult()));
 
-        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL, "1");
 
         verify(eqaStatisticsService).calculateAndUpdateStatistics(1L);
     }
@@ -188,7 +191,7 @@ public class EQAResultServiceTest {
         when(eqaResultDAO.insert(any(EQAResult.class))).thenReturn(1L);
         when(eqaResultDAO.findByDistributionId(1L)).thenReturn(Arrays.asList(new EQAResult(), new EQAResult()));
 
-        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+        resultService.submitResult(1L, 10L, 20L, new BigDecimal("5.5"), EQASubmissionMethod.MANUAL, "1");
 
         verify(eqaStatisticsService, never()).calculateAndUpdateStatistics(anyLong());
     }
@@ -197,7 +200,7 @@ public class EQAResultServiceTest {
     public void testSubmitResult_WithInvalidDistribution_ThrowsException() {
         when(eqaDistributionDAO.get(999L)).thenReturn(Optional.empty());
         resultService.submitResult(999L, 10L, 20L,
-                new BigDecimal("5.5"), EQASubmissionMethod.MANUAL);
+                new BigDecimal("5.5"), EQASubmissionMethod.MANUAL, "1");
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/sample/service/SamplePatientEntryEQAReceiptIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/sample/service/SamplePatientEntryEQAReceiptIntegrationTest.java
@@ -98,8 +98,7 @@ public class SamplePatientEntryEQAReceiptIntegrationTest extends EQASpineTestBas
     }
 
     /**
-     * FR-V2.2-12: the receipt on Add Order takes delivery of the imported
-     * consignment it names.
+     * The receipt on Add Order takes delivery of the imported consignment it names.
      */
     @Test
     public void orderSaveWithAConsignment_receivesTheBoxAndRecordsItOnTheReceipt() {


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3 [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide) documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing [Guidelines](https://openelis-global.org/community/get-involved/) of this project.

## Summary

Three commits that together let a provider and a participant on two OpenELIS instances close an EQA cycle.

**1. Provider-side intake of participant results.** A provider had no screen to take in a participant's results: the only way past SUBMISSIONS_OPEN was a JSON call against a numeric-only endpoint, so the four qualitative CPHL domains could not be scored at all. The Receipt Monitor gains **Enter results** per participant — a grid of the scheme's tests taking the value as reported (a number, or a word such as Reactive) and a paste box that imports the participant's export-bundle CSV, matching analytes by name because the two instances do not share ids. New `eqa_result.result_text` (changeset `qa-078`, slot 039) holds qualitative values; they are judged by exact match against the panel's sealed target and carry no Z. The new cycle-level endpoints take the provider grant. The participant's export bundle gains an `analyte_name` column.

Two latent defects fixed on the way: peer statistics pooled every result of a distribution into one mean regardless of test (now per test), and `eqa_result.sys_user_id` is NOT NULL yet the V1 intake never set it, so no result had ever been written through that path.

**2. Exchange over the provider's FHIR store.** Both "FHIR" writes only ever reached the sender's own store. The participant's bundle is now also pushed to every configured remote store and names its consignment (the SupplyDelivery uuid both instances hold), the scheme and the cycle number; each observation names its analyte. The provider polls its own store for such reports, places them by the consignment's box (its cycle and the participant organization) and takes the values in once. The provider's score return is addressed to the same consignment; the participant polls its provider's store for scores addressed to its imported boxes and applies them through the existing score intake once. Both polls run on the delivery-reconcile cadence and are no-ops when the store they read is not configured. A remote the participant cannot reach counts as a failed attempt, so the existing backoff and alert apply.

**3. Truthful toast and a scores CSV on My Cycles.** The Receipt Monitor said "Scores returned over FHIR" when they had only reached the provider's own store; it now says where they went. For a provider that is not an OpenELIS instance, a participant can paste the provider's scores CSV on My Cycles (`POST /rest/eqa/cycles/{id}/score-intake/csv`, manage grant); analytes are matched by name, unrecognised rows are reported back, and a second paste has nothing left to score.

## Tests

- `EQAProviderIntakeIntegrationTest` (5): numbers and words stored and echoed; per-test statistics with a sign-flip assertion the pooled code fails; qualitative verdicts from the panel target reaching the follow-up register; CSV by analyte name with an unmapped row reported; refusals for a foreign test and an unshipped cycle.
- `EQAFhirExchangeIntegrationTest` (4): the round trip on one database standing in for both instances — report identity, provider intake once, score report addressed to the consignment, participant scoring once, unknown consignment refused.
- `EQAScoreCsvIntakeIntegrationTest` (2).
- Controller and service unit tests updated for the acting user; Jest +3; auto-submission (17), oversight (15), follow-up (9), guard-matrix, security-slice and shipment-workbench (43) suites green.
- Live on the dev stack with its own HAPI as the "remote": the grid saved, prefilled and imported a CSV with an unmapped row reported; **Send scores** placed a report in the store addressed to the consignment; a participant report hand-placed in the store was taken in by the provider poll within 40 s; the toast reads as described; the import modal shows the server's refusal on a cycle with nothing submitted. The participant-side score poll needs two instances and rests on the integration test.

## Related Issue

[OGC-613](https://uwdigi.atlassian.net/browse/OGC-613), [OGC-610](https://uwdigi.atlassian.net/browse/OGC-610)

## Other

Liquibase slot 039 / `qa-078`. **Merge after** the participant-cycle PR (https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4166) and the receipt PR (https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4167); the overlap is the last include line of `base-changelog.xml` and the tail of `en.json`, both trivial to resolve on rebase. Decisions to confirm: consignment uuid as the cross-instance identity, analyte *name* as the analyte identity.


[OGC-613]: https://uwdigi.atlassian.net/browse/OGC-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ