### PR TITLE
feat(eqa): a provider prints the performance report for one participant (OGC-933)

### DIFF
--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -33,6 +33,7 @@ import {
   saveIntake,
   scoreCycle,
   scoresCsvUrl,
+  participantReportUrl,
   sendRepeat,
 } from "./workbenchApi";
 
@@ -524,6 +525,17 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                             href={scoresCsvUrl(cycleId, row.organizationId)}
                           >
                             {t("eqa.score.downloadCsv", "Scores CSV")}
+                          </Button>
+                          <Button
+                            kind="ghost"
+                            size="sm"
+                            href={participantReportUrl(
+                              cycleId,
+                              row.organizationId,
+                            )}
+                            target="_blank"
+                          >
+                            {t("eqa.score.downloadReport", "Report PDF")}
                           </Button>
                         </>
                       )}

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -190,6 +190,10 @@ export const distributeScores = (cycleId, organizationId, callback) =>
 export const scoresCsvUrl = (cycleId, organizationId) =>
   `${config.serverBaseUrl}/rest/eqa/cycles/${cycleId}/scores/${organizationId}/csv`;
 
+/** The same rows as the scores CSV, printed as the report a participant is sent. */
+export const participantReportUrl = (cycleId, organizationId) =>
+  `${config.serverBaseUrl}/rest/eqa/cycles/${cycleId}/participants/${organizationId}/performance-report`;
+
 // --- Provider-side result intake (phoned/emailed results, export bundles) ---
 
 /** The scheme's tests with what this participant has reported so far. */

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8578,5 +8578,6 @@
   "eqa.receipt.readOnly.title": "Read-only view of receipts and scores",
   "eqa.receipt.readOnly.body": "Recording a delivery, dispatching a repeat, entering results and returning scores all need the provider grant; scoring the cycle needs the manage grant. The table below is the whole cycle either way.",
   "eqa.inhouse.readOnly.title": "Read-only view of in-house panels",
