### PR TITLE
fix(eqa): a bare numeric target should not fail a near miss, and a targeted cycle should score (OGC-611, OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -137,11 +137,16 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         EQADistribution distribution = findOrOpenDistribution(cycle, sysUserId);
         long reported = eqaResultDAO.findByDistributionId(distribution.getId()).stream()
                 .filter(result -> result.getResultValue() != null || result.getResultText() != null).count();
-        // Refused rather than silently half-scored: below this the peer mean and SD
-        // describe nothing, and the statistics service would leave every verdict null.
-        if (reported < EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS) {
-            throw new IllegalStateException("Scoring needs at least " + EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS
-                    + " reported results; this cycle has " + reported);
+        if (reported == 0) {
+            throw new IllegalStateException("This cycle has no reported results to score");
+        }
+        // The floor protects the peer statistic, which is all an untargeted cycle
+        // has: below it the mean and SD describe nothing. A cycle whose panel sealed
+        // a target needs no crowd, so it scores at whatever roster size it ran.
+        if (reported < EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS && !hasSealedTarget(cycle)) {
+            throw new IllegalStateException("Scoring against peers needs at least "
+                    + EQAStatisticsService.MIN_PARTICIPANTS_FOR_STATS + " reported results; this cycle has " + reported
+                    + " and its panel carries no target to judge them against");
         }
 
         // The peer statistics run first and stay on the row as the reported z. They
@@ -362,7 +367,10 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
      * statistics decided — a scheme that reports without a target has nothing else
      * to be judged against.
      */
-    private void judgeAgainstPanelTargets(EQACycle cycle, Long distributionId) {
+    /**
+     * The targets this cycle's panel material sealed, by the analyte each answers.
+     */
+    private Map<Long, EQAPanelSample> sealedTargetsByAnalyte(EQACycle cycle) {
         Map<Long, EQAPanelSample> targetByAnalyte = new HashMap<>();
         for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycle.getId())) {
             for (EQAPanelSample sample : eqaPanelSampleDAO.getAllMatching("panel.id", panel.getId())) {
@@ -371,6 +379,15 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
                 }
             }
         }
+        return targetByAnalyte;
+    }
+
+    private boolean hasSealedTarget(EQACycle cycle) {
+        return !sealedTargetsByAnalyte(cycle).isEmpty();
+    }
+
+    private void judgeAgainstPanelTargets(EQACycle cycle, Long distributionId) {
+        Map<Long, EQAPanelSample> targetByAnalyte = sealedTargetsByAnalyte(cycle);
         for (EQAResult result : eqaResultDAO.findByDistributionId(distributionId)) {
             Long analyteId = analyteIdOrNull(result.getTestId());
             EQAPanelSample target = analyteId == null ? null : targetByAnalyte.get(analyteId);
@@ -389,6 +406,14 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
                 // The report and the scores CSV show what a number was judged against;
                 // a target that is a word has no column here and needs none.
                 result.setTargetValue(EqaPanelVerdict.numericTargetOf(target));
+                if (!EqaPanelVerdict.hasRange(target)) {
+                    // A bare target compares for equality, and a laboratory reporting
+                    // 39.5 against a target of 40 has not failed a proficiency test.
+                    // Without a sealed tolerance the peer verdict is the only honest
+                    // one; the target is still recorded above, for the report.
+                    eqaResultDAO.update(result);
+                    continue;
+                }
             }
             result.setPerformanceStatus(EqaPanelVerdict.of(target, reported));
             eqaResultDAO.update(result);

--- a/src/main/java/org/openelisglobal/eqa/service/EqaPanelVerdict.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EqaPanelVerdict.java
@@ -28,10 +28,20 @@ final class EqaPanelVerdict {
     private EqaPanelVerdict() {
     }
 
+    /**
+     * Whether the sample seals an acceptance range. Without one there is no
+     * tolerance to judge a measurement by, only equality, which is the right rule
+     * for a supervisor's in-house target and the wrong one for a number reported
+     * from another laboratory's instrument.
+     */
+    static boolean hasRange(EQAPanelSample sample) {
+        return sample != null && (sample.getAcceptanceRangeLow() != null || sample.getAcceptanceRangeHigh() != null);
+    }
+
     /** The verdict for one reported value against one sealed panel sample. */
     static EQAPerformanceStatus of(EQAPanelSample target, String reported) {
         String value = reported == null ? "" : reported.trim();
-        if (target.getAcceptanceRangeLow() != null || target.getAcceptanceRangeHigh() != null) {
+        if (hasRange(target)) {
             BigDecimal numeric = parseOrNull(value);
             if (numeric == null) {
                 return EQAPerformanceStatus.UNACCEPTABLE;

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
@@ -1,0 +1,182 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.service.EQAProviderScoringService;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * What a sealed target may and may not decide on the provider side, and when a
+ * cycle can be scored at all.
+ *
+ * <p>
+ * A target with an acceptance range states a tolerance, and a measurement
+ * outside it has failed. A target with no range states only a number, and
+ * comparing a measurement to it for equality would fail a laboratory that
+ * answered 39.5 to a target of 40 — so there the peer statistic stays the
+ * verdict. The participant floor exists to protect that statistic, which means
+ * a cycle whose panel does seal a target does not need the crowd.
+ */
+public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase {
+
+    private static final long FIRST_ORG = 9925L;
+    private static final long TEST_CD4 = 9927L;
+    private static final long ANALYTE_CD4 = 9828L;
+    private static final int TEST_ANALYTE_LINK = 99827;
+
+    @Autowired
+    private EQAProviderScoringService scoringService;
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+
+    private EQACycle cycle;
+    private EQAPanel panel;
+
+    @Before
+    public void seed() {
+        for (long id = FIRST_ORG; id < FIRST_ORG + 5; id++) {
+            jdbc.update("INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                    + " VALUES (?, ?, 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING", id, "Tolerance lab " + id);
+        }
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE_CD4, "Tolerance CD4");
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                TEST_CD4, "Tolerance CD4 test", "Tolerance CD4 test", UUID.randomUUID().toString(), TEST_CD4);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
+        jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
+                TEST_ANALYTE_LINK, TEST_CD4, ANALYTE_CD4);
+
+        EQAProgram scheme = insertScheme("Tolerance scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
+        eqaProgramService.assignTest(scheme.getId(), TEST_CD4);
+        cycle = readBack(insertCycle(scheme, 1));
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
+        panel = insertPanel(scheme, p -> {
+            p.setCycle(cycle);
+            p.setPanelName("Tolerance panel");
+        });
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.eqa_result");
+            jdbc.update("DELETE FROM clinlims.eqa_distribution WHERE cycle_id IS NOT NULL");
+        }
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
+            jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST_CD4);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE_CD4);
+            jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_ORG, FIRST_ORG + 5);
+        }
+    }
+
+    @Test
+    public void aTargetWithNoAcceptanceRangeDoesNotFailANearMiss() {
+        sealTarget("40", null, null);
+        report("39.5", "40", "40.5", "41", "80");
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("39.5 against a bare target of 40 is not a proficiency failure", "ACCEPTABLE", verdict(FIRST_ORG));
+        assertEquals("nor is 40.5", "ACCEPTABLE", verdict(FIRST_ORG + 2));
+        assertEquals("the target is still recorded for the report", 0,
+                new BigDecimal("40").compareTo(targetValue(FIRST_ORG)));
+    }
+
+    @Test
+    public void aSealedRangeStillDecides() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        report("39.5", "40", "40.5", "41", "80");
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("outside the range", "UNACCEPTABLE", verdict(FIRST_ORG + 4));
+        assertEquals("inside it", "ACCEPTABLE", verdict(FIRST_ORG));
+    }
+
+    @Test
+    public void aTargetedCycleScoresBelowThePeerFloor() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        report("40", "41", "80");
+
+        scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("UNACCEPTABLE", verdict(FIRST_ORG + 2));
+        assertEquals("ACCEPTABLE", verdict(FIRST_ORG));
+    }
+
+    @Test
+    public void anUntargetedCycleBelowThePeerFloorIsStillRefused() {
+        report("40", "41", "80");
+
+        try {
+            scoringService.scoreCycle(cycle.getId(), USER);
+            fail("with no target and no crowd there is nothing to judge against");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("no target"));
+        }
+    }
+
+    @Test
+    public void aCycleWithNothingReportedIsRefused() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+
+        try {
+            scoringService.scoreCycle(cycle.getId(), USER);
+            fail("there is nothing to score");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("no reported results"));
+        }
+    }
+
+    // ---- helpers ----
+
+    private void sealTarget(String targetValue, BigDecimal low, BigDecimal high) {
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode("T01");
+        sample.setAnalyteId(ANALYTE_CD4);
+        sample.setTargetValue(targetValue);
+        sample.setAcceptanceRangeLow(low);
+        sample.setAcceptanceRangeHigh(high);
+        sample.setSysUserId(USER);
+        eqaPanelSampleDAO.insert(sample);
+    }
+
+    private void report(String... values) {
+        for (int i = 0; i < values.length; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i, Map.of(TEST_CD4, values[i]), EQASubmissionMethod.MANUAL,
+                    USER);
+        }
+    }
+
+    private String verdict(long organizationId) {
+        return jdbc.queryForObject(
+                "SELECT performance_status FROM clinlims.eqa_result"
+                        + " WHERE participant_organization_id = ? AND test_id = ?",
+                String.class, organizationId, TEST_CD4);
+    }
+
+    private BigDecimal targetValue(long organizationId) {
+        return jdbc.queryForObject(
+                "SELECT target_value FROM clinlims.eqa_result WHERE participant_organization_id = ? AND test_id = ?",
+                BigDecimal.class, organizationId, TEST_CD4);
+    }
+}


