### PR TITLE
fix(eqa): make panel material the tests a participant can actually order (OGC-609, OGC-613)

### DIFF
--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -458,9 +458,10 @@ const CycleWizard = () => {
                               "Select a test",
                             )}
                           />
-                          {/* /rest/test-list carries the display name in `value`
-                              on some rows and `name` on others — same fallback
-                              T-21's wizard uses, or the option renders blank. */}
+                          {/* The catalog list carries the display name in
+                              `value` on some rows and `name` on others — the
+                              same fallback the blinding wizard uses, or the
+                              option renders blank. */}
                           {tests.map((test) => (
                             <SelectItem
                               key={test.id}

--- a/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
@@ -36,9 +36,10 @@ const renderWizard = () => {
     if (url === "/rest/eqa/programs/3")
       cb({ id: 3, name: "National HIV VL PT" });
     else if (url === "/rest/eqa/programs/3/enrollments") cb(ENROLLMENTS);
-    // T-21's fetchTests: testable-tests narrows the standard catalog.
+    // fetchTests: testable-tests narrows the whole catalog to the tests a
+    // participant could order.
     else if (url === "/rest/eqa/testable-tests") cb(["55", "56"]);
-    else if (url === "/rest/test-list")
+    else if (url === "/rest/displayList/ALL_TESTS")
       cb([
         { id: "55", name: "HIV Viral Load" },
         { id: "56", name: "HIV EID" },

--- a/frontend/src/components/eqa/eqaApi.js
+++ b/frontend/src/components/eqa/eqaApi.js
@@ -20,13 +20,15 @@ export const asList = (data) => (Array.isArray(data) ? data : []);
 export const failed = (response) =>
   !response || response.error || (response.status && response.status >= 400);
 
-// The standard test list, narrowed to the tests that carry an analyte: a panel
-// target is stored against an analyte, so offering the rest is a dead end the
-// wizard would only discover at write time.
+// The tests a panel can be built from: those a participating laboratory could
+// raise an order for, named from the whole catalog rather than from the
+// lab-unit-scoped list. Panel material is not lab-unit scoped, and the scoped
+// list is empty for a QA officer, who holds no bench role — which left both
+// wizards with an empty Test column for the very persona they are written for.
 export const fetchTests = (callback) => {
   getFromOpenElisServer("/rest/eqa/testable-tests", (testable) => {
     const usable = new Set(asList(testable).map(String));
-    getFromOpenElisServer("/rest/test-list", (tests) =>
+    getFromOpenElisServer("/rest/displayList/ALL_TESTS", (tests) =>
       callback(asList(tests).filter((test) => usable.has(String(test.id)))),
     );
   });

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -239,16 +239,27 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
         if (!analytes.isEmpty()) {
             return Long.valueOf(analytes.get(0).getAnalyte().getId());
         }
-        return Long.valueOf(createAnalyteFor(test).getId());
+        return Long.valueOf(analyteFor(test).getId());
     }
 
-    /** analyte.name is 60 characters, and a test name can be longer. */
-    private Analyte createAnalyteFor(Test test) {
+    /**
+     * An analyte already named after the test is the one meant, so it is adopted
+     * rather than duplicated — analyte names are unique, and a catalog commonly
+     * carries the analyte while leaving the link to the test unmade. Only the link
+     * is new in that case. analyte.name is 60 characters, and a test name can be
+     * longer.
+     */
+    private Analyte analyteFor(Test test) {
         String name = test.getName() == null ? "Test " + test.getId() : test.getName().trim();
-        Analyte analyte = new Analyte();
-        analyte.setAnalyteName(name.length() > 60 ? name.substring(0, 60) : name);
-        analyte.setIsActive(IActionConstants.YES);
-        analyte = analyteService.save(analyte);
+        String analyteName = name.length() > 60 ? name.substring(0, 60) : name;
+
+        Analyte probe = new Analyte();
+        probe.setAnalyteName(analyteName);
+        Analyte analyte = analyteService.getAnalyteByName(probe, true);
+        if (analyte == null) {
+            probe.setIsActive(IActionConstants.YES);
+            analyte = analyteService.save(probe);
+        }
 
         TestAnalyte link = new TestAnalyte();
         link.setTest(test);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelServiceImpl.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.analyte.service.AnalyteService;
+import org.openelisglobal.analyte.valueholder.Analyte;
+import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
@@ -24,6 +26,8 @@ import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.valueholder.Test;
 import org.openelisglobal.testanalyte.service.TestAnalyteService;
 import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
+import org.openelisglobal.typeofsample.service.TypeOfSampleTestService;
+import org.openelisglobal.typeofsample.valueholder.TypeOfSampleTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,6 +64,9 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
 
     @Autowired
     private TestAnalyteService testAnalyteService;
+
+    @Autowired
+    private TypeOfSampleTestService typeOfSampleTestService;
 
     public EQAPanelServiceImpl() {
         super(EQAPanel.class);
@@ -206,8 +213,20 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
      * still pass. Same reason EQAPanelRestController field-injects it rather than
      * taking it in its constructor.
      */
+    /**
+     * The analyte is the grain a panel target is stored against and the name a
+     * score is matched by across instances, so a panel sample needs one. Most of
+     * the catalog has none: no administration screen writes a test analyte, and on
+     * a fresh database the great majority of active tests carry none, which used to
+     * make them unusable as panel material however orderable they were.
+     *
+     * <p>
+     * So the analyte is resolved on write and created from the test's own name when
+     * it is missing, which is what the reflex-rule editor already does with the
+     * analytes it needs. Existing analytes are reused, and creating one is
+     * idempotent for a given test.
+     */
     @Override
-    @Transactional(readOnly = true)
     public Long analyteIdForTest(String testId) {
         if (GenericValidator.isBlankOrNull(testId)) {
             return null;
@@ -217,11 +236,25 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
             throw new IllegalArgumentException("Unknown test " + testId);
         }
         List<TestAnalyte> analytes = testAnalyteService.getAllTestAnalytesPerTest(test);
-        if (analytes.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "Test " + test.getName() + " has no analyte, so it cannot carry a panel target");
+        if (!analytes.isEmpty()) {
+            return Long.valueOf(analytes.get(0).getAnalyte().getId());
         }
-        return Long.valueOf(analytes.get(0).getAnalyte().getId());
+        return Long.valueOf(createAnalyteFor(test).getId());
+    }
+
+    /** analyte.name is 60 characters, and a test name can be longer. */
+    private Analyte createAnalyteFor(Test test) {
+        String name = test.getName() == null ? "Test " + test.getId() : test.getName().trim();
+        Analyte analyte = new Analyte();
+        analyte.setAnalyteName(name.length() > 60 ? name.substring(0, 60) : name);
+        analyte.setIsActive(IActionConstants.YES);
+        analyte = analyteService.save(analyte);
+
+        TestAnalyte link = new TestAnalyte();
+        link.setTest(test);
+        link.setAnalyte(analyte);
+        testAnalyteService.save(link);
+        return analyte;
     }
 
     @Override
@@ -254,12 +287,20 @@ public class EQAPanelServiceImpl extends BaseObjectServiceImpl<EQAPanel, Long> i
     @Override
     @Transactional(readOnly = true)
     public List<String> getTestableTestIds() {
+        // What disqualifies a test as panel material is that no participant could
+        // answer it: a panel sample the receiving laboratory cannot raise an order
+        // for is a dead end. Its analyte, by contrast, is created on write when the
+        // catalog has none, so it is not a precondition. Filtering on the analyte
+        // instead — as this did — left 17 of 210 active tests offerable on a fresh
+        // database and no numeric test that was also orderable, so a numeric cycle
+        // could be built but never answered.
+        //
         // Resolved here rather than in the controller: test is held in a legacy
         // ValueHolder, which needs the session open to answer.
         Set<String> ids = new LinkedHashSet<>();
-        for (TestAnalyte testAnalyte : testAnalyteService.getAllTestAnalytes()) {
-            if (testAnalyte.getTest() != null) {
-                ids.add(testAnalyte.getTest().getId());
+        for (TypeOfSampleTest sampleTypeTest : typeOfSampleTestService.getAllTypeOfSampleTests()) {
+            if (sampleTypeTest.getTestId() != null) {
+                ids.add(sampleTypeTest.getTestId());
             }
         }
         return new ArrayList<>(ids);

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelMaterialEligibilityIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelMaterialEligibilityIntegrationTest.java
@@ -1,0 +1,123 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQAPanelService;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Which tests a panel can be built from, and where the analyte behind a panel
+ * sample comes from.
+ *
+ * <p>
+ * A test reaches a panel wizard if a participating laboratory could raise an
+ * order for it, which is the half of the loop no deployment can repair from
+ * inside the application. The analyte a target is stored against is the half it
+ * can: no administration screen writes one, so it is created on write from the
+ * test's own name.
+ */
+public class EQAPanelMaterialEligibilityIntegrationTest extends EQASpineTestBase {
+
+    private static final long ORDERABLE_TEST = 9941L;
+    private static final long UNORDERABLE_TEST = 9942L;
+    private static final int SAMPLE_TYPE_LINK = 99441;
+
+    @Autowired
+    private EQAPanelService eqaPanelService;
+
+    private EQAProgram scheme;
+
+    @Before
+    public void seedCatalog() {
+        seedTest(ORDERABLE_TEST, "Eligibility orderable test");
+        seedTest(UNORDERABLE_TEST, "Eligibility unorderable test");
+        // An existing sample type, not a new one: type_of_sample requires a
+        // localization row, and which type it is does not matter here.
+        Long sampleType = jdbc.queryForObject("SELECT min(id) FROM clinlims.type_of_sample", Long.class);
+        jdbc.update("DELETE FROM clinlims.sampletype_test WHERE id = ?", SAMPLE_TYPE_LINK);
+        jdbc.update("INSERT INTO clinlims.sampletype_test (id, sample_type_id, test_id) VALUES (?, ?, ?)",
+                SAMPLE_TYPE_LINK, sampleType, ORDERABLE_TEST);
+
+        scheme = insertScheme("Eligibility scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE test_id IN (?, ?)", ORDERABLE_TEST, UNORDERABLE_TEST);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE name LIKE 'Eligibility %'");
+            jdbc.update("DELETE FROM clinlims.sampletype_test WHERE id = ?", SAMPLE_TYPE_LINK);
+            jdbc.update("DELETE FROM clinlims.test WHERE id IN (?, ?)", ORDERABLE_TEST, UNORDERABLE_TEST);
+        }
+    }
+
+    @Test
+    public void aTestAParticipantCanOrderIsOfferedEvenWithNoAnalyte() {
+        assertEquals("the fixture test starts with no analyte", Integer.valueOf(0), analyteLinkCount(ORDERABLE_TEST));
+
+        List<String> offered = eqaPanelService.getTestableTestIds();
+
+        assertTrue("a test with a sample type is panel material", offered.contains(String.valueOf(ORDERABLE_TEST)));
+        assertFalse("a test no laboratory can order is a dead end", offered.contains(String.valueOf(UNORDERABLE_TEST)));
+    }
+
+    @Test
+    public void theAnalyteIsCreatedFromTheTestNameOnFirstUseAndReusedAfterwards() {
+        Long analyteId = eqaPanelService.analyteIdForTest(String.valueOf(ORDERABLE_TEST));
+
+        assertNotNull(analyteId);
+        assertEquals("Eligibility orderable test",
+                jdbc.queryForObject("SELECT name FROM clinlims.analyte WHERE id = ?", String.class, analyteId));
+        assertEquals(Integer.valueOf(1), analyteLinkCount(ORDERABLE_TEST));
+
+        assertEquals("a second call reuses the analyte rather than minting another", analyteId,
+                eqaPanelService.analyteIdForTest(String.valueOf(ORDERABLE_TEST)));
+        assertEquals(Integer.valueOf(1), analyteLinkCount(ORDERABLE_TEST));
+    }
+
+    @Test
+    public void aPanelSampleCanBeWrittenForATestTheCatalogNeverGaveAnAnalyte() {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setSampleCode("E01");
+        sample.setAnalyteId(eqaPanelService.analyteIdForTest(String.valueOf(ORDERABLE_TEST)));
+        sample.setTargetValue("40");
+        sample.setSysUserId(USER);
+
+        EQAPanel panel = new EQAPanel();
+        panel.setScheme(scheme);
+        panel.setPanelName("Eligibility panel");
+        panel.setSysUserId(USER);
+        EQAPanel created = eqaPanelService.create(panel, List.of(sample), USER);
+
+        assertEquals(Integer.valueOf(1),
+                jdbc.queryForObject(
+                        "SELECT count(*) FROM clinlims.eqa_panel_sample WHERE panel_id = ? AND analyte_id IS NOT NULL",
+                        Integer.class, created.getId()));
+    }
+
+    // ---- helpers ----
+
+    private Integer analyteLinkCount(long testId) {
+        return jdbc.queryForObject("SELECT count(*) FROM clinlims.test_analyte WHERE test_id = ?", Integer.class,
+                testId);
+    }
+
+    private void seedTest(long id, String name) {
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                id, name, name, UUID.randomUUID().toString(), id);
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
@@ -72,6 +72,9 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
         if (jdbc != null) {
             jdbc.update("DELETE FROM clinlims.eqa_program_enrollment WHERE organization_id IN (9970, 9971, 9972)");
             jdbc.update("DELETE FROM clinlims.test_analyte WHERE id IN (99801, 99802)");
+            // The link a panel write resolves takes a sequence id, so it is cleaned
+            // by the test it belongs to, not by id.
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE test_id = ?", Long.valueOf(TEST_NO_ANALYTE));
         }
         super.cleanEqaTables();
         if (jdbc != null) {
@@ -203,18 +206,30 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
                 Integer.class, created.getId()));
     }
 
+    /**
+     * The catalog leaves most tests without an analyte and no screen writes one, so
+     * a panel sample resolves it on write instead of refusing: an analyte already
+     * named after the test is adopted, and one is created only when the name is
+     * new. This fixture's test 9704 and analyte 9804 are both "HIV recency", which
+     * is the adoption case.
+     */
     @Test
-    public void aTestWithNoAnalyteBehindItIsRefused() {
+    public void aTestWithNoAnalyteLinkResolvesOneOnWrite() {
         List<PanelSampleRequest> samples = List
                 .of(new PanelSampleRequest("PS-1", TEST_NO_ANALYTE, null, null, null, null));
 
-        try {
-            cycleService.createProviderCycle(with(samples, List.of(ORG_A)), USER);
-            fail("a panel target has nowhere to live without an analyte");
-        } catch (IllegalArgumentException expected) {
-            assertTrue(expected.getMessage(), expected.getMessage().contains("no analyte"));
-        }
-        assertNothingWasCreated();
+        EQACycle created = cycleService.createProviderCycle(with(samples, List.of(ORG_A)), USER);
+
+        assertEquals("the sample carries the analyte the test's name names", Long.valueOf(9804L),
+                jdbc.queryForObject(
+                        "SELECT s.analyte_id FROM clinlims.eqa_panel_sample s"
+                                + " JOIN clinlims.eqa_panel p ON p.id = s.panel_id WHERE p.cycle_id = ?",
+                        Long.class, created.getId()));
+        assertEquals("adopted, not duplicated", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.analyte WHERE name = 'HIV recency'", Integer.class));
+        assertEquals("and the missing link is the only row written", Integer.valueOf(1),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.test_analyte WHERE test_id = ?", Integer.class,
+                        Long.valueOf(TEST_NO_ANALYTE)));
     }
 
     @Test


### PR DESCRIPTION
## The defect

Two catalog tables gated the two ends of the EQA loop, and nothing lined them up:

- a test reached a **panel wizard** only if it had a `test_analyte` row
- it reached **Add Order** only if it had a `sampletype_test` row

Measured on a fresh database: 210 active tests, 175 orderable, **20** with an analyte, **10** with both — and **no numeric test had both**. So a provider could build a numeric panel that no participating laboratory could answer, and four of the six national programmes had no usable test at all. Neither row has a write path in the application (a test added through Test Management lands with zero analytes), so a deployment could not repair the intersection from inside OpenELIS.

Separately, both wizards filled their Test dropdown from the **lab-unit-scoped** catalog list, which is empty for a QA Officer — a global role carrying no bench lab unit. The persona both lanes are written for saw a blank Test column and could not finish either wizard.

## The change

The two halves are not equally hard. Whether a laboratory can raise an order for a test is real catalog configuration. The analyte is only the grain a target is stored against and a score is matched by — and it can be derived.

- **Panel eligibility now means orderable**: a test with at least one sample-type association. `getTestableTestIds()` reads `sampletype_test` instead of `test_analyte`.
- **The analyte is resolved on write**: `analyteIdForTest` creates one from the test's own name when the catalog never gave it one, reuses an existing one, and is idempotent per test. This is what the reflex-rule editor already does with the analytes it needs.
- **The wizards' test list comes from the whole catalog** rather than the lab-unit-scoped one, still narrowed to the orderable tests. Panel material is not lab-unit scoped.

## Tests

`EQAPanelMaterialEligibilityIntegrationTest` — 3 tests against the real schema:

- an orderable test with no analyte is offered as panel material; an unorderable one is not
- the analyte is created from the test name on first use and reused on the second, with one link row either way
- a panel sample can be written for a test the catalog never gave an analyte

Green locally: 3 new + 11 panel lifecycle + 5 in-house wizard + 10 panel spine; 161 frontend tests across `components/eqa`.

## Verified on a dev stack

- `GET /rest/eqa/testable-tests` went from 20 ids to **175**
- the in-house wizard's Test dropdown now lists numeric orderable tests (Alanine Aminotransferase, Amylase, …) where it previously offered 17 legacy entries and no numeric orderable test
- creating a panel on **Amylase(Serum)** — a numeric test that had no analyte — answered `201` with the analyte minted and linked (`test_analyte` 294 → analyte 278 "Amylase"), and the panel sample carried it. The throwaway panel was removed afterwards.