### PR TITLE
feat(eqa): choose a scheme's arrangement type when creating it (OGC-612, OGC-609)

### DIFF
--- a/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
@@ -4,6 +4,8 @@ import {
   TextInput,
   TextArea,
   Toggle,
+  Select,
+  SelectItem,
   FilterableMultiSelect,
   InlineNotification,
 } from "@carbon/react";
@@ -15,6 +17,15 @@ import {
   resolveApiErrorMessage,
 } from "../../utils/Utils";
 
+// The four arrangement types a scheme can have. IN_HOUSE is the only one that
+// may omit a provider, which is why the form branches on it.
+const SCHEME_TYPES = [
+  "INTERNATIONAL_PT",
+  "REGIONAL_PT",
+  "INTER_LAB_SPLIT",
+  "IN_HOUSE",
+];
+
 const ProgramForm = ({ program, onClose }) => {
   const intl = useIntl();
   const isEditing = !!program;
@@ -24,9 +35,16 @@ const ProgramForm = ({ program, onClose }) => {
   const [description, setDescription] = useState(program?.description || "");
   const [isActive, setIsActive] = useState(program?.isActive !== false);
   const [perAnalyst, setPerAnalyst] = useState(program?.perAnalyst === true);
+  const [schemeType, setSchemeType] = useState(
+    program?.schemeType || "INTERNATIONAL_PT",
+  );
   const [nameError, setNameError] = useState("");
   const [providerError, setProviderError] = useState("");
   const [saveError, setSaveError] = useState("");
+
+  // An in-house scheme is run by this laboratory, so it has no external provider
+  // to name; every other type must have one.
+  const providerRequired = schemeType !== "IN_HOUSE";
 
   // The tests this programme collects. Provider intake reads exactly this map —
   // the results grid and its CSV import both iterate it — so a programme with
@@ -126,7 +144,7 @@ const ProgramForm = ({ program, onClose }) => {
       setNameError(intl.formatMessage({ id: "eqa.program.name.required" }));
       valid = false;
     }
-    if (!provider.trim()) {
+    if (providerRequired && !provider.trim()) {
       setProviderError(
         intl.formatMessage({ id: "eqa.program.provider.required" }),
       );
@@ -137,9 +155,10 @@ const ProgramForm = ({ program, onClose }) => {
 
     const payload = {
       name,
-      provider,
+      provider: providerRequired ? provider : "",
       description,
       perAnalyst,
+      schemeType,
     };
 
     setSaveError("");
@@ -197,20 +216,50 @@ const ProgramForm = ({ program, onClose }) => {
           invalid={!!nameError}
           invalidText={nameError}
         />
-        <TextInput
-          id="program-provider"
-          labelText={intl.formatMessage({ id: "eqa.admin.col.provider" })}
-          placeholder={intl.formatMessage({
-            id: "eqa.admin.form.provider.placeholder",
+        <Select
+          id="program-scheme-type"
+          labelText={intl.formatMessage({
+            id: "eqa.program.schemeType",
+            defaultMessage: "Scheme type",
           })}
-          value={provider}
+          helperText={intl.formatMessage({
+            id: "eqa.program.schemeType.helper",
+            defaultMessage:
+              "In-house schemes are run by this laboratory and need no provider; every other type does.",
+          })}
+          value={schemeType}
           onChange={(e) => {
-            setProvider(e.target.value);
+            setSchemeType(e.target.value);
             if (providerError) setProviderError("");
           }}
-          invalid={!!providerError}
-          invalidText={providerError}
-        />
+        >
+          {SCHEME_TYPES.map((type) => (
+            <SelectItem
+              key={type}
+              value={type}
+              text={intl.formatMessage({
+                id: `eqa.scheme.type.${type.toLowerCase()}`,
+                defaultMessage: type.replace(/_/g, " "),
+              })}
+            />
+          ))}
+        </Select>
+        {providerRequired && (
+          <TextInput
+            id="program-provider"
+            labelText={intl.formatMessage({ id: "eqa.admin.col.provider" })}
+            placeholder={intl.formatMessage({
+              id: "eqa.admin.form.provider.placeholder",
+            })}
+            value={provider}
+            onChange={(e) => {
+              setProvider(e.target.value);
+              if (providerError) setProviderError("");
+            }}
+            invalid={!!providerError}
+            invalidText={providerError}
+          />
+        )}
         <TextArea
           id="program-description"
           labelText={intl.formatMessage({ id: "eqa.program.description" })}

--- a/frontend/src/components/eqa/EQAProgram/ProgramManagement.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramManagement.jsx
@@ -100,6 +100,10 @@ const ProgramManagement = () => {
       header: intl.formatMessage({ id: "eqa.admin.col.provider" }),
     },
     {
+      key: "schemeType",
+      header: intl.formatMessage({ id: "eqa.filter.schemeType" }),
+    },
+    {
       key: "participantCount",
       header: intl.formatMessage({ id: "eqa.admin.col.participants" }),
     },
@@ -116,7 +120,13 @@ const ProgramManagement = () => {
   const rows = programs.map((p) => ({
     id: String(p.id),
     name: p.name,
-    provider: p.provider || "",
+    provider: p.provider || "—",
+    schemeType: p.schemeType
+      ? intl.formatMessage({
+          id: `eqa.scheme.type.${p.schemeType.toLowerCase()}`,
+          defaultMessage: p.schemeType.replace(/_/g, " "),
+        })
+      : "—",
     participantCount: p.participantCount != null ? p.participantCount : 0,
     status: p.isActive
       ? intl.formatMessage({ id: "eqa.program.active" })

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
@@ -167,6 +167,55 @@ describe("ProgramManagement", () => {
 });
 
 describe("ProgramForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFromOpenElisServer.mockImplementation((url, callback) => callback([]));
+  });
+
+  test("an in-house scheme needs no provider and says so on the way out", () => {
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector("#program-scheme-type"), {
+      target: { value: "IN_HOUSE" },
+    });
+    expect(container.querySelector("#program-provider")).toBeNull();
+
+    fireEvent.change(container.querySelector("#program-name"), {
+      target: { value: "In-house blinded PT" },
+    });
+    fireEvent.click(screen.getByText("Add Program"));
+
+    expect(screen.queryByText("Provider is required")).toBeNull();
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload)).toMatchObject({
+      name: "In-house blinded PT",
+      schemeType: "IN_HOUSE",
+      provider: "",
+    });
+  });
+
+  test("an external scheme carries the type the user picked", () => {
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector("#program-name"), {
+      target: { value: "Regional serology" },
+    });
+    fireEvent.change(container.querySelector("#program-scheme-type"), {
+      target: { value: "REGIONAL_PT" },
+    });
+    fireEvent.change(container.querySelector("#program-provider"), {
+      target: { value: "CPHL" },
+    });
+    fireEvent.click(screen.getByText("Add Program"));
+
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload).schemeType).toBe("REGIONAL_PT");
+  });
+
   test("renders create mode with correct heading", () => {
     renderWithIntl(<ProgramForm program={null} onClose={vi.fn()} />);
     expect(screen.getByText("Add New EQA Program")).toBeTruthy();

--- a/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
+++ b/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
@@ -183,7 +183,7 @@ const InHousePanelsPage = () => {
             <Tile>
               {label(
                 "eqa.inhouse.noSchemes",
-                "No in-house scheme exists yet. Create one under EQA scheme management first.",
+                "No in-house scheme exists yet. Create one under EQA Program Management, choosing the In-house scheme type.",
               )}
             </Tile>
           ) : (

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8562,5 +8562,7 @@
   "eqa.cycle.importScores.import": "Import scores",
   "eqa.cycle.importScores.imported": "{count} scores recorded.",
   "eqa.cycle.importScores.unmapped": "Not recognised here: {names}",
-  "eqa.cycle.importScores.failed": "Could not import the scores"
+  "eqa.cycle.importScores.failed": "Could not import the scores",
+  "eqa.program.schemeType": "Scheme type",
+  "eqa.program.schemeType.helper": "In-house schemes are run by this laboratory and need no provider; every other type does."
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
@@ -12,6 +12,7 @@ import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.systemuser.service.SystemUserService;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,14 +33,21 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize(EQAGuards.READ)
 public class EQAProgramRestController extends ControllerUtills {
 
-    @Autowired
-    private EQAProgramService programService;
+    private final EQAProgramService programService;
 
-    @Autowired
-    private EQAProgramEnrollmentService enrollmentService;
+    private final EQAProgramEnrollmentService enrollmentService;
 
+    private final SystemUserService systemUserService;
+
+    // Constructor injection so the integration suite can drive this controller
+    // with the real services, the way EQACycleRestController is exercised.
     @Autowired
-    private SystemUserService systemUserService;
+    public EQAProgramRestController(EQAProgramService programService, EQAProgramEnrollmentService enrollmentService,
+            SystemUserService systemUserService) {
+        this.programService = programService;
+        this.enrollmentService = enrollmentService;
+        this.systemUserService = systemUserService;
+    }
 
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize(EQAGuards.PROVIDER)
@@ -52,12 +60,16 @@ public class EQAProgramRestController extends ControllerUtills {
                 return ResponseEntity.badRequest().body(Map.of("error", "Program name is required"));
             }
 
-            String provider = (String) body.get("provider");
+            String schemeType = body.get("schemeType") == null ? "" : String.valueOf(body.get("schemeType")).trim();
+            if (schemeType.isEmpty()) {
+                return ResponseEntity.badRequest().body(Map.of("error", "Scheme type is required"));
+            }
 
             EQAProgram program = new EQAProgram();
             program.setName(name);
             program.setDescription(description);
-            program.setProvider(provider);
+            program.setSchemeType(schemeTypeOf(schemeType));
+            program.setProvider(blankToNull((String) body.get("provider")));
             program.setPerAnalyst(Boolean.TRUE.equals(body.get("perAnalyst")));
             program.setIsActive(true);
             program.setSysUserId(getSysUserId(request));
@@ -115,7 +127,15 @@ public class EQAProgramRestController extends ControllerUtills {
             }
 
             if (body.containsKey("provider")) {
-                program.setProvider((String) body.get("provider"));
+                program.setProvider(blankToNull((String) body.get("provider")));
+            }
+
+            if (body.containsKey("schemeType")) {
+                String schemeType = body.get("schemeType") == null ? "" : String.valueOf(body.get("schemeType")).trim();
+                if (schemeType.isEmpty()) {
+                    return ResponseEntity.badRequest().body(Map.of("error", "Scheme type cannot be empty"));
+                }
+                program.setSchemeType(schemeTypeOf(schemeType));
             }
 
             if (body.containsKey("isActive")) {
@@ -233,6 +253,28 @@ public class EQAProgramRestController extends ControllerUtills {
         dto.put("displayName", user == null ? String.valueOf(analyst.getSystemUserId())
                 : (user.getFirstName() == null ? "" : user.getFirstName() + " ") + user.getLastName());
         return dto;
+    }
+
+    /**
+     * The arrangement type is a user decision, not a default: an in-house scheme is
+     * unreachable from the UI while the endpoint ignores it, and a regional or
+     * split-sample scheme created without it is silently filed as international. An
+     * unknown value is refused by name rather than falling back.
+     */
+    private EQASchemeType schemeTypeOf(String value) {
+        try {
+            return EQASchemeType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown scheme type: " + value);
+        }
+    }
+
+    /**
+     * A blank provider is stored as NULL, so the BR-004 check and every reader see
+     * "no provider" as one value instead of two.
+     */
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private Map<String, Object> toProgramDto(EQAProgram program) {

--- a/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
@@ -1,0 +1,163 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.eqa.controller.rest.EQAProgramRestController;
+import org.openelisglobal.eqa.service.EQAProgramEnrollmentService;
+import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQAProgramTest;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Scheme administration from the application, against the real schema: the
+ * arrangement type the user chose reaches the row instead of defaulting
+ * silently, an in-house scheme may omit the provider every other type requires,
+ * and the scheme's test map — which provider result intake and its CSV import
+ * both read — can be written through the endpoint the Programs screen calls.
+ */
+public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
+
+    private static final long TEST_SERO = 9971L;
+    private static final long TEST_VL = 9972L;
+
+    @Autowired
+    private EQAProgramEnrollmentService enrollmentService;
+
+    private EQAProgramRestController controller;
+
+    @Before
+    public void buildController() {
+        controller = new EQAProgramRestController(eqaProgramService, enrollmentService, systemUserService);
+    }
+
+    @Test
+    public void createProgram_writesTheChosenTypeRatherThanTheEntityDefault() {
+        Long id = created(Map.of("name", "Regional serology " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+
+        assertEquals(EQASchemeType.REGIONAL_PT, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void createProgram_acceptsAnInHouseSchemeWithNoProvider() {
+        Long id = created(Map.of("name", "In-house blinded " + System.nanoTime(), "schemeType", "IN_HOUSE"));
+
+        EQAProgram scheme = eqaProgramService.get(id);
+        assertEquals(EQASchemeType.IN_HOUSE, scheme.getSchemeType());
+        assertNull("a blank provider is stored as NULL, not as an empty string", scheme.getProvider());
+    }
+
+    @Test
+    public void createProgram_refusesAMissingType() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "No type " + System.nanoTime(), "provider", "CPHL"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Scheme type is required", error(response));
+    }
+
+    @Test
+    public void createProgram_refusesAnUnknownType() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "Bad type " + System.nanoTime(), "schemeType", "NATIONAL_PT", "provider", "CPHL"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Unknown scheme type: NATIONAL_PT", error(response));
+    }
+
+    @Test
+    public void createProgram_stillEnforcesTheProviderRuleForExternalTypes() {
+        ResponseEntity<?> response = controller.createProgram(request(),
+                Map.of("name", "Provider-less international " + System.nanoTime(), "schemeType", "INTERNATIONAL_PT"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(error(response).contains("Provider is required"));
+    }
+
+    @Test
+    public void updateProgram_movesAnExternalSchemeInHouseAndDropsItsProvider() {
+        Long id = created(Map.of("name", "Becomes in-house " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "IN_HOUSE", "provider", ""));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        EQAProgram scheme = eqaProgramService.get(id);
+        assertEquals(EQASchemeType.IN_HOUSE, scheme.getSchemeType());
+        assertNull(scheme.getProvider());
+    }
+
+    @Test
+    public void updateTestAssignments_writesTheMapProviderIntakeReads() {
+        seedTest(TEST_SERO, "Scheme admin serology");
+        seedTest(TEST_VL, "Scheme admin viral load");
+        Long id = created(
+                Map.of("name", "Mapped scheme " + System.nanoTime(), "schemeType", "REGIONAL_PT", "provider", "CPHL"));
+
+        controller.updateTestAssignments(id, Map.of("testIds", List.of(TEST_SERO, TEST_VL)));
+
+        assertEquals(List.of(TEST_SERO, TEST_VL), assignedTestIds(id));
+
+        // Re-sending a narrowed selection replaces the map rather than adding to
+        // it. Dropping a test deactivates its row instead of deleting it — the
+        // UNIQUE(scheme, test) row is reused if the test comes back — so what the
+        // intake readers see is the active set, not the row count.
+        controller.updateTestAssignments(id, Map.of("testIds", List.of(TEST_VL)));
+
+        assertEquals(List.of(TEST_VL), assignedTestIds(id));
+        assertEquals(2, eqaProgramService.getTestAssignments(id).size());
+    }
+
+    // ---- helpers ----
+
+    private Long created(Map<String, Object> body) {
+        ResponseEntity<?> response = controller.createProgram(request(), body);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        return Long.valueOf(String.valueOf(dto(response).get("id")));
+    }
+
+    private List<Long> assignedTestIds(Long programId) {
+        return eqaProgramService.getTestAssignments(programId).stream()
+                .filter(assignment -> Boolean.TRUE.equals(assignment.getIsActive())).map(EQAProgramTest::getTestId)
+                .sorted().toList();
+    }
+
+    private void seedTest(long id, String name) {
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                id, name, name, UUID.randomUUID().toString(), id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> dto(ResponseEntity<?> response) {
+        return (Map<String, Object>) response.getBody();
+    }
+
+    private String error(ResponseEntity<?> response) {
+        return String.valueOf(dto(response).get("error"));
+    }
+
+    private HttpServletRequest request() {
+        UserSessionData sessionData = new UserSessionData();
+        sessionData.setSytemUserId(Integer.parseInt(USER));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession(true).setAttribute(IActionConstants.USER_SESSION_DATA, sessionData);
+        return request;
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
@@ -25,6 +25,7 @@ import org.openelisglobal.eqa.service.EQAProgramService;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.systemuser.service.SystemUserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -36,6 +37,9 @@ public class EQAProgramRestControllerTest {
 
     @Mock
     private EQAProgramEnrollmentService enrollmentService;
+
+    @Mock
+    private SystemUserService systemUserService;
 
     @Mock
     private HttpServletRequest request;
@@ -76,7 +80,8 @@ public class EQAProgramRestControllerTest {
         when(programService.insert(any(EQAProgram.class))).thenReturn(1L);
         when(programService.get(1L)).thenReturn(program1);
 
-        Map<String, Object> body = Map.of("name", "Chemistry PT", "description", "Chemistry proficiency testing");
+        Map<String, Object> body = Map.of("name", "Chemistry PT", "description", "Chemistry proficiency testing",
+                "schemeType", "INTERNATIONAL_PT", "provider", "NHLS");
         ResponseEntity<?> response = controller.createProgram(request, body);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
@@ -142,7 +142,8 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
     @Test
     public void providerWrite_providerTierReturns200() throws Exception {
         mockMvc.perform(post("/rest/eqa/programs").contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"HIV VL PT\"}").sessionAttr(IActionConstants.USER_SESSION_DATA, sessionUser())
+                .content("{\"name\":\"HIV VL PT\",\"schemeType\":\"INTERNATIONAL_PT\",\"provider\":\"NHLS\"}")
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, sessionUser())
                 .with(user("provider").authorities(new SimpleGrantedAuthority("qa.eqa.provider"))))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.name").value("HIV VL PT"));
     }
@@ -240,11 +241,8 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
 
         @Bean
         EQAProgramRestController programRestController(EQAProgramService programService,
-                EQAProgramEnrollmentService programEnrollmentService) {
-            EQAProgramRestController controller = new EQAProgramRestController();
-            ReflectionTestUtils.setField(controller, "programService", programService);
-            ReflectionTestUtils.setField(controller, "enrollmentService", programEnrollmentService);
-            return controller;
+                EQAProgramEnrollmentService programEnrollmentService, SystemUserService systemUserService) {
+            return new EQAProgramRestController(programService, programEnrollmentService, systemUserService);
         }
 
         @Bean


### PR DESCRIPTION
Replaces #4176, which is being closed: its test-map half landed as #4179 while it was in review, and rebasing onto that left this — the scheme-type half, untouched by #4179.

## The defect

The Add/Edit Program dialog never sent `schemeType` and `POST /rest/eqa/programs` never read it, so every scheme created from the application took the entity default of **international PT**. Two consequences:

- regional and split-sample schemes were silently misfiled, affecting the type filters and the conditional rules that read them
- an **in-house** scheme — which the In-House Blinding page requires, and which may carry no provider — could not be created at all. The endpoint refused it for the missing provider, and the only working path was hand-editing the programme CSV on the server. The In-House page's own empty state pointed at the screen that could not do it.

## The change

- type selector on the dialog, the four arrangement types
- the endpoint requires the type on create and refuses an unknown value by name; update accepts it
- the provider field appears only for the types that require a provider, and a blank provider is stored as `NULL` so the provider-required rule and every reader see one value rather than two
- `Scheme type` column on the programs table, so the choice is visible after saving
- the in-house panels empty state now names the screen that can create the scheme it asks for

`EQAProgramRestController` moves to constructor injection so the integration suite can drive it with the real services, the way the cycle controller is driven.

## Tests

`EQASchemeAdministrationIntegrationTest` — 7 tests against the real schema: the type on create and on update, the in-house provider exemption, the two refusals (missing, unknown), the provider rule still holding for external types, and the test map replacing rather than accumulating.

`ProgramManagement.test.jsx` — 2 new cases: the in-house branch hides the provider and posts without one; the chosen type reaches the payload.

Green locally: 39 backend (new class + program controller + guard slice + guard matrix), 21 frontend in the touched file.

## Verified on a dev stack

Created an in-house scheme from Add Program with no provider → `scheme_type = IN_HOUSE`, `provider` NULL, and it appears immediately in the In-House Blinding wizard's scheme list. That was previously impossible without editing a file on the server.