### PR TITLE
fix(eqa): assign tests to a scheme from the EQA Programs dialog (OGC-613, OGC-609)

### DIFF
--- a/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
@@ -1,13 +1,15 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Modal,
   TextInput,
   TextArea,
   Toggle,
+  FilterableMultiSelect,
   InlineNotification,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import {
+  getFromOpenElisServer,
   postToOpenElisServerFullResponse,
   putToOpenElisServerFullResponse,
   resolveApiErrorMessage,
@@ -26,10 +28,89 @@ const ProgramForm = ({ program, onClose }) => {
   const [providerError, setProviderError] = useState("");
   const [saveError, setSaveError] = useState("");
 
+  // The tests this programme collects. Provider intake reads exactly this map —
+  // the results grid and its CSV import both iterate it — so a programme with
+  // none of them cannot take in a single participant result.
+  const [tests, setTests] = useState([]);
+  const [selectedTests, setSelectedTests] = useState([]);
+  const [assignedTestIds, setAssignedTestIds] = useState([]);
+  // FilterableMultiSelect takes its selection on mount only, so it waits for
+  // both reads rather than mounting empty and never catching up.
+  const [testsReady, setTestsReady] = useState(false);
+
+  useEffect(() => {
+    // The unscoped catalog, as the participant enrollment form uses: /rest/test-list
+    // is narrowed by the caller's Results lab-unit role, which a QA Officer has no
+    // reason to hold.
+    getFromOpenElisServer("/rest/displayList/ALL_TESTS", (data) => {
+      // A nameless entry would reach Carbon's sort as undefined and take the
+      // dialog down with it, so it is dropped rather than offered.
+      const items = (Array.isArray(data) ? data : [])
+        .filter((t) => t && t.id != null && t.value)
+        .map((t) => ({ id: String(t.id), text: String(t.value) }));
+      setTests(items);
+
+      if (!isEditing) {
+        setTestsReady(true);
+        return;
+      }
+      getFromOpenElisServer(
+        `/rest/eqa/programs/${program.id}/tests`,
+        (assignments) => {
+          const ids = (Array.isArray(assignments) ? assignments : [])
+            .filter((a) => a.isActive !== false)
+            .map((a) => String(a.testId));
+          setAssignedTestIds(ids);
+          setSelectedTests(items.filter((t) => ids.includes(t.id)));
+          setTestsReady(true);
+        },
+      );
+    });
+  }, []);
+
+  const saveTestAssignments = (programId, done) => {
+    const chosen = selectedTests.map((t) => String(t.id));
+    const unchanged =
+      chosen.length === assignedTestIds.length &&
+      chosen.every((id) => assignedTestIds.includes(id));
+    // Every save would otherwise delete and re-create the rows, so a rename would
+    // churn assignments it never touched.
+    if (unchanged) {
+      done();
+      return;
+    }
+    putToOpenElisServerFullResponse(
+      `/rest/eqa/programs/${programId}/tests`,
+      JSON.stringify({ testIds: chosen.map(Number) }),
+      (response) => {
+        if (response && response.ok) {
+          done();
+          return;
+        }
+        Promise.resolve(
+          response ? response.json().catch(() => null) : null,
+        ).then((body) =>
+          setSaveError(
+            resolveApiErrorMessage(intl, body, "eqa.program.tests.saveFailed"),
+          ),
+        );
+      },
+    );
+  };
+
   // keep the modal open and show why the server refused, instead of closing as if saved
   const handleResponse = (response) => {
     if (response && response.ok) {
-      if (onClose) onClose();
+      Promise.resolve(response.json().catch(() => null)).then((body) => {
+        const programId = isEditing ? program.id : body?.id;
+        if (programId == null) {
+          if (onClose) onClose();
+          return;
+        }
+        saveTestAssignments(programId, () => {
+          if (onClose) onClose();
+        });
+      });
       return;
     }
     Promise.resolve(response ? response.json().catch(() => null) : null).then(
@@ -139,6 +220,20 @@ const ProgramForm = ({ program, onClose }) => {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
+        {testsReady && (
+          <FilterableMultiSelect
+            id="program-tests"
+            titleText={intl.formatMessage({ id: "eqa.program.tests" })}
+            helperText={intl.formatMessage({ id: "eqa.program.tests.helper" })}
+            items={tests}
+            itemToString={(item) => (item ? item.text : "")}
+            initialSelectedItems={selectedTests}
+            onChange={(e) => setSelectedTests(e.selectedItems)}
+            placeholder={intl.formatMessage({
+              id: "eqa.program.tests.select",
+            })}
+          />
+        )}
         <Toggle
           id="program-per-analyst"
           labelText={intl.formatMessage({

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
@@ -1,12 +1,19 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+// This project's @testing-library/react is v9, which predates waitFor; the dom
+// package is where the rest of the suite takes it from.
+import { waitFor } from "@testing-library/dom";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import messages from "../../../../languages/en.json";
 import ProgramManagement from "../ProgramManagement";
 import UserSessionDetailsContext from "../../../../UserSessionDetailsContext";
 import ProgramForm from "../ProgramForm";
-import { getFromOpenElisServer } from "../../../utils/Utils";
+import {
+  getFromOpenElisServer,
+  postToOpenElisServerFullResponse,
+  putToOpenElisServerFullResponse,
+} from "../../../utils/Utils";
 
 vi.mock("../../../../components/common/PageBreadCrumb", () => {
   return {
@@ -211,5 +218,106 @@ describe("ProgramForm", () => {
     renderWithIntl(<ProgramForm program={null} onClose={onClose} />);
     fireEvent.click(screen.getByText("Cancel"));
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("ProgramForm test assignments", () => {
+  const catalog = [
+    { id: 41, value: "CD4 count" },
+    { id: 57, value: "Determine(Serum)" },
+    { id: 45, value: "Genie III(Serum)" },
+  ];
+
+  // Answers each read by URL, so the form's two fetches cannot be confused for
+  // one another.
+  const serveCatalogAnd = (assignments) =>
+    getFromOpenElisServer.mockImplementation((url, callback) => {
+      if (url === "/rest/displayList/ALL_TESTS") return callback(catalog);
+      if (/\/rest\/eqa\/programs\/\d+\/tests$/.test(url))
+        return callback(assignments);
+      return callback([]);
+    });
+
+  const ok = (body) => ({ ok: true, json: () => Promise.resolve(body) });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    putToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb(ok({ id: 3 })),
+    );
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb(ok({ id: 7 })),
+    );
+  });
+
+  const editableProgram = {
+    id: 3,
+    name: "HIV Serology",
+    provider: "CPHL",
+    description: "",
+    isActive: true,
+  };
+
+  test("offers the catalog when editing a program", async () => {
+    serveCatalogAnd([]);
+    const { container } = renderWithIntl(
+      <ProgramForm program={editableProgram} onClose={vi.fn()} />,
+    );
+    await waitFor(() =>
+      expect(container.querySelector("#program-tests")).toBeTruthy(),
+    );
+    expect(screen.getByText("Assigned Tests")).toBeTruthy();
+  });
+
+  test("saving an untouched form leaves the existing assignments alone", async () => {
+    // The write is a delete-and-recreate, so a rename must not reach it. If the
+    // assigned tests failed to preselect, the guard would see an empty selection
+    // and clear the program's tests here.
+    serveCatalogAnd([
+      { id: 11, testId: 57, isActive: true },
+      { id: 12, testId: 45, isActive: true },
+    ]);
+    const onClose = vi.fn();
+    const { container } = renderWithIntl(
+      <ProgramForm program={editableProgram} onClose={onClose} />,
+    );
+    await waitFor(() =>
+      expect(container.querySelector("#program-tests")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText("Save Program"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    const urls = putToOpenElisServerFullResponse.mock.calls.map((c) => c[0]);
+    expect(urls).toEqual(["/rest/eqa/programs/3"]);
+  });
+
+  test("a new program's tests are written against the id the server assigned", async () => {
+    serveCatalogAnd([]);
+    const onClose = vi.fn();
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={onClose} />,
+    );
+    await waitFor(() =>
+      expect(container.querySelector("#program-tests")).toBeTruthy(),
+    );
+
+    fireEvent.change(screen.getByLabelText("Program Name"), {
+      target: { value: "HIV Viral Load" },
+    });
+    fireEvent.change(screen.getByLabelText("Provider"), {
+      target: { value: "CPHL" },
+    });
+    // The menu opens off the combobox input, not the wrapper the id sits on.
+    fireEvent.click(screen.getByPlaceholderText("Select tests to assign"));
+    fireEvent.click(await screen.findByText("Determine(Serum)"));
+    fireEvent.click(screen.getByText("Add Program"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(putToOpenElisServerFullResponse).toHaveBeenCalledWith(
+      "/rest/eqa/programs/7/tests",
+      JSON.stringify({ testIds: [57] }),
+      expect.any(Function),
+    );
   });
 });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -2122,6 +2122,8 @@
   "eqa.program.status": "Status",
   "eqa.program.tests": "Assigned Tests",
   "eqa.program.tests.assign": "Assign Tests",
+  "eqa.program.tests.helper": "Result intake for this program offers exactly these tests, on the results grid and in its CSV import.",
+  "eqa.program.tests.saveFailed": "The program was saved but its tests were not. Reopen it and set them again.",
   "eqa.program.tests.select": "Select tests to assign",
   "eqa.provider.label": "EQA Provider Organization",
   "eqa.provider.sampleId": "Provider Sample ID",


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Provider result intake reads a scheme's test assignments — the results grid and its CSV import both iterate them — but nothing in the frontend ever wrote one. The only writer, `PUT /rest/eqa/programs/{id}/tests`, shipped guarded and uncalled, so on a clean install every intake grid opened as *"This scheme has no tests assigned yet"* and a provider could not take in a single participant result.

The **Add/Edit Program** dialog now carries an **Assigned Tests** multiselect:

- fed from `/rest/displayList/ALL_TESTS`, the unscoped catalog the participant enrollment form already uses — `/rest/test-list` is narrowed by the caller's Results lab-unit role, which a QA Officer has no reason to hold, and would have offered nothing;
- preselected from the existing `GET /rest/eqa/programs/{id}/tests`, rendered once both reads return (Carbon's `FilterableMultiSelect` takes its initial selection on mount only);
- written through the existing `PUT` after the programme save, taking a new programme's id from the create response;
- silent when the selection is untouched, because the endpoint deletes and re-creates the rows and a rename must not churn assignments it never touched.

Frontend only: `ProgramForm.jsx`, its test file, and two `en.json` keys. No schema change, no new endpoint.

## Tests

Three added to `ProgramManagement.test.jsx`, each checked by disabling the behaviour it guards:

- the control renders when editing a programme;
- an untouched form leaves the existing assignments alone — with the guard removed, the `PUT` fires and would clear the scheme's tests;
- a new programme's tests are written against the id the server assigned — with the response id ignored, the `PUT` never fires.

The EQA suite (164 tests) and the full frontend suite (1204 tests) pass.

## Verification on the two-instance UAT rig

As a QA Officer on the provider instance the dialog offered 202 tests. A scheme with no assignments took two through the dialog and `eqa_program_test` holds both. On a scheme that already had one, a test added through the dialog appeared in a scored cycle's **Enter results** grid beside the existing one, and deselecting it removed it again. No direct API call was needed at any step.

## Related Issue

OGC-613 (provider-side EQA programme), OGC-609 (EQA data model and programme management).

## Other

The endpoint deactivates a removed assignment rather than deleting it, so a deselected test leaves an `is_active = false` row that the intake grid already skips.
