### PR TITLE
fix(eqa): resolve a participant's reporting analyte the way the provider does (OGC-610, OGC-613)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -55,8 +55,6 @@ import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.openelisglobal.result.service.ResultService;
 import org.openelisglobal.result.valueholder.Result;
 import org.openelisglobal.spring.util.SpringContext;
-import org.openelisglobal.testanalyte.service.TestAnalyteService;
-import org.openelisglobal.testanalyte.valueholder.TestAnalyte;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,7 +121,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
     private EQALabProgramEnrollmentDAO enrollmentDAO;
 
     @Autowired
-    private TestAnalyteService testAnalyteService;
+    private EQAPanelService eqaPanelService;
 
     @Autowired
     private AnalysisService analysisService;
@@ -238,10 +236,8 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
                 // Same unmapped-analyte case the bridge logs, and worth saying twice:
                 // here a user has explicitly named an analyst and would otherwise get
                 // no record and no reason.
-                logger.warn(
-                        "EQA analyst not recorded for analysis {} (test {}): it reports no analyte. Map the test to"
-                                + " its scheme analyte on the enrollment first.",
-                        analysis.getId(), analysis.getTest() == null ? "?" : analysis.getTest().getId());
+                logger.warn("EQA analyst not recorded for analysis {}: it names no test, so it resolves no analyte",
+                        analysis.getId());
                 continue;
             }
             String value = EqaReportedValue.of(resultService, pipelineResult);
@@ -344,10 +340,8 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
                 // Logged rather than skipped quietly: the cycle then stays short of
                 // its denominator and never submits, and this line is the only thing
                 // that says why.
