### PR TITLE
fix(eqa): score provider results against the sealed target (OGC-612, OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.eqa.service;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -477,46 +476,11 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     }
 
     /**
-     * FR-V2.4-07 / AC-V2.4-07/-08: numeric when an acceptance range is sealed
-     * (inside the closed range = acceptable), categorical exact match otherwise. A
-     * non-numeric report against a numeric target is a mismatch, not an error.
+     * FR-V2.4-07 / AC-V2.4-07/-08. The comparison itself is shared with the
+     * provider lane, which judges against the same sealed target.
      */
     private EQAPerformanceStatus verdictFor(EQAPanelSample target, String reported) {
-        String value = reported == null ? "" : reported.trim();
-        if (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null) {
-            BigDecimal numeric;
-            try {
-                numeric = new BigDecimal(value);
-            } catch (NumberFormatException e) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            if (target.getAcceptanceRangeLow() != null && numeric.compareTo(target.getAcceptanceRangeLow()) < 0) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            if (target.getAcceptanceRangeHigh() != null && numeric.compareTo(target.getAcceptanceRangeHigh()) > 0) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            return EQAPerformanceStatus.ACCEPTABLE;
-        }
-        String targetValue = target.getTargetValue() == null ? "" : target.getTargetValue().trim();
-        // A quantitative target sealed without a range still has to compare as a
-        // number, or "100.0" fails against a target of "100".
-        BigDecimal targetNumber = parseOrNull(targetValue);
-        BigDecimal reportedNumber = parseOrNull(value);
-        if (targetNumber != null && reportedNumber != null) {
-            return targetNumber.compareTo(reportedNumber) == 0 ? EQAPerformanceStatus.ACCEPTABLE
-                    : EQAPerformanceStatus.UNACCEPTABLE;
-        }
-        return targetValue.equalsIgnoreCase(value) ? EQAPerformanceStatus.ACCEPTABLE
-                : EQAPerformanceStatus.UNACCEPTABLE;
-    }
-
-    private static BigDecimal parseOrNull(String value) {
-        try {
-            return new BigDecimal(value);
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return EqaPanelVerdict.of(target, reported);
     }
 
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -144,8 +144,14 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
                     + " reported results; this cycle has " + reported);
         }
 
+        // The peer statistics run first and stay on the row as the reported z. They
+        // cannot carry the verdict on their own: with the sample SD taken over every
+        // reported value, the largest z anyone can reach is (n-1)/sqrt(n) — 1.79 at
+        // the five participants MIN_PARTICIPANTS_FOR_STATS requires, below the
+        // questionable threshold — so a laboratory reporting double the target scored
+        // acceptable. Where the panel sealed a target, that target is the verdict.
         eqaStatisticsService.calculateAndUpdateStatistics(distribution.getId());
-        judgeReportedText(cycle, distribution.getId());
+        judgeAgainstPanelTargets(cycle, distribution.getId());
         advanceToScored(cycle, sysUserId);
 
         int followups = 0;
@@ -345,33 +351,46 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     }
 
     /**
-     * Qualitative results have no peer mean: the verdict is an exact,
-     * case-insensitive match against the panel's sealed target for the test's
-     * analyte (the same rule in-house scoring applies). A test with no sealed
-     * target leaves the verdict blank rather than guessing.
+     * Judge every reported value against the target its panel sealed, numeric and
+     * qualitative alike, through the same comparison the in-house lane uses. A
+     * qualitative result has no peer z and never had one; a numeric result keeps
+     * the z the statistics pass computed, as the reported statistic beside the
+     * verdict rather than as the verdict.
+     *
+     * <p>
+     * A result whose analyte has no sealed target keeps whatever the peer
+     * statistics decided — a scheme that reports without a target has nothing else
+     * to be judged against.
      */
