### PR TITLE
fix(order): patientless environmental orders reach the dashboard and no longer crash patient-joining code (OGC-1192)

### DIFF
--- a/frontend/src/components/order/OrderContext.jsx
+++ b/frontend/src/components/order/OrderContext.jsx
@@ -300,139 +300,142 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
    * Used when user scans a barcode or enters a lab number.
    * Loads in read-only mode by default (user must click Edit to modify).
    */
-  const loadOrder = useCallback(async (searchLabNumber, readOnly = true) => {
-    setIsLoading(true);
-    setError(null);
+  const loadOrder = useCallback(
+    async (searchLabNumber, readOnly = true) => {
+      setIsLoading(true);
+      setError(null);
 
-    return new Promise((resolve, reject) => {
-      getFromOpenElisServer(
-        `/rest/order/search?labNumber=${encodeURIComponent(searchLabNumber)}`,
-        (response) => {
-          setIsLoading(false);
+      return new Promise((resolve, reject) => {
+        getFromOpenElisServer(
+          `/rest/order/search?labNumber=${encodeURIComponent(searchLabNumber)}`,
+          (response) => {
+            setIsLoading(false);
 
-          if (response && response.labNumber) {
-            setOrderId(response.id);
-            setLabNumber(response.labNumber);
+            if (response && response.labNumber) {
+              setOrderId(response.id);
+              setLabNumber(response.labNumber);
 
-            // Capture reference-data lists already loaded by the mount fetch
-            // ( /rest/SamplePatientEntry ) — /rest/order/search does not return
-            // them, so without this we'd clobber referralOrganizations,
-            // referralReasons, sampleTypes, etc. to null on every load.
-            const prior = orderDataRef.current || {};
-            const preservedRefData = {
-              sampleTypes: prior.sampleTypes,
-              testSectionList: prior.testSectionList,
-              rejectReasonList: prior.rejectReasonList,
-              referralOrganizations: prior.referralOrganizations,
-              referralReasons: prior.referralReasons,
-            };
+              // Capture reference-data lists already loaded by the mount fetch
+              // ( /rest/SamplePatientEntry ) — /rest/order/search does not return
+              // them, so without this we'd clobber referralOrganizations,
+              // referralReasons, sampleTypes, etc. to null on every load.
+              const prior = orderDataRef.current || {};
+              const preservedRefData = {
+                sampleTypes: prior.sampleTypes,
+                testSectionList: prior.testSectionList,
+                rejectReasonList: prior.rejectReasonList,
+                referralOrganizations: prior.referralOrganizations,
+                referralReasons: prior.referralReasons,
+              };
 
-            // Build order data by merging response fields with defaults
-            // The backend returns patientProperties at top level and inside orderData
-            const loadedOrderData = {
-              ...SampleOrderFormValues,
-              ...preservedRefData,
-              ...(response.orderData || {}),
-              patientProperties: {
-                ...SampleOrderFormValues.patientProperties,
-                ...(response.patientProperties || {}),
-                ...(response.orderData?.patientProperties || {}),
-                // Keep patient status from response or default to NO_ACTION for subsequent saves
-                // Only set UPDATE when patient data has actually been modified
-                patientUpdateStatus:
-                  response.patientProperties?.patientUpdateStatus ||
-                  "NO_ACTION",
-              },
-              sampleOrderItems: {
-                ...SampleOrderFormValues.sampleOrderItems,
-                ...(response.sampleOrderItems || {}),
-                environmentalFields: {
-                  ...(prior?.sampleOrderItems?.environmentalFields || {}),
-                  ...(response.sampleOrderItems?.environmentalFields || {}),
+              // Build order data by merging response fields with defaults
+              // The backend returns patientProperties at top level and inside orderData
+              const loadedOrderData = {
+                ...SampleOrderFormValues,
+                ...preservedRefData,
+                ...(response.orderData || {}),
+                patientProperties: {
+                  ...SampleOrderFormValues.patientProperties,
+                  ...(response.patientProperties || {}),
+                  ...(response.orderData?.patientProperties || {}),
+                  // Keep patient status from response or default to NO_ACTION for subsequent saves
+                  // Only set UPDATE when patient data has actually been modified
+                  patientUpdateStatus:
+                    response.patientProperties?.patientUpdateStatus ||
+                    "NO_ACTION",
                 },
-                labNo: response.labNumber,
-              },
-            };
+                sampleOrderItems: {
+                  ...SampleOrderFormValues.sampleOrderItems,
+                  ...(response.sampleOrderItems || {}),
+                  environmentalFields: {
+                    ...(prior?.sampleOrderItems?.environmentalFields || {}),
+                    ...(response.sampleOrderItems?.environmentalFields || {}),
+                  },
+                  labNo: response.labNumber,
+                },
+              };
 
-            setOrderDataState(loadedOrderData);
+              setOrderDataState(loadedOrderData);
 
-            // Load sample type requests if no sample_items exist (decoupled workflow)
-            // This handles Step 1 edit where samples are stored as requests, not items
-            const hasSampleItems =
-              response.samples &&
-              response.samples.length > 0 &&
-              response.samples.some((s) => s.sampleItemId);
+              // Load sample type requests if no sample_items exist (decoupled workflow)
+              // This handles Step 1 edit where samples are stored as requests, not items
+              const hasSampleItems =
+                response.samples &&
+                response.samples.length > 0 &&
+                response.samples.some((s) => s.sampleItemId);
 
-            const loadedEnvFields =
-              loadedOrderData?.sampleOrderItems?.environmentalFields || {};
-            const injectVectorFields = (samplesList) =>
-              flattenSampleManifestFields(
-                samplesList,
-                loadedEnvFields,
-                isDayFirst,
+              const loadedEnvFields =
+                loadedOrderData?.sampleOrderItems?.environmentalFields || {};
+              const injectVectorFields = (samplesList) =>
+                flattenSampleManifestFields(
+                  samplesList,
+                  loadedEnvFields,
+                  isDayFirst,
+                );
+
+              setIsReadOnly(readOnly);
+              setIsEditMode(false);
+              setIsDirty(false);
+              setSaveStatus(SaveStatus.SAVED);
+
+              setStepProgress(
+                response.stepProgress || {
+                  enter: false,
+                  collect: false,
+                  label: false,
+                  qa: false,
+                },
               );
 
-            setIsReadOnly(readOnly);
-            setIsEditMode(false);
-            setIsDirty(false);
-            setSaveStatus(SaveStatus.SAVED);
+              // Load storageSkipped from backend response
+              const savedStorageSkipped = response.storageSkipped === true;
+              setStorageSkippedState(savedStorageSkipped);
 
-            setStepProgress(
-              response.stepProgress || {
-                enter: false,
-                collect: false,
-                label: false,
-                qa: false,
-              },
-            );
+              setError(null);
+              lastSavedDataRef.current = JSON.stringify({
+                orderData: loadedOrderData,
+                samples: response.samples,
+              });
 
-            // Load storageSkipped from backend response
-            const savedStorageSkipped = response.storageSkipped === true;
-            setStorageSkippedState(savedStorageSkipped);
-
-            setError(null);
-            lastSavedDataRef.current = JSON.stringify({
-              orderData: loadedOrderData,
-              samples: response.samples,
-            });
-
-            if (!hasSampleItems && response.id) {
-              // Load sample type requests and resolve only after samples are set,
-              // so callers that await loadOrder() see the full samples state.
-              getRequestsBySample(response.id)
-                .then((requests) => {
-                  if (requests && requests.length > 0) {
-                    setSamplesState(
-                      injectVectorFields(convertRequestsToSamples(requests)),
-                    );
-                  } else {
+              if (!hasSampleItems && response.id) {
+                // Load sample type requests and resolve only after samples are set,
+                // so callers that await loadOrder() see the full samples state.
+                getRequestsBySample(response.id)
+                  .then((requests) => {
+                    if (requests && requests.length > 0) {
+                      setSamplesState(
+                        injectVectorFields(convertRequestsToSamples(requests)),
+                      );
+                    } else {
+                      setSamplesState(
+                        injectVectorFields(response.samples || [sampleObject]),
+                      );
+                    }
+                    resolve(response);
+                  })
+                  .catch(() => {
                     setSamplesState(
                       injectVectorFields(response.samples || [sampleObject]),
                     );
-                  }
-                  resolve(response);
-                })
-                .catch(() => {
-                  setSamplesState(
-                    injectVectorFields(response.samples || [sampleObject]),
-                  );
-                  resolve(response);
-                });
+                    resolve(response);
+                  });
+              } else {
+                setSamplesState(
+                  injectVectorFields(response.samples || [sampleObject]),
+                );
+                resolve(response);
+              }
             } else {
-              setSamplesState(
-                injectVectorFields(response.samples || [sampleObject]),
-              );
-              resolve(response);
+              const errorMsg = "Order not found";
+              setError(errorMsg);
+              reject(new Error(errorMsg));
             }
-          } else {
-            const errorMsg = "Order not found";
-            setError(errorMsg);
-            reject(new Error(errorMsg));
-          }
-        },
-      );
-    });
-  }, []);
+          },
+        );
+      });
+    },
+    [isDayFirst],
+  );
 
   /**
    * Convert samples array to XML format expected by backend
@@ -453,6 +456,7 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
 
       const orderRequiredBy = convertBackendDateToIso(
         orderData?.sampleOrderItems?.requiredBy || "",
+        isDayFirst,
       );
       let sampleXmlString = '<?xml version="1.0" encoding="utf-8"?>';
       sampleXmlString += `<samples requiredBy='${orderRequiredBy}'>`;
@@ -1031,6 +1035,7 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
                           flattenSampleManifestFields(
                             response.samples,
                             envFields,
+                            isDayFirst,
                           ),
                         );
                       }
@@ -1085,7 +1090,7 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
         );
       });
     },
-    [orderId, orderData, samples, isReadOnly, isEditMode],
+    [orderId, orderData, samples, isReadOnly, isEditMode, isDayFirst],
   );
 
   /**
@@ -1311,14 +1316,23 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
     });
   }, []);
 
-  // On mount (and on refresh), if ?order=<labNumber> is in the URL and the
-  // path prefix matches this provider's workflowType, auto-load the order.
+  // On mount (and on refresh), if the URL addresses an order — ?order=<labNumber>,
+  // or ?labNumber= as the dashboards push it — and the path prefix matches this
+  // provider's workflowType, auto-load the order. The load waits for the site's
+  // date locale, because backend dates are parsed with its day/month order;
+  // loading before it arrives transposed day and month (OGC-1192). The layout
+  // publishes the anonymous configuration first, which has no date locale, so a
+  // non-empty configuration alone is not enough to go on.
   // After load, if the order's workflowType doesn't match this provider's
   // (e.g. a clinical ?order= carried into the environmental provider), strip
   // the param and reset so the form starts clean.
+  const configurationReady =
+    configurationProperties?.DEFAULT_DATE_LOCALE !== undefined;
+  const urlOrderLoadStarted = useRef(false);
   useEffect(() => {
+    if (urlOrderLoadStarted.current || !configurationReady) return;
     const params = new URLSearchParams(location.search);
-    const orderParam = params.get("order");
+    const orderParam = params.get("order") || params.get("labNumber");
     if (!orderParam || orderId) return;
 
     const path = location.pathname;
@@ -1330,8 +1344,9 @@ export const OrderProvider = ({ children, workflowType = "clinical" }) => {
 
     if (pathWorkflow !== workflowType) return;
 
+    urlOrderLoadStarted.current = true;
     loadOrder(orderParam, false); // eslint-disable-line react-hooks/set-state-in-effect
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [configurationReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * Auto-save effect - saves every 30 seconds if form is dirty and has minimum required data.

--- a/frontend/src/components/order/OrderContext.urlLoad.test.jsx
+++ b/frontend/src/components/order/OrderContext.urlLoad.test.jsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConfigurationContext } from "../layout/Layout";
+import { OrderProvider, useOrderContext } from "./OrderContext";
+
+// OGC-1192 §3 — loading an order from the URL.
+//   * The dashboards push `?labNumber=`, the deep links use `?order=`; both must load.
+//   * Backend dates are day-first or month-first depending on the site locale, so the
+//     load has to wait for the configuration instead of parsing with a default.
+
+const { getFromOpenElisServerMock } = vi.hoisted(() => ({
+  getFromOpenElisServerMock: vi.fn(),
+}));
+
+vi.mock("../utils/Utils", () => ({
+  getFromOpenElisServer: (...args) => getFromOpenElisServerMock(...args),
+  postToOpenElisServer: vi.fn(),
+  putToOpenElisServer: vi.fn(),
+}));
+
+vi.mock("./api/sampleTypeRequestApi", () => ({
+  createRequestsForSamples: vi.fn(),
+  getRequestsBySample: vi.fn(() => Promise.resolve([])),
+  convertRequestsToSamples: vi.fn(() => []),
+}));
+
+const orderResponse = (labNumber) => ({
+  id: "77",
+  labNumber,
+  samples: [
+    { sampleItemId: "1", sampleTypeId: "2", collectionDate: "03/09/2026" },
+  ],
+  orderData: {},
+  sampleOrderItems: { environmentalFields: { workflowType: "environmental" } },
+});
+
+const answerServer = (url, callback) => {
+  if (url.startsWith("/rest/order/search?labNumber=")) {
+    const labNumber = decodeURIComponent(url.split("labNumber=")[1]);
+    callback(orderResponse(labNumber));
+  } else if (typeof callback === "function") {
+    callback({});
+  }
+};
+
+const Probe = () => {
+  const { labNumber, samples } = useOrderContext();
+  return (
+    <div>
+      <span data-testid="lab">{labNumber || ""}</span>
+      <span data-testid="date">{samples?.[0]?.collectionDate || ""}</span>
+    </div>
+  );
+};
+
+const tree = (url, configurationProperties) => (
+  <ConfigurationContext.Provider value={{ configurationProperties }}>
+    <MemoryRouter initialEntries={[url]}>
+      <OrderProvider workflowType="environmental">
+        <Probe />
+      </OrderProvider>
+    </MemoryRouter>
+  </ConfigurationContext.Provider>
+);
+
+const searchCalls = () =>
+  getFromOpenElisServerMock.mock.calls
+    .map((c) => c[0])
+    .filter((url) => url.startsWith("/rest/order/search"));
+
+describe("OrderContext — loading an order from the URL", () => {
+  beforeEach(() => {
+    getFromOpenElisServerMock.mockReset();
+    getFromOpenElisServerMock.mockImplementation(answerServer);
+  });
+
+  it("loads the order the dashboard addresses with ?labNumber=", async () => {
+    render(
+      tree("/order/environmental/enter?labNumber=DEV01260000000000655", {
+        DEFAULT_DATE_LOCALE: "fr-FR",
+      }),
+    );
+    expect(await screen.findByText("DEV01260000000000655")).toBeTruthy();
+    expect(searchCalls()).toEqual([
+      "/rest/order/search?labNumber=DEV01260000000000655",
+    ]);
+  });
+
+  it("still loads the order addressed with ?order=", async () => {
+    render(
+      tree("/order/environmental/enter?order=DEV-2", {
+        DEFAULT_DATE_LOCALE: "fr-FR",
+      }),
+    );
+    expect(await screen.findByText("DEV-2")).toBeTruthy();
+  });
+
+  it("reads a day-first backend date as the day it was entered", async () => {
+    render(
+      tree("/order/environmental/enter?labNumber=DEV-3", {
+        DEFAULT_DATE_LOCALE: "fr-FR",
+      }),
+    );
+    expect(await screen.findByText("2026-09-03")).toBeTruthy();
+  });
+
+  it("reads a month-first backend date under a month-first locale", async () => {
+    render(
+      tree("/order/environmental/enter?labNumber=DEV-4", {
+        DEFAULT_DATE_LOCALE: "en-US",
+      }),
+    );
+    expect(await screen.findByText("2026-03-09")).toBeTruthy();
+  });
+
+  it("waits for the site's date locale before loading, then loads once", async () => {
+    const { rerender } = render(
+      tree("/order/environmental/enter?labNumber=DEV-5", {}),
+    );
+    expect(searchCalls()).toEqual([]);
+
+    // The anonymous configuration the layout publishes first has no locale.
+    rerender(
+      tree("/order/environmental/enter?labNumber=DEV-5", {
+        currentDateAsText: "07/09/2026",
+      }),
+    );
+    expect(searchCalls()).toEqual([]);
+
+    rerender(
+      tree("/order/environmental/enter?labNumber=DEV-5", {
+        DEFAULT_DATE_LOCALE: "fr-FR",
+      }),
+    );
+    expect(await screen.findByText("DEV-5")).toBeTruthy();
+    expect(searchCalls()).toEqual(["/rest/order/search?labNumber=DEV-5"]);
+    expect(screen.getByTestId("date")).toHaveTextContent("2026-09-03");
+  });
+});

--- a/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
+++ b/frontend/src/components/order/steps/EnvironmentalOrderEnter.jsx
@@ -61,10 +61,12 @@ const EnvironmentalOrderEnter = () => {
   const [errors, setErrors] = useState({});
   const [showNceForm, setShowNceForm] = useState(false);
 
-  // Reset on mount for new orders. Only skip reset when ?order= is present
-  // AND the URL path belongs to this workflow.
+  // Reset on mount for new orders. Only skip reset when an order is addressed
+  // in the URL (?order= or the dashboard's ?labNumber=) AND the URL path
+  // belongs to this workflow.
   useEffect(() => {
-    const orderParam = new URLSearchParams(location.search).get("order");
+    const params = new URLSearchParams(location.search);
+    const orderParam = params.get("order") || params.get("labNumber");
     const pathMatchesWorkflow = location.pathname.startsWith(
       "/order/environmental",
     );

--- a/src/main/java/org/openelisglobal/reports/action/implementation/PatientReport.java
+++ b/src/main/java/org/openelisglobal/reports/action/implementation/PatientReport.java
@@ -279,6 +279,9 @@ public abstract class PatientReport extends Report {
                 sampleCompleteMap.put(convertToAlphaNumericDisplay(sample), Boolean.TRUE);
                 findCompletionDate();
                 findPatientFromSample();
+                if (currentPatient == null) {
+                    continue;
+                }
                 findContactInfo();
                 findPatientInfo();
                 createReportItems();
@@ -474,6 +477,13 @@ public abstract class PatientReport extends Report {
 
     protected void findPatientFromSample() {
         Patient patient = sampleHumanService.getPatientForSample(currentSample);
+
+        if (patient == null) {
+            STNumber = null;
+            patientDOB = null;
+            currentPatient = null;
+            return;
+        }
 
         if (currentPatient == null || !patient.getId().equals(patientService.getPatientId(currentPatient))) {
             STNumber = null;

--- a/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
@@ -209,6 +209,7 @@ public class OrderSearchRestController extends BaseRestController {
      * "true" leaves the list unscoped.
      */
     private static final String RESTRICT_RECENT_ORDERS_PROPERTY = "restrictRecentOrdersByTestSection";
+    private static final int MAX_DASHBOARD_PAGE_SIZE = 500;
 
     private String ADDRESS_PART_VILLAGE_ID;
     private String ADDRESS_PART_COMMUNE_ID;
@@ -250,9 +251,13 @@ public class OrderSearchRestController extends BaseRestController {
             String currentSysUserId = getSysUserId(request);
             Set<String> allowedSectionIds = resolveAllowedSectionIds(currentSysUserId);
 
-            // Get recent samples - getPageOfSamples expects 1-based startingRecNo
-            int startingRecNo = ((page - 1) * pageSize) + 1;
-            List<Sample> samples = sampleService.getPageOfSamples(startingRecNo);
+            // Newest orders first, in pages of the requested size (1-based startingRecNo).
+            // The system-default paging walks samples oldest-first in pages of
+            // page.defaultPageSize, which never reaches a freshly created order once the
+            // lab has more samples than that (OGC-1192).
+            int effectivePageSize = Math.min(Math.max(pageSize, 1), MAX_DASHBOARD_PAGE_SIZE);
+            int startingRecNo = ((Math.max(page, 1) - 1) * effectivePageSize) + 1;
+            List<Sample> samples = sampleService.getSamplesNewestFirst(startingRecNo, effectivePageSize);
 
             // Apply filters
             for (Sample sample : samples) {

--- a/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/SampleEditRestController.java
@@ -309,6 +309,9 @@ public class SampleEditRestController extends BaseSampleEntryController {
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
 
         Patient patient = sampleHumanService.getPatientForSample(sample);
+        if (patient == null) {
+            return;
+        }
         PatientService patientPatientService = SpringContext.getBean(PatientService.class);
         PersonService personService = SpringContext.getBean(PersonService.class);
         personService.getData(patient.getPerson());

--- a/src/main/java/org/openelisglobal/sample/dao/SampleDAO.java
+++ b/src/main/java/org/openelisglobal/sample/dao/SampleDAO.java
@@ -30,6 +30,16 @@ public interface SampleDAO extends BaseDAO<Sample, String> {
 
     List<Sample> getPageOfSamples(int startingRecNo) throws LIMSRuntimeException;
 
+    /**
+     * A page of samples, most recently created first (descending id). Unlike
+     * {@link #getPageOfSamples(int)} the page size is the caller's, not the system
+     * default.
+     *
+     * @param startingRecNo 1-based index of the first record
+     * @param pageSize      number of samples to return
+     */
+    List<Sample> getSamplesNewestFirst(int startingRecNo, int pageSize) throws LIMSRuntimeException;
+
     void getData(Sample sample) throws LIMSRuntimeException;
 
     // public void updateData(Sample sample) throws LIMSRuntimeException;

--- a/src/main/java/org/openelisglobal/sample/daoimpl/SampleDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/SampleDAOImpl.java
@@ -119,6 +119,21 @@ public class SampleDAOImpl extends BaseDAOImpl<Sample, String> implements Sample
 
     @Override
     @Transactional(readOnly = true)
+    public List<Sample> getSamplesNewestFirst(int startingRecNo, int pageSize) throws LIMSRuntimeException {
+        try {
+            Query<Sample> query = entityManager.unwrap(Session.class).createQuery("from Sample s order by s.id desc",
+                    Sample.class);
+            query.setFirstResult(Math.max(startingRecNo, 1) - 1);
+            query.setMaxResults(Math.max(pageSize, 1));
+            return query.list();
+        } catch (RuntimeException e) {
+            LogEvent.logError(e);
+            throw new LIMSRuntimeException("Error in Sample getSamplesNewestFirst()", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public void getSampleByAccessionNumber(Sample sample) throws LIMSRuntimeException {
         try {
             String sql = "from Sample s where s.accessionNumber = :param";

--- a/src/main/java/org/openelisglobal/sample/service/SampleService.java
+++ b/src/main/java/org/openelisglobal/sample/service/SampleService.java
@@ -60,6 +60,8 @@ public interface SampleService extends BaseObjectService<Sample, String> {
 
     List<Sample> getPageOfSamples(int startingRecNo);
 
+    List<Sample> getSamplesNewestFirst(int startingRecNo, int pageSize);
+
     List<Sample> getSamplesForPatient(String patientID);
 
     String generateAccessionNumberAndInsert(Sample sample);

--- a/src/main/java/org/openelisglobal/sample/service/SampleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SampleServiceImpl.java
@@ -531,6 +531,12 @@ public class SampleServiceImpl extends AuditableBaseObjectServiceImpl<Sample, St
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<Sample> getSamplesNewestFirst(int startingRecNo, int pageSize) {
+        return getBaseObjectDAO().getSamplesNewestFirst(startingRecNo, pageSize);
+    }
+
+    @Override
     public String generateAccessionNumberAndInsert(Sample sample) {
         sample.setAccessionNumber(getBaseObjectDAO().getNextAccessionNumber());
         return insert(sample);

--- a/src/main/java/org/openelisglobal/testreflex/action/util/TestReflexUtil.java
+++ b/src/main/java/org/openelisglobal/testreflex/action/util/TestReflexUtil.java
@@ -374,9 +374,8 @@ public class TestReflexUtil {
                     reflex.setActionScriptletId(splitActionId[1]);
                 }
 
-                Optional<Analysis> newAnalysis = addReflexTest(reflex, reflexBean.getResult(),
-                        reflexBean.getPatient().getId(), reflexBean.getSample(), true, true, addedActionId, false,
-                        sysUserId);
+                Optional<Analysis> newAnalysis = addReflexTest(reflex, reflexBean.getResult(), patientIdOf(reflexBean),
+                        reflexBean.getSample(), true, true, addedActionId, false, sysUserId);
                 if (newAnalysis.isPresent()) {
                     reflexAnalysises.add(newAnalysis.get());
                 }
@@ -424,8 +423,8 @@ public class TestReflexUtil {
                 boolean allSibAnalysisCausedReflex = doAllAnalysisHaveReflex(parentAnalysisList, reflexBean);
 
                 Optional<Analysis> newAnalysis = addReflexTest(reflexForResult, reflexBean.getResult(),
-                        reflexBean.getPatient().getId(), reflexBean.getSample(), true, true, null,
-                        allSibAnalysisCausedReflex, sysUserId);
+                        patientIdOf(reflexBean), reflexBean.getSample(), true, true, null, allSibAnalysisCausedReflex,
+                        sysUserId);
                 if (newAnalysis.isPresent()) {
                     reflexAnalysises.add(newAnalysis.get());
                 }
@@ -438,7 +437,7 @@ public class TestReflexUtil {
                     boolean handleAction = siblingReflex.getActionScriptletId() != null
                             && !siblingReflex.getActionScriptletId().equals(reflexForResult.getActionScriptletId());
 
-                    newAnalysis = addReflexTest(siblingReflex, reflexBean.getResult(), reflexBean.getPatient().getId(),
+                    newAnalysis = addReflexTest(siblingReflex, reflexBean.getResult(), patientIdOf(reflexBean),
                             reflexBean.getSample(), addTest, handleAction, null, allSibAnalysisCausedReflex, sysUserId);
                     if (newAnalysis.isPresent()) {
                         reflexAnalysises.add(newAnalysis.get());
@@ -554,6 +553,15 @@ public class TestReflexUtil {
             handledReflexsBySample.put(resultSet.getSample().getId(), handledReflexIdList);
         }
         return handledReflexIdList;
+    }
+
+    /**
+     * The patient id a reflex action is recorded against, or {@code null} for a
+     * sample without a patient (environmental and vector orders), which the
+     * observation history accepts (OGC-356).
+     */
+    public static String patientIdOf(TestReflexBean reflexBean) {
+        return reflexBean.getPatient() == null ? null : reflexBean.getPatient().getId();
     }
 
     private Optional<Analysis> addReflexTest(TestReflex reflex, Result result, String patientId, Sample sample,

--- a/src/test/java/org/openelisglobal/reports/action/implementation/PatientReportPatientlessTest.java
+++ b/src/test/java/org/openelisglobal/reports/action/implementation/PatientReportPatientlessTest.java
@@ -1,0 +1,45 @@
+package org.openelisglobal.reports.action.implementation;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.sample.service.SampleService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * OGC-1192 §2 — patient-scoped reports meet patientless (environmental)
+ * samples. Looking the patient up for such a sample must leave the report
+ * without a current patient instead of throwing, so the report loop can skip
+ * the sample.
+ */
+public class PatientReportPatientlessTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private SampleService sampleService;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/order-dashboard-patientless.xml");
+    }
+
+    @Test
+    public void findPatientFromSample_leavesNoCurrentPatient_forAPatientlessSample() {
+        PatientReport report = new PatientClinicalReport();
+        Sample patientless = sampleService.getSampleByAccessionNumber("DASH-0025");
+        assertNotNull(patientless);
+        ReflectionTestUtils.setField(report, "currentSample", patientless);
+        ReflectionTestUtils.setField(report, "currentPatient", new Patient());
+
+        ReflectionTestUtils.invokeMethod(report, "findPatientFromSample");
+
+        assertNull("a patientless sample must clear the current patient",
+                ReflectionTestUtils.getField(report, "currentPatient"));
+    }
+}

--- a/src/test/java/org/openelisglobal/sample/controller/rest/OrderDashboardPatientlessTest.java
+++ b/src/test/java/org/openelisglobal/sample/controller/rest/OrderDashboardPatientlessTest.java
@@ -1,0 +1,94 @@
+package org.openelisglobal.sample.controller.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * OGC-1192 §1 — the order dashboard must list a freshly saved order, including
+ * a patientless environmental one, no matter how many older samples the lab
+ * has. Fixture: {@code testdata/order-dashboard-patientless.xml} — 25 samples,
+ * the newest (DASH-0025) environmental and without a patient.
+ */
+public class OrderDashboardPatientlessTest extends BaseWebContextSensitiveTest {
+
+    private static final String NEWEST_ENVIRONMENTAL = "DASH-0025";
+
+    @Autowired
+    private IStatusService statusService;
+
+    private MockHttpSession session;
+    private MockMvc dashboardMvc;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/order-dashboard-patientless.xml");
+        authenticateAs("testUser");
+        statusService.refreshCache();
+        session = buildSession();
+        // The test context does not component-scan org.openelisglobal.sample.controller
+        // (AppTestConfig), so the controller is created against the real beans here.
+        dashboardMvc = MockMvcBuilders.standaloneSetup(
+                webApplicationContext.getAutowireCapableBeanFactory().createBean(OrderSearchRestController.class))
+                .build();
+    }
+
+    private MockHttpSession buildSession() {
+        UserDetails userDetails = User.withUsername("testUser").password("N/A").authorities("ROLE_ADMIN").build();
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, "N/A", userDetails.getAuthorities()));
+        UserSessionData userSessionData = new UserSessionData();
+        userSessionData.setSytemUserId(1);
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+        httpSession.setAttribute(IActionConstants.USER_SESSION_DATA, userSessionData);
+        return httpSession;
+    }
+
+    @Test
+    public void dashboard_listsTheNewestOrderFirst_evenBeyondTheDefaultPageSize() throws Exception {
+        dashboardMvc.perform(get("/rest/order/dashboard").param("page", "1").param("pageSize", "100").session(session))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.orders.length()").value(25))
+                .andExpect(jsonPath("$.orders[0].labNumber").value(NEWEST_ENVIRONMENTAL))
+                .andExpect(jsonPath("$.orders[24].labNumber").value("DASH-0001"));
+    }
+
+    @Test
+    public void dashboard_environmentalFilter_findsThePatientlessOrder() throws Exception {
+        dashboardMvc
+                .perform(get("/rest/order/dashboard").param("page", "1").param("pageSize", "100")
+                        .param("workflowType", "environmental").session(session))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.orders.length()").value(1))
+                .andExpect(jsonPath("$.orders[0].labNumber").value(NEWEST_ENVIRONMENTAL))
+                .andExpect(jsonPath("$.orders[0].workflowType").value("environmental"))
+                .andExpect(jsonPath("$.orders[0].samplingSiteName").value("CPHL"))
+                .andExpect(jsonPath("$.orders[0].patientName").isEmpty());
+    }
+
+    @Test
+    public void dashboard_honoursTheRequestedPageSize() throws Exception {
+        dashboardMvc.perform(get("/rest/order/dashboard").param("page", "2").param("pageSize", "10").session(session))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.orders.length()").value(10))
+                .andExpect(jsonPath("$.orders[0].labNumber").value("DASH-0015"))
+                .andExpect(jsonPath("$.orders[9].labNumber").value("DASH-0006"));
+    }
+}

--- a/src/test/java/org/openelisglobal/sample/controller/rest/SampleEditPatientlessTest.java
+++ b/src/test/java/org/openelisglobal/sample/controller/rest/SampleEditPatientlessTest.java
@@ -1,0 +1,110 @@
+package org.openelisglobal.sample.controller.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import org.apache.commons.validator.GenericValidator;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.action.IActionConstants;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.common.services.StatusService.SampleStatus;
+import org.openelisglobal.login.valueholder.UserSessionData;
+import org.openelisglobal.sample.form.SampleEditForm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * OGC-1192 §2 — a sample that exists but has no patient (an environmental
+ * order) must load in SampleEdit like any other sample, with the patient block
+ * simply empty, instead of failing with a NullPointerException (HTTP 500).
+ *
+ * The controller is exercised directly: the test context does not
+ * component-scan {@code org.openelisglobal.sample.controller}, and the form's
+ * JSON view needs the accession-number generator that only a running
+ * application configures.
+ */
+public class SampleEditPatientlessTest extends BaseWebContextSensitiveTest {
+
+    private static final String PATIENTLESS_ACCESSION = "DASH-0025";
+
+    @Autowired
+    private IStatusService statusService;
+
+    private SampleEditRestController controller;
+    private MockHttpServletRequest request;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        executeDataSetWithStateManagement("testdata/order-dashboard-patientless.xml");
+        authenticateAs("testUser");
+        statusService.refreshCache();
+        controller = webApplicationContext.getAutowireCapableBeanFactory().createBean(SampleEditRestController.class);
+        pinStatusIdsToThisFixture();
+        request = new MockHttpServletRequest();
+        request.setSession(buildSession());
+    }
+
+    /**
+     * The controller caches the "entered" sample status and the "canceled" analysis
+     * status in static sets when its class loads, i.e. against whichever fixture an
+     * earlier test class had loaded. Point them at this fixture's ids so the test
+     * does not depend on class order.
+     */
+    @SuppressWarnings("unchecked")
+    private void pinStatusIdsToThisFixture() {
+        Set<String> entered = (Set<String>) ReflectionTestUtils.getField(SampleEditRestController.class,
+                "ENTERED_STATUS_SAMPLE_LIST");
+        entered.clear();
+        entered.add(statusService.getStatusID(SampleStatus.Entered));
+        Set<String> excluded = (Set<String>) ReflectionTestUtils.getField(SampleEditRestController.class,
+                "excludedAnalysisStatusList");
+        excluded.clear();
+        excluded.add(statusService.getStatusID(AnalysisStatus.Canceled));
+    }
+
+    private MockHttpSession buildSession() {
+        UserDetails userDetails = User.withUsername("testUser").password("N/A").authorities("ROLE_ADMIN").build();
+        SecurityContext securityContext = new SecurityContextImpl();
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, "N/A", userDetails.getAuthorities()));
+        UserSessionData userSessionData = new UserSessionData();
+        userSessionData.setSytemUserId(1);
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+        httpSession.setAttribute(IActionConstants.USER_SESSION_DATA, userSessionData);
+        return httpSession;
+    }
+
+    @Test
+    public void sampleEdit_loadsAPatientlessSample_withAnEmptyPatientBlock() throws Exception {
+        SampleEditForm form = controller.showSampleEdit(request, PATIENTLESS_ACCESSION, null);
+
+        assertEquals(PATIENTLESS_ACCESSION, form.getAccessionNumber());
+        assertFalse("an existing sample is not reported as missing", Boolean.TRUE.equals(form.getNoSampleFound()));
+        assertEquals(1, form.getExistingTests().size());
+        assertEquals("Lead (Pb)", form.getExistingTests().get(0).getTestName());
+        assertTrue("no patient name for a patientless sample", GenericValidator.isBlankOrNull(form.getPatientName()));
+        assertTrue("no patient id for a patientless sample", GenericValidator.isBlankOrNull(form.getPatientId()));
+    }
+
+    @Test
+    public void sampleEdit_stillReportsAMissingSample() throws Exception {
+        SampleEditForm form = controller.showSampleEdit(request, "DASH-9999", null);
+
+        assertTrue(form.getNoSampleFound());
+    }
+}

--- a/src/test/java/org/openelisglobal/testReflex/action/util/TestReflexUtilPatientIdTest.java
+++ b/src/test/java/org/openelisglobal/testReflex/action/util/TestReflexUtilPatientIdTest.java
@@ -1,0 +1,32 @@
+package org.openelisglobal.testReflex.action.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.testreflex.action.util.TestReflexBean;
+import org.openelisglobal.testreflex.action.util.TestReflexUtil;
+
+/**
+ * OGC-1192 §2 — reflex handling for a patientless (environmental) sample: the
+ * patient id passed along to reflex actions is null instead of a
+ * NullPointerException on {@code reflexBean.getPatient().getId()}.
+ */
+public class TestReflexUtilPatientIdTest {
+
+    @Test
+    public void patientIdOf_isNull_whenTheSampleHasNoPatient() {
+        TestReflexBean bean = new TestReflexBean();
+        assertNull(TestReflexUtil.patientIdOf(bean));
+    }
+
+    @Test
+    public void patientIdOf_isThePatientId_whenThereIsOne() {
+        Patient patient = new Patient();
+        patient.setId("42");
+        TestReflexBean bean = new TestReflexBean();
+        bean.setPatient(patient);
+        assertEquals("42", TestReflexUtil.patientIdOf(bean));
+    }
+}

--- a/src/test/resources/testdata/order-dashboard-patientless.xml
+++ b/src/test/resources/testdata/order-dashboard-patientless.xml
@@ -1,0 +1,177 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <!-- OGC-1192: patientless (environmental) samples on the order dashboard
+        and in SampleEdit. 25 samples; only DASH-0025 (id 9125, the newest) is environmental
+        and it has no sample_human row. The count matters: the dashboard used to
+        page the OLDEST page.defaultPageSize+1 (=21) samples, so DASH-0025 was invisible. -->
+    <system_user id="1" login_name="testUser" last_name="Doe"
+        first_name="John" is_active="Y" is_employee="Y"
+        lastupdated="2025-01-01 12:00:00" />
+    <!-- status names must match StatusService.addTo*Map(): "SampleEntered"
+        is SampleStatus.Entered, which SampleEdit requires on sample items. -->
+    <status_of_sample id="1" description="Sample Entered"
+        code="1" status_type="SAMPLE" name="SampleEntered"
+        lastupdated="2025-01-01 12:00:00" />
+    <status_of_sample id="4" description="Not Tested"
+        code="4" status_type="ANALYSIS" name="Not Tested"
+        lastupdated="2025-01-01 12:00:00" />
+    <localization id="1" description="Test Name" />
+    <localization_value id="1" localization_id="1"
+        locale="en" value="Lead (Pb)" />
+    <supported_locale id="1" locale_code="en"
+        display_name="English" is_active="true" is_fallback="true"
+        sort_order="1" />
+    <type_of_sample id="1" description="Water Sample"
+        domain="E" name_localization_id="1" lastupdated="2025-01-01 12:00:00" />
+    <test_section id="1" name="Environmental"
+        description="Environmental Testing" is_external="N"
+        lastupdated="2025-01-01 12:00:00" sort_order="1"
+        name_localization_id="1" display_key="env" domain="ENVIRONMENTAL" />
+    <test_formats id="1" lastupdated="2025-01-01 12:00:00" />
+    <test id="1" description="Lead (Pb)" loinc="10368-9" is_active="Y"
+        is_reportable="Y" orderable="true" lastupdated="2025-01-01 12:00:00"
+        test_section_id="1" test_format_id="1" sort_order="1" name="Lead"
+        guid="test-lead-001" name_localization_id="1" />
+    <observation_history_type id="9001"
+        type_name="envWorkflowType" description="Environmental workflow type" />
+    <observation_history_type id="9002"
+        type_name="vecCollectionSiteName" description="Collection site name" />
+    <sample id="9101" accession_number="DASH-0001" domain="H"
+        status_id="1" received_date="2025-06-02 00:00:00.0"
+        entered_date="2025-06-02 00:00:00.0"
+        collection_date="2025-06-02 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-02 12:00:00" />
+    <sample id="9102" accession_number="DASH-0002" domain="H"
+        status_id="1" received_date="2025-06-03 00:00:00.0"
+        entered_date="2025-06-03 00:00:00.0"
+        collection_date="2025-06-03 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-03 12:00:00" />
+    <sample id="9103" accession_number="DASH-0003" domain="H"
+        status_id="1" received_date="2025-06-04 00:00:00.0"
+        entered_date="2025-06-04 00:00:00.0"
+        collection_date="2025-06-04 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-04 12:00:00" />
+    <sample id="9104" accession_number="DASH-0004" domain="H"
+        status_id="1" received_date="2025-06-05 00:00:00.0"
+        entered_date="2025-06-05 00:00:00.0"
+        collection_date="2025-06-05 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-05 12:00:00" />
+    <sample id="9105" accession_number="DASH-0005" domain="H"
+        status_id="1" received_date="2025-06-06 00:00:00.0"
+        entered_date="2025-06-06 00:00:00.0"
+        collection_date="2025-06-06 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-06 12:00:00" />
+    <sample id="9106" accession_number="DASH-0006" domain="H"
+        status_id="1" received_date="2025-06-07 00:00:00.0"
+        entered_date="2025-06-07 00:00:00.0"
+        collection_date="2025-06-07 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-07 12:00:00" />
+    <sample id="9107" accession_number="DASH-0007" domain="H"
+        status_id="1" received_date="2025-06-08 00:00:00.0"
+        entered_date="2025-06-08 00:00:00.0"
+        collection_date="2025-06-08 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-08 12:00:00" />
+    <sample id="9108" accession_number="DASH-0008" domain="H"
+        status_id="1" received_date="2025-06-09 00:00:00.0"
+        entered_date="2025-06-09 00:00:00.0"
+        collection_date="2025-06-09 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-09 12:00:00" />
+    <sample id="9109" accession_number="DASH-0009" domain="H"
+        status_id="1" received_date="2025-06-10 00:00:00.0"
+        entered_date="2025-06-10 00:00:00.0"
+        collection_date="2025-06-10 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-10 12:00:00" />
+    <sample id="9110" accession_number="DASH-0010" domain="H"
+        status_id="1" received_date="2025-06-11 00:00:00.0"
+        entered_date="2025-06-11 00:00:00.0"
+        collection_date="2025-06-11 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-11 12:00:00" />
+    <sample id="9111" accession_number="DASH-0011" domain="H"
+        status_id="1" received_date="2025-06-12 00:00:00.0"
+        entered_date="2025-06-12 00:00:00.0"
+        collection_date="2025-06-12 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-12 12:00:00" />
+    <sample id="9112" accession_number="DASH-0012" domain="H"
+        status_id="1" received_date="2025-06-13 00:00:00.0"
+        entered_date="2025-06-13 00:00:00.0"
+        collection_date="2025-06-13 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-13 12:00:00" />
+    <sample id="9113" accession_number="DASH-0013" domain="H"
+        status_id="1" received_date="2025-06-14 00:00:00.0"
+        entered_date="2025-06-14 00:00:00.0"
+        collection_date="2025-06-14 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-14 12:00:00" />
+    <sample id="9114" accession_number="DASH-0014" domain="H"
+        status_id="1" received_date="2025-06-15 00:00:00.0"
+        entered_date="2025-06-15 00:00:00.0"
+        collection_date="2025-06-15 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-15 12:00:00" />
+    <sample id="9115" accession_number="DASH-0015" domain="H"
+        status_id="1" received_date="2025-06-16 00:00:00.0"
+        entered_date="2025-06-16 00:00:00.0"
+        collection_date="2025-06-16 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-16 12:00:00" />
+    <sample id="9116" accession_number="DASH-0016" domain="H"
+        status_id="1" received_date="2025-06-17 00:00:00.0"
+        entered_date="2025-06-17 00:00:00.0"
+        collection_date="2025-06-17 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-17 12:00:00" />
+    <sample id="9117" accession_number="DASH-0017" domain="H"
+        status_id="1" received_date="2025-06-18 00:00:00.0"
+        entered_date="2025-06-18 00:00:00.0"
+        collection_date="2025-06-18 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-18 12:00:00" />
+    <sample id="9118" accession_number="DASH-0018" domain="H"
+        status_id="1" received_date="2025-06-19 00:00:00.0"
+        entered_date="2025-06-19 00:00:00.0"
+        collection_date="2025-06-19 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-19 12:00:00" />
+    <sample id="9119" accession_number="DASH-0019" domain="H"
+        status_id="1" received_date="2025-06-20 00:00:00.0"
+        entered_date="2025-06-20 00:00:00.0"
+        collection_date="2025-06-20 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-20 12:00:00" />
+    <sample id="9120" accession_number="DASH-0020" domain="H"
+        status_id="1" received_date="2025-06-21 00:00:00.0"
+        entered_date="2025-06-21 00:00:00.0"
+        collection_date="2025-06-21 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-21 12:00:00" />
+    <sample id="9121" accession_number="DASH-0021" domain="H"
+        status_id="1" received_date="2025-06-22 00:00:00.0"
+        entered_date="2025-06-22 00:00:00.0"
+        collection_date="2025-06-22 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-22 12:00:00" />
+    <sample id="9122" accession_number="DASH-0022" domain="H"
+        status_id="1" received_date="2025-06-23 00:00:00.0"
+        entered_date="2025-06-23 00:00:00.0"
+        collection_date="2025-06-23 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-23 12:00:00" />
+    <sample id="9123" accession_number="DASH-0023" domain="H"
+        status_id="1" received_date="2025-06-24 00:00:00.0"
+        entered_date="2025-06-24 00:00:00.0"
+        collection_date="2025-06-24 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-24 12:00:00" />
+    <sample id="9124" accession_number="DASH-0024" domain="H"
+        status_id="1" received_date="2025-06-25 00:00:00.0"
+        entered_date="2025-06-25 00:00:00.0"
+        collection_date="2025-06-25 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-25 12:00:00" />
+    <sample id="9125" accession_number="DASH-0025" domain="E"
+        status_id="1" received_date="2025-06-26 00:00:00.0"
+        entered_date="2025-06-26 00:00:00.0"
+        collection_date="2025-06-26 00:00:00.0" sys_user_id="1"
+        lastupdated="2025-06-26 12:00:00" />
+    <sample_item id="9125" sort_order="1" status_id="1"
+        samp_id="9125" typeosamp_id="1" collection_date="2025-06-26 10:00:00"
+        lastupdated="2025-06-26 12:00:00" />
+    <analysis id="9125" sampitem_id="9125" test_id="1"
+        test_sect_id="1" revision="0" status_id="4"
+        lastupdated="2025-06-26 12:00:00" analysis_type="MANUAL"
+        is_reportable="Y" />
+    <observation_history id="9125" sample_id="9125"
+        observation_history_type_id="9001" value_type="L"
+        value="environmental" lastupdated="2025-06-26 12:00:00" />
+    <observation_history id="9126" sample_id="9125"
+        observation_history_type_id="9002" value_type="L" value="CPHL"
+        lastupdated="2025-06-26 12:00:00" />
+</dataset>


### PR DESCRIPTION
Fixes [OGC-1192](https://uwdigi.atlassian.net/browse/OGC-1192).

**What changed**
- The order dashboard now lists the newest orders first and honours the requested page size, so a freshly saved environmental order shows up immediately (before: the oldest 21 samples, always).
- Editing a sample that has no patient (environmental orders) works instead of failing with a 500; the patient block is simply empty.
- Patient-scoped reports skip samples that have no patient instead of crashing, and reflex handling no longer assumes a patient.
- Reopening an environmental order from the dashboard (`?labNumber=`) loads it again, and its collection date keeps the day and month it was entered with.

**Why**
- The dashboard paged samples oldest-first with the system default page size, so nothing newer than the first page ever reached it — not a patient join, as the ticket suspected. Three separate code paths dereferenced the patient without a null check. The order page only read `?order=` and parsed backend dates before the site's date locale had loaded.

**How it was tested**
- New backend tests: dashboard newest-first / page size / environmental filter, SampleEdit on a patientless sample, patient report guard, reflex helper. New frontend test for loading an order from either URL parameter under both date locales. Full backend and frontend suites green; live check on a dev stack with a patientless environmental sample (dashboard, SampleEdit, order reload, ModifyOrder, patient report).

**Notes**
- §4 of the ticket (empty CONTAINER dropdown) is reference data, not code: that server has no `Sample Container` dictionary rows. They come from `volume/configuration/backend/dictionaries/environmental-site-dictionaries.csv`; a fresh dev install has all seven. On testing, check `dictionary_category` for `Sample Container` and reload the configuration with `force=true` if the file is newer than the recorded checksum (adjacent to OGC-1161).
- Deep links now wait for the site configuration before loading the order; if that request never completes the page stays blank rather than guessing the date order.


[OGC-1192]: https://uwdigi.atlassian.net/browse/OGC-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