### PR TITLE
fix(eqa): judge a provider result against the panel's acceptance range (OGC-611, OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.eqa.service;
 
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -477,46 +476,11 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     }
 
     /**
-     * FR-V2.4-07 / AC-V2.4-07/-08: numeric when an acceptance range is sealed
-     * (inside the closed range = acceptable), categorical exact match otherwise. A
-     * non-numeric report against a numeric target is a mismatch, not an error.
+     * The comparison lives in one place for both lanes: inside a sealed acceptance
+     * range, or an exact match against the target, is acceptable.
      */
     private EQAPerformanceStatus verdictFor(EQAPanelSample target, String reported) {
-        String value = reported == null ? "" : reported.trim();
-        if (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null) {
-            BigDecimal numeric;
-            try {
-                numeric = new BigDecimal(value);
-            } catch (NumberFormatException e) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            if (target.getAcceptanceRangeLow() != null && numeric.compareTo(target.getAcceptanceRangeLow()) < 0) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            if (target.getAcceptanceRangeHigh() != null && numeric.compareTo(target.getAcceptanceRangeHigh()) > 0) {
-                return EQAPerformanceStatus.UNACCEPTABLE;
-            }
-            return EQAPerformanceStatus.ACCEPTABLE;
-        }
-        String targetValue = target.getTargetValue() == null ? "" : target.getTargetValue().trim();
-        // A quantitative target sealed without a range still has to compare as a
-        // number, or "100.0" fails against a target of "100".
-        BigDecimal targetNumber = parseOrNull(targetValue);
-        BigDecimal reportedNumber = parseOrNull(value);
-        if (targetNumber != null && reportedNumber != null) {
-            return targetNumber.compareTo(reportedNumber) == 0 ? EQAPerformanceStatus.ACCEPTABLE
-                    : EQAPerformanceStatus.UNACCEPTABLE;
-        }
-        return targetValue.equalsIgnoreCase(value) ? EQAPerformanceStatus.ACCEPTABLE
-                : EQAPerformanceStatus.UNACCEPTABLE;
-    }
-
-    private static BigDecimal parseOrNull(String value) {
-        try {
-            return new BigDecimal(value);
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return EqaTargetVerdict.of(target, reported);
     }
 
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -137,15 +137,21 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         EQADistribution distribution = findOrOpenDistribution(cycle, sysUserId);
         long reported = eqaResultDAO.findByDistributionId(distribution.getId()).stream()
                 .filter(result -> result.getResultValue() != null || result.getResultText() != null).count();
-        // Refused rather than silently half-scored: below this the peer mean and SD
-        // describe nothing, and the statistics service would leave every verdict null.
-        if (reported < EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS) {
-            throw new IllegalStateException("Scoring needs at least " + EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS
-                    + " reported results; this cycle has " + reported);
+        if (reported == 0) {
+            throw new IllegalStateException("This cycle has no reported results to score");
+        }
+        Map<Long, EQAPanelSample> targetByAnalyte = panelTargets(cycle);
+        // The peer statistic is the only judge for a test whose panel material
+        // carries no target, and below this floor its mean and SD describe nothing.
+        // A targeted cycle needs no crowd, so it scores whatever its roster size.
+        if (reported < EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS && targetByAnalyte.isEmpty()) {
+            throw new IllegalStateException("Scoring against peers needs at least "
+                    + EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS + " reported results; this cycle has " + reported
+                    + " and its panel carries no target to judge them against");
         }
 
         eqaStatisticsService.calculateAndUpdateStatistics(distribution.getId());
-        judgeReportedText(cycle, distribution.getId());
+        int judgedAgainstTarget = judgeAgainstPanelTargets(targetByAnalyte, distribution.getId());
         advanceToScored(cycle, sysUserId);
 
         int followups = 0;
@@ -162,6 +168,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         summary.put("cycleId", cycleId);
         summary.put("distributionId", distribution.getId());
         summary.put("scoredCount", (int) reported);
+        summary.put("judgedAgainstTargetCount", judgedAgainstTarget);
         summary.put("followupCount", followups);
         summary.put("cycleStatus",
                 eqaCycleDAO.get(cycleId).map(EQACycle::getStatus).map(EQACycleStatus::name).orElse(null));
@@ -345,35 +352,72 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     }
 
     /**
-     * Qualitative results have no peer mean: the verdict is an exact,
-     * case-insensitive match against the panel's sealed target for the test's
-     * analyte (the same rule in-house scoring applies). A test with no sealed
-     * target leaves the verdict blank rather than guessing.
+     * The panel material this cycle shipped, by the analyte each sample answers.
      */
-    private void judgeReportedText(EQACycle cycle, Long distributionId) {
-        Map<Long, String> targetByAnalyte = new HashMap<>();
+    private Map<Long, EQAPanelSample> panelTargets(EQACycle cycle) {
+        Map<Long, EQAPanelSample> targetByAnalyte = new HashMap<>();
         for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycle.getId())) {
             for (EQAPanelSample sample : eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId())) {
-                if (sample.getAnalyteId() != null && sample.getTargetValue() != null) {
-                    targetByAnalyte.put(sample.getAnalyteId(), sample.getTargetValue().trim());
+                if (sample.getAnalyteId() != null
+                        && (sample.getTargetValue() != null || EqaTargetVerdict.hasRange(sample))) {
+                    targetByAnalyte.put(sample.getAnalyteId(), sample);
                 }
             }
         }
+        return targetByAnalyte;
+    }
+
+    /**
+     * What the panel says the answer is decides the verdict, and the peer Z stays
+     * beside it as reporting. A quantitative result is judged when its sample seals
+     * an acceptance range; a word is judged by an exact, case-insensitive match
+     * against the target. Everything else keeps the peer verdict the statistics
+     * service left, which is all a cycle with untargeted material has.
+     *
+     * <p>
+     * Judging against the target is what makes a wrong answer reachable at all: the
+     * largest |Z| a classical peer score can attain over n values is (n−1)/√n,
+     * which at the five participants a peer statistic already requires is 1.79 —
+     * under its own questionable threshold, so a laboratory reporting double the
+     * target came out acceptable.
+     *
+     * @return how many results the target judged
+     */
+    private int judgeAgainstPanelTargets(Map<Long, EQAPanelSample> targetByAnalyte, Long distributionId) {
+        if (targetByAnalyte.isEmpty()) {
+            return 0;
+        }
+        int judged = 0;
         for (EQAResult result : eqaResultDAO.findByDistributionId(distributionId)) {
-            if (result.getResultText() == null || result.getResultValue() != null) {
-                continue;
-            }
             Long analyteId = analyteIdOrNull(result.getTestId());
-            String target = analyteId == null ? null : targetByAnalyte.get(analyteId);
+            EQAPanelSample target = analyteId == null ? null : targetByAnalyte.get(analyteId);
             if (target == null) {
                 continue;
             }
-            result.setZScore(null);
-            result.setPerformanceStatus(
-                    target.equalsIgnoreCase(result.getResultText().trim()) ? EQAPerformanceStatus.ACCEPTABLE
-                            : EQAPerformanceStatus.UNACCEPTABLE);
+            // Carried onto the result so the report, the scores CSV and the exchange
+            // can show what the verdict was measured against.
+            if (result.getTargetValue() == null) {
+                result.setTargetValue(EqaTargetVerdict.numericTarget(target));
+            }
+            boolean quantitative = result.getResultValue() != null;
+            if (quantitative && !EqaTargetVerdict.hasRange(target)) {
+                // A target with no range would compare for equality, and a lab is not
+                // wrong for answering 39.5 to a target of 40. The peer verdict stands.
+                eqaResultDAO.update(result);
+                continue;
+            }
+            String reported = quantitative ? result.getResultValue().toPlainString() : result.getResultText();
+            if (reported == null) {
+                continue;
+            }
+            if (!quantitative) {
+                result.setZScore(null);
+            }
+            result.setPerformanceStatus(EqaTargetVerdict.of(target, reported));
             eqaResultDAO.update(result);
+            judged++;
         }
+        return judged;
     }
 
     private static Object reportedOf(EQAResult result) {

--- a/src/main/java/org/openelisglobal/eqa/service/EqaTargetVerdict.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EqaTargetVerdict.java
@@ -1,0 +1,81 @@
+package org.openelisglobal.eqa.service;
+
+import java.math.BigDecimal;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+
+/**
+ * The verdict a reported value earns against the panel material it answers.
+ *
+ * <p>
+ * A panel sample carries what the right answer is: an acceptance range for a
+ * quantitative analyte, or a target value for a qualitative one. Judging
+ * against it is the only comparison that works on its own — a peer statistic
+ * needs a crowd, and with a small roster its own thresholds are out of reach —
+ * so both the in-house lane and the provider lane decide the same way, here.
+ *
+ * <p>
+ * A value outside a sealed range is unacceptable, and so is a word that does
+ * not match the target. A quantitative target with no range compares as a
+ * number rather than as text, so "100.0" answers a target of "100"; a caller
+ * that does not want equality that strict checks {@link #hasRange} first and
+ * keeps its own judgement.
+ */
+final class EqaTargetVerdict {
+
+    private EqaTargetVerdict() {
+    }
+
+    /**
+     * Whether the sample seals a range, which is what makes a numeric verdict safe.
+     */
+    static boolean hasRange(EQAPanelSample target) {
+        return target != null && (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null);
+    }
+
+    /** The target as a number, or null when it is a word. */
+    static BigDecimal numericTarget(EQAPanelSample target) {
+        return target == null ? null : parseOrNull(target.getTargetValue());
+    }
+
+    /**
+     * Inside a sealed range, or an exact match against the target, is acceptable. A
+     * non-numeric report against a numeric target is a mismatch, not an error.
+     */
+    static EQAPerformanceStatus of(EQAPanelSample target, String reported) {
+        String value = reported == null ? "" : reported.trim();
+        if (hasRange(target)) {
+            BigDecimal numeric = parseOrNull(value);
+            if (numeric == null) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeLow() != null && numeric.compareTo(target.getAcceptanceRangeLow()) < 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            if (target.getAcceptanceRangeHigh() != null && numeric.compareTo(target.getAcceptanceRangeHigh()) > 0) {
+                return EQAPerformanceStatus.UNACCEPTABLE;
+            }
+            return EQAPerformanceStatus.ACCEPTABLE;
+        }
+        String targetValue = target == null || target.getTargetValue() == null ? "" : target.getTargetValue().trim();
+        BigDecimal targetNumber = parseOrNull(targetValue);
+        BigDecimal reportedNumber = parseOrNull(value);
+        if (targetNumber != null && reportedNumber != null) {
+            return targetNumber.compareTo(reportedNumber) == 0 ? EQAPerformanceStatus.ACCEPTABLE
+                    : EQAPerformanceStatus.UNACCEPTABLE;
+        }
+        return targetValue.equalsIgnoreCase(value) ? EQAPerformanceStatus.ACCEPTABLE
+                : EQAPerformanceStatus.UNACCEPTABLE;
+    }
+
+    private static BigDecimal parseOrNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderTargetScoringIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderTargetScoringIntegrationTest.java
@@ -1,0 +1,205 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.service.EQAProviderScoringService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Provider scoring judges a quantitative result against the acceptance range
+ * the panel seals, not only against the other participants.
+ *
+ * <p>
+ * The peer score alone cannot reach its own thresholds on a small roster — the
+ * largest |Z| attainable over n values is (n−1)/√n, so at five participants no
+ * value can exceed 1.79 and nothing downstream of an unacceptable verdict (a
+ * follow-up, a non-conformity, a competency event) could ever fire.
+ */
+public class EQAProviderTargetScoringIntegrationTest extends EQASpineTestBase {
+
+    private static final long FIRST_ORG = 9955L;
+    private static final int ORGS = 5;
+    private static final long TEST_CD4 = 9967L;
+    private static final long ANALYTE_CD4 = 9868L;
+    private static final int TEST_ANALYTE_LINK = 99867;
+
+    @Autowired
+    private EQAProviderScoringService scoringService;
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    private EQAProgram scheme;
+    private EQACycle cycle;
+    private EQAPanel panel;
+
+    @Before
+    public void seed() {
+        for (long id = FIRST_ORG; id < FIRST_ORG + ORGS; id++) {
+            jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                    + " VALUES (?, ?, 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING", id, "Target lab " + id);
+        }
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE_CD4, "Target CD4");
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                TEST_CD4, "Target CD4 test", "Target CD4 test", UUID.randomUUID().toString(), TEST_CD4);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
+        jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
+                TEST_ANALYTE_LINK, TEST_CD4, ANALYTE_CD4);
+
+        scheme = insertScheme("Target scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+        eqaProgramService.assignTest(scheme.getId(), TEST_CD4);
+        cycle = readBack(insertCycle(scheme, 1));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
+        panel = insertPanel(scheme, p -> {
+            p.setCycle(cycle);
+            p.setPanelName("Target panel");
+        });
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.eqa_result");
+            jdbc.update("DELETE FROM clinlims.eqa_distribution WHERE cycle_id IS NOT NULL");
+        }
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
+            jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST_CD4);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE_CD4);
+            jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_ORG, FIRST_ORG + ORGS);
+        }
+    }
+
+    @Test
+    public void aLaboratoryReportingDoubleTheTargetIsUnacceptableAtFiveParticipants() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        report("39.5", "40", "40.5", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        long outlier = FIRST_ORG + ORGS - 1;
+        assertEquals("double the target is outside the sealed range", "UNACCEPTABLE", verdict(outlier));
+        for (int i = 0; i < ORGS - 1; i++) {
+            assertEquals("inside the range", "ACCEPTABLE", verdict(FIRST_ORG + i));
+        }
+        assertEquals(5, summary.get("judgedAgainstTargetCount"));
+        assertEquals("the failing laboratory reaches the follow-up register", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_participant_followup WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()));
+        assertEquals(Integer.valueOf(1), summary.get("followupCount"));
+    }
+
+    @Test
+    public void thePeerScoreIsKeptBesideTheVerdictAndTheTargetIsRecorded() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        report("39.5", "40", "40.5", "41", "80");
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        long outlier = FIRST_ORG + ORGS - 1;
+        assertNotNull("the peer statistic still reports, it just no longer decides", zScore(outlier));
+        assertEquals(0, new BigDecimal("40").compareTo(targetValue(outlier)));
+        String csv = scoringService.buildScoreCsv(cycle.getId(), outlier);
+        String row = csv.lines().filter(line -> line.startsWith("Target CD4 test")).findFirst().orElse("");
+        assertTrue("the scores CSV shows the target the verdict was measured against: " + row,
+                row.contains(",40.00000,") || row.contains(",40,"));
+        assertTrue("and the verdict beside it: " + row, row.contains("UNACCEPTABLE"));
+    }
+
+    @Test
+    public void aTargetWithNoAcceptanceRangeLeavesThePeerVerdictAlone() {
+        // No range sealed: comparing for equality would fail a laboratory for
+        // answering 39.5 to a target of 40, which is not what a range-less target
+        // means. The peer verdict stands and the target is recorded for the report.
+        sealTarget("40", null, null);
+        report("39.5", "40", "40.5", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG));
+        assertEquals(0, summary.get("judgedAgainstTargetCount"));
+        assertEquals(0, new BigDecimal("40").compareTo(targetValue(FIRST_ORG)));
+    }
+
+    @Test
+    public void aTargetedCycleScoresBelowThePeerFloor() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        report("40", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("UNACCEPTABLE", verdict(FIRST_ORG + 2));
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG));
+        assertEquals(3, summary.get("judgedAgainstTargetCount"));
+    }
+
+    @Test
+    public void anUntargetedCycleBelowThePeerFloorIsStillRefused() {
+        report("40", "41", "80");
+
+        try {
+            scoringService.scoreCycle(cycle.getId(), USER);
+            fail("with no target and no crowd there is nothing to judge against");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("no target"));
+        }
+    }
+
+    // ---- helpers ----
+
+    private void sealTarget(String targetValue, BigDecimal low, BigDecimal high) {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode("T01");
+        sample.setAnalyteId(ANALYTE_CD4);
+        sample.setTargetValue(targetValue);
+        sample.setAcceptanceRangeLow(low);
+        sample.setAcceptanceRangeHigh(high);
+        sample.setSysUserId(USER);
+        eqaPanelSampleDAO.insert(sample);
+    }
+
+    private void report(String... values) {
+        for (int i = 0; i < values.length; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i, Map.of(TEST_CD4, values[i]), EQASubmissionMethod.MANUAL,
+                    USER);
+        }
+    }
+
+    private String verdict(long organizationId) {
+        return jdbc.queryForObject(
+                "SELECT performance_status FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                String.class, organizationId, TEST_CD4);
+    }
+
+    private BigDecimal zScore(long organizationId) {
+        return jdbc.queryForObject(
+                "SELECT z_score FROM clinlims.eqa_result WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, TEST_CD4);
+    }
+
+    private BigDecimal targetValue(long organizationId) {
+        return jdbc.queryForObject(
+                "SELECT target_value FROM clinlims.eqa_result WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, TEST_CD4);
+    }
+}


### PR DESCRIPTION
## The defect

Provider scoring consulted only the peer statistic. A classical peer Z cannot reach its own thresholds on a small roster: over `n` values the largest attainable `|Z|` is `(n-1)/√n`, which at the **five reported results scoring already demanded** is **1.79** — under the questionable threshold of 2, nowhere near the unacceptable threshold of 3.

Measured on a five-laboratory cycle with a target of 40 and a range of 36–44:

| Laboratory | Reported | z | Verdict |
|---|---|---|---|
| Lae | 39.50 | -0.489 | ACCEPTABLE |
| Goroka | 40.00 | -0.461 | ACCEPTABLE |
| Kimbe | 40.50 | -0.433 | ACCEPTABLE |
| Mt Hagen | 41.00 | -0.405 | ACCEPTABLE |
| PMGH | **80.00** | 1.78797 | **ACCEPTABLE** |

So no verdict could ever be unacceptable, and nothing downstream of one — a follow-up entry, a non-conformity, a competency event — could fire. The acceptance range typed into the cycle wizard had no effect on any verdict, and `eqa_result.target_value` was never populated, so the report and the scores CSV printed an empty target column.

## The change

- Where a cycle's panel material seals an **acceptance range** for a test's analyte, a quantitative result is judged against that range. The peer Z is kept beside the verdict as reporting rather than as the decision.
- Qualitative results keep their exact, case-insensitive match against the target — and the comparison now lives in **one** place for both lanes: the in-house scorer delegates to the same helper (`EqaTargetVerdict`) instead of holding a second copy.
- A target sealed **without** a range deliberately does not decide a numeric verdict: a laboratory is not wrong for answering 39.5 to a target of 40. The peer verdict stands there, and material with no target at all behaves exactly as before.
- The target is copied onto the result when it judges one, so the printed report, the scores CSV and the follow-up register snapshot show what the verdict was measured against. All three already carried the column.
- The participant floor now blocks only what it protects: a cycle whose panel carries a target scores at any roster size (a target needs no crowd), while a cycle with no target and too few reported results is still refused — with a message that says which of the two is missing. Scoring a cycle with nothing reported is refused outright. The summary reports how many results the target judged.

## Deliberately not in here

A peer statistic robust to the outlier it exists to detect (a median with a normalised IQR, or a Z computed against the *other* participants' mean and SD), and whether the peer floor should be configurable. Those change what an **untargeted** cycle reports and deserve their own decision; this change is what makes a wrong answer reachable at all.

## Tests

`EQAProviderTargetScoringIntegrationTest` — 5 tests against the real schema:

- a laboratory reporting double the target is UNACCEPTABLE at five participants, and its follow-up row opens
- the peer Z survives as reporting, and the recorded target appears in the scores CSV beside the verdict
- a range-less target leaves the peer verdict alone (the guard against turning a missing range into mass failures)
- a targeted cycle scores below the peer floor
- an untargeted cycle below the floor is still refused, and the message names what is missing

Green locally: 5 new + 5 provider intake + 13 in-house blinding + 14 score triage. The in-house and triage suites cover the shared helper's other caller and pass unchanged.

Not driven through the UI on a stack: reproducing it there needs a fresh wizard run with a ranged target, prep and dispatch. The integration tests drive the same service path (`takeIn` → `scoreCycle` → follow-up row → CSV) against a Liquibase-provisioned database.