-    private void judgeReportedText(EQACycle cycle, Long distributionId) {
-        Map<Long, String> targetByAnalyte = new HashMap<>();
+    private void judgeAgainstPanelTargets(EQACycle cycle, Long distributionId) {
+        Map<Long, EQAPanelSample> targetByAnalyte = new HashMap<>();
         for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycle.getId())) {
             for (EQAPanelSample sample : eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId())) {
                 if (sample.getAnalyteId() != null && sample.getTargetValue() != null) {
-                    targetByAnalyte.put(sample.getAnalyteId(), sample.getTargetValue().trim());
+                    targetByAnalyte.put(sample.getAnalyteId(), sample);
                 }
             }
         }
         for (EQAResult result : eqaResultDAO.findByDistributionId(distributionId)) {
-            if (result.getResultText() == null || result.getResultValue() != null) {
-                continue;
-            }
             Long analyteId = analyteIdOrNull(result.getTestId());
-            String target = analyteId == null ? null : targetByAnalyte.get(analyteId);
+            EQAPanelSample target = analyteId == null ? null : targetByAnalyte.get(analyteId);
             if (target == null) {
                 continue;
             }
-            result.setZScore(null);
-            result.setPerformanceStatus(
-                    target.equalsIgnoreCase(result.getResultText().trim()) ? EQAPerformanceStatus.ACCEPTABLE
-                            : EQAPerformanceStatus.UNACCEPTABLE);
+            String reported = result.getResultText() != null ? result.getResultText()
+                    : result.getResultValue() == null ? null : result.getResultValue().toPlainString();
+            if (reported == null) {
+                continue;
+            }
+            if (result.getResultText() != null) {
+                // Qualitative: no peer mean to place it against.
+                result.setZScore(null);
+            } else {
+                // The report and the scores CSV show what a number was judged against;
+                // a target that is a word has no column here and needs none.
+                result.setTargetValue(EqaPanelVerdict.numericTargetOf(target));
+            }
+            result.setPerformanceStatus(EqaPanelVerdict.of(target, reported));
             eqaResultDAO.update(result);
         }
     }

