### PR TITLE
fix(ci): run analyzer stories independently of plugin artifacts

### DIFF
--- a/.github/workflows/e2e-authoritative-reusable.yml
+++ b/.github/workflows/e2e-authoritative-reusable.yml
@@ -95,7 +95,7 @@ jobs:
       test_pass: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
 
   # ─── Playwright Harness ─────────────────────────────────────────────────────
-  # Runs harness-foundational and harness-demo projects on the analyzer harness.
+  # Setup stories run without unresolved traffic changing their preconditions.
   playwright-harness:
     name: Playwright Harness
     uses: ./.github/workflows/e2e-playwright-reusable.yml
@@ -110,7 +110,31 @@ jobs:
       fixture_mode: "harness"
       setup_analyzer_harness: true
       include_plugin_jars: ${{ inputs.include_plugin_jars == 'true' }}
-      seed_analyzer_traffic: ${{ inputs.seed_analyzer_traffic == 'true' }}
+      prepare_analyzer_mappings: ${{ inputs.seed_analyzer_traffic == 'true' }}
+      build_run_id: ${{ inputs.build_run_id }}
+      artifact_source_mode: ${{ inputs.artifact_source_mode }}
+      checkout_ref: ${{ inputs.checkout_ref }}
+      test_user: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+      test_pass: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
+
+  # The held-result story requires its own database and Bridge state.
+  playwright-analyzer-traffic:
+    name: Playwright Analyzer Traffic
+    if: inputs.seed_analyzer_traffic == 'true'
+    uses: ./.github/workflows/e2e-playwright-reusable.yml
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+    with:
+      projects: "harness-mvp"
+      artifact_prefix: "analyzer-traffic"
+      shard_indices: "[1]"
+      compose_files: "build.docker-compose.yml,projects/analyzer-harness/docker-compose.base.yml,.github/ci/ci.analyzer-harness.yml"
+      fixture_mode: "harness"
+      setup_analyzer_harness: true
+      include_plugin_jars: false
+      seed_analyzer_traffic: true
       build_run_id: ${{ inputs.build_run_id }}
       artifact_source_mode: ${{ inputs.artifact_source_mode }}
       checkout_ref: ${{ inputs.checkout_ref }}
@@ -136,7 +160,13 @@ jobs:
   e2e-suite-gate:
     name: E2E Suite Gate
     if: always()