-                logger.warn(
-                        "EQA analysis {} (test {}) reports no analyte; map the test to its scheme analyte on the"
-                                + " enrollment before this cycle can be submitted",
-                        analysis.getId(), analysis.getTest() == null ? "?" : analysis.getTest().getId());
+                logger.warn("EQA analysis {} names no test, so it resolves no analyte and cannot be submitted",
+                        analysis.getId());
                 continue;
             }
             if (upsert(cycle, roundId, enrollmentId, analysis, analyteId, value.trim(), sysUserId, tally)) {
@@ -369,8 +363,12 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
      * <li>the enrollment's scheme mapping (qa/030) — what the lab declared this
      * test reports for this scheme. The normal external-PT case: most test
      * configurations carry no test_analyte row at all, so source 1 is null.
-     * <li>test_analyte for the analysis's test — covers a result saved before the
-     * catalog mapping was added.
+     * <li>the test's own analyte, created from the test name when the catalog has
+     * none. This is the same resolution the provider makes when it seals a panel
+     * sample, and that is the point: a result crosses to the provider under its
+     * <em>analyte name</em>, and scores come back matched the same way, so both
+     * instances have to derive the same name. Deriving it from the shared test name
+     * on both sides is what makes them agree without a new field on the wire.
      * </ol>
      */
     private Long analyteIdOf(Result pipelineResult, Analysis analysis, Map<Long, Long> schemeAnalytes) {
@@ -385,12 +383,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
         if (analysis.getTest() == null) {
             return null;
         }
-        for (TestAnalyte testAnalyte : testAnalyteService.getAllTestAnalytesPerTest(analysis.getTest())) {
-            if (testAnalyte.getAnalyte() != null && testAnalyte.getAnalyte().getId() != null) {
-                return Long.valueOf(testAnalyte.getAnalyte().getId());
-            }
-        }
-        return null;
+        return eqaPanelService.analyteIdForTest(analysis.getTest().getId());
     }
 
     /** This enrollment's declared test-to-analyte mapping, empty when unmapped. */

--- a/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
@@ -43,8 +43,10 @@ import org.springframework.test.util.ReflectionTestUtils;
  * {@code test_analyte} — rather than writing
  * {@code eqa_participant_result.result_value} directly. Writing that column in
  * a test is what previously hid the fact that nothing in production filled it.
- * {@link #analysisWithNoAnalyte_neverSubmitsAPartialSet()} pins the other half:
- * a result the bridge cannot map must stop the submission, not shrink it.
+ * {@link #analysisWhoseTestTheCatalogNeverMapped_isBridgedUnderAnAnalyteNamedAfterTheTest()}
+ * pins the other half: a test the lab never declared is still bridged, under an
+ * analyte derived from the test's own name, because that name is what the
+ * provider matches the result by.
  *
  * <p>
  * The FHIR post itself is stubbed. What matters here is what the workflow does
@@ -58,6 +60,11 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
     private static final long SEROLOGY_ANALYTE = 9801L;
     private static final long VL_TEST = 9702L;
     private static final long SEROLOGY_TEST = 9701L;
+    /**
+     * A test deliberately outside the spine fixture, so no analyte shares its name.
+     */
+    private static final long UNNAMED_TEST = 9703L;
+    private static final String UNNAMED_TEST_NAME = "EQA derived-analyte probe";
     private static final long SAMPLE = 9901L;
     private static final long SAMPLE_ITEM = 9901L;
     private static final long SAMPLE_EQA = 9901L;
@@ -183,6 +190,15 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
         jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id = ?", SAMPLE);
         jdbc.update("DELETE FROM clinlims.sample_item WHERE id = ?", SAMPLE_ITEM);
         jdbc.update("DELETE FROM clinlims.sample WHERE id = ?", SAMPLE);
+        // Last, and in this order: the bridge mints a test_analyte link — and for the
+        // probe test an analyte too — for a test the catalog never mapped, and the
+        // analyses that reference them have to go first. Dropping them keeps the next
+        // class from inheriting catalog rows this one invented. The two fixture
+        // analytes stay: adopting one again is what the resolution is meant to do.
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE test_id IN (?, ?, ?) AND analyte_id NOT IN (?, ?)",
+                SEROLOGY_TEST, VL_TEST, UNNAMED_TEST, SEROLOGY_ANALYTE, VL_ANALYTE);
+        jdbc.update("DELETE FROM clinlims.analyte WHERE name = ?", UNNAMED_TEST_NAME);
+        jdbc.update("DELETE FROM clinlims.test WHERE id = ?", UNNAMED_TEST);
     }
 
     // ---- fixture builders ----
@@ -451,26 +467,64 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
     }
 
     /**
-     * The inversion of the happy path: {@code analyte_id} is a NOT NULL FK, so a
-     * result the bridge cannot map produces no row — and the cycle must then stop
-     * short rather than submit a set that is missing an analyte the provider
-     * expects.
+     * A lab that never declared a test in its enrollment still reports it. The
+     * analyte comes from the test itself, and an analyte already carrying that name
+     * is adopted rather than duplicated — two analytes of one name would reach the
+     * provider as two different measurements.
      */
     @Test
-    public void analysisWithNoAnalyte_neverSubmitsAPartialSet() {
+    public void analysisWhoseTestTheCatalogNeverMapped_isBridgedUnderAnAnalyteNamedAfterTheTest() {
         EQAProgram scheme = externalScheme(false);
         EQACycle cycle = readBack(insertCycle(scheme, 9));
         Long roundId = insertRound(cycle, 1, "OPEN");
         eqaOrder(cycle, roundId);
+        mapTestToSchemeAnalyte(VL_TEST, VL_ANALYTE);
         finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
-        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, "Positive", AnalysisStatus.Finalized, false);
+        long unmapped = analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, "Positive", AnalysisStatus.Finalized, false);
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
         windowElapsed();
 
         cycleSubmissionService.advanceCycle(cycle.getId());
 