--- a/src/main/java/org/openelisglobal/eqa/service/EqaPanelVerdict.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EqaPanelVerdict.java
@@ -1,0 +1,70 @@
+package org.openelisglobal.eqa.service;
+
+import java.math.BigDecimal;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+
+/**
+ * Whether a reported value meets the target sealed on a panel sample.
+ *
+ * <p>
+ * Numeric when an acceptance range is sealed (inside the closed range is
+ * acceptable), a numeric comparison when a quantitative target carries no range
+ * so that "100.0" matches a target of "100", and a case-insensitive exact match
+ * otherwise. A non-numeric report against a numeric target is a mismatch, not
+ * an error.
+ *
+ * <p>
+ * Both lanes judge against the same target. In-house blinding has no peer group
+ * and never had another rule. The provider lane also has a peer group, but the
+ * peer z-score cannot carry the verdict on its own: with the sample standard
+ * deviation over every reported value, the largest z any participant can reach
+ * is (n-1)/sqrt(n), which is 1.79 at the five participants scoring requires —
+ * so a laboratory reporting double the target scored acceptable until this
+ * became the verdict and the z became the reported statistic beside it.
+ */
+final class EqaPanelVerdict {
+
+    private EqaPanelVerdict() {
+    }
+
+    /** The verdict for one reported value against one sealed panel sample. */
+    static EQAPerformanceStatus of(EQAPanelSample target, String reported) {
+        String value = reported == null ? "" : reported.trim();
+        if (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null) {
+            BigDecimal numeric = parseOrNull(value);
+            if (numeric == null) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeLow() != null && numeric.compareTo(target.getAcceptanceRangeLow()) < 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeHigh() != null && numeric.compareTo(target.getAcceptanceRangeHigh()) > 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            return EQAPerformanceStatus.ACCEPTABLE;
+        }
+        String targetValue = target.getTargetValue() == null ? "" : target.getTargetValue().trim();
+        BigDecimal targetNumber = parseOrNull(targetValue);
+        BigDecimal reportedNumber = parseOrNull(value);
+        if (targetNumber != null && reportedNumber != null) {
+            return targetNumber.compareTo(reportedNumber) == 0 ? EQAPerformanceStatus.ACCEPTABLE
+                    : EQAPerformanceStatus.UNACCEPTABLE;
+        }
+        return targetValue.equalsIgnoreCase(value) ? EQAPerformanceStatus.ACCEPTABLE
+                : EQAPerformanceStatus.UNACCEPTABLE;
+    }
+
+    /** The numeric form of a sealed target, or null when the target is a word. */
+    static BigDecimal numericTargetOf(EQAPanelSample sample) {
+        return sample.getTargetValue() == null ? null : parseOrNull(sample.getTargetValue().trim());
+    }
+
+    private static BigDecimal parseOrNull(String value) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
@@ -45,6 +45,7 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
 
     private EQAProgram scheme;
     private EQACycle cycle;
+    private EQAPanel panel;
 
     @Before
     public void seed() {
@@ -66,7 +67,7 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
         cycle = readBack(insertCycle(scheme, 1));
         jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
 
-        EQAPanel panel = insertPanel(scheme, p -> {
+        panel = insertPanel(scheme, p -> {
             p.setCycle(cycle);
             p.setPanelName("Intake panel");
         });
@@ -156,6 +157,49 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
                         Integer.class, cycle.getId()));
     }
 
+    /**
+     * The peer z-score cannot carry a verdict at the roster size scoring requires:
+     * with the sample standard deviation taken over every reported value, the
+     * largest z anyone can reach is (n-1)/sqrt(n), which is 1.79 for five
+     * participants — below the questionable threshold, let alone the unacceptable
+     * one. So a laboratory reporting double the target used to score acceptable.
+     * The panel's sealed target and range decide instead, and the z stays on the
+     * row as the reported statistic. The other tests here keep twelve participants,
+     * where the ceiling happens to clear 3, which is why this went unnoticed.
+     */
+    @Test
+    public void aNumericOutlierIsUnacceptableAtTheFiveParticipantScoringFloor() {
+        EQAPanelSample sealed = new EQAPanelSample();
+        sealed.setPanel(panel);
+        sealed.setSampleCode("S02");
+        sealed.setAnalyteId(ANALYTE_VL);
+        sealed.setTargetValue("40");
+        sealed.setAcceptanceRangeLow(new BigDecimal("36"));
+        sealed.setAcceptanceRangeHigh(new BigDecimal("44"));
+        sealed.setSysUserId(USER);
+        eqaPanelSampleDAO.insert(sealed);
+
+        String[] reported = { "39.5", "40", "40.5", "41", "80" };
+        for (int i = 0; i < reported.length; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i, Map.of(TEST_VL, reported[i]),
+                    EQASubmissionMethod.MANUAL, USER);
+        }
+        long outlier = FIRST_ORG + reported.length - 1;
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("a value inside the sealed range is acceptable", "ACCEPTABLE", verdict(FIRST_ORG, TEST_VL));
+        assertEquals("double the target is unacceptable however tight the peer group is", "UNACCEPTABLE",
+                verdict(outlier, TEST_VL));
+        assertTrue("the peer z is still reported, and is below the threshold it could not reach",
+                zScore(outlier, TEST_VL).abs().compareTo(new BigDecimal("2")) < 0);
+        assertEquals("the report and the scores CSV can show what the number was judged against", 0,
+                targetValue(outlier, TEST_VL).compareTo(new BigDecimal("40")));
+        assertEquals("the failure reaches the follow-up register", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_participant_followup WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()));
+    }
+
     @Test
     public void aParticipantExportBundleImportsByAnalyteName() {
         String csv = "cycle_id,cycle_name,round_number,analyte_id,analyte_name,result_value,result_unit,"
@@ -231,6 +275,13 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
                 "SELECT performance_status FROM clinlims.eqa_result"
                         + " WHERE participant_organization_id = ? AND test_id = ?",
                 String.class, organizationId, testId);
