### PR TITLE
fix(eqa): keep an enrollment's reporting analytes when its status is toggled (OGC-610)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
@@ -112,8 +112,10 @@ public class EQAMyProgramsRestController extends ControllerUtills {
             List<Long> testIds = toLongList(body.get("testIds"));
             List<Long> panelIds = toLongList(body.get("panelIds"));
 
+            // An absent testAnalytes leaves the stored map alone; an empty one clears it.
+            Object testAnalytes = body.get("testAnalytes");
             EQALabProgramEnrollment result = enrollmentService.updateEnrollment(id, updated, labUnitIds, testIds,
-                    panelIds, toLongMap(body.get("testAnalytes")));
+                    panelIds, testAnalytes == null ? null : toLongMap(testAnalytes));
             return ResponseEntity.ok(toDto(result));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
@@ -68,6 +69,12 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
         EQALabProgramEnrollment existing = enrollmentDAO.get(id)
                 .orElseThrow(() -> new IllegalArgumentException("Enrollment not found: " + id));
 
+        // The test maps are cleared and rebuilt below, so a caller that omits the
+        // reporting-analyte map must mean "leave it as it is" rather than "clear it".
+        // Toggling an enrollment's status has no business rewriting the map, and the
+        // participant's submission bridge resolves the analyte through it.
+        Map<Long, Long> effectiveAnalytes = testAnalytes != null ? testAnalytes : storedTestAnalytes(existing);
+
         existing.setProgramName(updated.getProgramName());
         existing.setProvider(updated.getProvider());
         existing.setDescription(updated.getDescription());
@@ -80,7 +87,7 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
         existing = enrollmentDAO.update(existing);
         entityManager.flush();
 
-        setMappings(existing, labUnitIds, testIds, panelIds, testAnalytes);
+        setMappings(existing, labUnitIds, testIds, panelIds, effectiveAnalytes);
         enrollmentDAO.update(existing);
         entityManager.flush();
         entityManager.clear();
