### PR TITLE
fix(test): make two shared-fixture seeds survive suite ordering

### DIFF
--- a/docs/workplan/eqa-interaction.md
+++ b/docs/workplan/eqa-interaction.md
@@ -5,8 +5,8 @@ Workplan, and the one rule that keeps blinding intact.
 
 ## What the Workplan shows
 
-An in-house blinded panel (EQA V2.4, OGC-612) is distributed as standard
-orders. Each order's accession number is the panel sample's blind code
+An in-house blinded panel (EQA V2.4, OGC-612) is distributed as standard orders.
+Each order's accession number is the panel sample's blind code
 (`IH-{panel}-{nn}`), so the Workplan lists the order under that code in the
 sample column, exactly as it lists any other order. Nothing about the row
 reveals the panel, the analyte's target value, or the acceptance range: those
@@ -17,24 +17,23 @@ result-entry page renders). The badge marks the row as proficiency-testing
 material; it does not say which panel or scheme it belongs to.
 
 The analyst assigned to a blinded sample sees it in the Workplan and on the
-result-entry page like any other work and enters the result through the
-standard pipeline. Scoring happens later, at unblind, against the sealed
-target (see `docs/eqa/analyst-competency-rules.md` for what a scored result
-means for the analyst).
+result-entry page like any other work and enters the result through the standard
+pipeline. Scoring happens later, at unblind, against the sealed target (see
+`docs/eqa/analyst-competency-rules.md` for what a scored result means for the
+analyst).
 
 ## The rule: never add an "exclude EQA" filter
 
-FR-V2.4-15 requires blinded orders to sit among routine work. The Workplan
-must not grow a filter, tab, or default that hides EQA rows: an analyst who
-could tell a proficiency sample from a patient sample by where it appears
-would defeat the blinding. Filters that already exist (test section, priority,
-date) apply to EQA rows the same way they apply to everything else.
+FR-V2.4-15 requires blinded orders to sit among routine work. The Workplan must
+not grow a filter, tab, or default that hides EQA rows: an analyst who could
+tell a proficiency sample from a patient sample by where it appears would defeat
+the blinding. Filters that already exist (test section, priority, date) apply to
+EQA rows the same way they apply to everything else.
 
 The EQA badge is deliberately the only EQA-specific element on the row. It
-exists so a supervisor reviewing the Workplan can account for the material;
-it stays acceptable because the analyst working the row is also the one who
-will be scored on it, so knowing it is EQA material grants no advantage on
-the value.
+exists so a supervisor reviewing the Workplan can account for the material; it
+stays acceptable because the analyst working the row is also the one who will be
+scored on it, so knowing it is EQA material grants no advantage on the value.
 
 ## Unblinding and timing
 
@@ -43,9 +42,8 @@ distributed panel on its first pass after midnight of that date, or a holder of
 `qa.eqa.inhouse.unblind` does it earlier with **Unblind now**. Results entered
 after the unblind are still scored, but the participant result is flagged
 `MISSED_DEADLINE` and the analyst receives an `IN_HOUSE_MISSED_DEADLINE`
-competency event. The Workplan does not change at unblind; the orders stay
-where they are until they finish through the normal result and validation
-steps.
+competency event. The Workplan does not change at unblind; the orders stay where
+they are until they finish through the normal result and validation steps.
 
 ## Where to look
 