-        assertEquals("only the mappable analyte is bridged", 1, participantResults(cycle.getId()).size());
-        assertEquals(EQACycleStatus.TESTING, readBack(cycle.getId()).getStatus());
-        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+        assertEquals("both analyses are bridged, not just the declared one", 2,
+                participantResults(cycle.getId()).size());
+        Map<String, Object> derived = participantResults(cycle.getId()).stream()
+                .filter(row -> unmapped == ((Number) row.get("analysis_id")).longValue()).findFirst()
+                .orElseThrow(AssertionError::new);
+
+        // The name is the whole point. A result crosses to the provider under its
+        // analyte name, and the provider derives its own from the same test name, so
+        // the two agree only if this one is taken from the test rather than invented.
+        assertEquals("the analyte is named after the test it reports", nameOfTest(SEROLOGY_TEST),
+                nameOfAnalyte(((Number) derived.get("analyte_id")).longValue()));
+        assertEquals("an analyte of that name already existed, so it is adopted rather than duplicated", 1,
+                countAnalytesNamed(nameOfTest(SEROLOGY_TEST)));
+        assertEquals("a declared mapping still wins for the test that has one", VL_ANALYTE,
+                participantResults(cycle.getId()).stream()
+                        .filter(row -> unmapped != ((Number) row.get("analysis_id")).longValue())
+                        .mapToLong(row -> ((Number) row.get("analyte_id")).longValue()).findFirst()
+                        .orElseThrow(AssertionError::new));
+
+        assertEquals("nothing is left unbridged, so the set is complete and submits", EQACycleStatus.SUBMITTED,
+                readBack(cycle.getId()).getStatus());
+        verify(fhirStub).submitCycleViaFhir(cycle.getId(), ENROLLMENT);
+    }
+
+    private String nameOfTest(long testId) {
+        return jdbc.queryForObject("SELECT name FROM clinlims.test WHERE id = ?", String.class, testId);
+    }
+
+    private String nameOfAnalyte(long analyteId) {
+        return jdbc.queryForObject("SELECT name FROM clinlims.analyte WHERE id = ?", String.class, analyteId);
+    }
+
+    private int countAnalytesNamed(String name) {
+        return jdbc.queryForObject("SELECT count(*) FROM clinlims.analyte WHERE name = ?", Integer.class, name);
+    }
+
+    private int countTestAnalyteLinks(long testId) {
+        return jdbc.queryForObject("SELECT count(*) FROM clinlims.test_analyte WHERE test_id = ?", Integer.class,
+                testId);
     }
 
     /**
@@ -502,26 +556,44 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
     }
 
     /**
-     * An unmapped test stays unbridgeable: the mapping is the only source once the
-     * result carries no analyte, so the cycle holds rather than submitting a set
-     * the provider cannot reconcile.
+     * The other half of the same rule: where no analyte carries the test's name,
+     * one is created from it, once. A second sweep must adopt that one rather than
+     * add another — the provider matches on the name, so a test with two of them
+     * reports as two measurements.
      */
     @Test
-    public void aTestWithNoSchemeMapping_holdsTheCycle() {
+    public void aTestWithNoAnalyteOfItsName_getsOneCreatedAndThenReused() {
         EQAProgram scheme = externalScheme(false);
         EQACycle cycle = readBack(insertCycle(scheme, 17));
         Long roundId = insertRound(cycle, 1, "OPEN");
         eqaOrder(cycle, roundId);
-        mapTestToSchemeAnalyte(VL_TEST, VL_ANALYTE);
-        analysis(VL_TEST, VL_ANALYTE, "4.75", AnalysisStatus.Finalized, false);
-        analysis(SEROLOGY_TEST, SEROLOGY_ANALYTE, "Positive", AnalysisStatus.Finalized, false);
+        seedUnnamedTest();
+        analysis(UNNAMED_TEST, VL_ANALYTE, "7.1", AnalysisStatus.Finalized, false);
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
         windowElapsed();
+        assertEquals("no analyte carries this test's name yet", 0, countAnalytesNamed(UNNAMED_TEST_NAME));
 
         cycleSubmissionService.advanceCycle(cycle.getId());
+        long created = ((Number) participantResults(cycle.getId()).get(0).get("analyte_id")).longValue();
+        cycleSubmissionService.advanceCycle(cycle.getId());
 
-        assertEquals("only the mapped test is bridged", 1, participantResults(cycle.getId()).size());
-        assertEquals(EQACycleStatus.TESTING, readBack(cycle.getId()).getStatus());
-        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+        assertEquals("the analyte is created from the test's name", UNNAMED_TEST_NAME, nameOfAnalyte(created));
+        assertEquals("once, not once per sweep", 1, countAnalytesNamed(UNNAMED_TEST_NAME));
+        assertEquals("and one link from the test to it", 1, countTestAnalyteLinks(UNNAMED_TEST));
+        assertEquals("the same analyte is reused", created,
+                ((Number) participantResults(cycle.getId()).get(0).get("analyte_id")).longValue());
+    }
+
+    /**
+     * A catalog test no analyte is named after, so the resolution has to create
+     * one.
+     */
+    private void seedUnnamedTest() {
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', 'eqa-t14-derived', now()"
+                        + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                UNNAMED_TEST, UNNAMED_TEST_NAME, UNNAMED_TEST_NAME, UNNAMED_TEST);
     }
 
     @Test