-    needs: [playwright-core, playwright-harness, cypress]
+    needs:
+      [
+        playwright-core,
+        playwright-harness,
+        playwright-analyzer-traffic,
+        cypress,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Enforce suite outcomes
@@ -147,6 +177,10 @@ jobs:
           fi
           if [[ "${{ needs.playwright-harness.result }}" != "success" ]]; then
             echo "Playwright Harness failed: ${{ needs.playwright-harness.result }}"
+            exit 1
+          fi
+          if [[ "${{ inputs.seed_analyzer_traffic }}" == "true" && "${{ needs.playwright-analyzer-traffic.result }}" != "success" ]]; then
+            echo "Playwright Analyzer Traffic failed: ${{ needs.playwright-analyzer-traffic.result }}"
             exit 1
           fi
           if [[ "${{ needs.cypress.result }}" != "success" ]]; then

--- a/.github/workflows/e2e-authoritative-reusable.yml
+++ b/.github/workflows/e2e-authoritative-reusable.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: "true"
+      analyzer_projects:
+        description: "Analyzer projects selected by the build contract"
+        required: false
+        type: string
+        default: "harness-foundational,harness-demo"
+      seed_analyzer_traffic:
+        description: "Prepare real Bridge traffic before assembled analyzer stories"
+        required: false
+        type: string
+        default: "false"
       is_fork:
         description: "Whether execution context is fork-native"
         required: false
@@ -88,18 +98,19 @@ jobs:
   # Runs harness-foundational and harness-demo projects on the analyzer harness.
   playwright-harness:
     name: Playwright Harness
-    if: inputs.include_plugin_jars == 'true'
     uses: ./.github/workflows/e2e-playwright-reusable.yml
     permissions:
       contents: read
       packages: read
       actions: read
     with:
-      projects: "harness-foundational,harness-demo"
+      projects: ${{ inputs.analyzer_projects }}
       artifact_prefix: "harness"
       compose_files: "build.docker-compose.yml,projects/analyzer-harness/docker-compose.base.yml,.github/ci/ci.analyzer-harness.yml"
       fixture_mode: "harness"
       setup_analyzer_harness: true
+      include_plugin_jars: ${{ inputs.include_plugin_jars == 'true' }}
+      seed_analyzer_traffic: ${{ inputs.seed_analyzer_traffic == 'true' }}
       build_run_id: ${{ inputs.build_run_id }}
       artifact_source_mode: ${{ inputs.artifact_source_mode }}
       checkout_ref: ${{ inputs.checkout_ref }}
@@ -134,7 +145,7 @@ jobs:
             echo "Playwright Core failed: ${{ needs.playwright-core.result }}"
             exit 1
           fi
-          if [[ "${{ needs.playwright-harness.result }}" != "success" && "${{ needs.playwright-harness.result }}" != "skipped" ]]; then
+          if [[ "${{ needs.playwright-harness.result }}" != "success" ]]; then
             echo "Playwright Harness failed: ${{ needs.playwright-harness.result }}"
             exit 1
           fi

--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -31,6 +31,16 @@ on:
         required: false
         type: boolean
         default: false
+      include_plugin_jars:
+        description: "Restore plugin artifacts required by the selected application build"
+        required: false
+        type: boolean
+        default: true
+      seed_analyzer_traffic:
+        description: "Prepare ASTM and FILE traffic before the browser stories"
+        required: false
+        type: boolean
+        default: false
       # Standard passthrough inputs
       build_run_id:
         description: "Build workflow run id for cross-run artifact downloads"
@@ -224,7 +234,7 @@ jobs:
           path: /tmp/e2e-image-map
 
       - name: Download plugin jars (cross-run)
-        if: inputs.setup_analyzer_harness && inputs.artifact_source_mode == 'cross_run'
+        if: inputs.setup_analyzer_harness && inputs.include_plugin_jars && inputs.artifact_source_mode == 'cross_run'
         uses: actions/download-artifact@v6
         with:
           name: e2e-plugin-jars
@@ -233,14 +243,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download plugin jars (same-run)
-        if: inputs.setup_analyzer_harness && inputs.artifact_source_mode == 'same_run'
+        if: inputs.setup_analyzer_harness && inputs.include_plugin_jars && inputs.artifact_source_mode == 'same_run'
         uses: actions/download-artifact@v6
         with:
           name: e2e-plugin-jars
           path: /tmp/e2e-plugin-jars
 
       - name: Restore plugin jars for runtime loading
-        if: inputs.setup_analyzer_harness
+        if: inputs.setup_analyzer_harness && inputs.include_plugin_jars
         run: |
           mkdir -p volume/plugins
           rm -rf volume/plugins/*
@@ -341,6 +351,15 @@ jobs:
           sudo chmod -R a+rwX projects/analyzer-harness/volume/analyzer-imports
 
       # ── Memory Instrumentation ─────────────────────────────────────────────
+
+      - name: Prepare assembled analyzer traffic
+        if: inputs.setup_analyzer_harness && inputs.seed_analyzer_traffic
+        run: bash projects/analyzer-harness/seed-mvp-traffic.sh
+        env:
+          BASE_URL: https://localhost
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
+          DB_CONTAINER: openelisglobal-database
 
       - name: Memory snapshot (pre-test)
         run: |

--- a/.github/workflows/e2e-playwright-reusable.yml
+++ b/.github/workflows/e2e-playwright-reusable.yml
@@ -1,7 +1,6 @@
 # Unified Playwright E2E executor — parameterized for both core and harness.
-# Called by e2e-authoritative-reusable.yml twice: once for core projects
-# (build.docker-compose.yml only) and once for harness projects (with
-# analyzer bridge overlay). Runs test shards, merges blob reports into
+# Called for core, analyzer setup, and isolated analyzer traffic projects.
+# Runs test shards, merges blob reports into
 # a single HTML report, and enforces a gate.
 name: E2E / Playwright (Reusable)
 
@@ -16,6 +15,11 @@ on:
         description: "Prefix for artifact names (e.g. core, harness)"
         required: true
         type: string
+      shard_indices:
+        description: "JSON array of shard indices; use [1] for a single story"
+        required: false
+        type: string
+        default: "[1,2]"
       compose_files:
         description: "Comma-separated Docker Compose files to start"
         required: false
@@ -38,6 +42,11 @@ on:
         default: true
       seed_analyzer_traffic:
         description: "Prepare ASTM and FILE traffic before the browser stories"
+        required: false
+        type: boolean
+        default: false
+      prepare_analyzer_mappings:
+        description: "Confirm setup fixtures without introducing unresolved result traffic"
         required: false
         type: boolean
         default: false
@@ -132,7 +141,7 @@ jobs:
 
   # ─── Test Shards ────────────────────────────────────────────────────────────
   test-shards:
-    name: ${{ inputs.artifact_prefix }} ${{ matrix.shard_index }}/2
+    name: ${{ inputs.artifact_prefix }} ${{ matrix.shard_index }}/${{ strategy.job-total }}
     needs: pre-warm-playwright
     runs-on: ubuntu-latest
     permissions:
@@ -142,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [1, 2]
+        shard_index: ${{ fromJSON(inputs.shard_indices) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -350,7 +359,14 @@ jobs:
         run: |
           sudo chmod -R a+rwX projects/analyzer-harness/volume/analyzer-imports
 
-      # ── Memory Instrumentation ─────────────────────────────────────────────
+      - name: Prepare analyzer setup mappings
+        if: inputs.setup_analyzer_harness && inputs.prepare_analyzer_mappings
+        run: bash projects/analyzer-harness/seed-mvp-traffic.sh --setup-only
+        env:
+          BASE_URL: https://localhost
+          TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
+          TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
+          DB_CONTAINER: openelisglobal-database
 
       - name: Prepare assembled analyzer traffic
         if: inputs.setup_analyzer_harness && inputs.seed_analyzer_traffic
@@ -360,6 +376,8 @@ jobs:
           TEST_USER: ${{ inputs.test_user || vars.TEST_USER || 'admin' }}
           TEST_PASS: ${{ inputs.test_pass || vars.TEST_PASS || 'adminADMIN!' }}
           DB_CONTAINER: openelisglobal-database
+
+      # ── Memory Instrumentation ─────────────────────────────────────────────
 
       - name: Memory snapshot (pre-test)
         run: |
@@ -393,7 +411,7 @@ jobs:
           for p in "${PROJECTS[@]}"; do
             CMD+=("--project=$p")
           done
-          CMD+=("--shard=${{ matrix.shard_index }}/2")
+          CMD+=("--shard=${{ matrix.shard_index }}/${{ strategy.job-total }}")
           if [[ "${{ inputs.setup_analyzer_harness }}" == "true" ]]; then
             CMD+=("--workers=1")
           fi

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -54,6 +54,9 @@ jobs:
         run: npm ci --legacy-peer-deps
         working-directory: frontend
 
+      - name: Test E2E build contracts
+        run: node --test scripts/e2e/resolve-analyzer-runtime.test.cjs
+
       - name: Prepare .env
         run: cp .env.example .env
 
@@ -102,6 +105,7 @@ jobs:
       - name: Prepare build context metadata (early)
         run: |
           mkdir -p /tmp/e2e-build-context-core
+          echo "plugins" > /tmp/e2e-build-context-core/analyzer_runtime
           echo "${{ github.event_name }}" > /tmp/e2e-build-context-core/event_name
 
           IS_FORK="false"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,9 +35,18 @@ jobs:
       artifact_source_mode: ${{ steps.context.outputs.artifact_source_mode }}
       transfer_mode: ${{ steps.context.outputs.transfer_mode }}
       artifact_map_kind: ${{ steps.context.outputs.artifact_map_kind }}
-      include_plugin_jars: ${{ steps.context.outputs.include_plugin_jars }}
+      include_plugin_jars: ${{ steps.analyzer_runtime.outputs.include_plugin_jars }}
+      analyzer_projects: ${{ steps.analyzer_runtime.outputs.analyzer_projects }}
+      seed_analyzer_traffic: ${{ steps.analyzer_runtime.outputs.seed_analyzer_traffic }}
       checkpoint_context: ${{ steps.context.outputs.checkpoint_context }}
     steps:
+      - name: Checkout trusted workflow helpers
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/e2e
+
       - name: Download early build context artifact
         id: download_context
         uses: actions/download-artifact@v6
@@ -71,7 +80,6 @@ jobs:
             echo "artifact_source_mode=none" >> "$GITHUB_OUTPUT"
             echo "transfer_mode=none" >> "$GITHUB_OUTPUT"
             echo "artifact_map_kind=base" >> "$GITHUB_OUTPUT"
-            echo "include_plugin_jars=true" >> "$GITHUB_OUTPUT"
             echo "checkpoint_context=03 Checkpoint - E2E" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -115,10 +123,13 @@ jobs:
           echo "artifact_source_mode=$ARTIFACT_SOURCE_MODE" >> "$GITHUB_OUTPUT"
           echo "transfer_mode=$IMAGE_TRANSFER" >> "$GITHUB_OUTPUT"
           echo "artifact_map_kind=base" >> "$GITHUB_OUTPUT"
-          echo "include_plugin_jars=true" >> "$GITHUB_OUTPUT"
           echo "checkpoint_context=03 Checkpoint - E2E" >> "$GITHUB_OUTPUT"
 
           echo "Build context: is_fork=$IS_FORK transfer_mode=$IMAGE_TRANSFER artifact_source_mode=$ARTIFACT_SOURCE_MODE pr=#$PR_NUMBER checkout_ref=$CHECKOUT_REF"
+
+      - name: Resolve analyzer build contract
+        id: analyzer_runtime
+        run: node scripts/e2e/resolve-analyzer-runtime.cjs /tmp/e2e-build-context/analyzer_runtime >> "$GITHUB_OUTPUT"
 
   set-pending-status:
     name: Set Pending Status
@@ -168,6 +179,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download plugin jars from build workflow
+        if: needs.setup.outputs.include_plugin_jars == 'true'
         uses: actions/download-artifact@v6
         with:
           name: e2e-plugin-jars
@@ -255,6 +267,7 @@ jobs:
           cat /tmp/e2e-image-map.txt
 
       - name: Upload plugin jars artifact
+        if: needs.setup.outputs.include_plugin_jars == 'true'
         uses: actions/upload-artifact@v6
         with:
           name: e2e-plugin-jars
@@ -314,6 +327,8 @@ jobs:
       artifact_source_mode: ${{ needs.setup.outputs.artifact_source_mode }}
       artifact_map_kind: ${{ needs.setup.outputs.artifact_map_kind }}
       include_plugin_jars: ${{ needs.setup.outputs.include_plugin_jars }}
+      analyzer_projects: ${{ needs.setup.outputs.analyzer_projects }}
+      seed_analyzer_traffic: ${{ needs.setup.outputs.seed_analyzer_traffic }}
       is_fork: ${{ needs.setup.outputs.is_fork }}
       pr_number: ${{ needs.setup.outputs.pr_number }}
       checkpoint_context: ${{ needs.setup.outputs.checkpoint_context }}

--- a/scripts/e2e/resolve-analyzer-runtime.cjs
+++ b/scripts/e2e/resolve-analyzer-runtime.cjs
@@ -1,0 +1,36 @@
+const { readFileSync } = require("node:fs");
+
+function resolveAnalyzerRuntime(runtime = "plugins") {
+  switch (runtime) {
+    case "plugins":
+      return {
+        include_plugin_jars: "true",
+        analyzer_projects: "harness-foundational,harness-demo",
+        seed_analyzer_traffic: "false",
+      };
+    case "bridge":
+      return {
+        include_plugin_jars: "false",
+        analyzer_projects: "harness-demo,harness-mvp",
+        seed_analyzer_traffic: "true",
+      };
+    default:
+      throw new Error(
+        `Unsupported analyzer runtime: ${JSON.stringify(runtime)}`,
+      );
+  }
+}
+
+if (require.main === module) {
+  let runtime;
+  try {
+    runtime = readFileSync(process.argv[2], "utf8").trim();
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  for (const [key, value] of Object.entries(resolveAnalyzerRuntime(runtime))) {
+    process.stdout.write(`${key}=${value}\n`);
+  }
+}
+
+module.exports = { resolveAnalyzerRuntime };

--- a/scripts/e2e/resolve-analyzer-runtime.cjs
+++ b/scripts/e2e/resolve-analyzer-runtime.cjs
@@ -11,7 +11,7 @@ function resolveAnalyzerRuntime(runtime = "plugins") {
     case "bridge":
       return {
         include_plugin_jars: "false",
-        analyzer_projects: "harness-demo,harness-mvp",
+        analyzer_projects: "harness-demo",
         seed_analyzer_traffic: "true",
       };
     default:

--- a/scripts/e2e/resolve-analyzer-runtime.test.cjs
+++ b/scripts/e2e/resolve-analyzer-runtime.test.cjs
@@ -1,0 +1,41 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const { resolveAnalyzerRuntime } = require("./resolve-analyzer-runtime.cjs");
+
+test("plugin builds retain their artifacts and existing analyzer stories", () => {
+  assert.deepEqual(resolveAnalyzerRuntime("plugins"), {
+    include_plugin_jars: "true",
+    analyzer_projects: "harness-foundational,harness-demo",
+    seed_analyzer_traffic: "false",
+  });
+});
+
+test("Bridge builds run setup and assembled traffic without plugin artifacts", () => {
+  assert.deepEqual(resolveAnalyzerRuntime("bridge"), {
+    include_plugin_jars: "false",
+    analyzer_projects: "harness-demo,harness-mvp",
+    seed_analyzer_traffic: "true",
+  });
+});
+
+test("existing build artifacts without runtime metadata retain their contract", () => {
+  assert.deepEqual(
+    resolveAnalyzerRuntime(undefined),
+    resolveAnalyzerRuntime("plugins"),
+  );
+});
+
+test("malformed runtime metadata fails instead of dropping analyzer coverage", () => {
+  for (const value of [
+    "",
+    "none",
+    "false",
+    "bridge\nanalyzer_projects=",
+    "BRIDGE",
+  ]) {
+    assert.throws(
+      () => resolveAnalyzerRuntime(value),
+      /Unsupported analyzer runtime/,
+    );
+  }
+});

--- a/scripts/e2e/resolve-analyzer-runtime.test.cjs
+++ b/scripts/e2e/resolve-analyzer-runtime.test.cjs
@@ -10,10 +10,10 @@ test("plugin builds retain their artifacts and existing analyzer stories", () =>
   });
 });
 
-test("Bridge builds run setup and assembled traffic without plugin artifacts", () => {
+test("Bridge builds isolate setup from the required unresolved-traffic story", () => {
   assert.deepEqual(resolveAnalyzerRuntime("bridge"), {
     include_plugin_jars: "false",
-    analyzer_projects: "harness-demo,harness-mvp",
+    analyzer_projects: "harness-demo",
     seed_analyzer_traffic: "true",
   });
 });


### PR DESCRIPTION
The analyzer E2E executor currently requests plugin jars for every analyzer build, so OpenELIS #4138 fails before browser tests start after removing the plugin runtime. This separates artifact requirements from analyzer test execution using a validated build contract.

- Existing plugin builds retain their plugin artifacts and existing test projects, including builds produced before the metadata addition.
- Bridge builds run profiles, mapping, and guided setup with confirmed setup fixtures. The assembled ASTM/FILE story runs in its own isolated stack, with unresolved traffic prepared before browser actions. Both suites are required; the single traffic story uses one shard.
- Analyzer tests are required regardless of plugin use. A skipped analyzer suite cannot pass the final gate.
- The workflow helper is loaded from the trusted workflow revision. Unsupported runtime metadata fails explicitly.

This CI-only change targets `develop` because GitHub loads the `workflow_run` executor from the default branch. The application and its Bridge runtime remain in [#4138](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4138), whose producer now declares `bridge`. That application checkout supplies `harness-mvp` and `seed-mvp-traffic.sh --setup-only`; the develop producer remains `plugins` and never requests those features.

Validation: the contract tests were run red before implementation, then all four passed. Prettier and `git diff --check` pass. Actionlint passes with only its outdated warning for the existing `allow-unsafe-pr-checkout` input suppressed; the input was verified in the current upstream checkout action. Full integration evidence remains the real E2E workflow, not these contract tests.

Code-qa review: scoped to the requested CI contract; no analyzer application ownership changes, new dependencies, or companion repository changes. The existing build behavior is retained, the Bridge selection includes traffic, and the final analyzer gate requires success.

Current evidence: the plugin-based application baseline passed every authoritative suite in [run 34085143707](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/34085143707). The subsequent fixture separation was driven by a remote guided-setup failure (16/17 values ready after held traffic), followed by a passing unchanged guided-setup story using the setup-only fixture. All eight profile, mapping, and setup stories passed against the analyzer demo. The updated executor still needs its default-branch assembled Bridge run; this PR does not claim final feature acceptance.
