### PR TITLE
fix(eqa): score dictionary results by value, not markup (OGC-610, OGC-612)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -450,7 +450,7 @@ public class EQABlindingServiceImpl implements EQABlindingService {
             return null;
         }
         for (Result pipelineResult : resultService.getResultsByAnalysis(analysis)) {
-            String value = resultService.getResultValue(pipelineResult, ",", true, false);
+            String value = EqaReportedValue.of(resultService, pipelineResult);
             if (!GenericValidator.isBlankOrNull(value)) {
                 return value.trim();
             }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -244,7 +244,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
                         analysis.getId(), analysis.getTest() == null ? "?" : analysis.getTest().getId());
                 continue;
             }
-            String value = resultService.getResultValue(pipelineResult, ",", true, false);
+            String value = EqaReportedValue.of(resultService, pipelineResult);
             recorded |= recordAnalyst(cycle, roundId, enrollmentId, analysis, analyteId, value, analystId, sysUserId);
         }
         return recorded;
@@ -335,7 +335,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             Map<Long, Long> schemeAnalytes, String sysUserId, Tally tally) {
         boolean answered = false;
         for (Result pipelineResult : resultService.getResultsByAnalysis(analysis)) {
-            String value = resultService.getResultValue(pipelineResult, ",", true, false);
+            String value = EqaReportedValue.of(resultService, pipelineResult);
             if (GenericValidator.isBlankOrNull(value)) {
                 continue;
             }

--- a/src/main/java/org/openelisglobal/eqa/service/EqaReportedValue.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EqaReportedValue.java
@@ -1,0 +1,33 @@
+package org.openelisglobal.eqa.service;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.openelisglobal.result.service.ResultService;
+import org.openelisglobal.result.valueholder.Result;
+
+/**
+ * The value an analyst reported, as data rather than as markup.
+ *
+ * <p>
+ * {@code ResultService.getResultValue} renders a dictionary result for HTML
+ * display and escapes it on the way out, so an entry such as "Négatif" arrives
+ * as "N&amp;eacute;gatif". EQA does not display that string: it compares it
+ * against a target a supervisor typed in the clear, stores it as the reported
+ * value of record, and ships it to the provider over FHIR and CSV. Escaped, a
+ * correct answer fails the comparison and a right result is scored
+ * unacceptable.
+ *
+ * <p>
+ * The escaping stays where it is, because the display callers rely on it; every
+ * EQA reader comes through here instead.
+ */
+final class EqaReportedValue {
+
+    private EqaReportedValue() {
+    }
+
+    /** The reported value of a single pipeline result, unescaped. */
+    static String of(ResultService resultService, Result pipelineResult) {
+        String printable = resultService.getResultValue(pipelineResult, ",", true, false);
+        return printable == null ? null : StringEscapeUtils.unescapeHtml4(printable);
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -141,6 +141,7 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         // organization row is FK-referenced by the follow-up register.
         jdbc.update("DELETE FROM clinlims.eqa_participant_followup");
         jdbc.update("DELETE FROM clinlims.organization WHERE name = 'This laboratory'");
+        jdbc.update("DELETE FROM clinlims.dictionary WHERE local_abbrev = 'IHACC'");
     }
 
     // ---- fixture builders ----
@@ -203,6 +204,30 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
                         + " lastupdated, fhir_uuid)"
                         + " VALUES (nextval('clinlims.result_seq'), ?, 'N', ?, 1, 'Y', now(), gen_random_uuid())",
                 analysisId, value);
+    }
+
+    /**
+     * A dictionary result the way result entry writes one: result_type 'D' with the
+     * dictionary id as the value. The existing helper writes 'N', which never
+     * reaches the escaping branch of the display formatter.
+     */
+    private void enterDictionaryResultViaPipeline(String blindCode, long dictionaryId) {
+        Long analysisId = jdbc.queryForObject(
+                "SELECT a.id FROM clinlims.analysis a JOIN clinlims.sample_item si ON a.sampitem_id = si.id"
+                        + " JOIN clinlims.sample s ON si.samp_id = s.id WHERE s.accession_number = ?",
+                Long.class, blindCode);
+        jdbc.update(
+                "INSERT INTO clinlims.result (id, analysis_id, result_type, value, sort_order, is_reportable,"
+                        + " lastupdated, fhir_uuid)"
+                        + " VALUES (nextval('clinlims.result_seq'), ?, 'D', ?, 1, 'Y', now(), gen_random_uuid())",
+                analysisId, String.valueOf(dictionaryId));
+    }
+
+    private long seedDictionaryEntry(String entry) {
+        Long id = jdbc.queryForObject("SELECT nextval('clinlims.dictionary_seq')", Long.class);
+        jdbc.update("INSERT INTO clinlims.dictionary (id, is_active, dict_entry, local_abbrev, lastupdated)"
+                + " VALUES (?, 'Y', ?, 'IHACC', now())", id, entry);
+        return id;
     }
 
     private Map<String, Object> panelRow(Long panelId) {
@@ -436,6 +461,45 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         assertEquals("UNACCEPTABLE", bySample.get(failingSample).get("performance_status"));
         assertEquals("only the analyst who entered nothing misses the deadline", "MISSED_DEADLINE",
                 bySample.get(silentSample).get("submission_status"));
+    }
+
+    @Test
+    public void unblind_scoresAnAccentedDictionaryAnswerAgainstItsIdenticalTarget() {
+        // The defect this covers: the reported value was read through the display
+        // formatter, which escapes a dictionary entry for HTML. An analyst who
+        // answered "Negatif" with its accent was compared as "N&eacute;gatif"
+        // against the target a supervisor typed in the clear, so an answer
+        // identical to the target scored UNACCEPTABLE — and the same escaped
+        // string went to the provider over FHIR and in the export CSV. The other
+        // categorical cases here use ASCII words written as numeric-typed rows,
+        // which never reach that branch.
+        EQAProgram scheme = inHouseScheme("IH Accent Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.PREPARING, LocalDate.now().plusDays(1));
+        String target = "N\u00e9gatif";
+        Long matching = insertPanelSample(panel, "IH-01", "IHBLIND-AC1", CATEGORICAL_ANALYTE, target, null, null);
+        Long differing = insertPanelSample(panel, "IH-02", "IHBLIND-AC2", CATEGORICAL_ANALYTE, target, null, null);
+
+        blindingService.sealAndDistribute(panel.getId(), List.of(new BlindOrderSpec(matching, SEEDED_TEST_ID, 1L),
+                new BlindOrderSpec(differing, SEEDED_TEST_ID, 1L)), USER);
+
+        enterDictionaryResultViaPipeline("IHBLIND-AC1", seedDictionaryEntry(target));
+        enterDictionaryResultViaPipeline("IHBLIND-AC2", seedDictionaryEntry("Positif"));
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        Map<Long, Map<String, Object>> bySample = new java.util.HashMap<>();
+        for (Map<String, Object> row : jdbc.queryForList("SELECT panel_sample_id, performance_status, result_value"
+                + " FROM clinlims.eqa_participant_result WHERE cycle_id = ?", cycle.getId())) {
+            bySample.put(((Number) row.get("panel_sample_id")).longValue(), row);
+        }
+        assertEquals("the accented entry is stored as itself, not as markup", target,
+                bySample.get(matching).get("result_value"));
+        assertEquals("an answer identical to the target is acceptable", "ACCEPTABLE",
+                bySample.get(matching).get("performance_status"));
+        assertEquals("Positif", bySample.get(differing).get("result_value"));
+        assertEquals("a different answer is still unacceptable", "UNACCEPTABLE",
+                bySample.get(differing).get("performance_status"));
     }
 
     @Test


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

An analyst who answers a dictionary result containing a non-ASCII character is
scored against the escaped form of that answer.

Result entry stores a dictionary id. EQA reads the printable value back through
the shared result formatter, which escapes it for HTML display, so `Négatif`
comes back as `N&eacute;gatif`. The verdict is a string comparison against the
target a supervisor typed in the clear, so **an answer identical to the target
scores unacceptable**. That false verdict then opens a follow-up register row
and writes a competency event against the analyst.

The same escaped string leaves the participant instance. The submission bridge
builds both the FHIR bundle and the export CSV from the same read, so a
provider taking those results in compares and reports markup as well.

Two of the three values in the HIV serology result list this catalog ships are
non-ASCII, so a francophone deployment mis-scores routinely.

### The change

A new package-private `EqaReportedValue.of(...)` unescapes the reported value at
the EQA boundary, and all three EQA readers of the formatter go through it:

| call site | path it feeds |
| --- | --- |
| `EQABlindingServiceImpl` | in-house unblind and scoring |
| `EQACycleSubmissionServiceImpl` — analyst attribution | per-analyst capture |
| `EQACycleSubmissionServiceImpl` — submission bridge | FHIR bundle and export CSV |

The escaping stays in `ResultServiceImpl`, where the display callers depend on
it. Three lines of production change plus the helper. No schema change.

### Verification

Found and re-verified on a two-instance rig — a provider install and a
participant install on separate databases. Same instance, same sealed target,
same answer entered through standard result entry:

| build | stored reported value | verdict | follow-up row | competency event |
| --- | --- | --- | --- | --- |
| before | `N&eacute;gatif` (14 bytes) | UNACCEPTABLE | created | `UNACCEPTABLE_SCORE` |
| after | `Négatif` (7 bytes) | **ACCEPTABLE** | none | none |

## Screenshots

Not applicable: this is a backend scoring fix with no UI change. The defect and
its correction show up in the stored reported value and the resulting verdict,
in the table above.

## Related Issue

OGC-610, OGC-612.

## Other

**Why the existing tests did not catch this.** `EQABlindingIntegrationTest`
already covers categorical scoring, but its helper writes `result_type = 'N'`
rows, which never reach the formatter's dictionary branch, and its categorical
values are ASCII either way. The new test inserts a genuine dictionary-typed
result against a seeded accented entry. With the fix disabled it fails:

```
ComparisonFailure: the accented entry is stored as itself, not as markup
  expected:<N[é]gatif> but was:<N[&eacute;]gatif>
```

62 tests pass across the five classes that cover both changed files:
`EQABlindingIntegrationTest`, `EQAAutoSubmissionIntegrationTest`,
`EQAPerAnalystCaptureIntegrationTest`,
`EQAParticipantResultLifecycleIntegrationTest`, `EQADeadlineAlertSchedulerTest`.