--- a/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedMalformedInputTest.java
+++ b/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedMalformedInputTest.java
@@ -71,13 +71,11 @@ public class SystemPresetSeedMalformedInputTest extends BaseWebContextSensitiveT
 
     @After
     public void restoreCanonicalSeed() throws Exception {
-        // Restore the pristine baseline for sibling tests: canonical presets + their
-        // LAB_NUMBER field rows (031 re-run, since clearSystemPresets cascade-deletes
-        // them) + no fixture keys. Shared committed Testcontainer (NOT_SUPPORTED).
-        SystemPresetSeedTest.clearSystemPresets(dataSource);
+        // Restore the pristine baseline for sibling tests: canonical presets, their
+        // LAB_NUMBER field rows, the universality backfill, and no fixture keys.
+        // Shared committed Testcontainer (NOT_SUPPORTED).
         SystemPresetSeedTest.clearBarcodeSiteInformation(dataSource);
-        SystemPresetSeedTest.executeSeedSql(dataSource, SEED_CHANGESET);
-        SystemPresetSeedTest.executeSeedSql(dataSource, SystemPresetSeedTest.FIELD_SEED_CHANGESET);
+        SystemPresetSeedTest.restoreCanonicalSeed(dataSource);
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedTest.java
+++ b/src/test/java/org/openelisglobal/labelpreset/migration/SystemPresetSeedTest.java
@@ -72,7 +72,7 @@ import org.w3c.dom.NodeList;
  */
 public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
 
-    private static final String SEED_CHANGESET = "liquibase/3.3.x.x/030-seed-system-presets.xml";
+    static final String SEED_CHANGESET = "liquibase/3.3.x.x/030-seed-system-presets.xml";
     /**
      * Field-seed changeset (031). The Liquibase init run executes 030 THEN 031, so
      * the pristine baseline has every system preset carrying its {@code LAB_NUMBER}
@@ -82,6 +82,14 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
      * {@code label_preset_field}.
      */
     static final String FIELD_SEED_CHANGESET = "liquibase/3.3.x.x/031-seed-system-preset-fields.xml";
+    /**
+     * Universality backfill changeset (032). The seed SQL in 030 inserts every
+     * system preset with {@code is_universal} at its column default of false; 032
+     * is what marks Specimen Label universal. Re-running 030 alone therefore
+     * restores the presets in a state the pristine baseline never had, and every
+     * later reader of the seeded Specimen Label sees a non-universal preset.
+     */
+    static final String UNIVERSAL_BACKFILL_CHANGESET = "liquibase/3.3.x.x/032-label-preset-is-universal.xml";
     private static final String FIXTURE = "fixtures/v1-barcode-config.sql";
 
     /**
@@ -104,18 +112,8 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
 
     @After
     public void restoreCanonicalSeed() throws Exception {
-        // Leave the DB the way the rest of the suite expects: canonical system presets
-        // (built from fallbacks, since no barcode.* keys remain), their LAB_NUMBER
-        // field
-        // rows (re-seeded via 031, since clearSystemPresets cascade-deleted them), and
-        // no
-        // fixture keys. The Testcontainer is shared + committed (NOT_SUPPORTED), so
-        // this
-        // restore protects sibling tests that read label_preset / label_preset_field.
-        clearSystemPresets();
         clearBarcodeSiteInformation();
-        runRealSeedChangesetSql();
-        executeSeedSql(dataSource, FIELD_SEED_CHANGESET);
+        restoreCanonicalSeed(dataSource);
     }
 
     @Test
@@ -147,6 +145,44 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
                 "seed must read fixture dimensions, not fallbacks — "
                         + "Specimen Label width should not equal the canonical fallback " + FALLBACK_WIDTH,
                 isWidthEqual("Specimen Label", FALLBACK_WIDTH));
+    }
+
+    /**
+     * The restore this class runs after every test is what sibling classes read for
+     * the rest of the suite, so it must reproduce the whole init run and not just
+     * the insert half. Re-running 030 alone leaves Specimen Label at the column
+     * default of false, and the aggregation tests that assert the universal column
+     * then fail depending only on surefire ordering.
+     */
+    @Test
+    public void restoreCanonicalSeed_leavesSpecimenLabelUniversal() throws Exception {
+        clearSystemPresets();
+
+        restoreCanonicalSeed(dataSource);
+
+        assertEquals("restore must re-apply the universality backfill, not only the preset insert", Boolean.TRUE,
+                isSpecimenLabelUniversal());
+        assertEquals("restore must leave exactly one seeded Specimen Label", 1, countSeededSpecimenLabels());
+    }
+
+    private Boolean isSpecimenLabelUniversal() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement("SELECT is_universal FROM clinlims.label_preset"
+                        + " WHERE is_system = true AND name = 'Specimen Label'");
+                ResultSet rs = stmt.executeQuery()) {
+            assertTrue("the seeded Specimen Label preset must exist after a restore", rs.next());
+            return rs.getBoolean(1);
+        }
+    }
+
+    private int countSeededSpecimenLabels() throws Exception {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement("SELECT COUNT(*) FROM clinlims.label_preset"
+                        + " WHERE is_system = true AND name = 'Specimen Label'");
+                ResultSet rs = stmt.executeQuery()) {
+            rs.next();
+            return rs.getInt(1);
+        }
     }
 
     @Test
