### PR TITLE
issue-3376: Handle string escalationDelayMinutes in alert notification config POST

### DIFF
--- a/src/main/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestController.java
+++ b/src/main/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('ADMIN')")
 public class AlertNotificationConfigRestController {
 
+    private static final String INVALID_ESCALATION_DELAY_MESSAGE = "Invalid escalationDelayMinutes: must be an integer";
+
     @Autowired
     private AlertNotificationConfigService alertNotificationConfigService;
 
@@ -43,6 +45,8 @@ public class AlertNotificationConfigRestController {
         try {
             alertNotificationConfigService.saveAlertNotificationConfig(config, sysUserId);
             return ResponseEntity.ok(Map.of("message", "Alert notification configuration saved successfully"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", INVALID_ESCALATION_DELAY_MESSAGE));
         } catch (Exception e) {
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "Failed to save configuration: " + e.getMessage()));

--- a/src/main/java/org/openelisglobal/alert/service/AlertNotificationConfigServiceImpl.java
+++ b/src/main/java/org/openelisglobal/alert/service/AlertNotificationConfigServiceImpl.java
@@ -1,5 +1,6 @@
 package org.openelisglobal.alert.service;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 @SuppressWarnings("unused")
 public class AlertNotificationConfigServiceImpl implements AlertNotificationConfigService {
 
+    static final String INVALID_ESCALATION_DELAY_MESSAGE = "Invalid escalationDelayMinutes: must be an integer";
+
     private final NotificationConfigOptionDAO notificationConfigOptionDAO;
     private final SiteInformationService siteInformationService;
 
+    private static final int DEFAULT_ESCALATION_DELAY_MINUTES = 15;
     private static final String SITE_INFO_ESCALATION_ENABLED = "alert.escalation.enabled";
     private static final String SITE_INFO_ESCALATION_DELAY_MINUTES = "alert.escalation.delayMinutes";
     private static final String SITE_INFO_SUPERVISOR_EMAIL = "alert.supervisor.email";
@@ -79,7 +83,7 @@ public class AlertNotificationConfigServiceImpl implements AlertNotificationConf
         @SuppressWarnings("unchecked")
         Map<String, Map<String, Boolean>> alertConfigs = (Map<String, Map<String, Boolean>>) config.get("alertConfigs");
         Boolean escalationEnabled = (Boolean) config.get("escalationEnabled");
-        Integer escalationDelayMinutes = (Integer) config.get("escalationDelayMinutes");
+        Integer escalationDelayMinutes = parseEscalationDelayMinutes(config.get("escalationDelayMinutes"));
         String supervisorEmail = (String) config.get("supervisorEmail");
 
         if (alertConfigs != null) {
@@ -107,10 +111,44 @@ public class AlertNotificationConfigServiceImpl implements AlertNotificationConf
 
         saveSiteInformation(SITE_INFO_ESCALATION_ENABLED,
                 escalationEnabled != null ? escalationEnabled.toString() : "false", "boolean", sysUserId);
-        saveSiteInformation(SITE_INFO_ESCALATION_DELAY_MINUTES,
-                escalationDelayMinutes != null ? escalationDelayMinutes.toString() : "15", "text", sysUserId);
+        saveSiteInformation(SITE_INFO_ESCALATION_DELAY_MINUTES, escalationDelayMinutes.toString(), "text", sysUserId);
         saveSiteInformation(SITE_INFO_SUPERVISOR_EMAIL, supervisorEmail != null ? supervisorEmail : "", "text",
                 sysUserId);
+    }
+
+    private Integer parseEscalationDelayMinutes(Object rawValue) {
+        if (rawValue == null) {
+            return DEFAULT_ESCALATION_DELAY_MINUTES;
+        }
+
+        if (rawValue instanceof Integer) {
+            return (Integer) rawValue;
+        }
+
+        if (rawValue instanceof Number) {
+            try {
+                BigDecimal numericValue = new BigDecimal(rawValue.toString()).stripTrailingZeros();
+                return numericValue.intValueExact();
+            } catch (NumberFormatException | ArithmeticException e) {
+                throw new IllegalArgumentException(INVALID_ESCALATION_DELAY_MESSAGE, e);
+            }
+        }
+
+        if (rawValue instanceof String) {
+            String normalized = ((String) rawValue).trim();
+
+            if (normalized.isEmpty()) {
+                return DEFAULT_ESCALATION_DELAY_MINUTES;
+            }
+
+            try {
+                return Integer.parseInt(normalized);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(INVALID_ESCALATION_DELAY_MESSAGE, e);
+            }
+        }
+
+        throw new IllegalArgumentException(INVALID_ESCALATION_DELAY_MESSAGE);
     }
 
     private void updateAlertNotificationConfig(NotificationNature nature, NotificationMethod method, boolean active,

--- a/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/alert/controller/rest/AlertNotificationConfigRestControllerTest.java
@@ -1,0 +1,56 @@
+package org.openelisglobal.alert.controller.rest;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openelisglobal.alert.service.AlertNotificationConfigService;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlertNotificationConfigRestControllerTest {
+
+    @InjectMocks
+    private AlertNotificationConfigRestController controller;
+
+    @Mock
+    private AlertNotificationConfigService alertNotificationConfigService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpSession session;
+
+    @Test
+    public void saveAlertNotificationConfig_returnsBadRequestForInvalidEscalationDelayMinutes() {
+        UserSessionData userSessionData = new UserSessionData();
+        userSessionData.setSytemUserId(1);
+        when(request.getSession()).thenReturn(session);
+        when(session.getAttribute(IActionConstants.USER_SESSION_DATA)).thenReturn(userSessionData);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("escalationDelayMinutes", "abc");
+
+        doThrow(new IllegalArgumentException("some internal validation detail")).when(alertNotificationConfigService)
+                .saveAlertNotificationConfig(config, "1");
+
+        ResponseEntity<Map<String, String>> response = controller.saveAlertNotificationConfig(config, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertNotNull(response.getBody());
+        Assert.assertEquals("Invalid escalationDelayMinutes: must be an integer", response.getBody().get("error"));
+    }
+}

--- a/src/test/java/org/openelisglobal/alert/service/AlertNotificationConfigIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/alert/service/AlertNotificationConfigIntegrationTest.java
@@ -104,6 +104,96 @@ public class AlertNotificationConfigIntegrationTest extends BaseWebContextSensit
     }
 
     @Test
+    public void testSaveAlertNotificationConfig_AcceptsStringEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", "15");
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+
+        SiteInformation escalationDelay = siteInformationService
+                .getSiteInformationByName("alert.escalation.delayMinutes");
+
+        assertNotNull("Escalation delay setting should exist", escalationDelay);
+        assertEquals("Escalation delay should be saved from string input", "15", escalationDelay.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSaveAlertNotificationConfig_RejectsNonNumericEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", "abc");
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+    }
+
+    @Test
+    public void testSaveAlertNotificationConfig_DefaultsNullEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", null);
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+
+        SiteInformation escalationDelay = siteInformationService
+                .getSiteInformationByName("alert.escalation.delayMinutes");
+
+        assertNotNull("Escalation delay setting should exist", escalationDelay);
+        assertEquals("Null delay should default to 15", "15", escalationDelay.getValue());
+    }
+
+    @Test
+    public void testSaveAlertNotificationConfig_DefaultsBlankEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", "   ");
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+
+        SiteInformation escalationDelay = siteInformationService
+                .getSiteInformationByName("alert.escalation.delayMinutes");
+
+        assertNotNull("Escalation delay setting should exist", escalationDelay);
+        assertEquals("Blank delay should default to 15", "15", escalationDelay.getValue());
+    }
+
+    @Test
+    public void testSaveAlertNotificationConfig_AcceptsNumericNumberEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", Long.valueOf(15));
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+
+        SiteInformation escalationDelay = siteInformationService
+                .getSiteInformationByName("alert.escalation.delayMinutes");
+
+        assertNotNull("Escalation delay setting should exist", escalationDelay);
+        assertEquals("Numeric Number delay should be saved", "15", escalationDelay.getValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSaveAlertNotificationConfig_RejectsNonIntegralNumberEscalationDelayMinutes() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("alertConfigs", new HashMap<>());
+        config.put("escalationEnabled", true);
+        config.put("escalationDelayMinutes", Double.valueOf(15.5));
+        config.put("supervisorEmail", "escalation@lab.com");
+
+        alertNotificationConfigService.saveAlertNotificationConfig(config, TEST_SYS_USER_ID);
+    }
+
+    @Test
     public void testGetAlertNotificationConfig_ReturnsExistingConfiguration() {
         Map<String, Object> savedConfig = getStringObjectMap();
         alertNotificationConfigService.saveAlertNotificationConfig(savedConfig, TEST_SYS_USER_ID);


### PR DESCRIPTION
## Summary

Fixes the alert notification config POST endpoint so `escalationDelayMinutes` sent as a JSON string no longer causes `500 Internal Server Error`.

Closes #3376. Supersedes the closed #3377 (same fix, rebased on current `develop`).

## What changed

- Replaced the raw `(Integer)` cast with safe parsing in `AlertNotificationConfigServiceImpl`
- Accept numeric string input like `"15"` and other numeric JSON types (`Long`, etc.)
- Return `400 Bad Request` for invalid non-numeric values like `"abc"`
- Default `null` / blank string values to 15 minutes
- Added controller and integration test coverage

## Before

```json
{
  "alertConfigs": {},
  "escalationEnabled": true,
  "escalationDelayMinutes": "15",
  "supervisorEmail": "supervisor@lab.com"
}
```

→ `500 Internal Server Error` (`ClassCastException`)

## After

- `"15"` is accepted and saved correctly → `200 OK`
- `"abc"` is rejected → `400 Bad Request`
- Integer `15` continues to work → `200 OK`

## Testing

```bash
mvn test -Dtest=AlertNotificationConfigRestControllerTest,AlertNotificationConfigIntegrationTest
```

Results: 13 tests, 0 failures.