### PR TITLE
test(e2e): wait for the app's own post-save navigations in the e-signature validation spec

### DIFF
--- a/frontend/playwright/tests/foundational/core/esig-result-validation.spec.ts
+++ b/frontend/playwright/tests/foundational/core/esig-result-validation.spec.ts
@@ -144,12 +144,19 @@ test("E-Signature — full result entry and validation flow", async ({
     await pwInput.click();
     await pwInput.pressSequentially(password, { delay: 30 });
 
-    // The signature releases the result save; sync on that request so the
-    // navigation that follows cannot cancel it mid-flight.
+    // The signature releases the result save, and a successful save makes the
+    // page navigate back to the results search on its own. Sync on both so the
+    // next page.goto neither cancels the save nor collides with that reload
+    // (net::ERR_ABORTED).
     const resultsSaved = page.waitForResponse(
       (response) =>
         response.url().includes("/rest/LogbookResults") &&
         response.request().method() === "POST",
+      { timeout: LONG_TIMEOUT },
+    );
+    const resultsReloaded = page.waitForRequest(
+      (request) =>
+        request.isNavigationRequest() && request.url().includes("/result?"),
       { timeout: LONG_TIMEOUT },
     );
 
@@ -159,6 +166,8 @@ test("E-Signature — full result entry and validation flow", async ({
     // Modal should close after successful signature
     await expect(modal).toBeHidden({ timeout: LONG_TIMEOUT });
     await resultsSaved;
+    await resultsReloaded;
+    await page.waitForLoadState("domcontentloaded");
   });
 
   // ── Step 4: Validation — VALIDATED_AND_RELEASED signature ─────
@@ -220,13 +229,19 @@ test("E-Signature — full result entry and validation flow", async ({
 
     // In password-only mode, just enter password
     await modal.locator('input[type="password"]').fill(password);
+
+    // A successful release reloads the validation page; wait for that
+    // navigation so the cleanup step's own navigation cannot collide with it.
+    const queueReloaded = page.waitForRequest(
+      (request) =>
+        request.isNavigationRequest() && request.url().includes("/validation"),
+      { timeout: LONG_TIMEOUT },
+    );
     await modal.getByRole("button", { name: /sign/i }).click();
 
     await expect(modal).toBeHidden({ timeout: LONG_TIMEOUT });
-
-    // Wait for the page to finish any post-sign navigation/redirect
-    // before attempting cleanup navigation
-    await page.waitForLoadState("networkidle");
+    await queueReloaded;
+    await page.waitForLoadState("domcontentloaded");
   });
 
   // ── Cleanup: Restore original e-sig setting ───────────────────

--- a/frontend/playwright/tests/foundational/core/esig-result-validation.spec.ts
+++ b/frontend/playwright/tests/foundational/core/esig-result-validation.spec.ts
@@ -154,11 +154,11 @@ test("E-Signature — full result entry and validation flow", async ({
         response.request().method() === "POST",
       { timeout: LONG_TIMEOUT },
     );
-    const resultsReloaded = page.waitForRequest(
-      (request) =>
-        request.isNavigationRequest() && request.url().includes("/result?"),
-      { timeout: LONG_TIMEOUT },
-    );
+    const resultsReloaded = page.waitForEvent("framenavigated", {
+      predicate: (frame) =>
+        frame === page.mainFrame() && frame.url().includes("/result?"),
+      timeout: LONG_TIMEOUT,
+    });
 
     // Click Sign
     await modal.getByRole("button", { name: /sign/i }).click();
@@ -232,11 +232,11 @@ test("E-Signature — full result entry and validation flow", async ({
 
     // A successful release reloads the validation page; wait for that
     // navigation so the cleanup step's own navigation cannot collide with it.
-    const queueReloaded = page.waitForRequest(
-      (request) =>
-        request.isNavigationRequest() && request.url().includes("/validation"),
-      { timeout: LONG_TIMEOUT },
-    );
+    const queueReloaded = page.waitForEvent("framenavigated", {
+      predicate: (frame) =>
+        frame === page.mainFrame() && frame.url().includes("/validation"),
+      timeout: LONG_TIMEOUT,
+    });
     await modal.getByRole("button", { name: /sign/i }).click();
 
     await expect(modal).toBeHidden({ timeout: LONG_TIMEOUT });


### PR DESCRIPTION
**What changed**
- The e-signature E2E spec now waits for the app's own page reload after saving a result and after releasing a result, before it navigates on.

**Why**
- Both pages navigate by themselves after those actions, so the spec's next `page.goto` raced them and Chromium aborted one (`net::ERR_ABORTED`). It failed once on the develop push `7e50b92b5` and passed on re-run; when it fails on a develop push it also blocks image publishing until two workflows are re-run by hand.

**How it was tested**
- Prettier and ESLint clean; the spec drives the legacy results page that only the CI seed serves, so this PR's E2E run is the check.