@@ -246,38 +282,75 @@ public class SystemPresetSeedTest extends BaseWebContextSensitiveTest {
     // ----------------------------------------------------------------------------------------------
 
     static void executeSeedSql(DataSource dataSource, String changesetPath) throws Exception {
-        String seedSql = extractSeedSql(changesetPath);
+        executeChangesetSql(dataSource, changesetPath, "INSERT INTO");
+    }
+
+    /** Runs the {@code UPDATE} block of a changeset, such as 032's backfill. */
+    static void executeUpdateSql(DataSource dataSource, String changesetPath) throws Exception {
+        executeChangesetSql(dataSource, changesetPath, "UPDATE CLINLIMS.LABEL_PRESET");
+    }
+
+    private static void executeChangesetSql(DataSource dataSource, String changesetPath, String statementKeyword)
+            throws Exception {
+        String sql = extractChangesetSql(changesetPath, statementKeyword);
         try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
-            stmt.execute(seedSql);
+            stmt.execute(sql);
         }
     }
 
-    /**
-     * Parses the changeset XML and returns the text of its (single) {@code <sql>}
-     * child. Reads the production artifact so the executed SQL is never a copy.
-     */
     static String extractSeedSql(String changesetPath) throws Exception {
+        return extractChangesetSql(changesetPath, "INSERT INTO");
+    }
+
+    /**
+     * Parses the changeset XML and returns the text of the top-level {@code <sql>}
+     * block containing {@code statementKeyword}. Reads the production artifact so
+     * the executed SQL is never a copy. Only {@code <sql>} elements whose parent is
+     * a {@code <changeSet>} are considered, so a {@code <rollback>} carrying the
+     * inverse statement never matches.
+     */
+    static String extractChangesetSql(String changesetPath, String statementKeyword) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         ClassPathResource resource = new ClassPathResource(changesetPath);
         try (InputStream in = resource.getInputStream()) {
             NodeList sqlNodes = builder.parse(in).getElementsByTagNameNS("*", "sql");
-            // The seed changeset contains exactly one top-level <sql> insert block;
-            // <rollback>
-            // wraps its own <sql>, so filter to the element whose parent is a <changeSet>.
+            // <rollback> wraps its own <sql> and carries the inverse statement, so
+            // filter to the elements whose parent is a <changeSet> before matching on
+            // the keyword.
             for (int i = 0; i < sqlNodes.getLength(); i++) {
                 Element sql = (Element) sqlNodes.item(i);
                 String parentLocal = sql.getParentNode().getLocalName();
                 if (parentLocal != null && parentLocal.equals("changeSet")) {
                     String text = sql.getTextContent();
-                    if (text != null && text.toUpperCase().contains("INSERT INTO")) {
+                    if (text != null && text.toUpperCase().contains(statementKeyword)) {
                         return text;
                     }
                 }
             }
-            throw new IllegalStateException("No top-level <sql> INSERT block found in changeset " + changesetPath);
+            throw new IllegalStateException(
+                    "No top-level <sql> " + statementKeyword + " block found in changeset " + changesetPath);
         }
+    }
+
+    /**
+     * Rebuilds the canonical system presets the way the Liquibase init run leaves
+     * them, for a test that cleared them: 030 re-inserts the presets, 031 re-adds
+     * the LAB_NUMBER field rows {@link #clearSystemPresets(DataSource)}
+     * cascade-deleted, and 032 re-marks Specimen Label universal.
+     *
+     * <p>
+     * The Testcontainer is shared and committed ({@code NOT_SUPPORTED}), so an
+     * incomplete restore is not local damage — it is the state every later test
+     * class in the run reads. Add the matching call here whenever a new changeset
+     * conditions the seeded presets.
+     */
+    static void restoreCanonicalSeed(DataSource dataSource) throws Exception {
+        clearSystemPresets(dataSource);
+        executeSeedSql(dataSource, SEED_CHANGESET);
+        executeSeedSql(dataSource, FIELD_SEED_CHANGESET);
+        executeUpdateSql(dataSource, UNIVERSAL_BACKFILL_CHANGESET);
     }
 
     static void clearSystemPresets(DataSource dataSource) throws Exception {

--- a/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorRangesIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/testcatalog/controller/TestCatalogEditorRangesIntegrationTest.java
@@ -247,8 +247,14 @@ public class TestCatalogEditorRangesIntegrationTest extends BaseWebContextSensit
     public void saveRanges_preservesDictionaryLimitsAndReportingBounds() {
         // The Ranges editor manages only NUMERIC ranges. Seed a non-numeric
         // (dictionary) limit via the service — it must survive a ranges save.
-        Long dictTypeId = jdbc
-                .queryForObject("SELECT id FROM clinlims.type_of_test_result WHERE test_result_type = 'D'", Long.class);
+        // MIN(id), not a bare lookup by code: the Testcontainer is shared across the
+        // suite, and a fixture that remaps this vocabulary to ids of its own
+        // (result-limit.xml loads Dictionary as id 203) leaves the canonical seed row
+        // alongside the fixture's, so a bare lookup returns two rows and this test
+        // fails on surefire ordering alone. The canonical seed always holds the lower
+        // id, and it is the row ResultLimitServiceImpl cached at startup.
+        Long dictTypeId = jdbc.queryForObject(
+                "SELECT MIN(id) FROM clinlims.type_of_test_result WHERE test_result_type = 'D'", Long.class);
         org.openelisglobal.resultlimits.valueholder.ResultLimit dict = new org.openelisglobal.resultlimits.valueholder.ResultLimit();
         dict.setTestId(testId());
         dict.setResultTypeId(String.valueOf(dictTypeId));


### PR DESCRIPTION
- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Two backend test classes fail depending only on surefire ordering. Adding
unrelated test classes to the suite is enough to trip both, which is what
surfaced them.

The Testcontainer is shared and committed across the whole run, so a class that
leaves a reference table in a state the pristine baseline never had becomes a
landmine for every class after it.

**`OrderEntryLabelRequestServiceAggregationTest` — two failures.**
`SystemPresetSeedTest` and `SystemPresetSeedMalformedInputTest` clear the seeded
system presets and rebuild them by re-running changesets 030 and 031. Changeset
032 is what marks **Specimen Label** universal, and neither restore re-ran it,
so both classes left the seeded preset at the column default of `false`. Any
later class reading that preset saw a non-universal Specimen Label:

```
032 must mark the seeded Specimen Label universal
at least one system sample column present (universal Specimen)
```

Both restores now call one shared helper that re-runs 030, 031 and 032 together.
A new test asserts the helper leaves Specimen Label universal, so a future
changeset that conditions the seeded presets cannot be forgotten the same way.

**`TestCatalogEditorRangesIntegrationTest` — one error.** A fixture may remap
`type_of_test_result` to ids of its own — `result-limit.xml` loads Dictionary as
id 203 — and the base class then restores the canonical seed row by id, because
`ResultLimitServiceImpl` caches those ids at startup and FKs to them. The table
therefore legitimately holds the same result-type code twice, and a bare lookup
by code returned two rows:

```
IncorrectResultSizeDataAccessException: Incorrect result size: expected 1, actual 2
```

The test now takes `MIN(id)`, which is the canonical seed row and the one the
service cached. The by-id restore in `BaseWebContextSensitiveTest` is left
alone: keying it on the code instead would stop it from re-creating a canonical
id a fixture displaced, and the cached FK targets would go missing.

## Verification

`SystemPresetSeedTest`, `SystemPresetSeedMalformedInputTest`,
`OrderEntryLabelRequestServiceAggregationTest`,
`TestCatalogEditorRangesIntegrationTest` and `ResultLimitComponentIdIntegrationTest`
run green together in one JVM, in the order that previously reproduced all three
failures — 28 tests, no failures, no errors.

## Related Issue

OGC-608

## Other

Blocks the EQA cross-instance fixes: the same three failures are what turn
#4166, #4167 and #4168 red. Merge this first.
