### PR TITLE
fix(ci): check out .trivyignore in the publish job so images publish and deploy again

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -118,6 +118,17 @@ jobs:
           - compose_image: openelisglobal-databse.build
             dockerhub_suffix: database
     steps:
+      # The Trivy step below reads .trivyignore from the workspace, but this job
+      # otherwise never checks the repository out (it only retags images), so
+      # Trivy failed with "cannot find ignorefile" on every publish since the
+      # scan was added. Check out just that file, at the commit being published.
+      - name: Checkout Trivy ignore list
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.setup.outputs.head_sha }}
+          sparse-checkout: .trivyignore
+          sparse-checkout-cone-mode: false
+
       - name: Download image map from triggering build workflow
         uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
## Problem

Nothing merged to `develop` since **2026-08-28** has reached DockerHub or testing.openelis-global.org, even though every push shows green checks.

Root cause: #3952 (2026-08-30) added a Trivy scan to the `publish-images` matrix job with `trivyignores: .trivyignore`, but that job never runs `actions/checkout` — it only downloads the image map artifact and retags GHCR images. Trivy therefore exits 1 before scanning:

```
ERROR: cannot find ignorefile '.trivyignore'.
Process completed with exit code 1.
```

`exit-code: 0` on the action only suppresses vulnerability findings, not this configuration error. All five publish jobs fail, so `deploy-testing` (which `needs: publish-images`) is skipped.

**Evidence**

- Push-triggered "Publish Images" runs on 2026-09-04 for `f07ba0775`, `f10954904` and `d6bab7a5a` (e.g. run 33887282944): `Wait For 03 Checkpoint - E2E=success`, all `Publish *=failure` at "Scan tested image for vulnerabilities", `Deploy to testing VM=skipped`.
- DockerHub `itechuw/openelis-global-2{,-frontend,-proxy,-fhir,-database}:develop` all last updated **2026-08-28**.
- Push-triggered publish history: last green publish + deploy was `bad26eae6` on 2026-08-28 16:36Z; the first failure is the #3952 merge itself (`eed13101d`, 2026-08-30 02:07Z, `Publish *=failure, Deploy=skipped`), and every develop push since fails the same way.
- The dozens of green "Publish Images" runs since are triggered by pull-request E2E runs; for those the wait/publish/deploy jobs are skipped by design and the run still reports success.
- `backend.yml` and `frontend.yml` use the same `trivyignores` input and are fine because they check the repository out.

## Fix

One step, first in the `publish-images` job: a sparse `actions/checkout@v6` of `.trivyignore` at `needs.setup.outputs.head_sha` (the commit whose images are being published). Nothing else changes.

## Verification

- `actionlint` on the workflow file: clean.
- This cannot be exercised before merge: the workflow runs on `workflow_run` of "03 - E2E" and only publishes for push/release events, and a re-run of an old failed run reuses the workflow file it started with. **Merging this PR is the test**: the push to `develop` triggers 03 - E2E → Publish Images → the five publish jobs should pass "Scan tested image for vulnerabilities" and push `:develop` tags → `Deploy to testing VM` runs. Expected observables afterwards: DockerHub `:develop` tag timestamps move to the merge time, and the testing VM serves the merged build (which also carries everything merged since 2026-08-28, including the OGC-817 validation slices).

## Assumptions / limits

- Checking out at the published commit rather than the default branch keeps the ignore list in step with the images being scanned; for release events that is the tag's commit.
- `sparse-checkout-cone-mode: false` is used so only the one root file is fetched. If that ever proves fragile, dropping the option (cone mode) still works — cone mode always includes top-level files.