+    }
+
+    private BigDecimal targetValue(long organizationId, long testId) {
+        return jdbc.queryForObject(
+                "SELECT target_value FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, testId);
     }
 
     private BigDecimal zScore(long organizationId, long testId) {


### PR DESCRIPTION
## The problem

Provider scoring judged a participant purely by its peer z-score, and at the roster size scoring itself requires, that verdict is unreachable.

`EQAStatisticsServiceImpl` takes a classical mean and a **sample** standard deviation (`n-1` denominator) over every reported value, then classifies `|Z| >= 3` unacceptable and `|Z| >= 2` questionable. Under that formula the largest `|Z|` any one of `n` values can attain is `(n-1)/sqrt(n)`. At the five participants `MIN_PARTICIPANTS_FOR_STATS` demands, that ceiling is **1.79** — below the questionable threshold, let alone the unacceptable one. Questionable first becomes reachable at n = 6, unacceptable at n = 11.

Found while running the two-instance acceptance walkthrough. Five laboratories, a panel sealing target 40 with an acceptance range of 36–44:

| laboratory | reported | z | verdict |
| --- | --- | --- | --- |
| Lae | 39.50 | −0.489 | ACCEPTABLE |
| Goroka | 40.00 | −0.461 | ACCEPTABLE |
| Kimbe | 40.50 | −0.433 | ACCEPTABLE |
| Mt Hagen | 41.00 | −0.405 | ACCEPTABLE |
| **PMGH** | **80.00** | **1.78797** | **ACCEPTABLE** |

A laboratory reporting **double the target**, well outside the panel's own acceptance range, scored acceptable. The z is not wrong arithmetically — the threshold is simply unreachable.

Nothing downstream of a verdict could happen either: no follow-up row, no persistent-failure flag, no competency event, and no non-conformity on the participant.

A second cause sat beside it. **The panel already seals a target and an acceptance range, and provider scoring never looked at them.** `eqa_result.target_value` was never populated, so the performance report and the scores CSV came out with an empty target column.

## The change

Where the panel carries a target for the result's analyte, **that target decides the verdict**, and the peer z stays on the row as the reported statistic beside it rather than as the verdict. A result whose analyte has no sealed target keeps the peer verdict, so a scheme that reports without a target behaves exactly as before.

**The comparison was not written twice.** In-house blinding already had it — acceptance range as a closed interval, numeric comparison for a quantitative target sealed without a range so `100.0` matches `100`, case-insensitive match otherwise — as a private method. It moves into a shared package-private `EqaPanelVerdict` and both lanes call it, which leaves `EQABlindingServiceImpl` **42 lines lighter with no change in behaviour**.

`judgeReportedText` becomes `judgeAgainstPanelTargets` and now covers numeric results as well as qualitative ones. A numeric target is copied onto `eqa_result.target_value` so the report and the CSV can show what a number was judged against.

**No schema change and no liquibase slot.**

| file | change |
| --- | --- |
| `EqaPanelVerdict.java` | new — the shared comparison |
| `EQABlindingServiceImpl.java` | delegates to it; −42 lines |
| `EQAProviderScoringServiceImpl.java` | judges numeric results against the target, stores it |
| `EQAProviderIntakeIntegrationTest.java` | the five-participant test |

## Why the suite missed it

`EQAProviderIntakeIntegrationTest` seeds **twelve** organizations. At n = 12 the ceiling is 3.18, so its fourfold outlier does clear 3 and the existing assertion passes. The new test uses **five** — the floor the production code itself enforces:

```
aNumericOutlierIsUnacceptableAtTheFiveParticipantScoringFloor
  panel seals target 40, acceptance range 36-44
  five participants report 39.5  40  40.5  41  80
  -> 80 is UNACCEPTABLE, z 1.788 still reported,
     target_value 40 stored, one follow-up row opened
```

Inverted, it fails exactly as the running system did:

```
ComparisonFailure: double the target is unacceptable however tight the peer group is
  expected:<[UN]ACCEPTABLE> but was:<[]ACCEPTABLE>
```

**44 tests pass** across the five classes covering both changed files: `EQAProviderIntakeIntegrationTest`, `EQABlindingIntegrationTest`, `EQAScoreTriageIntegrationTest`, `EQAProviderFollowupIntegrationTest`, `EQAScoreCsvIntakeIntegrationTest`.

## Verified on a running system

Both instances of the two-instance rig were redeployed from one WAR and fingerprinted (`EqaPanelVerdict.class` 2172 bytes in all four Tomcat contexts), then a cycle was driven with the same panel and the same five values that had scored all-clear:

| laboratory | reported | target | z | before | after |
| --- | --- | --- | --- | --- | --- |
| Lae | 39.50 | 40.00 | −0.489 | ACCEPTABLE | ACCEPTABLE |
| Goroka | 40.00 | 40.00 | −0.461 | ACCEPTABLE | ACCEPTABLE |
| Kimbe | 40.50 | 40.00 | −0.433 | ACCEPTABLE | ACCEPTABLE |
| Mt Hagen | 41.00 | 40.00 | −0.405 | ACCEPTABLE | ACCEPTABLE |
| **PMGH** | **80.00** | **40.00** | 1.78797 | ACCEPTABLE | **UNACCEPTABLE** |

The target now lands on every row, the z is untouched, and `nc_event` on the provider stays at 0 — a provider-role unacceptable still opens no non-conformity in the provider's own register.

The follow-up register then received the failure and behaved: row `NOTIFIED`, source `External provider`, snapshot `reported 80 / target 40 / z 1.78797`, the expansion showing **Test / Reported / Target / Z-score** with the target populated, and the triage actions working.