### PR DESCRIPTION
Found driving the numeric lane across two instances after [#4178](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4178) landed, and caused by it.

## The defect

A participant cannot submit a result for any test the catalog never gave an analyte — which, now that panel material means *orderable* rather than *has an analyte*, is most of the catalog. The analysis validates, **no `eqa_participant_result` row appears**, and the cycle sits at `PANEL_RECEIVED` with a log line as the only explanation:

```
WARN  EQA analysis 16 (test 3) reports no analyte; map the test to its scheme
      analyte on the enrollment before this cycle can be submitted
```

`eqa_participant_result.analyte_id` is a NOT NULL FK, and the bridge resolved it from three sources: the result's own analyte, the enrollment's scheme mapping, then a `test_analyte` scan. All three are empty for a test with no catalog analyte, so the result was skipped and the cycle never reached its denominator.

Reconfiguring the participant is not a way out. The submission carries the analyte **name**, and returning scores are matched by name too, so the participant has to be able to name an analyte the provider also knows. #4178 mints that analyte on the **provider** only; the participant's enrollment form offers 168 analytes and none matches, no screen creates one, and the consignment import carries no analyte identity.

Before #4178 this could not arise: panel material was restricted to the tests that already had `test_analyte` rows, whose analytes are seeded identically on both instances. That is exactly why the dictionary lane works and the numeric one did not.

## The change

The third source now delegates to `EQAPanelService.analyteIdForTest` — the same mint-or-adopt the provider already runs when it seals a panel sample.

That symmetry is the point rather than a convenience. Both instances derive the analyte from the test's own name, so the names agree with nothing added to the wire. A laboratory's declared enrollment mapping still wins where it set one; deriving is only the default.

`TestAnalyteService` was used by nothing but the loop that went, so its field and two imports go with it. The two warnings that survive can now only fire for an analysis naming no test at all, and say so.

**Five net lines of logic. No schema change.**

## Tests

Two rewritten in `EQAAutoSubmissionIntegrationTest`, because two existing cases asserted the behaviour this removes — *"a result the bridge cannot map must stop the submission"* and *"an unmapped test stays unbridgeable"*. Both premises are void, so both were repurposed rather than dropped:

- **adoption** — where an analyte already carries the test's name it is adopted, not duplicated. This is the live shape: the spine fixture's test and analyte are both named `HIV serology (rapid)`.
- **creation** — where none does, one is created from the test name, once, and a second sweep reuses it. Two analytes of one name would reach the provider as two measurements.

Inverted, the first fails `expected:<2> but was:<1>` and the second throws on an empty result list. With the fix, **560 EQA tests pass**.

## Verified on a two-instance stack

A provider cycle on `Glucose` — a numeric test with no catalog analyte — target 100 mg/dl, range 90–110, dispatched to five laboratories with the participant's slot deliberately left empty so its own submission had to fill it. The participant entered 105 and validated; then, with nothing clicked:

| time | event |
| --- | --- |
| 23:23:18 | participant bridges and submits — analyte minted from the test name, value 105 |
| 23:23:32 | provider takes it in — *"1 participant result(s) taken in from the store"*, method FHIR, **nothing unmapped** |
| — | provider scores: 105 against target 100 inside 90–110 → `ACCEPTABLE` |
| 23:25:19 | participant collects the score — cycle `SCORED` |

Fourteen seconds to the provider, round trip in two minutes. Worth noting the cycle scored on a **single** reported result, which only works because [#4181](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4181) lets a targeted cycle score below the five-participant floor — the two changes close this lane together.