### PR TITLE
fix(shipment): name this laboratory in Shipment Settings and export damaged panel material (OGC-610)

### DIFF
--- a/frontend/src/components/shipment/ShipmentSettings.jsx
+++ b/frontend/src/components/shipment/ShipmentSettings.jsx
@@ -84,15 +84,22 @@ const ShipmentSettings = () => {
     );
   };
 
+  // Every organization that carries a FHIR UUID, which is exactly what the save
+  // below will accept. The referral list this used to read cannot contain the row
+  // representing this laboratory — a lab is not a referral destination to itself —
+  // so the one organization an operator most needs to pick was never on offer.
   const fetchOrganizations = () => {
-    getFromOpenElisServer(
-      "/rest/displayList/REFERRAL_ORGANIZATIONS",
-      (response) => {
-        if (response && Array.isArray(response)) {
-          setOrganizations(response);
-        }
-      },
-    );
+    getFromOpenElisServer("/rest/organization-list", (response) => {
+      if (!Array.isArray(response)) {
+        return;
+      }
+      setOrganizations(
+        response
+          .filter((org) => org.fhirUuid && org.organizationName)
+          .map((org) => ({ id: String(org.id), value: org.organizationName }))
+          .sort((a, b) => a.value.localeCompare(b.value)),
+      );
+    });
   };
 
   const handleSaveSiteOrgUuid = () => {
@@ -375,6 +382,24 @@ const ShipmentSettings = () => {
                   })}
                   subtitle={intl.formatMessage({
                     id: "shipment.settings.siteOrgUnsetSubtitle",
+                  })}
+                  style={{ marginBottom: "1rem" }}
+                />
+              )}
+              {siteOrgFhirUuid !== "" && siteOrgId === "" && (
+                // A partner laboratory addresses this site by the UUID it holds for
+                // it, which need not be any local organization's own. Without this
+                // the control renders its placeholder and a configured site reads as
+                // unconfigured.
+                <InlineNotification
+                  kind="info"
+                  lowContrast
+                  hideCloseButton
+                  title={intl.formatMessage({
+                    id: "shipment.settings.siteOrgUnmatchedTitle",
+                  })}
+                  subtitle={intl.formatMessage({
+                    id: "shipment.settings.siteOrgUnmatchedSubtitle",
                   })}
                   style={{ marginBottom: "1rem" }}
                 />

--- a/frontend/src/components/shipment/__tests__/ShipmentSettings.test.jsx
+++ b/frontend/src/components/shipment/__tests__/ShipmentSettings.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+// ShipmentNavigation reads the router location, so the screen needs one.
+import { MemoryRouter } from "react-router-dom";
+import messages from "../../../languages/en.json";
+import ShipmentSettings from "../ShipmentSettings";
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+vi.mock("../../utils/Utils", async () => {
+  const actual = await vi.importActual("../../utils/Utils");
+  return {
+    ...actual,
+    getFromOpenElisServer: vi.fn(),
+    putToOpenElisServerFullResponse: vi.fn(),
+  };
+});
+
+vi.mock("../../common/PageBreadCrumb", () => ({
+  default: function MockBreadCrumb() {
+    return <div data-testid="breadcrumb" />;
+  },
+}));
+
+// vi.mock is hoisted, so the context is created inside the factory.
+vi.mock("../../layout/Layout", async () => {
+  const { createContext } = await import("react");
+  return {
+    NotificationContext: createContext({
+      addNotification: () => {},
+      notificationVisible: false,
+      setNotificationVisible: () => {},
+    }),
+  };
+});
+
+// The row representing this laboratory carries no organization type, which is why
+// the referral list this screen used to read could never offer it.
+const organizations = [
+  { id: 2, organizationName: "Test LIMS", fhirUuid: "f21b8d74" },
+  { id: 26, organizationName: "PMGH Lab", fhirUuid: "895c8e6b" },
+  { id: 3, organizationName: "ACEH" },
+];
+
+const serve = ({ siteOrg }) =>
+  getFromOpenElisServer.mockImplementation((url, callback) => {
+    if (url === "/rest/organization-list") return callback(organizations);
+    if (url === "/rest/shipping-box/site-organization-uuid")
+      return callback(siteOrg);
+    if (url === "/rest/shipping-box/box-label-prefix") return callback("CPHL");
+    if (url === "/rest/shipping-box/fhir-mapping-config")
+      return callback({ nonConformityCodes: "{}" });
+    return callback(null);
+  });
+
+const renderSettings = () =>
+  render(
+    <MemoryRouter initialEntries={["/SampleShipment/settings"]}>
+      <IntlProvider locale="en" messages={messages}>
+        <ShipmentSettings />
+      </IntlProvider>
+    </MemoryRouter>,
+  );
+
+describe("ShipmentSettings site organization", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("offers this laboratory's own organization, not just referral destinations", async () => {
+    serve({ siteOrg: { fhirUuid: "f21b8d74", orgId: "2" } });
+    renderSettings();
+    // Named as the current selection, which is only possible if the list holds it.
+    await waitFor(() =>
+      expect(screen.getAllByText("Test LIMS").length).toBeGreaterThan(0),
+    );
+  });
+
+  test("says so when the configured UUID belongs to no local organization", async () => {
+    // The cross-instance case: a partner addresses this site by a UUID this
+    // instance does not hold, so the control has nothing to preselect.
+    serve({ siteOrg: { fhirUuid: "895c8e6b-not-local", orgId: "" } });
+    renderSettings();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Set to an organization this instance does not hold"),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByText("Site organization not set")).toBeNull();
+  });
+
+  test("still warns when nothing is configured at all", async () => {
+    serve({ siteOrg: { fhirUuid: "", orgId: "" } });
+    renderSettings();
+    await waitFor(() =>
+      expect(screen.getByText("Site organization not set")).toBeTruthy(),
+    );
+    expect(
+      screen.queryByText("Set to an organization this instance does not hold"),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8501,6 +8501,8 @@
   "eqa.result.analyst.tooltip": "Shown because this run includes an EQA sample whose scheme records who ran each sample. Non-EQA rows take no input.",
   "shipment.settings.siteOrgUnsetTitle": "Site organization not set",
   "shipment.settings.siteOrgUnsetSubtitle": "Incoming consignments are not filtered to this site and outgoing boxes carry no sender. Select the organization that represents this laboratory.",
+  "shipment.settings.siteOrgUnmatchedTitle": "Set to an organization this instance does not hold",
+  "shipment.settings.siteOrgUnmatchedSubtitle": "The UUID below is the one a partner addresses this laboratory by, and it matches no organization here. Filtering works; leave it unless the partner changes it.",
   "eqa.receipt.openSubmissions": "Open submissions",
   "eqa.receipt.openSubmissionsHeading": "Open submissions with undelivered panels",
   "eqa.receipt.openSubmissionsHelp": "Participants that have not received their panel stay on the roster as late. This is a recorded manual override — give the reason.",

--- a/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
+++ b/src/main/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransform.java
@@ -266,20 +266,13 @@ public class ShippingBoxFhirTransform {
                 supplyDelivery.addExtension(contentExt);
             }
 
-            if (sampleItem == null || sampleItem.getFhirUuid() == null) {
-                String typeKey = typeDescription != null ? typeDescription : "Unknown";
-                specimenTypeCounts.put(typeKey, specimenTypeCounts.getOrDefault(typeKey, 0) + 1);
-                continue;
-            }
-
-            Reference specimenRef = new Reference("Specimen/" + sampleItem.getFhirUuidAsString());
-            if (typeDescription != null) {
-                specimenRef.setDisplay(typeDescription);
-            }
-
-            supplyDelivery.addExtension(new Extension(EXT_SPECIMEN, specimenRef));
-
-            // Non-conformity extension with SNOMED CT codes (Rule 6)
+            // Non-conformity codes (Rule 6). Every contents row can carry one: EQA
+            // panel material has no SampleItem, so keying this off the Specimen
+            // reference below meant material recorded as damaged left no trace on the
+            // wire — the one fact a sending laboratory most needs back.
+            // ponytail: the extension names a code but not which item it belongs to,
+            // as it always has. Naming the item means nesting {item, code}, which is a
+            // wire-format change and a separate decision.
             if (bsi.getReceptionStatus() != null && bsi.getReceptionStatus() != ReceptionStatus.PENDING
                     && bsi.getReceptionStatus() != ReceptionStatus.RECEIVED_GOOD) {
                 if (nonConformityOverrides == null) {
@@ -293,6 +286,17 @@ public class ShippingBoxFhirTransform {
 
             String typeKey = typeDescription != null ? typeDescription : "Unknown";
             specimenTypeCounts.put(typeKey, specimenTypeCounts.getOrDefault(typeKey, 0) + 1);
+
+            if (sampleItem == null || sampleItem.getFhirUuid() == null) {
+                continue;
+            }
+
+            Reference specimenRef = new Reference("Specimen/" + sampleItem.getFhirUuidAsString());
+            if (typeDescription != null) {
+                specimenRef.setDisplay(typeDescription);
+            }
+
+            supplyDelivery.addExtension(new Extension(EXT_SPECIMEN, specimenRef));
         }
 
         for (Map.Entry<String, Integer> entry : specimenTypeCounts.entrySet()) {

--- a/src/test/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransformNonConformityCodesTest.java
+++ b/src/test/java/org/openelisglobal/shipment/fhir/ShippingBoxFhirTransformNonConformityCodesTest.java
@@ -2,9 +2,26 @@ package org.openelisglobal.shipment.fhir;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.SupplyDelivery;
 import org.junit.Test;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.shipment.dao.BoxSampleItemDAO;
+import org.openelisglobal.shipment.valueholder.BoxSampleItem;
+import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.ReceptionStatus;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
+import org.openelisglobal.siteinformation.service.SiteInformationService;
+import org.openelisglobal.siteinformation.valueholder.SiteInformation;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * T-44: the fhirNonConformityCodes SiteInformation config must be parsed as
@@ -38,5 +55,75 @@ public class ShippingBoxFhirTransformNonConformityCodesTest {
     public void blankOrNull_yieldsEmptyMap() {
         assertTrue(ShippingBoxFhirTransform.parseNonConformityCodes("").isEmpty());
         assertTrue(ShippingBoxFhirTransform.parseNonConformityCodes(null).isEmpty());
+    }
+
+    /**
+     * The parser tests above pass on a build that never reaches the parser. EQA
+     * panel material has no SampleItem, and the export used to key non-conformity
+     * off the Specimen reference that material never gets — so a vial recorded as
+     * damaged travelled as an ordinary consignment. This drives the transform
+     * itself, which is the only place that distinction shows.
+     */
+    @Test
+    public void damagedPanelMaterialExportsItsConfiguredCode() {
+        ShippingBoxFhirTransform transform = new ShippingBoxFhirTransform();
+
+        BoxSampleItemDAO boxSampleItemDAO = mock(BoxSampleItemDAO.class);
+        when(boxSampleItemDAO.findByShippingBoxId(7)).thenReturn(panelMaterial());
+        ReflectionTestUtils.setField(transform, "boxSampleItemDAO", boxSampleItemDAO);
+
+        SiteInformationService siteInformationService = mock(SiteInformationService.class);
+        when(siteInformationService.getSiteInformationByName(anyString())).thenReturn(null);
+        when(siteInformationService.getSiteInformationByName("fhirNonConformityCodes"))
+                .thenReturn(siteInfo("{ \"RECEIVED_DAMAGED\" : \"398056004\" }"));
+        ReflectionTestUtils.setField(transform, "siteInformationService", siteInformationService);
+
+        SupplyDelivery delivery = transform.transformToSupplyDelivery(box());
+
+        List<Extension> nonConformities = delivery
+                .getExtensionsByUrl("http://openelis.org/fhir/extension/shipment-non-conformity");
+        assertEquals("one damaged vial, one code", 1, nonConformities.size());
+        org.hl7.fhir.r4.model.CodeableConcept code = (org.hl7.fhir.r4.model.CodeableConcept) nonConformities.get(0)
+                .getValue();
+        assertEquals("398056004", code.getCodingFirstRep().getCode());
+        assertEquals("http://snomed.info/sct", code.getCodingFirstRep().getSystem());
+        assertEquals("RECEIVED_DAMAGED", code.getText());
+
+        // The manifest the receiving site renders must still carry both vials, so
+        // moving the code above the Specimen skip cannot have cost a content item.
+        assertEquals(2, delivery.getExtensionsByUrl("http://openelis.org/fhir/extension/shipment-content-item").size());
+    }
+
+    private static List<BoxSampleItem> panelMaterial() {
+        BoxSampleItem damaged = new BoxSampleItem();
+        damaged.setEqaPanelSample(panelSample("VL-A"));
+        damaged.setReceptionStatus(ReceptionStatus.RECEIVED_DAMAGED);
+
+        BoxSampleItem intact = new BoxSampleItem();
+        intact.setEqaPanelSample(panelSample("VL-B"));
+        intact.setReceptionStatus(ReceptionStatus.RECEIVED_GOOD);
+
+        return Arrays.asList(damaged, intact);
+    }
+
+    private static EQAPanelSample panelSample(String code) {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setSampleCode(code);
+        return sample;
+    }
+
+    private static ShippingBox box() {
+        ShippingBox box = new ShippingBox();
+        box.setId(7);
+        box.setBoxId("EQA-C5-28-R1");
+        box.setFhirUuid(UUID.randomUUID());
+        box.setState(BoxState.SENT);
+        return box;
+    }
+
+    private static SiteInformation siteInfo(String value) {
+        SiteInformation info = new SiteInformation();
+        info.setValue(value);
+        return info;
     }
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Two gaps the cross-instance EQA walkthrough found in the shipment module. Both are small and neither changes a schema or an endpoint.

**Shipment Settings can now name this laboratory.** The **This Laboratory** control was filled from `/rest/displayList/REFERRAL_ORGANIZATIONS`, which by definition excludes the row that represents this laboratory — a laboratory is not a referral destination to itself — so a configured value rendered as *Select* and an operator could not pick their own organization. It now reads `/rest/organization-list` narrowed to organizations that carry a FHIR UUID, which is exactly the set the save endpoint accepts (on the test rig: this laboratory plus five referral laboratories, and none of the thirty administrative rows). When the stored UUID matches no local organization — a partner addresses this site by the UUID *it* holds for it, which need not be any local row's own — the tile now says so instead of looking unconfigured.

**A damaged panel sample now reaches the wire.** `ShippingBoxFhirTransform` wrote the SNOMED non-conformity code only after resolving a patient `SampleItem`'s FHIR UUID. EQA panel material has no `SampleItem`, so a vial recorded as damaged on reception left no trace on the exported `SupplyDelivery` — the one fact a sending laboratory most needs back. The non-conformity block now runs for every contents row, before the Specimen skip; the specimen-type count moved with it and runs once per row. Nothing reads the extension back, so its shape is unchanged.

## Tests

- New `ShipmentSettings.test.jsx`: the control offers the laboratory's own organization (fails against the referral list); the unmatched-UUID notice appears (fails with the notice removed); the unset warning still appears when nothing is configured.
- `ShippingBoxFhirTransformNonConformityCodesTest` gains a case that drives the transform itself with two panel-material rows, one damaged, under a custom code: the export carries one `shipment-non-conformity` extension with that code and both content items. With the Specimen skip restored above the block it fails `expected:<1> but was:<0>`. The existing cases in that class only exercised the JSON parser, which a build that never reaches the parser passes.

The full frontend suite (1204 tests) passes.

## Verification on the two-instance UAT rig

The provider's control reads its own organization where it read *Select*; the participant's, whose stored UUID is the provider's row for it, shows the notice and now offers its own organization too. With the rebuilt WAR on both instances, a panel sample marked **Damaged** on reception exported `shipment-non-conformity` = `398056004` (`http://snomed.info/sct`) between the two content items, where the identical scenario on the previous build had exported the content items and nothing else.

## Related Issue

OGC-610 (cross-instance EQA exchange over the shipment module).

## Other

Still open on the receiving side: an imported consignment carries no contents rows, so a participant's Reception screen has nothing to mark as damaged. That is the manifest-to-rows question the import deliberately left open and is not addressed here.