### PR DESCRIPTION
Two refinements on top of #4174, which made the sealed target the verdict. Found while writing a second version of that fix in parallel (closed as #4177 — this is the part of it that was not duplicate work).

## A target with no acceptance range should not decide by equality

The shared comparison tries the acceptance range first and falls through to **equality** when no range was sealed. That is right for an in-house target — a supervisor typed it, the round is exploratory — and wrong for a measurement reported from another laboratory's instrument:

| target | reported | verdict on `feat/eqa-next` | verdict here |
|---|---|---|---|
| 40 (no range) | 39.5 | UNACCEPTABLE | ACCEPTABLE |
| 40 (no range) | 40.5 | UNACCEPTABLE | ACCEPTABLE |
| 40, range 36–44 | 80 | UNACCEPTABLE | UNACCEPTABLE |

A quantitative result is now judged against the target only where a range was sealed. Otherwise the peer verdict stands — and the target is still written onto the row, so the report and the scores CSV show it either way. Qualitative matching is untouched.

## A cycle whose panel seals a target should score at any roster size

The five-participant floor exists because a peer mean and standard deviation over fewer values describe nothing. But a targeted cycle does not need the crowd, and was refused anyway — so a three-laboratory national scheme with a sealed range could not be scored at all.

- nothing reported → refused ("no reported results to score")
- short **and** untargeted → refused, and the message now says which of the two is missing
- short **and** targeted → scores

## Tests

`EQAProviderTargetToleranceIntegrationTest` — 5 tests against the real schema: the near miss staying acceptable against a range-less target with the target still recorded, a sealed range still deciding, a three-laboratory targeted cycle scoring, an untargeted short cycle still refused, and an empty cycle refused.

Green locally: 5 new + 6 provider intake + 13 in-house blinding + 14 score triage + 15 provider cycle oversight = 53, `BUILD SUCCESS`.