-  "eqa.inhouse.readOnly.body": "Designing and sealing a blinded panel needs the manage grant. The panels below are the whole picture either way."
+  "eqa.inhouse.readOnly.body": "Designing and sealing a blinded panel needs the manage grant. The panels below are the whole picture either way.",
+  "eqa.score.downloadReport": "Report PDF"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -118,6 +118,25 @@ public class EQACycleRestController extends BaseRestController {
     }
 
     /**
+     * The provider's copy of the report for one participating laboratory, built
+     * from what that laboratory reported into this cycle. Same grain as the scores
+     * CSV beside it on the workbench, so the two cannot disagree.
+     */
+    @GetMapping(value = "/cycles/{cycleId}/participants/{organizationId}/performance-report", produces = MediaType.APPLICATION_PDF_VALUE)
+    public ResponseEntity<byte[]> participantPerformanceReport(@PathVariable Long cycleId,
+            @PathVariable Long organizationId) {
+        byte[] pdf;
+        try {
+            pdf = performanceReportService.generateParticipantPerformanceReport(cycleId, organizationId);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+        String filename = "eqa-performance-report-cycle-" + cycleId + "-org-" + organizationId + ".pdf";
+        return ResponseEntity.ok().header("Content-Disposition", "inline; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_PDF).body(pdf);
+    }
+
+    /**
      * OGC-934: the pre-approved comment library the picker offers. Maintained as a
      * dictionary category, so an installation edits the wording without a release.
      */

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFService.java
@@ -9,4 +9,15 @@ public interface EQAPerformanceReportPDFService {
 
     /** Renders one cycle's report. Unsubmitted (DRAFT) results are excluded. */
     byte[] generatePerformanceReport(Long cycleId);
+
+    /**
+     * Renders the report a provider sends one participating laboratory, from the
+     * results that laboratory reported into this cycle. Same layout as the report a
+     * laboratory prints for itself, minus the two columns that belong to the
+     * reporting laboratory rather than to the provider judging it.
+     *
+     * @param cycleId        the provider cycle
+     * @param organizationId the participating laboratory
+     */
+    byte[] generateParticipantPerformanceReport(Long cycleId, Long organizationId);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPerformanceReportPDFServiceImpl.java
@@ -37,19 +37,27 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
+import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQADistribution;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
+import org.openelisglobal.eqa.valueholder.EQAResult;
+import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.internationalization.MessageUtil;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.qaevent.service.EqaScoreNceService;
 import org.openelisglobal.qaevent.service.NCEventService;
 import org.openelisglobal.qaevent.valueholder.NcEvent;
 import org.openelisglobal.systemuser.dao.SystemUserDAO;
 import org.openelisglobal.systemuser.valueholder.SystemUser;
+import org.openelisglobal.test.service.TestService;
+import org.openelisglobal.test.valueholder.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,27 +95,59 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
     private NCEventService ncEventService;
     @Autowired
     private EQAReportCommentService reportCommentService;
+    @Autowired
+    private EQAProviderScoringService providerScoringService;
+    @Autowired
+    private EQARoundDAO eqaRoundDAO;
+    @Autowired
+    private TestService testService;
+    @Autowired
+    private OrganizationService organizationService;
 
     @Override
     public byte[] generatePerformanceReport(Long cycleId) {
-        EQACycle cycle = eqaCycleDAO.get(cycleId)
-                .orElseThrow(() -> new IllegalArgumentException("Unknown cycle " + cycleId));
-        EQAProgram scheme = cycle.getScheme();
-
+        EQACycle cycle = cycleOrThrow(cycleId);
         // Everything the PDF prints is resolved inside this transaction: the
         // renderer runs after the session would otherwise be gone.
-        List<Row> rows = collectRows(cycleId);
+        return render(cycle, collectRows(cycleId), null, true);
+    }
 
+    /**
+     * The provider's copy for one participating laboratory. Its rows come from
+     * {@code eqa_result} — where a remote laboratory's submissions land — rather
+     * than from {@code eqa_participant_result}, which holds only this instance's
+     * own participation, so a provider cycle prints the results its Receipts tab
+     * shows instead of an empty report.
+     */
+    @Override
+    public byte[] generateParticipantPerformanceReport(Long cycleId, Long organizationId) {
+        EQACycle cycle = cycleOrThrow(cycleId);
+        return render(cycle, collectProviderRows(cycle, organizationId), participantName(organizationId), false);
+    }
+
+    private EQACycle cycleOrThrow(Long cycleId) {
+        return eqaCycleDAO.get(cycleId).orElseThrow(() -> new IllegalArgumentException("Unknown cycle " + cycleId));
+    }
+
+    /**
+     * One layout, two data sources. {@code includeLabColumns} drops the three
+     * columns a provider's copy cannot fill — NCE and Analyst belong to the
+     * laboratory that reported the result rather than to the provider judging it,
+     * and {@code eqa_result} carries no per-row scoring stamp — rather than
+     * printing them empty, because a column that is always blank reads as a missing
+     * value.
+     */
+    private byte[] render(EQACycle cycle, List<Row> rows, String participant, boolean includeLabColumns) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Document document = new Document(PageSize.A4.rotate(), 36, 36, 42, 42);
         try {
             PdfWriter.getInstance(document, out);
             document.open();
-            addHeader(document, cycle, scheme, rows.size());
+            addHeader(document, cycle, cycle.getScheme(), rows.size(), participant);
             addProgrammeSummary(document, rows);
             addSectionSummary(document, rows);
-            addScoringTable(document, rows);
-            addInterpretiveComments(document, cycleId);
+            addScoringTable(document, rows, includeLabColumns);
+            addInterpretiveComments(document, cycle.getId());
             addSignOff(document);
             document.close();
         } catch (DocumentException e) {
@@ -179,7 +219,89 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
         return rows;
     }
 
-    private void addHeader(Document document, EQACycle cycle, EQAProgram scheme, int rowCount)
+    /**
+     * The provider's view of one laboratory's submissions. Everything the layout
+     * needs is on {@code eqa_result} or derivable from its test: the round through
+     * the distribution, the section through the test, and the analyte through the
+     * test's own name — the route the submission bridge already resolves analytes
+     * by, so both instances name the same one.
+     */
+    private List<Row> collectProviderRows(EQACycle cycle, Long organizationId) {
+        // A numeric target is copied onto the result when it is scored; a
+        // qualitative one is numeric-typed there and so lives only on the panel
+        // sample that sealed it.
+        Map<Long, String> sealedTargets = providerScoringService.sealedTargetsByTest(cycle.getId());
+        List<Row> rows = new ArrayList<>();
+        for (EQAResult result : providerScoringService.reportedResultsFor(cycle.getId(), organizationId)) {
+            Test test = testOf(result.getTestId());
+            rows.add(new Row(roundNumberOf(result), sectionOf(test), analyteLabelOf(test, result.getTestId()),
+                    reportedOf(result), targetOf(result, sealedTargets), null, result.getZScore(),
+                    result.getPerformanceStatus(), null, null,
+                    result.getSubmissionDate() == null ? null : formatDay(result.getSubmissionDate()), null));
+        }
+        rows.sort(Comparator.comparing(Row::round, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(Row::section, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(Row::analyte, Comparator.nullsLast(Comparator.naturalOrder())));
+        return rows;
+    }
+
+    /**
+     * A numeric target is copied onto the result when it is scored, so that is the
+     * value it was actually judged against. The sealed target is consulted only for
+     * a qualitative answer, whose target is a word that {@code target_value} —
+     * numeric — cannot hold: falling back for a number as well would guess, since a
+     * panel may seal two samples against one analyte.
+     */
+    private static String targetOf(EQAResult result, Map<Long, String> sealedTargets) {
+        if (result.getResultText() != null) {
+            return sealedTargets.get(result.getTestId());
+        }
+        return number(result.getTargetValue());
+    }
+
+    /** Numeric results carry the value; a qualitative one carries its text. */
+    private static String reportedOf(EQAResult result) {
+        return result.getResultText() != null ? result.getResultText() : number(result.getResultValue());
+    }
+
+    private static String number(BigDecimal value) {
+        return value == null ? null : value.stripTrailingZeros().toPlainString();
+    }
+
+    private Integer roundNumberOf(EQAResult result) {
+        EQADistribution distribution = result.getEqaDistribution();
+        if (distribution == null || distribution.getRoundId() == null) {
+            return null;
+        }
+        return eqaRoundDAO.get(distribution.getRoundId()).map(EQARound::getRoundNumber).orElse(null);
+    }
+
+    private Test testOf(Long testId) {
+        return testId == null ? null : testService.get(String.valueOf(testId));
+    }
+
+    private String sectionOf(Test test) {
+        return test == null || test.getTestSection() == null ? null : test.getTestSection().getTestSectionName();
+    }
+
+    /**
+     * An id that resolves to no test still prints as the id, the way the
+     * participant's report does: a blank cell would hide which row the data fault
+     * is on.
+     */
+    private String analyteLabelOf(Test test, Long testId) {
+        return test == null ? key(testId) : test.getName();
+    }
+
+    private String participantName(Long organizationId) {
+        if (organizationId == null) {
+            return null;
+        }
+        Organization organization = organizationService.get(String.valueOf(organizationId));
+        return organization == null ? String.valueOf(organizationId) : organization.getOrganizationName();
+    }
+
+    private void addHeader(Document document, EQACycle cycle, EQAProgram scheme, int rowCount, String participant)
             throws DocumentException {
         document.add(paragraph(MessageUtil.getMessage("eqa.report.title"), TITLE_FONT, 6f));
 
@@ -194,6 +316,12 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
         metaCell(meta, MessageUtil.getMessage("eqa.report.period"), period(cycle));
         metaCell(meta, MessageUtil.getMessage("eqa.report.laboratory"), siteName());
         metaCell(meta, MessageUtil.getMessage("eqa.report.generated"), formatDate(new Date()));
+        if (participant != null) {
+            // Whose results these are. On the provider's copy the Laboratory cell
+            // above names the provider, so without this line the two would be
+            // indistinguishable.
+            metaCell(meta, MessageUtil.getMessage("eqa.report.participant"), participant);
+        }
         document.add(meta);
 
         if (rowCount == 0) {
@@ -250,22 +378,32 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
      * A cycle can run several rounds, and the same analyte is reported in each. The
      * round column is what keeps two such rows apart.
      */
-    private void addScoringTable(Document document, List<Row> rows) throws DocumentException {
+    private void addScoringTable(Document document, List<Row> rows, boolean includeLabColumns)
+            throws DocumentException {
         if (rows.isEmpty()) {
             return;
         }
         document.add(paragraph(MessageUtil.getMessage("eqa.report.table.title"), SECTION_FONT, 14f));
 
-        PdfPTable table = new PdfPTable(new float[] { 0.8f, 2f, 1.5f, 1.5f, 0.9f, 1.4f, 1.4f, 1.4f, 1.2f, 1.2f });
+        float[] widths = includeLabColumns ? new float[] { 0.8f, 2f, 1.5f, 1.5f, 0.9f, 1.4f, 1.4f, 1.4f, 1.2f, 1.2f }
+                : new float[] { 0.8f, 2.4f, 1.7f, 1.7f, 1f, 1.6f, 1.4f };
+        int columns = widths.length;
+        PdfPTable table = new PdfPTable(widths);
         table.setWidthPercentage(100);
         table.setHeaderRows(1);
-        headerRow(table, MessageUtil.getMessage("eqa.report.table.round"),
+        List<String> headers = new ArrayList<>(List.of(MessageUtil.getMessage("eqa.report.table.round"),
                 MessageUtil.getMessage("eqa.report.table.analyte"), MessageUtil.getMessage("eqa.report.table.reported"),
                 MessageUtil.getMessage("eqa.report.table.target"), MessageUtil.getMessage("eqa.report.table.zscore"),
-                MessageUtil.getMessage("eqa.report.table.performance"), MessageUtil.getMessage("eqa.report.table.nce"),
-                MessageUtil.getMessage("eqa.report.table.analyst"),
-                MessageUtil.getMessage("eqa.report.table.submitted"),
-                MessageUtil.getMessage("eqa.report.table.scored"));
+                MessageUtil.getMessage("eqa.report.table.performance")));
+        if (includeLabColumns) {
+            headers.add(MessageUtil.getMessage("eqa.report.table.nce"));
+            headers.add(MessageUtil.getMessage("eqa.report.table.analyst"));
+        }
+        headers.add(MessageUtil.getMessage("eqa.report.table.submitted"));
+        if (includeLabColumns) {
+            headers.add(MessageUtil.getMessage("eqa.report.table.scored"));
+        }
+        headerRow(table, headers.toArray(new String[0]));
 
         // Section rides above its rows as a banner rather than repeating in every
         // line: as a column it wrapped each row onto two lines and made the table
@@ -275,14 +413,22 @@ public class EQAPerformanceReportPDFServiceImpl implements EQAPerformanceReportP
             if (!row.sectionLabel().equals(currentSection)) {
                 currentSection = row.sectionLabel();
                 PdfPCell banner = new PdfPCell(new Phrase(currentSection, SECTION_ROW_FONT));
-                banner.setColspan(10);
+                banner.setColspan(columns);
                 banner.setBackgroundColor(SECTION_BG);
                 banner.setPadding(4f);
                 table.addCell(banner);
             }
-            bodyRow(table, row.roundLabel(), row.analyteLabel(), row.reportedLabel(), row.targetLabel(), row.zLabel(),
-                    row.performanceLabel(), dash(row.nceNumber()), dash(row.analyst()), dash(row.submittedAt()),
-                    dash(row.scoredAt()));
+            List<String> cells = new ArrayList<>(List.of(row.roundLabel(), row.analyteLabel(), row.reportedLabel(),
+                    row.targetLabel(), row.zLabel(), row.performanceLabel()));
+            if (includeLabColumns) {
+                cells.add(dash(row.nceNumber()));
+                cells.add(dash(row.analyst()));
+            }
+            cells.add(dash(row.submittedAt()));
+            if (includeLabColumns) {
+                cells.add(dash(row.scoredAt()));
+            }
+            bodyRow(table, cells.toArray(new String[0]));
         }
         document.add(table);
     }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
@@ -2,6 +2,7 @@ package org.openelisglobal.eqa.service;
 
 import java.util.List;
 import java.util.Map;
+import org.openelisglobal.eqa.valueholder.EQAResult;
 import org.openelisglobal.eqa.valueholder.EQASubmissionMethod;
 
 /**
@@ -40,6 +41,23 @@ public interface EQAProviderScoringService {
 
     /** One participant's scores as CSV (FR-V2.5-04 manual return channel). */
     String buildScoreCsv(Long cycleId, Long organizationId);
+
+    /**
+     * What one participating laboratory reported into this cycle, as scored. Shared
+     * with the per-participant performance report so the PDF and the scores CSV
+     * cannot disagree about which rows belong to a laboratory.
+     */
+    List<EQAResult> reportedResultsFor(Long cycleId, Long organizationId);
+
+    /**
+     * The sealed target for each of the cycle's tests, keyed by test id, as a word
+     * or a number. {@code eqa_result.target_value} is numeric, so a qualitative
+     * target lives only on the panel sample that sealed it — the report reads it
+     * here rather than deriving the panel a second time. Where a panel seals two
+     * samples against one analyte the last wins, which is the same reading the
+     * scoring pass itself takes.
+     */
+    Map<Long, String> sealedTargetsByTest(Long cycleId);
 
     /**
      * The intake grid for one participant: the scheme's tests with the value

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -370,6 +370,22 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     /**
      * The targets this cycle's panel material sealed, by the analyte each answers.
      */
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Long, String> sealedTargetsByTest(Long cycleId) {
+        EQACycle cycle = cycle(cycleId);
+        Map<Long, EQAPanelSample> byAnalyte = sealedTargetsByAnalyte(cycle);
+        Map<Long, String> byTest = new HashMap<>();
+        for (EQAProgramTest assignment : eqaProgramService.getTestAssignments(cycle.getScheme().getId())) {
+            Long analyteId = analyteIdOrNull(assignment.getTestId());
+            EQAPanelSample sample = analyteId == null ? null : byAnalyte.get(analyteId);
+            if (sample != null) {
+                byTest.put(assignment.getTestId(), sample.getTargetValue());
+            }
+        }
+        return byTest;
+    }
+
     private Map<Long, EQAPanelSample> sealedTargetsByAnalyte(EQACycle cycle) {
         Map<Long, EQAPanelSample> targetByAnalyte = new HashMap<>();
         for (EQAPanel panel : eqaPanelDAO.getAllMatching("cycle.id", cycle.getId())) {
@@ -527,6 +543,12 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             byOrganization.computeIfAbsent(result.getParticipantOrganizationId(), key -> new ArrayList<>()).add(result);
         }
         return byOrganization;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EQAResult> reportedResultsFor(Long cycleId, Long organizationId) {
+        return resultsFor(cycleId, organizationId);
     }
 
     private List<EQAResult> resultsFor(Long cycleId, Long organizationId) {

--- a/src/main/resources/languages/message_en.properties
+++ b/src/main/resources/languages/message_en.properties
@@ -8496,6 +8496,7 @@ eqa.report.cycle = Cycle
 eqa.report.period = Planned period
 eqa.report.laboratory = Laboratory
 eqa.report.generated = Generated
+eqa.report.participant = Participant
 eqa.report.noResults = No participant results have been recorded for this cycle.
 eqa.report.unassignedSection = Unassigned section
 eqa.report.summary.programme = Programme summary

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.itextpdf.text.pdf.PdfReader;
+import com.itextpdf.text.pdf.parser.PdfTextExtractor;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +15,7 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.service.EQAPerformanceReportPDFService;
 import org.openelisglobal.eqa.service.EQAProviderScoringService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
@@ -42,6 +46,8 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
     private EQAProviderScoringService scoringService;
     @Autowired
     private EQAPanelSampleDAO eqaPanelSampleDAO;
+    @Autowired
+    private EQAPerformanceReportPDFService reportService;
 
     private EQAProgram scheme;
     private EQACycle cycle;
@@ -198,6 +204,63 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
         assertEquals("the failure reaches the follow-up register", Integer.valueOf(1),
                 jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_participant_followup WHERE cycle_id = ?",
                         Integer.class, cycle.getId()));
+    }
+
+    /**
+     * The provider's own copy of the performance report. It reads
+     * {@code eqa_result} — where a remote laboratory's submissions land — so a
+     * provider cycle prints the results its Receipts tab shows rather than the
+     * empty report the participant-table build produced for every external cycle.
+     */
+    @Test
+    public void theProviderPrintsAPerParticipantReportFromWhatTheLaboratoryReported() throws IOException {
+        for (int i = 0; i < ORGS; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i,
+                    Map.of(TEST_SERO, i == ORGS - 1 ? "Non-reactive" : "reactive"), EQASubmissionMethod.MANUAL, USER);
+        }
+        scoringService.scoreCycle(cycle.getId(), USER);
+        long failing = FIRST_ORG + ORGS - 1;
+
+        String text = providerReportText(failing);
+
+        assertTrue("the report names the laboratory it is about, not just the provider",
+                text.contains("Intake lab " + failing));
+        assertTrue("the analyte the laboratory reported", text.contains("Intake HIV serology test"));
+        assertTrue("the value it reported", text.contains("Non-reactive"));
+        assertTrue("the target it was judged against", text.contains("Reactive"));
+        assertTrue("its verdict", text.contains("Unacceptable"));
+        assertTrue("the scoring detail renders rather than the empty-report notice", text.contains("Scoring detail"));
+        assertTrue("the empty-report notice is gone",
+                !text.contains("No participant results have been recorded for this cycle"));
+
+        // The two columns that belong to the reporting laboratory rather than to the
+        // provider judging it are dropped, not printed empty: a column that can only
+        // ever be blank on this lane reads as a missing value.
+        assertTrue("no NCE column on a provider's copy", !text.contains("NCE"));
+        assertTrue("no Analyst column on a provider's copy", !text.contains("Analyst"));
+        assertTrue("no Scored on column either: eqa_result carries no per-row scoring stamp",
+                !text.contains("Scored on"));
+
+        // Same grain as the scores CSV beside it on the workbench, so the two cannot
+        // disagree about which rows belong to a laboratory.
+        assertTrue("another laboratory's value is not on this report",
+                !providerReportText(FIRST_ORG).contains("Non-reactive"));
+        assertEquals("one printed row per scores-CSV row", 1,
+                scoringService.buildScoreCsv(cycle.getId(), failing).lines().count() - 1);
+    }
+
+    private String providerReportText(long organizationId) throws IOException {
+        byte[] pdf = reportService.generateParticipantPerformanceReport(cycle.getId(), organizationId);
+        PdfReader reader = new PdfReader(pdf);
+        try {
+            StringBuilder text = new StringBuilder();
+            for (int page = 1; page <= reader.getNumberOfPages(); page++) {
+                text.append(PdfTextExtractor.getTextFromPage(reader, page)).append('\n');
+            }
+            return text.toString();
+        } finally {
+            reader.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

A provider cycle's performance report rendered *"No participant results have been recorded for this cycle"* while the same cycle's **Receipts & scoring** tab listed every value. And nothing linked to it: the only caller of `/performance-report` was the participant's My Cycles page.

## Why it happened

`EQAPerformanceReportPDFServiceImpl` built every report from `eqa_participant_result`, which holds only this instance's own participation — a remote laboratory's submissions land in `eqa_result`, at organization grain. So an in-house cycle printed a full report and every external cycle printed the empty one.

The specs put this report on the provider, per participant: FR-V2.5-04 has the provider *"package a PDF / CSV performance report"*, the V2.5 narrative has the provider export it at cycle close, and the CSV half already ships at exactly that grain (`buildScoreCsv(cycleId, organizationId)`, with a **Scores CSV** button on every participant row). This is the PDF half of that FR.

## The change

`GET /rest/eqa/cycles/{cycleId}/participants/{organizationId}/performance-report`, and a **Report PDF** button beside the Scores CSV one it matches.

One layout, two data sources — the shipped renderer is reused unchanged, so the two reports cannot drift apart. The provider's rows come from `eqa_result`:

- direct — reported value (numeric or text), target, z-score, verdict, submitted date
- derived — round through `eqa_distribution.round_id`, section through the test, analyte through the test's own name (the route [#4199](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4199) established, so both instances name the same one)
- the laboratory itself, named in a new **Participant** header cell

**Three columns are dropped rather than printed empty.** NCE and Analyst belong to the laboratory that reported the result rather than to the provider judging it, and `eqa_result` carries no per-row scoring stamp — so on this lane they could only ever be blank, and a column that is always blank reads as a missing value. The report a laboratory prints for itself is unchanged, all ten columns included.

A qualitative target is read from the panel sample that sealed it, because `eqa_result.target_value` is numeric and cannot hold a word. A numeric target is not looked up that way: the value copied onto the result when it was scored is what it was actually judged against, and a panel may seal two samples against one analyte.

Interpretive comments stay keyed on the cycle. They come from a curated library with no free-text input, so nothing laboratory-specific can be written and identical standardised commentary is what a cycle-wide observation means. Settled with the epic before this was built.

## Verification

Driven on the UAT rig against three provider cycles, each report compared with its own scores CSV:

| cycle | CSV row | printed row |
| --- | --- | --- |
| 7 | `80.00000, 40.00000, 1.78797, UNACCEPTABLE` | `80 / 40 / 1.78797 / Unacceptable` |
| 12 | `105.00000, 100.00000, , ACCEPTABLE` | `105 / 100 / — / Acceptable` |
| 5 | one row for this laboratory | one printed row, another laboratory's value absent |

Cycle 12's report also prints its attached interpretive comment with attribution. The workbench renders **Report PDF** on all five participant rows pointing at the new endpoint, and the same instance's own report for a provider cycle is untouched — still the participant's copy.

The deployed class fingerprints 35463 bytes in all four Tomcat contexts across both instances.

## Tests

561 EQA tests green, one new: the provider prints a per-participant report from what the laboratory reported, naming the laboratory, its value, the sealed target it was judged against and its verdict; without the NCE, Analyst or Scored-on columns; with another laboratory's value absent; and at the same row count as the scores CSV. Inverted — pointing the provider report back at the participant table — it fails on the analyte the laboratory reported.

166 EQA frontend tests green.

## Not in scope

`eqa_cycle.actual_end_date` has no writer anywhere in the tree, so a scored cycle records no scoring date. That is why the Scored-on column is dropped here rather than filled, and it is carded separately.
