### PR TITLE
issue-2913: All Permissions selects every lab unit role, not four hardcoded ids

### DIFF
--- a/frontend/src/components/admin/userManagement/UserAddModify.jsx
+++ b/frontend/src/components/admin/userManagement/UserAddModify.jsx
@@ -45,6 +45,23 @@ const passwordPatternRegex = /^(?=.*[*$#!])(?=.*[a-zA-Z0-9]).{7,}$/;
 const loginNameRegex = /^[a-zA-Z]+$/;
 const nameRegex = /^(?=.*[a-zA-Z])[a-zA-Z .'_@-]*$/;
 
+const labUnitRoleIds = (labUnitRoles) =>
+  (labUnitRoles || []).map((role) => role.roleId);
+
+// A lab unit with no roles on offer must not read as "everything selected".
+const hasEveryLabUnitRole = (selectedRoles, roleIds) =>
+  roleIds.length > 0 &&
+  roleIds.every((roleId) => (selectedRoles || []).includes(roleId));
+
+const toggleEveryLabUnitRole = (selectedRoles, roleIds) => {
+  const currentRoles = selectedRoles || [];
+  return hasEveryLabUnitRole(currentRoles, roleIds)
+    ? currentRoles.filter((roleId) => !roleIds.includes(roleId))
+    : currentRoles.concat(
+        roleIds.filter((roleId) => !currentRoles.includes(roleId)),
+      );
+};
+
 function UserAddModify() {
   const { notificationVisible, setNotificationVisible, addNotification } =
     useContext(NotificationContext);
@@ -768,6 +785,8 @@ function UserAddModify() {
     );
   }
 
+  const availableLabUnitRoleIds = labUnitRoleIds(userDataShow?.labUnitRoles);
+
   return (
     <>
       {notificationVisible === true ? <AlertDialog /> : ""}
@@ -1318,34 +1337,17 @@ function UserAddModify() {
                           id={`all-permissions-${key}`}
                           data-testid={`all-permissions-${(userDataShow?.testSections?.find((s) => s.id === key)?.value || key).replace(/\s+/g, "-")}`}
                           labelText={"All Permissions"}
-                          checked={["4", "5", "7", "10"].every(
-                            (num) =>
-                              selectedTestSectionLabUnits[key] &&
-                              selectedTestSectionLabUnits[key].includes(num),
+                          checked={hasEveryLabUnitRole(
+                            selectedTestSectionLabUnits[key],
+                            availableLabUnitRoleIds,
                           )}
                           onChange={() => {
-                            const numbersToAdd = ["4", "5", "7", "10"];
-                            const updatedRoles = selectedTestSectionLabUnits[
-                              key
-                            ]
-                              ? [...selectedTestSectionLabUnits[key]]
-                              : [];
-                            const numbersToRemove = numbersToAdd.filter((num) =>
-                              updatedRoles.includes(num),
-                            );
-                            if (numbersToRemove.length > 0) {
-                              numbersToRemove.forEach((num) => {
-                                const index = updatedRoles.indexOf(num);
-                                if (index !== -1) {
-                                  updatedRoles.splice(index, 1);
-                                }
-                              });
-                            } else {
-                              updatedRoles.push(...numbersToAdd);
-                            }
                             setSelectedTestSectionLabUnits((prev) => ({
                               ...prev,
-                              [key]: updatedRoles,
+                              [key]: toggleEveryLabUnitRole(
+                                prev[key],
+                                availableLabUnitRoleIds,
+                              ),
                             }));
                             setSaveButton(false);
                             setValidation({ ...validation, selectedLab: true });

--- a/frontend/src/components/admin/userManagement/UserAddModify.test.jsx
+++ b/frontend/src/components/admin/userManagement/UserAddModify.test.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { waitFor } from "@testing-library/dom";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
+import UserAddModify from "./UserAddModify";
+import { ConfigurationContext, NotificationContext } from "../../layout/Layout";
+import messages from "../../../languages/en.json";
+
+const { getFromOpenElisServerMock } = vi.hoisted(() => ({
+  getFromOpenElisServerMock: vi.fn(),
+}));
+
+vi.mock("../../utils/Utils", () => ({
+  getFromOpenElisServer: (...args) => getFromOpenElisServerMock(...args),
+  postToOpenElisServerJsonResponse: vi.fn(),
+}));
+
+// A lab unit that offers more roles than the four the checkbox used to hardcode.
+const LAB_UNIT_ROLES = [
+  { elementID: "role-4", roleId: "4", roleName: "Reception" },
+  { elementID: "role-5", roleId: "5", roleName: "Reports" },
+  { elementID: "role-7", roleId: "7", roleName: "Results" },
+  { elementID: "role-10", roleId: "10", roleName: "Validation" },
+  { elementID: "role-12", roleId: "12", roleName: "Chemical Analyst" },
+  { elementID: "role-15", roleId: "15", roleName: "Data Manager" },
+];
+
+const ROLE_NAMES = LAB_UNIT_ROLES.map((role) => role.roleName);
+
+function ContextProviders({ children }) {
+  return (
+    <ConfigurationContext.Provider value={{ configurationProperties: {} }}>
+      <NotificationContext.Provider
+        value={{
+          notificationVisible: false,
+          setNotificationVisible: vi.fn(),
+          addNotification: vi.fn(),
+        }}
+      >
+        {children}
+      </NotificationContext.Provider>
+    </ConfigurationContext.Provider>
+  );
+}
+
+function userResponse({ labUnitRoles = LAB_UNIT_ROLES, selected = [] } = {}) {
+  return {
+    accountActive: "Y",
+    accountDisabled: "N",
+    accountLocked: "N",
+    globalRoles: [],
+    labUnitRoles: labUnitRoles,
+    loginUserId: "1",
+    selectedRoles: [],
+    selectedTestSectionLabUnits: { 1: selected },
+    systemUserId: "1",
+    testSections: [{ id: "1", value: "Serology" }],
+    userFirstName: "Ada",
+    userLastName: "Lovelace",
+    userLoginName: "ada",
+  };
+}
+
+async function renderUserAddModify(response) {
+  getFromOpenElisServerMock.mockImplementation((url, callback) => {
+    if (url.startsWith("/rest/UnifiedSystemUser")) {
+      callback(response);
+    } else {
+      callback([]);
+    }
+  });
+
+  render(
+    <MemoryRouter initialEntries={["/MasterListsPage/userEdit?ID=1"]}>
+      <ContextProviders>
+        <IntlProvider locale="en" messages={messages}>
+          <UserAddModify />
+        </IntlProvider>
+      </ContextProviders>
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(allPermissions()).toBeInTheDocument());
+}
+
+function allPermissions() {
+  return screen.getByLabelText("All Permissions");
+}
+
+function role(roleName) {
+  return screen.getByLabelText(roleName);
+}
+
+describe("UserAddModify lab unit All Permissions checkbox", () => {
+  beforeEach(() => {
+    getFromOpenElisServerMock.mockReset();
+  });
+
+  test("selects every role the lab unit offers", async () => {
+    await renderUserAddModify(userResponse());
+
+    fireEvent.click(allPermissions());
+
+    ROLE_NAMES.forEach((roleName) => expect(role(roleName)).toBeChecked());
+    expect(allPermissions()).toBeChecked();
+  });
+
+  test("keeps the roles already selected while adding the missing ones", async () => {
+    await renderUserAddModify(userResponse({ selected: ["12"] }));
+
+    fireEvent.click(allPermissions());
+
+    ROLE_NAMES.forEach((roleName) => expect(role(roleName)).toBeChecked());
+  });
+
+  test("stays unticked while any offered role is unselected", async () => {
+    await renderUserAddModify(
+      userResponse({ selected: ["4", "5", "7", "10"] }),
+    );
+
+    expect(role("Reception")).toBeChecked();
+    expect(role("Chemical Analyst")).not.toBeChecked();
+    expect(allPermissions()).not.toBeChecked();
+  });
+
+  test("clears every offered role when it is unticked", async () => {
+    await renderUserAddModify(
+      userResponse({ selected: LAB_UNIT_ROLES.map((r) => r.roleId) }),
+    );
+    expect(allPermissions()).toBeChecked();
+
+    fireEvent.click(allPermissions());
+
+    ROLE_NAMES.forEach((roleName) => expect(role(roleName)).not.toBeChecked());
+    expect(allPermissions()).not.toBeChecked();
+  });
+
+  test("stays unticked when the lab unit offers no roles", async () => {
+    await renderUserAddModify(userResponse({ labUnitRoles: [] }));
+
+    expect(allPermissions()).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
This PR proposes fixing the lab unit "All Permissions" checkbox in User Management so that it selects every role the lab unit actually offers, instead of the four role ids it hardcodes today. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/510. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

Fixes #2913.

`frontend/src/components/admin/userManagement/UserAddModify.jsx` renders one **All Permissions** checkbox per selected lab unit, and both its `checked` expression and its `onChange` handler work off the literal `["4", "5", "7", "10"]`. On a lab unit that offers more roles than those four, ticking the box selects only Reception, Reports, Results and Validation and leaves the rest unselected — while the box itself renders as ticked, so the screen reports "all permissions" when it is not. Unticking clears only those same four. On a lab unit whose roles do not include those ids, it selects ids that are not on screen at all.

The fix derives the ids from the roles the form already renders, `userDataShow.labUnitRoles`, through three small helpers placed next to the existing module-level constants. `hasEveryLabUnitRole` drives `checked` and `toggleEveryLabUnitRole` drives `onChange`: ticking adds only the ids that are missing, so roles the user had already picked individually are kept; unticking removes exactly the ids the lab unit offers and leaves any other entry in `selectedTestSectionLabUnits[key]` untouched. Two edges are handled explicitly — a lab unit with an empty role list stays unticked (`[].every(...)` is vacuously true and would otherwise render ticked with nothing selected), and the state update now reads `prev[key]` inside the updater rather than the closed-over value.

Reproduced on `develop` at `d6bab7a`, with the test file from this PR added and the component left untouched:

```
$ cd frontend && npx vitest run src/components/admin/userManagement/UserAddModify.test.jsx

 FAIL  UserAddModify lab unit All Permissions checkbox > selects every role the lab unit offers
 FAIL  UserAddModify lab unit All Permissions checkbox > keeps the roles already selected while adding the missing ones
 FAIL  UserAddModify lab unit All Permissions checkbox > stays unticked while any offered role is unselected
 FAIL  UserAddModify lab unit All Permissions checkbox > clears every offered role when it is unticked

      Tests  4 failed | 1 passed (5)
```

The assertion that trips first is `expect(element).toBeChecked()` on `<input id="role-12-1" value="12">`, the fifth role offered by the lab unit, still unchecked after the click. The single test that passes on `develop` is the empty-role-list edge, which is the control: it must stay green either way.

With the component change applied the same command reports `Tests  5 passed (5)`. The full front-end suite was run on the same tree before and after: `npm run test` gives `Test Files  186 passed (186)` and `Tests  1336 passed | 13 skipped (1349)` before, and `Test Files  187 passed (187)` and `Tests  1341 passed | 13 skipped (1354)` after — the only movement is this new file and its five tests, with nothing newly red. `npx prettier --check` is clean on both files, and `npx eslint` on `UserAddModify.jsx` reports exactly what it reports on `develop` (the same pre-existing findings, all in effects this change does not touch); the new test file is clean.

Two notes for review. The change is front-end behaviour only, with no API or payload shape change — `selectedTestSectionLabUnits` is still a map of lab unit key to an array of role ids, so saved users are unaffected. And #3443 also edits this file, but in `handleCheckboxChange` and the global-roles column rather than in this checkbox, so the two should not conflict beyond adjacency. There is no screen recording attached; the behaviour is pinned by the component tests above instead, which are the first automated tests for this screen.

## How this was managed

This work maps to the story at https://eastagiletracker.com/projects/510/stories/454293 on the board at https://eastagiletracker.com/projects/510 — imported from this repository's own issues, pull requests and milestones (4,049 stories) — which is where the work above was tracked from pick-up to review.

![board](https://raw.githubusercontent.com/eastagiletracker/OpenELIS-Global-2/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
