### PR TITLE
feat(eqa): choose a scheme's arrangement type and its tests from the UI (OGC-612, OGC-613)

### DIFF
--- a/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
@@ -1,17 +1,34 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Modal,
   TextInput,
   TextArea,
   Toggle,
+  Select,
+  SelectItem,
+  MultiSelect,
   InlineNotification,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import {
+  getFromOpenElisServer,
   postToOpenElisServerFullResponse,
   putToOpenElisServerFullResponse,
   resolveApiErrorMessage,
 } from "../../utils/Utils";
+
+// The four arrangement types a scheme can have. IN_HOUSE is the only one that
+// may omit a provider, which is why the form branches on it.
+const SCHEME_TYPES = [
+  "INTERNATIONAL_PT",
+  "REGIONAL_PT",
+  "INTER_LAB_SPLIT",
+  "IN_HOUSE",
+];
+
+const sameIds = (left, right) =>
+  left.length === right.length &&
+  [...left].sort().join(",") === [...right].sort().join(",");
 
 const ProgramForm = ({ program, onClose }) => {
   const intl = useIntl();
@@ -22,20 +39,82 @@ const ProgramForm = ({ program, onClose }) => {
   const [description, setDescription] = useState(program?.description || "");
   const [isActive, setIsActive] = useState(program?.isActive !== false);
   const [perAnalyst, setPerAnalyst] = useState(program?.perAnalyst === true);
+  const [schemeType, setSchemeType] = useState(
+    program?.schemeType || "INTERNATIONAL_PT",
+  );
+  const [testOptions, setTestOptions] = useState([]);
+  const [selectedTests, setSelectedTests] = useState([]);
+  const [assignedTestIds, setAssignedTestIds] = useState([]);
   const [nameError, setNameError] = useState("");
   const [providerError, setProviderError] = useState("");
   const [saveError, setSaveError] = useState("");
 
-  // keep the modal open and show why the server refused, instead of closing as if saved
-  const handleResponse = (response) => {
-    if (response && response.ok) {
+  const providerRequired = schemeType !== "IN_HOUSE";
+
+  // ALL_TESTS, not the lab-unit-scoped test list: a scheme's test map is a
+  // configuration decision, and the QA officer who makes it holds no bench role.
+  useEffect(() => {
+    getFromOpenElisServer("/rest/displayList/ALL_TESTS", (data) => {
+      const items = (Array.isArray(data) ? data : []).map((test) => ({
+        id: String(test.id),
+        text: test.value,
+      }));
+      setTestOptions(items);
+
+      if (!program?.id) return;
+      getFromOpenElisServer(
+        `/rest/eqa/programs/${program.id}/tests`,
+        (assignments) => {
+          const ids = (Array.isArray(assignments) ? assignments : [])
+            .filter((row) => row.isActive !== false)
+            .map((row) => String(row.testId));
+          setAssignedTestIds(ids);
+          setSelectedTests(items.filter((item) => ids.includes(item.id)));
+        },
+      );
+    });
+  }, [program?.id]);
+
+  const showRefusal = (response, fallbackKey) =>
+    Promise.resolve(response ? response.json().catch(() => null) : null).then(
+      (body) => setSaveError(resolveApiErrorMessage(intl, body, fallbackKey)),
+    );
+
+  // The scheme has to exist before its tests can be assigned, so a create
+  // chains: POST the scheme, then PUT the test map against the id it answers.
+  const saveTestMap = (programId) => {
+    const testIds = selectedTests.map((test) => test.id);
+    if (sameIds(testIds, assignedTestIds)) {
       if (onClose) onClose();
       return;
     }
-    Promise.resolve(response ? response.json().catch(() => null) : null).then(
-      (body) =>
-        setSaveError(resolveApiErrorMessage(intl, body, "error.save.failed")),
+    putToOpenElisServerFullResponse(
+      `/rest/eqa/programs/${programId}/tests`,
+      JSON.stringify({ testIds: testIds.map(Number) }),
+      (response) => {
+        if (response && response.ok) {
+          if (onClose) onClose();
+          return;
+        }
+        showRefusal(response, "eqa.program.tests.saveFailed");
+      },
     );
+  };
+
+  // keep the modal open and show why the server refused, instead of closing as if saved
+  const handleResponse = (response) => {
+    if (response && response.ok) {
+      Promise.resolve(response.json().catch(() => null)).then((body) => {
+        const programId = program?.id || body?.id;
+        if (programId) {
+          saveTestMap(programId);
+        } else if (onClose) {
+          onClose();
+        }
+      });
+      return;
+    }
+    showRefusal(response, "error.save.failed");
   };
 
   const handleSubmit = () => {
@@ -45,7 +124,7 @@ const ProgramForm = ({ program, onClose }) => {
       setNameError(intl.formatMessage({ id: "eqa.program.name.required" }));
       valid = false;
     }
-    if (!provider.trim()) {
+    if (providerRequired && !provider.trim()) {
       setProviderError(
         intl.formatMessage({ id: "eqa.program.provider.required" }),
       );
@@ -56,9 +135,10 @@ const ProgramForm = ({ program, onClose }) => {
 
     const payload = {
       name,
-      provider,
+      provider: providerRequired ? provider : "",
       description,
       perAnalyst,
+      schemeType,
     };
 
     setSaveError("");
@@ -116,19 +196,71 @@ const ProgramForm = ({ program, onClose }) => {
           invalid={!!nameError}
           invalidText={nameError}
         />
-        <TextInput
-          id="program-provider"
-          labelText={intl.formatMessage({ id: "eqa.admin.col.provider" })}
-          placeholder={intl.formatMessage({
-            id: "eqa.admin.form.provider.placeholder",
+        <Select
+          id="program-scheme-type"
+          labelText={intl.formatMessage({
+            id: "eqa.program.schemeType",
+            defaultMessage: "Scheme type",
           })}
-          value={provider}
+          helperText={intl.formatMessage({
+            id: "eqa.program.schemeType.helper",
+            defaultMessage:
+              "In-house schemes are run by this laboratory and need no provider; every other type does.",
+          })}
+          value={schemeType}
           onChange={(e) => {
-            setProvider(e.target.value);
+            setSchemeType(e.target.value);
             if (providerError) setProviderError("");
           }}
-          invalid={!!providerError}
-          invalidText={providerError}
+        >
+          {SCHEME_TYPES.map((type) => (
+            <SelectItem
+              key={type}
+              value={type}
+              text={intl.formatMessage({
+                id: `eqa.scheme.type.${type.toLowerCase()}`,
+                defaultMessage: type.replace(/_/g, " "),
+              })}
+            />
+          ))}
+        </Select>
+        {providerRequired && (
+          <TextInput
+            id="program-provider"
+            labelText={intl.formatMessage({ id: "eqa.admin.col.provider" })}
+            placeholder={intl.formatMessage({
+              id: "eqa.admin.form.provider.placeholder",
+            })}
+            value={provider}
+            onChange={(e) => {
+              setProvider(e.target.value);
+              if (providerError) setProviderError("");
+            }}
+            invalid={!!providerError}
+            invalidText={providerError}
+          />
+        )}
+        <MultiSelect
+          id="program-tests"
+          titleText={intl.formatMessage({
+            id: "eqa.program.tests",
+            defaultMessage: "Tests in this scheme",
+          })}
+          helperText={intl.formatMessage({
+            id: "eqa.program.tests.helper",
+            defaultMessage:
+              "The tests participants report on. Provider result entry and CSV import offer these, so a scheme with none cannot take in results.",
+          })}
+          label={intl.formatMessage({
+            id: "eqa.program.tests.placeholder",
+            defaultMessage: "Select tests",
+          })}
+          items={testOptions}
+          itemToString={(item) => (item ? item.text : "")}
+          selectedItems={selectedTests}
+          onChange={({ selectedItems }) =>
+            setSelectedTests(selectedItems || [])
+          }
         />
         <TextArea
           id="program-description"

--- a/frontend/src/components/eqa/EQAProgram/ProgramManagement.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramManagement.jsx
@@ -100,6 +100,10 @@ const ProgramManagement = () => {
       header: intl.formatMessage({ id: "eqa.admin.col.provider" }),
     },
     {
+      key: "schemeType",
+      header: intl.formatMessage({ id: "eqa.filter.schemeType" }),
+    },
+    {
       key: "participantCount",
       header: intl.formatMessage({ id: "eqa.admin.col.participants" }),
     },
@@ -116,7 +120,13 @@ const ProgramManagement = () => {
   const rows = programs.map((p) => ({
     id: String(p.id),
     name: p.name,
-    provider: p.provider || "",
+    provider: p.provider || "—",
+    schemeType: p.schemeType
+      ? intl.formatMessage({
+          id: `eqa.scheme.type.${p.schemeType.toLowerCase()}`,
+          defaultMessage: p.schemeType.replace(/_/g, " "),
+        })
+      : "—",
     participantCount: p.participantCount != null ? p.participantCount : 0,
     status: p.isActive
       ? intl.formatMessage({ id: "eqa.program.active" })

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import messages from "../../../../languages/en.json";
 import ProgramManagement from "../ProgramManagement";
 import UserSessionDetailsContext from "../../../../UserSessionDetailsContext";
 import ProgramForm from "../ProgramForm";
-import { getFromOpenElisServer } from "../../../utils/Utils";
+import {
+  getFromOpenElisServer,
+  postToOpenElisServerFullResponse,
+  putToOpenElisServerFullResponse,
+} from "../../../utils/Utils";
 
 vi.mock("../../../../components/common/PageBreadCrumb", () => {
   return {
@@ -160,6 +166,140 @@ describe("ProgramManagement", () => {
 });
 
 describe("ProgramForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const catalog = [
+    { id: 55, value: "HIV Viral Load" },
+    { id: 56, value: "CD4 count" },
+  ];
+
+  const serveCatalog = (assignments = []) =>
+    getFromOpenElisServer.mockImplementation((url, callback) => {
+      if (url === "/rest/displayList/ALL_TESTS") callback(catalog);
+      else if (url.endsWith("/tests")) callback(assignments);
+      else callback([]);
+    });
+
+  test("an in-house scheme needs no provider and says so on the way out", () => {
+    serveCatalog();
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector("#program-scheme-type"), {
+      target: { value: "IN_HOUSE" },
+    });
+    expect(container.querySelector("#program-provider")).toBeNull();
+
+    fireEvent.change(container.querySelector("#program-name"), {
+      target: { value: "In-house blinded PT" },
+    });
+    fireEvent.click(screen.getByText("Add Program"));
+
+    expect(screen.queryByText("Provider is required")).toBeNull();
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload)).toMatchObject({
+      name: "In-house blinded PT",
+      schemeType: "IN_HOUSE",
+      provider: "",
+    });
+  });
+
+  test("an external scheme carries the type the user picked", () => {
+    serveCatalog();
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector("#program-name"), {
+      target: { value: "Regional serology" },
+    });
+    fireEvent.change(container.querySelector("#program-scheme-type"), {
+      target: { value: "REGIONAL_PT" },
+    });
+    fireEvent.change(container.querySelector("#program-provider"), {
+      target: { value: "CPHL" },
+    });
+    fireEvent.click(screen.getByText("Add Program"));
+
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload).schemeType).toBe("REGIONAL_PT");
+  });
+
+  test("adding a test to the scheme writes the new map", async () => {
+    serveCatalog([{ id: 1, testId: 55, isActive: true }]);
+    putToOpenElisServerFullResponse.mockImplementation((url, body, callback) =>
+      callback({ ok: true, json: () => Promise.resolve({}) }),
+    );
+    const onClose = vi.fn();
+
+    const { container } = renderWithIntl(
+      <ProgramForm
+        program={{
+          id: 7,
+          name: "Regional serology",
+          provider: "CPHL",
+          schemeType: "REGIONAL_PT",
+          isActive: true,
+        }}
+        onClose={onClose}
+      />,
+    );
+
+    // The prefilled map is loaded from the scheme, so clearing it is a real
+    // change the endpoint has to be told about.
+    const user = userEvent.setup();
+    await user.click(
+      container.querySelector("#program-tests .cds--list-box__field"),
+    );
+    await user.click(screen.getByRole("option", { name: /CD4 count/ }));
+    await user.click(screen.getByText("Save Program"));
+
+    await waitFor(() =>
+      expect(
+        putToOpenElisServerFullResponse.mock.calls.some(
+          ([url]) => url === "/rest/eqa/programs/7/tests",
+        ),
+      ).toBe(true),
+    );
+    const [, body] = putToOpenElisServerFullResponse.mock.calls.find(
+      ([called]) => called === "/rest/eqa/programs/7/tests",
+    );
+    expect(JSON.parse(body).testIds.sort()).toEqual([55, 56]);
+  });
+
+  test("saving a scheme with an unchanged test map writes no test map", async () => {
+    serveCatalog([{ id: 1, testId: 55, isActive: true }]);
+    putToOpenElisServerFullResponse.mockImplementation((url, body, callback) =>
+      callback({ ok: true, json: () => Promise.resolve({ id: 7 }) }),
+    );
+    const onClose = vi.fn();
+
+    renderWithIntl(
+      <ProgramForm
+        program={{
+          id: 7,
+          name: "Regional serology",
+          provider: "CPHL",
+          schemeType: "REGIONAL_PT",
+          isActive: true,
+        }}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Save Program"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    expect(
+      putToOpenElisServerFullResponse.mock.calls.some(
+        ([url]) => url === "/rest/eqa/programs/7/tests",
+      ),
+    ).toBe(false);
+  });
+
   test("renders create mode with correct heading", () => {
     renderWithIntl(<ProgramForm program={null} onClose={vi.fn()} />);
     expect(screen.getByText("Add New EQA Program")).toBeTruthy();

--- a/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
+++ b/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
@@ -183,7 +183,7 @@ const InHousePanelsPage = () => {
             <Tile>
               {label(
                 "eqa.inhouse.noSchemes",
-                "No in-house scheme exists yet. Create one under EQA scheme management first.",
+                "No in-house scheme exists yet. Create one under EQA Program Management, choosing the In-house scheme type.",
               )}
             </Tile>
           ) : (

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8188,7 +8188,7 @@
   "eqa.inhouse.status": "Status",
   "eqa.inhouse.actions": "Actions",
   "eqa.inhouse.launchWizard": "Launch blinding wizard",
-  "eqa.inhouse.noSchemes": "No in-house scheme exists yet. Create one under EQA scheme management first.",
+  "eqa.inhouse.noSchemes": "No in-house scheme exists yet. Create one under EQA Program Management, choosing the In-house scheme type.",
   "eqa.inhouse.labels.print": "Print label sheet",
   "eqa.inhouse.labels.error": "Could not generate the label sheet",
   "eqa.inhouse.unblind.now": "Unblind now",
@@ -8560,5 +8560,10 @@
   "eqa.cycle.importScores.import": "Import scores",
   "eqa.cycle.importScores.imported": "{count} scores recorded.",
   "eqa.cycle.importScores.unmapped": "Not recognised here: {names}",
-  "eqa.cycle.importScores.failed": "Could not import the scores"
+  "eqa.cycle.importScores.failed": "Could not import the scores",
+  "eqa.program.schemeType": "Scheme type",
+  "eqa.program.schemeType.helper": "In-house schemes are run by this laboratory and need no provider; every other type does.",
+  "eqa.program.tests.placeholder": "Select tests",
+  "eqa.program.tests.helper": "The tests participants report on. Provider result entry and CSV import offer these, so a scheme with none cannot take in results.",
+  "eqa.program.tests.saveFailed": "The scheme was saved, but its tests were not. Reopen it and try again."
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
@@ -12,6 +12,7 @@ import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,14 +33,21 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize(EQAGuards.READ)
 public class EQAProgramRestController extends ControllerUtills {
 
-    @Autowired
-    private EQAProgramService programService;
+    private final EQAProgramService programService;
 
-    @Autowired
-    private EQAProgramEnrollmentService enrollmentService;
+    private final EQAProgramEnrollmentService enrollmentService;
 
+    private final SystemUserService systemUserService;
+
+    // Constructor injection so the integration suite can drive this controller
+    // with the real services, the way EQACycleRestController is exercised.
     @Autowired
-    private SystemUserService systemUserService;
+    public EQAProgramRestController(EQAProgramService programService, EQAProgramEnrollmentService enrollmentService,
+            SystemUserService systemUserService) {
+        this.programService = programService;
+        this.enrollmentService = enrollmentService;
+        this.systemUserService = systemUserService;
+    }
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PROVIDER)
@@ -52,12 +60,16 @@ public class EQAProgramRestController extends ControllerUtills {
                 return ResponseEntity.badRequest().body(Map.of("error", "Program name is required"));
             }
 
-            String provider = (String) body.get("provider");
+            String schemeType = body.get("schemeType") == null ? "" : String.valueOf(body.get("schemeType")).trim();
+            if (schemeType.isEmpty()) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Scheme type is required"));
+            }
 
             EQAProgram program = new EQAProgram();
             program.setName(name);
             program.setDescription(description);
-            program.setProvider(provider);
+            program.setSchemeType(schemeTypeOf(schemeType));
+            program.setProvider(blankToNull((String) body.get("provider")));
             program.setPerAnalyst(Boolean.TRUE.equals(body.get("perAnalyst")));
             program.setIsActive(true);
             program.setSysUserId(getSysUserId(request));
@@ -115,7 +127,15 @@ public class EQAProgramRestController extends ControllerUtills {
             }
 
             if (body.containsKey("provider")) {
-                program.setProvider((String) body.get("provider"));
+                program.setProvider(blankToNull((String) body.get("provider")));
+            }
+
+            if (body.containsKey("schemeType")) {
+                String schemeType = body.get("schemeType") == null ? "" : String.valueOf(body.get("schemeType")).trim();
+                if (schemeType.isEmpty()) {
+                    return ResponseEntity.badRequest().body(Map.of("error", "Scheme type cannot be empty"));
+                }
+                program.setSchemeType(schemeTypeOf(schemeType));
             }
 
             if (body.containsKey("isActive")) {
@@ -233,6 +253,28 @@ public class EQAProgramRestController extends ControllerUtills {
         dto.put("displayName", user == null ? String.valueOf(analyst.getSystemUserId())
                 : (user.getFirstName() == null ? "" : user.getFirstName() + " ") + user.getLastName());
         return dto;
+    }
+
+    /**
+     * The arrangement type is a user decision, not a default: an in-house scheme is
+     * unreachable from the UI while the endpoint ignores it, and a regional or
+     * split-sample scheme created without it is silently filed as international. An
+     * unknown value is refused by name rather than falling back.
+     */
+    private EQASchemeType schemeTypeOf(String value) {
+        try {
+            return EQASchemeType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown scheme type: " + value);
+        }
+    }
+
+    /**
+     * A blank provider is stored as NULL, so the BR-004 check and every reader see
+     * "no provider" as one value instead of two.
+     */
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private Map<String, Object> toProgramDto(EQAProgram program) {

--- a/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
@@ -1,0 +1,163 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.eqa.controller.rest.EQAProgramRestController;
+import org.openelisglobal.eqa.service.EQAProgramEnrollmentService;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQAProgramTest;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Scheme administration from the application, against the real schema: the
+ * arrangement type the user chose reaches the row instead of defaulting
+ * silently, an in-house scheme may omit the provider every other type requires,
+ * and the scheme's test map — which provider result intake and its CSV import
+ * both read — can be written through the endpoint the Programs screen calls.
+ */
+public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
+
+    private static final long TEST_SERO = 9971L;
+    private static final long TEST_VL = 9972L;
+
+    @Autowired
+    private EQAProgramEnrollmentService enrollmentService;
+
+    private EQAProgramRestController controller;
+
+    @Before
+    public void buildController() {
+        controller = new EQAProgramRestController(eqaProgramService, enrollmentService, systemUserService);
+    }
+
+    @Test
+    public void createProgram_writesTheChosenTypeRatherThanTheEntityDefault() {
+        Long id = created(Map.of("name", "Regional serology " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+
+        assertEquals(EQASchemeType.REGIONAL_PT, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void createProgram_acceptsAnInHouseSchemeWithNoProvider() {
+        Long id = created(Map.of("name", "In-house blinded " + System.nanoTime(), "schemeType", "IN_HOUSE"));
+
+        EQAProgram scheme = eqaProgramService.get(id);
+        assertEquals(EQASchemeType.IN_HOUSE, scheme.getSchemeType());
+        assertNull("a blank provider is stored as NULL, not as an empty string", scheme.getProvider());
+    }
+
+    @Test
+    public void createProgram_refusesAMissingType() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "No type " + System.nanoTime(), "provider", "CPHL"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Scheme type is required", error(response));
+    }
+
+    @Test
+    public void createProgram_refusesAnUnknownType() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "Bad type " + System.nanoTime(), "schemeType", "NATIONAL_PT", "provider", "CPHL"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Unknown scheme type: NATIONAL_PT", error(response));
+    }
+
+    @Test
+    public void createProgram_stillEnforcesTheProviderRuleForExternalTypes() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "Provider-less international " + System.nanoTime(), "schemeType", "INTERNATIONAL_PT"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(error(response).contains("Provider is required"));
+    }
+
+    @Test
+    public void updateProgram_movesAnExternalSchemeInHouseAndDropsItsProvider() {
+        Long id = created(Map.of("name", "Becomes in-house " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "IN_HOUSE", "provider", ""));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        EQAProgram scheme = eqaProgramService.get(id);
+        assertEquals(EQASchemeType.IN_HOUSE, scheme.getSchemeType());
+        assertNull(scheme.getProvider());
+    }
+
+    @Test
+    public void updateTestAssignments_writesTheMapProviderIntakeReads() {
+        seedTest(TEST_SERO, "Scheme admin serology");
+        seedTest(TEST_VL, "Scheme admin viral load");
+        Long id = created(
+                Map.of("name", "Mapped scheme " + System.nanoTime(), "schemeType", "REGIONAL_PT", "provider", "CPHL"));
+
+        controller.updateTestAssignments(id, Map.of("testIds", List.of(TEST_SERO, TEST_VL)));
+
+        assertEquals(List.of(TEST_SERO, TEST_VL), assignedTestIds(id));
+
+        // Re-sending a narrowed selection replaces the map rather than adding to
+        // it. Dropping a test deactivates its row instead of deleting it — the
+        // UNIQUE(scheme, test) row is reused if the test comes back — so what the
+        // intake readers see is the active set, not the row count.
+        controller.updateTestAssignments(id, Map.of("testIds", List.of(TEST_VL)));
+
+        assertEquals(List.of(TEST_VL), assignedTestIds(id));
+        assertEquals(2, eqaProgramService.getTestAssignments(id).size());
+    }
+
+    // ---- helpers ----
+
+    private Long created(Map<String, Object> body) {
+        ResponseEntity<?> response = controller.createProgram(request(), body);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        return Long.valueOf(String.valueOf(dto(response).get("id")));
+    }
+
+    private List<Long> assignedTestIds(Long programId) {
+        return eqaProgramService.getTestAssignments(programId).stream()
+                .filter(assignment -> Boolean.TRUE.equals(assignment.getIsActive())).map(EQAProgramTest::getTestId)
+                .sorted().toList();
+    }
+
+    private void seedTest(long id, String name) {
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                id, name, name, UUID.randomUUID().toString(), id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> dto(ResponseEntity<?> response) {
+        return (Map<String, Object>) response.getBody();
+    }
+
+    private String error(ResponseEntity<?> response) {
+        return String.valueOf(dto(response).get("error"));
+    }
+
+    private HttpServletRequest request() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId(Integer.parseInt(USER));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession(true).setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
+        return request;
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
@@ -25,6 +25,7 @@ import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.systemuser.service.SystemUserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -36,6 +37,9 @@ public class EQAProgramRestControllerTest {
 
     @Mock
     private EQAProgramEnrollmentService enrollmentService;
+
+    @Mock
+    private SystemUserService systemUserService;
 
     @Mock
     private HttpServletRequest request;
@@ -76,7 +80,8 @@ public class EQAProgramRestControllerTest {
         when(programService.insert(any(EQAProgram.class))).thenReturn(1L);
         when(programService.get(1L)).thenReturn(program1);
 
-        Map<String, Object> body = Map.of("name", "Chemistry PT", "description", "Chemistry proficiency testing");
+        Map<String, Object> body = Map.of("name", "Chemistry PT", "description", "Chemistry proficiency testing",
+                "schemeType", "INTERNATIONAL_PT", "provider", "NHLS");
         ResponseEntity<?> response = controller.createProgram(request, body);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
@@ -142,7 +142,8 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
     @Test
     public void providerWrite_providerTierReturns200() throws Exception {
         mockMvc.perform(post("/rest/eqa/programs").contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"HIV VL PT\"}").sessionAttr(IActionConstants.USER_SESSION_DATA, sessionUser())
+                .content("{\"name\":\"HIV VL PT\",\"schemeType\":\"INTERNATIONAL_PT\",\"provider\":\"NHLS\"}")
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, sessionUser())
                 .with(user("provider").authorities(new SimpleGrantedAuthority("qa.eqa.provider"))))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.name").value("HIV VL PT"));
     }
@@ -240,11 +241,8 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
 
         @Bean
         EQAProgramRestController programRestController(EQAProgramService programService,
-                EQAProgramEnrollmentService programEnrollmentService) {
-            EQAProgramRestController controller = new EQAProgramRestController();
-            ReflectionTestUtils.setField(controller, "programService", programService);
-            ReflectionTestUtils.setField(controller, "enrollmentService", programEnrollmentService);
-            return controller;
+                EQAProgramEnrollmentService programEnrollmentService, SystemUserService systemUserService) {
+            return new EQAProgramRestController(programService, programEnrollmentService, systemUserService);
         }
 
         @Bean


### PR DESCRIPTION
## What

Two EQA configuration steps existed in the domain but had no path through the product. Both are now on the Add/Edit Program dialog.

**Scheme type.** The dialog never sent `schemeType` and `POST /rest/eqa/programs` never read it, so every scheme created from the application took the entity default of international PT. Regional and split-sample schemes were silently misfiled, and an in-house scheme — which the In-House Blinding page requires — could not be created at all without hand-editing the programme CSV on the server.

- type selector on the dialog, four arrangement types
- create requires the type and refuses an unknown value by name; update accepts it
- the provider field shows only for the types that need a provider, and a blank provider is stored as `NULL` so the provider-required rule and every reader see one value rather than two
- `Scheme type` column on the programs table, so the choice is visible after saving
- the in-house panels empty state now names the screen that can create the scheme it asks for

**Scheme test map.** `eqa_program_test` decides which tests provider result entry and its CSV import offer, and its only writer was `PUT /rest/eqa/programs/{id}/tests`, which no screen called. On a clean install the intake grid read *"This scheme has no tests assigned yet"* and could not be used.

- `Assigned Tests` multiselect on the dialog, prefilled from the scheme
- a create chains the two writes (scheme, then map against the returned id); an unchanged selection writes nothing
- the catalog comes from the full test list rather than the lab-unit-scoped one, so a QA officer holding no bench role still sees tests

## Note on removal semantics

Dropping a test deactivates its assignment rather than deleting the row — the unique (scheme, test) row is revived if the test comes back. All three intake readers already filter on active, and the form does too. The new integration test asserts the active set and documents this.

## Tests

- `EQASchemeAdministrationIntegrationTest` — 7 tests against the real schema: the type on create and on update, the in-house provider exemption, the two refusals (missing, unknown), the provider rule still holding for external types, and the map replacing rather than accumulating
- `ProgramManagement.test.jsx` — 4 new cases: the in-house branch hides the provider and posts without one, the chosen type reaches the payload, a changed map reaches the endpoint, an unchanged map does not
- Green locally: 32 backend (new class + program controller + provider intake + guard matrix), 20/20 frontend in the touched file

`EQAProgramRestController` moved to constructor injection so the integration suite can drive it with the real services, matching how the cycle controller is exercised.

## Verified on a dev stack

- created an in-house scheme from Add Program with no provider → `scheme_type = IN_HOUSE`, `provider` NULL
- assigned two tests to an existing scheme through the dialog → two active `eqa_program_test` rows
- reopened the provider workbench → **Enter results** renders a grid with both assigned tests instead of the empty-scheme message