@@ -101,6 +108,20 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
     @Transactional(readOnly = true)
     public List<String> getDistinctProviders() {
         return enrollmentDAO.findDistinctProviders();
+    }
+
+    /**
+     * The analyte currently recorded against each test, keyed the way setMappings
+     * reads it.
+     */
+    private Map<Long, Long> storedTestAnalytes(EQALabProgramEnrollment enrollment) {
+        Map<Long, Long> analytes = new HashMap<>();
+        for (EQALabEnrollmentTestMap map : enrollment.getTestMaps()) {
+            if (map.getTestId() != null && map.getAnalyteId() != null) {
+                analytes.put(map.getTestId(), map.getAnalyteId());
+            }
+        }
+        return analytes;
     }
 
     private void setMappings(EQALabProgramEnrollment enrollment, List<Long> labUnitIds, List<Long> testIds,

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAMyProgramsRestControllerTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa.controller;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -19,6 +20,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -194,7 +196,7 @@ public class EQAMyProgramsRestControllerTest {
     @Test
     public void testUpdateMyProgram_Success() {
         when(enrollmentService.updateEnrollment(
-                        eq(1L), any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList(), anyMap()))
+                        eq(1L), any(EQALabProgramEnrollment.class), anyList(), anyList(), anyList(), any()))
                 .thenReturn(enrollment1);
 
         Map<String, Object> body = new HashMap<>();
@@ -207,6 +209,52 @@ public class EQAMyProgramsRestControllerTest {
         ResponseEntity<?> response = controller.updateMyProgram(request, 1L, body);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    /**
+     * A status toggle omits testAnalytes, and the service reads a null map as
+     * "leave the stored one alone" — so the omission must not arrive as an empty map,
+     * which would clear every reporting analyte on the enrollment.
+     */
+    @Test
+    public void testUpdateMyProgram_AbsentTestAnalytesPassesNull() {
+        when(enrollmentService.updateEnrollment(
+                        eq(1L), any(EQALabProgramEnrollment.class), any(), any(), any(), any()))
+                .thenReturn(enrollment1);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("programName", "Chemistry PT");
+        body.put("provider", "WHO");
+        body.put("isActive", Boolean.FALSE);
+        body.put("testIds", List.of(200));
+
+        controller.updateMyProgram(request, 1L, body);
+
+        ArgumentCaptor<Map<Long, Long>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(enrollmentService).updateEnrollment(
+                eq(1L), any(EQALabProgramEnrollment.class), any(), any(), any(), captor.capture());
+        assertNull(captor.getValue());
+    }
+
+    /** An explicit map still arrives parsed, so the Edit form keeps setting analytes. */
+    @Test
+    public void testUpdateMyProgram_ExplicitTestAnalytesPassedThrough() {
+        when(enrollmentService.updateEnrollment(
+                        eq(1L), any(EQALabProgramEnrollment.class), any(), any(), any(), any()))
+                .thenReturn(enrollment1);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("programName", "Chemistry PT");
+        body.put("provider", "WHO");
+        body.put("testIds", List.of(191));
+        body.put("testAnalytes", Map.of("191", 103));
+
+        controller.updateMyProgram(request, 1L, body);
+
+        ArgumentCaptor<Map<Long, Long>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(enrollmentService).updateEnrollment(
+                eq(1L), any(EQALabProgramEnrollment.class), any(), any(), any(), captor.capture());
+        assertEquals(Map.of(191L, 103L), captor.getValue());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.eqa.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openelisglobal.eqa.dao.EQALabProgramEnrollmentDAO;
+import org.openelisglobal.eqa.valueholder.EQALabEnrollmentTestMap;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -163,6 +166,76 @@ public class EQALabProgramEnrollmentServiceTest {
         assertEquals("New Name", result.getProgramName());
         assertEquals("New Provider", result.getProvider());
         assertNotNull(result.getLastModified());
+    }
+
+    /**
+     * A status toggle sends no reporting-analyte map, and the update clears and
+     * rebuilds the test maps — so the stored analyte has to survive it. The
+     * participant's submission bridge resolves the analyte through this map.
+     */
+    @Test
+    public void testUpdateEnrollment_AbsentTestAnalytesKeepsStoredAnalyte() {
+        EQALabProgramEnrollment existing = enrollmentWithTestAnalyte(191L, 103L);
+
+        when(enrollmentDAO.get(1L)).thenReturn(Optional.of(existing));
+        when(enrollmentDAO.update(any(EQALabProgramEnrollment.class))).thenReturn(existing);
+
+        EQALabProgramEnrollment updated = new EQALabProgramEnrollment();
+        updated.setProgramName("Viral Load PT");
+        updated.setProvider("CPHL");
+        updated.setIsActive(false);
+        updated.setSysUserId("1");
+
+        EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, null, List.of(191L), null, null);
+
+        assertFalse(result.getIsActive());
+        assertEquals(1, result.getTestMaps().size());
+        EQALabEnrollmentTestMap map = result.getTestMaps().iterator().next();
+        assertEquals(Long.valueOf(191L), map.getTestId());
+        assertEquals(Long.valueOf(103L), map.getAnalyteId());
+    }
+
+    /**
+     * An explicit empty map still means "no analytes", so deselecting one keeps
+     * working.
+     */
+    @Test
+    public void testUpdateEnrollment_EmptyTestAnalytesClearsStoredAnalyte() {
+        EQALabProgramEnrollment existing = enrollmentWithTestAnalyte(191L, 103L);
+
+        when(enrollmentDAO.get(1L)).thenReturn(Optional.of(existing));
+        when(enrollmentDAO.update(any(EQALabProgramEnrollment.class))).thenReturn(existing);
+
+        EQALabProgramEnrollment updated = new EQALabProgramEnrollment();
+        updated.setProgramName("Viral Load PT");
+        updated.setProvider("CPHL");
+        updated.setIsActive(true);
+        updated.setSysUserId("1");
+
+        EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, null, List.of(191L), null, Map.of());
+
+        assertEquals(1, result.getTestMaps().size());
+        EQALabEnrollmentTestMap map = result.getTestMaps().iterator().next();
+        assertEquals(Long.valueOf(191L), map.getTestId());
+        assertNull(map.getAnalyteId());
+    }
+
+    private EQALabProgramEnrollment enrollmentWithTestAnalyte(Long testId, Long analyteId) {
+        EQALabProgramEnrollment existing = new EQALabProgramEnrollment();
+        existing.setId(1L);
+        existing.setProgramName("Viral Load PT");
+        existing.setProvider("CPHL");
+        existing.setIsActive(true);
+        existing.setSysUserId("1");
+        existing.setLabUnits(new HashSet<>());
+        existing.setTestMaps(new HashSet<>());
+
+        EQALabEnrollmentTestMap stored = new EQALabEnrollmentTestMap();
+        stored.setEnrollment(existing);
+        stored.setTestId(testId);
+        stored.setAnalyteId(analyteId);
+        existing.getTestMaps().add(stored);
+        return existing;
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## What

Deactivating or reactivating an EQA enrollment from **My Programs** wiped the reporting analyte off every test in that enrollment's map. No warning, no toast, and the row's **Tests** count did not change, so nothing on screen said the mapping was gone.

## Why it happened

`PUT /rest/eqa/my-programs/{id}` clears and rebuilds the enrollment's test maps from its payload, and the status toggle sends no `testAnalytes` field. An omitted map was parsed into an empty one, so `setMappings` found no analyte for any test and wrote `analyte_id = NULL` across the enrollment.

That map is what a participant's submission bridge resolves an analyte through — the mapping [#4199](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4199) was about. A laboratory that paused an enrollment and resumed it silently stopped being able to report, and found out at submission time.

## The change

The endpoint now tells an **absent** `testAnalytes` apart from an **empty** one:

- absent — carry the stored analyte for each test forward, so a status toggle leaves the map alone
- empty — still clears, so deselecting a test's analyte in the Edit form keeps working

Fixed at the endpoint rather than in the single caller, so any future caller that omits the field is covered too. Two source files, five net lines, no schema change and no frontend change.

## Verification

Driven on the UAT rig against a participant instance's Viral Load enrollment, through the row's overflow menu:

| step | `eqa_lab_enrollment_test_map` |
| --- | --- |
| before | test 191 → analyte 103 |
| **Deactivate** | test 191 → analyte **103** |
| **Reactivate** | test 191 → analyte **103** |

The enrollment's status toggled correctly on the page both times (Active → Inactive → Active), and the map row id churns as it always has, which nothing references. On the previous build the analyte came back `NULL` after the first click and stayed `NULL` through the second.

The deployed class fingerprints 10142 bytes (was 9412) in all four Tomcat contexts across both instances.

## Tests

564 EQA tests green, four of them new:

- the service keeps the stored analyte when the map is absent, and still clears it when the map is explicitly empty
- the controller passes `null` for an absent map and the parsed map for an explicit one

Both halves are load-bearing — reverting either one fails its test.