### PR TITLE
feat(questionnaire): store programme questionnaires in OpenELIS, FHIR store optional

### DIFF
--- a/src/main/java/org/openelisglobal/common/services/SampleOrderService.java
+++ b/src/main/java/org/openelisglobal/common/services/SampleOrderService.java
@@ -20,12 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.validator.GenericValidator;
-import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.openelisglobal.common.formfields.FormFields;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.StringUtil;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.observationhistory.service.ObservationHistoryService;
 import org.openelisglobal.observationhistory.service.ObservationHistoryServiceImpl.ObservationType;
 import org.openelisglobal.observationhistory.valueholder.ObservationHistory;
@@ -39,6 +37,7 @@ import org.openelisglobal.program.service.ProgramSampleService;
 import org.openelisglobal.program.valueholder.ProgramSample;
 import org.openelisglobal.provider.service.ProviderService;
 import org.openelisglobal.provider.valueholder.Provider;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.requester.valueholder.SampleRequester;
 import org.openelisglobal.sample.bean.SampleOrderItem;
 import org.openelisglobal.sample.service.SampleService;
@@ -56,7 +55,6 @@ import org.springframework.stereotype.Service;
 public class SampleOrderService {
 
     private ProgramSampleService programSampleService = SpringContext.getBean(ProgramSampleService.class);
-    private FhirUtil fhirUtil = SpringContext.getBean(FhirUtil.class);
     private static SampleService sampleService = SpringContext.getBean(SampleService.class);
     private static OrganizationService orgService = SpringContext.getBean(OrganizationService.class);
     private ObservationHistoryService observationHistoryService = SpringContext
@@ -171,11 +169,8 @@ public class SampleOrderService {
                     .getProgrammeSampleBySample(Integer.valueOf(sample.getId()), programName);
             if (programSample != null) {
                 sampleOrder.setProgramId(programSample.getProgram().getId());
-                if (programSample.getQuestionnaireResponseUuid() != null) {
-                    sampleOrder.setAdditionalQuestions(
-                            fhirUtil.getLocalFhirClient().read().resource(QuestionnaireResponse.class)
-                                    .withId(programSample.getQuestionnaireResponseUuid().toString()).execute());
-                }
+                sampleOrder.setAdditionalQuestions(SpringContext.getBean(QuestionnaireStorageService.class)
+                        .getQuestionnaireResponse(programSample.getQuestionnaireResponseUuid()).orElse(null));
             }
 
             RequesterService requesterService = new RequesterService(sample.getId());

--- a/src/main/java/org/openelisglobal/dataexchange/fhir/controller/FhirQueryRestController.java
+++ b/src/main/java/org/openelisglobal/dataexchange/fhir/controller/FhirQueryRestController.java
@@ -6,6 +6,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import liquibase.repackaged.org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.CapabilityStatement;
@@ -14,6 +15,7 @@ import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.internationalization.MessageUtil;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -48,6 +50,8 @@ public class FhirQueryRestController extends BaseController {
 
     @Autowired
     private FhirUtil fhirUtil;
+    @Autowired
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private FhirConfig fhirConfig;
@@ -162,6 +166,18 @@ public class FhirQueryRestController extends BaseController {
             @PathVariable("resourceId") String resourceId) {
 
         try {
+            if ("Questionnaire".equals(resourceType) || "QuestionnaireResponse".equals(resourceType)) {
+                Optional<? extends org.hl7.fhir.instance.model.api.IBaseResource> stored = "Questionnaire"
+                        .equals(resourceType) ? questionnaireStorageService.getQuestionnaire(resourceId)
+                                : questionnaireStorageService.getQuestionnaireResponse(resourceId);
+                if (stored.isPresent()) {
+                    return ResponseEntity.ok(stored.get());
+                }
+                Map<String, String> errorResponse = new HashMap<>();
+                errorResponse.put("error", "Failed to get FHIR resource: " + resourceType + "/" + resourceId);
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+            }
+
             if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
                 Map<String, String> errorResponse = new HashMap<>();
                 errorResponse.put("error", "FHIR store path is not configured");

--- a/src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java
+++ b/src/main/java/org/openelisglobal/genericsample/service/GenericSampleOrderServiceImpl.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.GenericValidator;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.*;
@@ -45,10 +44,8 @@ import org.openelisglobal.common.services.IStatusService;
 import org.openelisglobal.common.services.StatusService.OrderStatus;
 import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.DateUtil;
-import org.openelisglobal.dataexchange.fhir.FhirConfig;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
-import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.genericsample.form.GenericSampleImportResult;
 import org.openelisglobal.genericsample.form.GenericSampleImportResult.ImportRow;
 import org.openelisglobal.genericsample.form.GenericSampleOrderForm;
@@ -60,6 +57,7 @@ import org.openelisglobal.program.service.ProgramSampleService;
 import org.openelisglobal.program.service.ProgramService;
 import org.openelisglobal.program.valueholder.Program;
 import org.openelisglobal.program.valueholder.ProgramSample;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.sample.dao.SampleDAO;
 import org.openelisglobal.sample.service.SampleService;
 import org.openelisglobal.sample.util.AccessionNumberUtil;
@@ -118,13 +116,10 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
     private NoteBookSampleService noteBookSampleService;
 
     @Autowired
-    private FhirPersistanceService fhirPersistanceService;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private FhirUtil fhirUtil;
-
-    @Autowired
-    private FhirConfig fhirConfig;
 
     @Autowired
     private BarcodeInfoService barcodeInfoService;
@@ -486,10 +481,10 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
             QuestionnaireResponse questionnaireResponse = createQuestionnaireResponse(form.getFhirQuestionnaire(),
                     form.getFhirResponses(), questionnaireResponseUuid);
             LogEvent.logInfo(this.getClass().getSimpleName(), "saveProgramSample",
-                    "Saving QuestionnaireResponse to FHIR store for sample: " + sample.getAccessionNumber());
-            fhirPersistanceService.updateFhirResourceInFhirStore(questionnaireResponse);
+                    "Saving QuestionnaireResponse for sample: " + sample.getAccessionNumber());
+            questionnaireStorageService.saveQuestionnaireResponse(questionnaireResponse);
             LogEvent.logInfo(this.getClass().getSimpleName(), "saveProgramSample",
-                    "QuestionnaireResponse saved successfully to FHIR store");
+                    "QuestionnaireResponse saved successfully");
         }
 
         LogEvent.logInfo(this.getClass().getSimpleName(), "saveProgramSample",
@@ -548,10 +543,10 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
             QuestionnaireResponse questionnaireResponse = createQuestionnaireResponse(form.getFhirQuestionnaire(),
                     form.getFhirResponses(), questionnaireResponseUuid);
             LogEvent.logInfo(this.getClass().getSimpleName(), "saveNotebookSample",
-                    "Saving QuestionnaireResponse to FHIR store for sample: " + sample.getAccessionNumber());
-            fhirPersistanceService.updateFhirResourceInFhirStore(questionnaireResponse);
+                    "Saving QuestionnaireResponse for sample: " + sample.getAccessionNumber());
+            questionnaireStorageService.saveQuestionnaireResponse(questionnaireResponse);
             LogEvent.logInfo(this.getClass().getSimpleName(), "saveNotebookSample",
-                    "QuestionnaireResponse saved successfully to FHIR store");
+                    "QuestionnaireResponse saved successfully");
         }
 
         LogEvent.logInfo(this.getClass().getSimpleName(), "saveNotebookSample",
@@ -1009,29 +1004,11 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
     }
 
     private QuestionnaireResponse getQuestionnaireResponseFromFhir(String uuid) {
-        try {
-            if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
-                return null;
-            }
-            IGenericClient fhirClient = fhirUtil.getLocalFhirClient();
-            return fhirClient.read().resource(QuestionnaireResponse.class).withId(uuid).execute();
-        } catch (Exception e) {
-            LogEvent.logError("Failed to retrieve QuestionnaireResponse from FHIR store: " + uuid, e);
-            return null;
-        }
+        return questionnaireStorageService.getQuestionnaireResponse(uuid).orElse(null);
     }
 
     private Questionnaire getQuestionnaireFromFhir(String questionnaireId) {
-        try {
-            if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
-                return null;
-            }
-            IGenericClient fhirClient = fhirUtil.getLocalFhirClient();
-            return fhirClient.read().resource(Questionnaire.class).withId(questionnaireId).execute();
-        } catch (Exception e) {
-            LogEvent.logError("Failed to retrieve Questionnaire from FHIR store: " + questionnaireId, e);
-            return null;
-        }
+        return questionnaireStorageService.getQuestionnaire(questionnaireId).orElse(null);
     }
 
     private Map<String, Object> extractResponsesFromQuestionnaireResponse(QuestionnaireResponse questionnaireResponse) {
@@ -1150,9 +1127,9 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
                 try {
                     QuestionnaireResponse questionnaireResponse = createQuestionnaireResponse(
                             form.getFhirQuestionnaire(), form.getFhirResponses(), questionnaireResponseUuid);
-                    fhirPersistanceService.updateFhirResourceInFhirStore(questionnaireResponse);
-                } catch (FhirLocalPersistingException e) {
-                    LogEvent.logError("Failed to update QuestionnaireResponse to FHIR store", e);
+                    questionnaireStorageService.saveQuestionnaireResponse(questionnaireResponse);
+                } catch (RuntimeException e) {
+                    LogEvent.logError("Failed to update QuestionnaireResponse", e);
                 }
             }
 
@@ -1202,9 +1179,9 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
                 try {
                     QuestionnaireResponse questionnaireResponse = createQuestionnaireResponse(
                             form.getFhirQuestionnaire(), form.getFhirResponses(), questionnaireResponseUuid);
-                    fhirPersistanceService.updateFhirResourceInFhirStore(questionnaireResponse);
-                } catch (FhirLocalPersistingException e) {
-                    LogEvent.logError("Failed to update QuestionnaireResponse to FHIR store", e);
+                    questionnaireStorageService.saveQuestionnaireResponse(questionnaireResponse);
+                } catch (RuntimeException e) {
+                    LogEvent.logError("Failed to update QuestionnaireResponse", e);
                 }
             }
 
@@ -2134,22 +2111,7 @@ public class GenericSampleOrderServiceImpl implements GenericSampleOrderService 
     }
 
     private Questionnaire loadQuestionnaire(String questionnaireId) {
-        if (GenericValidator.isBlankOrNull(questionnaireId)) {
-            return null;
-        }
-
-        try {
-            IGenericClient fhirClient = fhirUtil.getLocalFhirClient();
-            Questionnaire questionnaire = fhirClient.read().resource(Questionnaire.class).withId(questionnaireId)
-                    .execute();
-            LogEvent.logInfo(this.getClass().getSimpleName(), "loadQuestionnaire",
-                    "Loaded questionnaire " + questionnaireId);
-            return questionnaire;
-        } catch (Exception e) {
-            LogEvent.logWarn(this.getClass().getSimpleName(), "loadQuestionnaire",
-                    "Unable to load questionnaire " + questionnaireId + ". " + e.getMessage());
-            return null;
-        }
+        return questionnaireStorageService.getQuestionnaire(questionnaireId).orElse(null);
     }
 
     /**

--- a/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
+++ b/src/main/java/org/openelisglobal/notebook/controller/rest/NoteBookRestController.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.notebook.controller.rest;
 
-import ca.uhn.fhir.rest.client.api.IGenericClient;
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -15,8 +14,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.openelisglobal.audittrail.action.workers.AuditTrailItem;
 import org.openelisglobal.audittrail.form.AuditTrailViewForm;
@@ -26,7 +23,6 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.common.util.IdValuePair;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.notebook.bean.NoteBookDashboardMetrics;
 import org.openelisglobal.notebook.bean.NoteBookDisplayBean;
 import org.openelisglobal.notebook.bean.NoteBookFullDisplayBean;
@@ -36,6 +32,7 @@ import org.openelisglobal.notebook.service.NoteBookSampleService;
 import org.openelisglobal.notebook.service.NoteBookService;
 import org.openelisglobal.notebook.valueholder.NoteBook;
 import org.openelisglobal.notebook.valueholder.NoteBook.NoteBookStatus;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -62,7 +59,7 @@ public class NoteBookRestController extends BaseRestController {
     private FhirConfig fhirConfig;
 
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @GetMapping(value = "/dashboard/entries", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
@@ -224,59 +221,14 @@ public class NoteBookRestController extends BaseRestController {
     @GetMapping(value = "/questionnaires", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<List<IdValuePair>> getQuestionnaires() {
+        String identifierSystem = fhirConfig.getOeFhirSystem() + "/notebook_questionare";
         List<IdValuePair> questionnaires = new ArrayList<>();
-
-        if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
-            return ResponseEntity.ok(questionnaires);
+        for (Questionnaire questionnaire : questionnaireStorageService
+                .getActiveQuestionnairesByIdentifierSystem(identifierSystem)) {
+            String uuid = questionnaire.getIdElement().getIdPart();
+            questionnaires.add(new IdValuePair(uuid,
+                    StringUtils.firstNonBlank(questionnaire.getTitle(), questionnaire.getName(), uuid)));
         }
-
-        try {
-            IGenericClient fhirClient = fhirUtil.getFhirClient(fhirConfig.getLocalFhirStorePath());
-            String identifierSystem = fhirConfig.getOeFhirSystem() + "/notebook_questionare";
-
-            Bundle searchBundle = fhirClient.search().forResource(Questionnaire.class)
-                    .where(Questionnaire.IDENTIFIER.hasSystemWithAnyCode(identifierSystem))
-                    .where(Questionnaire.STATUS.exactly().code("active")).returnBundle(Bundle.class).execute();
-
-            for (BundleEntryComponent entry : searchBundle.getEntry()) {
-                if (entry.hasResource() && entry.getResource() instanceof Questionnaire) {
-                    Questionnaire questionnaire = (Questionnaire) entry.getResource();
-                    String uuid = questionnaire.getIdElement().getIdPart();
-                    String value = questionnaire.getTitle();
-                    if (StringUtils.isBlank(value)) {
-                        value = questionnaire.getName();
-                    }
-                    if (StringUtils.isBlank(value)) {
-                        value = uuid;
-                    }
-                    questionnaires.add(new IdValuePair(uuid, value));
-                }
-            }
-
-            // Handle pagination
-            while (searchBundle.getLink(org.hl7.fhir.instance.model.api.IBaseBundle.LINK_NEXT) != null) {
-                searchBundle = fhirClient.loadPage().next(searchBundle).execute();
-                for (BundleEntryComponent entry : searchBundle.getEntry()) {
-                    if (entry.hasResource() && entry.getResource() instanceof Questionnaire) {
-                        Questionnaire questionnaire = (Questionnaire) entry.getResource();
-                        String uuid = questionnaire.getIdElement().getIdPart();
-                        String value = questionnaire.getTitle();
-                        if (StringUtils.isBlank(value)) {
-                            value = questionnaire.getName();
-                        }
-                        if (StringUtils.isBlank(value)) {
-                            value = uuid;
-                        }
-                        questionnaires.add(new IdValuePair(uuid, value));
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // Log error and return empty list
-            org.openelisglobal.common.log.LogEvent.logError(this.getClass().getSimpleName(), "getQuestionnaires",
-                    "Error fetching questionnaires from FHIR server: " + e.getMessage());
-        }
-
         return ResponseEntity.ok(questionnaires);
     }
 

--- a/src/main/java/org/openelisglobal/program/controller/ProgramController.java
+++ b/src/main/java/org/openelisglobal/program/controller/ProgramController.java
@@ -1,7 +1,6 @@
 package org.openelisglobal.program.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.GenericValidator;
@@ -9,11 +8,9 @@ import org.hl7.fhir.r4.model.Questionnaire;
 import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.common.services.DisplayListService;
 import org.openelisglobal.common.services.DisplayListService.ListType;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
-import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
-import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.program.service.ProgramService;
 import org.openelisglobal.program.valueholder.Program;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.test.service.TestSectionService;
 import org.openelisglobal.test.valueholder.TestSection;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,9 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProgramController extends BaseRestController {
 
     @Autowired
-    private FhirPersistanceService fhirPersistanceService;
-    @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
     @Autowired
     private ProgramService programService;
     @Autowired
@@ -41,13 +36,11 @@ public class ProgramController extends BaseRestController {
 
     @GetMapping(value = "/program/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public EditProgramForm createProgram(@PathVariable String id) throws FhirLocalPersistingException {
+    public EditProgramForm createProgram(@PathVariable String id) {
         EditProgramForm form = new EditProgramForm();
         form.setProgram(programService.get(id));
-        if (form.getProgram().getQuestionnaireUUID() != null) {
-            form.setAdditionalOrderEntryQuestions(fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                    .withId(form.getProgram().getQuestionnaireUUID().toString()).execute());
-        }
+        form.setAdditionalOrderEntryQuestions(
+                questionnaireStorageService.getQuestionnaire(form.getProgram().getQuestionnaireUUID()).orElse(null));
         if (form.getProgram().getTestSection() != null) {
             form.setTestSectionId(form.getProgram().getTestSection().getId());
         }
@@ -56,7 +49,7 @@ public class ProgramController extends BaseRestController {
 
     @PostMapping(value = "/program", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public EditProgramForm createProgram(@RequestBody EditProgramForm form) throws FhirLocalPersistingException {
+    public EditProgramForm createProgram(@RequestBody EditProgramForm form) {
         Questionnaire questionnaire = form.getAdditionalOrderEntryQuestions();
         Program program = form.getProgram();
         if (!GenericValidator.isBlankOrNull(program.getId())) {
@@ -78,19 +71,18 @@ public class ProgramController extends BaseRestController {
         program.setManuallyChanged(true);
         program = programService.save(program);
         questionnaire.setId(program.getQuestionnaireUUID().toString());
-        fhirPersistanceService.updateFhirResourceInFhirStore(questionnaire);
+        questionnaireStorageService.saveQuestionnaire(questionnaire);
         DisplayListService.getInstance().refreshList(ListType.PROGRAM);
         return form;
     }
 
     @GetMapping(value = "/program/{id}/questionnaire", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public Questionnaire getAdditionalEntryQuestions(HttpServletRequest request, @PathVariable String id)
-            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
-        if (programService.get(id).getQuestionnaireUUID() != null) {
-            return fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                    .withId(programService.get(id).getQuestionnaireUUID().toString()).execute();
+    public Questionnaire getAdditionalEntryQuestions(HttpServletRequest request, @PathVariable String id) {
+        Program program = programService.get(id);
+        if (program == null) {
+            return null;
         }
-        return null;
+        return questionnaireStorageService.getQuestionnaire(program.getQuestionnaireUUID()).orElse(null);
     }
 }

--- a/src/main/java/org/openelisglobal/program/service/ImmunohistochemistryDisplayServiceImpl.java
+++ b/src/main/java/org/openelisglobal/program/service/ImmunohistochemistryDisplayServiceImpl.java
@@ -4,12 +4,9 @@ import jakarta.transaction.Transactional;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.openelisglobal.common.services.SampleOrderService;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dictionary.service.DictionaryService;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
@@ -22,6 +19,7 @@ import org.openelisglobal.program.valueholder.pathology.PathologyConclusion.Conc
 import org.openelisglobal.program.valueholder.pathology.PathologyRequest.RequestType;
 import org.openelisglobal.program.valueholder.pathology.PathologySample;
 import org.openelisglobal.program.valueholder.pathology.PathologyTechnique.TechniqueType;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.sample.bean.SampleOrderItem;
 import org.openelisglobal.sample.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +35,7 @@ public class ImmunohistochemistryDisplayServiceImpl implements Immunohistochemis
     @Autowired
     private DictionaryService dictionaryService;
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
     @Autowired
     private OrganizationService organizationService;
 
@@ -89,11 +87,10 @@ public class ImmunohistochemistryDisplayServiceImpl implements Immunohistochemis
         displayItem.setLabNumber(immunohistochemistrySample.getSample().getAccessionNumber());
         displayItem.setImmunohistochemistrySampleId(immunohistochemistrySample.getId());
         displayItem.setPatientPK(patient.getId());
-        displayItem.setProgramQuestionnaire(fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                .withId(immunohistochemistrySample.getProgram().getQuestionnaireUUID().toString()).execute());
-        displayItem.setProgramQuestionnaireResponse(
-                fhirUtil.getLocalFhirClient().read().resource(QuestionnaireResponse.class)
-                        .withId(immunohistochemistrySample.getQuestionnaireResponseUuid().toString()).execute());
+        displayItem.setProgramQuestionnaire(questionnaireStorageService
+                .getQuestionnaire(immunohistochemistrySample.getProgram().getQuestionnaireUUID()).orElse(null));
+        displayItem.setProgramQuestionnaireResponse(questionnaireStorageService
+                .getQuestionnaireResponse(immunohistochemistrySample.getQuestionnaireResponseUuid()).orElse(null));
 
         SampleOrderService sampleOrderService = new SampleOrderService(immunohistochemistrySample.getSample());
         SampleOrderItem sampleItem = sampleOrderService.getSampleOrderItem();

--- a/src/main/java/org/openelisglobal/program/service/OrderProgramsDisplayServiceImpl.java
+++ b/src/main/java/org/openelisglobal/program/service/OrderProgramsDisplayServiceImpl.java
@@ -2,16 +2,15 @@ package org.openelisglobal.program.service;
 
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Questionnaire;
 import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.openelisglobal.common.services.SampleOrderService;
 import org.openelisglobal.common.util.DateUtil;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.program.valueholder.OrderProgramDisplayItem;
 import org.openelisglobal.program.valueholder.ProgramSample;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.sample.bean.SampleOrderItem;
 import org.openelisglobal.sample.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +26,7 @@ public class OrderProgramsDisplayServiceImpl implements OrderProgramsDisplayServ
     private SampleService sampleService;
 
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private OrganizationService organizationService;
@@ -70,19 +69,15 @@ public class OrderProgramsDisplayServiceImpl implements OrderProgramsDisplayServ
 
         display.setRequester(sampleItem.getProviderLastName() + " " + sampleItem.getProviderFirstName());
 
-        if (ps.getProgram().getQuestionnaireUUID() != null) {
-            display.setProgramQuestionnaire(fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                    .withId(ps.getProgram().getQuestionnaireUUID().toString()).execute());
-        }
+        display.setProgramQuestionnaire(
+                questionnaireStorageService.getQuestionnaire(ps.getProgram().getQuestionnaireUUID()).orElse(null));
 
         if (ps.getQuestionnaireResponseUuid() != null) {
-
-            QuestionnaireResponse qr = fhirUtil.getLocalFhirClient().read().resource(QuestionnaireResponse.class)
-                    .withId(ps.getQuestionnaireResponseUuid().toString()).execute();
-
+            QuestionnaireResponse qr = questionnaireStorageService
+                    .getQuestionnaireResponse(ps.getQuestionnaireResponseUuid()).orElse(null);
             display.setProgramQuestionnaireResponse(qr);
-
-            display.setQuestionnaireStatus(qr.hasStatus() ? qr.getStatus().toCode().toUpperCase() : "UNKNOWN");
+            display.setQuestionnaireStatus(
+                    qr != null && qr.hasStatus() ? qr.getStatus().toCode().toUpperCase() : "UNKNOWN");
         } else {
             display.setQuestionnaireStatus("NOT_STARTED");
         }

--- a/src/main/java/org/openelisglobal/program/service/PathologyDisplayServiceImpl.java
+++ b/src/main/java/org/openelisglobal/program/service/PathologyDisplayServiceImpl.java
@@ -4,12 +4,9 @@ import jakarta.transaction.Transactional;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.openelisglobal.common.services.SampleOrderService;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dictionary.service.DictionaryService;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
@@ -22,6 +19,7 @@ import org.openelisglobal.program.valueholder.pathology.PathologyDisplayItem;
 import org.openelisglobal.program.valueholder.pathology.PathologyRequest.RequestType;
 import org.openelisglobal.program.valueholder.pathology.PathologySample;
 import org.openelisglobal.program.valueholder.pathology.PathologyTechnique.TechniqueType;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.sample.bean.SampleOrderItem;
 import org.openelisglobal.sample.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +35,7 @@ public class PathologyDisplayServiceImpl implements PathologyDisplayService {
     @Autowired
     private DictionaryService dictionaryService;
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
     @Autowired
     private OrganizationService organizationService;
 
@@ -91,11 +89,10 @@ public class PathologyDisplayServiceImpl implements PathologyDisplayService {
         displayItem.setLabNumber(pathologySample.getSample().getAccessionNumber());
         displayItem.setPathologySampleId(pathologySample.getId());
         displayItem.setPatientPK(patient.getId());
-        displayItem.setProgramQuestionnaire(fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                .withId(pathologySample.getProgram().getQuestionnaireUUID().toString()).execute());
-        displayItem.setProgramQuestionnaireResponse(
-                fhirUtil.getLocalFhirClient().read().resource(QuestionnaireResponse.class)
-                        .withId(pathologySample.getQuestionnaireResponseUuid().toString()).execute());
+        displayItem.setProgramQuestionnaire(questionnaireStorageService
+                .getQuestionnaire(pathologySample.getProgram().getQuestionnaireUUID()).orElse(null));
+        displayItem.setProgramQuestionnaireResponse(questionnaireStorageService
+                .getQuestionnaireResponse(pathologySample.getQuestionnaireResponseUuid()).orElse(null));
 
         displayItem.setGrossExam(pathologySample.getGrossExam());
         displayItem.setMicroscopyExam(pathologySample.getMicroscopyExam());

--- a/src/main/java/org/openelisglobal/program/service/ProgramAutocreateService.java
+++ b/src/main/java/org/openelisglobal/program/service/ProgramAutocreateService.java
@@ -22,12 +22,10 @@ import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.DisplayListService;
 import org.openelisglobal.common.services.DisplayListService.ListType;
 import org.openelisglobal.common.util.validator.GenericValidator;
-import org.openelisglobal.dataexchange.fhir.FhirConfig;
-import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
-import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.fhir.springserialization.QuestionnaireDeserializer;
 import org.openelisglobal.program.controller.EditProgramForm;
 import org.openelisglobal.program.valueholder.Program;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.security.DaemonContextExecutor;
 import org.openelisglobal.test.service.TestSectionService;
 import org.openelisglobal.test.valueholder.TestSection;
@@ -54,9 +52,7 @@ public class ProgramAutocreateService {
     @Autowired
     private TestSectionService testSectionService;
     @Autowired
-    private FhirPersistanceService fhirPersistanceService;
-    @Autowired
-    private FhirConfig fhirConfig;
+    private QuestionnaireStorageService questionnaireStorageService;
     @Autowired
     private DaemonContextExecutor daemonContextExecutor;
 
@@ -99,7 +95,7 @@ public class ProgramAutocreateService {
     }
 
     private void doAutocreateProgram() {
-        if (autocreateOn && StringUtils.isNotBlank(fhirConfig.getLocalFhirStorePath())) {
+        if (autocreateOn) {
             Resource[] programResources = getAllProgramResources();
             for (Resource programResource : programResources) {
                 try (BufferedReader reader = new BufferedReader(
@@ -207,12 +203,10 @@ public class ProgramAutocreateService {
                     }
                     program = programService.save(program);
                     questionnaire.setId(program.getQuestionnaireUUID().toString());
-                    fhirPersistanceService.updateFhirResourceInFhirStore(questionnaire);
+                    questionnaireStorageService.saveQuestionnaire(questionnaire);
                     DisplayListService.getInstance().refreshList(ListType.PROGRAM);
 
-                    // }
-
-                } catch (IOException | FhirLocalPersistingException e) {
+                } catch (IOException | RuntimeException e) {
                     LogEvent.logError(e);
                 }
             }

--- a/src/main/java/org/openelisglobal/program/service/cytology/CytologyDisplayServiceImpl.java
+++ b/src/main/java/org/openelisglobal/program/service/cytology/CytologyDisplayServiceImpl.java
@@ -5,12 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.QuestionnaireResponse;
 import org.openelisglobal.common.services.SampleOrderService;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dictionary.service.DictionaryService;
 import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.organization.valueholder.Organization;
@@ -20,6 +17,7 @@ import org.openelisglobal.program.valueholder.cytology.CytologyDiagnosis;
 import org.openelisglobal.program.valueholder.cytology.CytologyDiagnosis.CytologyDiagnosisResultType;
 import org.openelisglobal.program.valueholder.cytology.CytologyDisplayItem;
 import org.openelisglobal.program.valueholder.cytology.CytologySample;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.sample.bean.SampleOrderItem;
 import org.openelisglobal.sample.service.SampleService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +33,7 @@ public class CytologyDisplayServiceImpl implements CytologyDisplayService {
     private CytologySampleService cytologySampleService;
 
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private OrganizationService organizationService;
@@ -64,11 +62,10 @@ public class CytologyDisplayServiceImpl implements CytologyDisplayService {
         displayItem.setLabNumber(cytologySample.getSample().getAccessionNumber());
         displayItem.setPathologySampleId(cytologySample.getId());
         displayItem.setPatientPK(patient.getId());
-        displayItem.setProgramQuestionnaire(fhirUtil.getLocalFhirClient().read().resource(Questionnaire.class)
-                .withId(cytologySample.getProgram().getQuestionnaireUUID().toString()).execute());
-        displayItem.setProgramQuestionnaireResponse(
-                fhirUtil.getLocalFhirClient().read().resource(QuestionnaireResponse.class)
-                        .withId(cytologySample.getQuestionnaireResponseUuid().toString()).execute());
+        displayItem.setProgramQuestionnaire(questionnaireStorageService
+                .getQuestionnaire(cytologySample.getProgram().getQuestionnaireUUID()).orElse(null));
+        displayItem.setProgramQuestionnaireResponse(questionnaireStorageService
+                .getQuestionnaireResponse(cytologySample.getQuestionnaireResponseUuid()).orElse(null));
 
         cytologySample.getSlides().size();
         displayItem.setSlides(cytologySample.getSlides());

--- a/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireDaoImpl.java
+++ b/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireDaoImpl.java
@@ -1,12 +1,10 @@
-package org.openelisglobal.questionnaire.daoImpl;
+package org.openelisglobal.questionnaire.daoimpl;
 
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.questionnaire.dao.QuestionnaireDao;
 import org.openelisglobal.questionnaire.valueholder.Questionnaire;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @Component
 public class QuestionnaireDaoImpl extends BaseDAOImpl<Questionnaire, Integer> implements QuestionnaireDao {
 

--- a/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireItemDaoImpl.java
+++ b/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireItemDaoImpl.java
@@ -1,13 +1,11 @@
-package org.openelisglobal.questionnaire.daoImpl;
+package org.openelisglobal.questionnaire.daoimpl;
 
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.questionnaire.dao.QuestionnaireItemDao;
 import org.openelisglobal.questionnaire.valueholder.QuestionnaireItem;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
 public class QuestionnaireItemDaoImpl extends BaseDAOImpl<QuestionnaireItem, Integer> implements QuestionnaireItemDao {
 
     public QuestionnaireItemDaoImpl() {

--- a/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireResponseDaoImpl.java
+++ b/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireResponseDaoImpl.java
@@ -1,13 +1,11 @@
-package org.openelisglobal.questionnaire.daoImpl;
+package org.openelisglobal.questionnaire.daoimpl;
 
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.questionnaire.dao.QuestionnaireResponseDao;
 import org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
 public class QuestionnaireResponseDaoImpl extends BaseDAOImpl<QuestionnaireResponse, Integer>
         implements QuestionnaireResponseDao {
 

--- a/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireResponseItemDaoImpl.java
+++ b/src/main/java/org/openelisglobal/questionnaire/daoimpl/QuestionnaireResponseItemDaoImpl.java
@@ -1,13 +1,11 @@
-package org.openelisglobal.questionnaire.daoImpl;
+package org.openelisglobal.questionnaire.daoimpl;
 
 import org.openelisglobal.common.daoimpl.BaseDAOImpl;
 import org.openelisglobal.questionnaire.dao.QuestionnaireResponseItemDao;
 import org.openelisglobal.questionnaire.valueholder.QuestionnaireResponseItem;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
 public class QuestionnaireResponseItemDaoImpl extends BaseDAOImpl<QuestionnaireResponseItem, Integer>
         implements QuestionnaireResponseItemDao {
 

--- a/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireConfigurationHandler.java
+++ b/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireConfigurationHandler.java
@@ -4,21 +4,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.InputStream;
 import java.util.UUID;
-import liquibase.repackaged.org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Questionnaire;
 import org.openelisglobal.configuration.service.DomainConfigurationHandler;
 import org.openelisglobal.dataexchange.fhir.FhirConfig;
-import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.fhir.springserialization.QuestionnaireDeserializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+/**
+ * Loads the {@code questionnaires/*.json} configuration files into OpenELIS
+ * (and into the FHIR store when one is configured).
+ */
 @Component
 public class QuestionnaireConfigurationHandler implements DomainConfigurationHandler {
 
     @Autowired
-    private FhirPersistanceService fhirPersistanceService;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private FhirConfig fhirConfig;
@@ -40,10 +42,6 @@ public class QuestionnaireConfigurationHandler implements DomainConfigurationHan
 
     @Override
     public void processConfiguration(InputStream inputStream, String fileName) throws Exception {
-        if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
-            throw new IllegalStateException("FHIR store path is not configured. Cannot load questionnaires.");
-        }
-
         Questionnaire questionnaire = parseQuestionnaire(inputStream);
 
         if (questionnaire.getId() == null || questionnaire.getId().isEmpty()) {
@@ -56,8 +54,7 @@ public class QuestionnaireConfigurationHandler implements DomainConfigurationHan
                         : questionnaire.getName() != null ? questionnaire.getName()
                                 : questionnaire.getIdElement().getIdPart()));
 
-        // Save to FHIR store
-        fhirPersistanceService.updateFhirResourceInFhirStore(questionnaire);
+        questionnaireStorageService.saveQuestionnaire(questionnaire);
     }
 
     private Questionnaire parseQuestionnaire(InputStream inputStream) throws Exception {

--- a/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageService.java
+++ b/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageService.java
@@ -1,0 +1,53 @@
+package org.openelisglobal.questionnaire.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+
+/**
+ * Single entry point for reading and writing FHIR {@link Questionnaire} and
+ * {@link QuestionnaireResponse} resources used by programme forms.
+ *
+ * <p>
+ * The OpenELIS database is the system of record: every write lands there first.
+ * When a FHIR store is configured ({@code org.openelisglobal.fhirstore.uri})
+ * the resource is also pushed to it, and reads consult the store first and fall
+ * back to the local copy. Without a FHIR store everything works from the local
+ * database alone.
+ */
+public interface QuestionnaireStorageService {
+
+    boolean isFhirStoreConfigured();
+
+    /** Stores the questionnaire locally and, when configured, in the FHIR store. */
+    Questionnaire saveQuestionnaire(Questionnaire questionnaire);
+
+    /** FHIR store first (when configured), then the local database. */
+    Optional<Questionnaire> getQuestionnaire(String uuid);
+
+    /** Null-safe variant of {@link #getQuestionnaire(String)}. */
+    Optional<Questionnaire> getQuestionnaire(UUID uuid);
+
+    /**
+     * Active questionnaires carrying an identifier with the given system, merged
+     * from the local database and, when configured, the FHIR store.
+     */
+    List<Questionnaire> getActiveQuestionnairesByIdentifierSystem(String identifierSystem);
+
+    /** Stores the response locally and, when configured, in the FHIR store. */
+    QuestionnaireResponse saveQuestionnaireResponse(QuestionnaireResponse response);
+
+    /**
+     * Stores the response in the local database only. For callers whose FHIR write
+     * already happens elsewhere (the asynchronous order-entry transform).
+     */
+    QuestionnaireResponse storeQuestionnaireResponseLocally(QuestionnaireResponse response);
+
+    /** FHIR store first (when configured), then the local database. */
+    Optional<QuestionnaireResponse> getQuestionnaireResponse(String uuid);
+
+    /** Null-safe variant of {@link #getQuestionnaireResponse(String)}. */
+    Optional<QuestionnaireResponse> getQuestionnaireResponse(UUID uuid);
+}

--- a/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageServiceImpl.java
+++ b/src/main/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageServiceImpl.java
@@ -1,0 +1,377 @@
+package org.openelisglobal.questionnaire.service;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Resource;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
+import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+import org.openelisglobal.questionnaire.valueholder.Questionnaire.QuestionnaireStatus;
+import org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse.QuestionnaireResponseStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Local-first storage for programme questionnaires.
+ *
+ * <p>
+ * Writes go to the {@code questionnaire} / {@code questionnaire_response}
+ * tables (canonical JSON plus derived metadata columns) and, when a FHIR store
+ * is configured, are mirrored to it; a FHIR failure is logged and never undoes
+ * the local write. Reads consult the FHIR store first when configured so
+ * deployments that already hold their forms there keep working, and a resource
+ * that only exists remotely is copied locally on first read.
+ */
+@Service
+public class QuestionnaireStorageServiceImpl implements QuestionnaireStorageService {
+
+    private static final int TEXT_LENGTH = 255;
+    private static final int CODE_LENGTH = 10;
+    private static final int REFERENCE_LENGTH = 100;
+
+    @Autowired
+    private QuestionnaireService questionnaireService;
+    @Autowired
+    private QuestionnaireResponseService questionnaireResponseService;
+    @Autowired
+    private FhirConfig fhirConfig;
+    @Autowired
+    private FhirUtil fhirUtil;
+    @Autowired
+    private FhirPersistanceService fhirPersistanceService;
+
+    private final IParser parser = FhirContext.forR4Cached().newJsonParser();
+
+    @Override
+    public boolean isFhirStoreConfigured() {
+        return StringUtils.isNotBlank(fhirConfig.getLocalFhirStorePath());
+    }
+
+    @Override
+    @Transactional
+    public Questionnaire saveQuestionnaire(Questionnaire questionnaire) {
+        storeQuestionnaireLocally(questionnaire);
+        pushToFhirStore(questionnaire);
+        return questionnaire;
+    }
+
+    @Override
+    public Optional<Questionnaire> getQuestionnaire(String uuid) {
+        if (StringUtils.isBlank(uuid)) {
+            return Optional.empty();
+        }
+        Optional<Questionnaire> remote = readFromFhirStore(Questionnaire.class, uuid);
+        if (remote.isPresent()) {
+            backfillLocally(uuid, findLocalQuestionnaire(uuid).isEmpty(),
+                    () -> storeQuestionnaireLocally(remote.get()));
+            return remote;
+        }
+        return findLocalQuestionnaire(uuid).map(this::toFhir);
+    }
+
+    @Override
+    public Optional<Questionnaire> getQuestionnaire(UUID uuid) {
+        return uuid == null ? Optional.empty() : getQuestionnaire(uuid.toString());
+    }
+
+    @Override
+    public List<Questionnaire> getActiveQuestionnairesByIdentifierSystem(String identifierSystem) {
+        Map<String, Questionnaire> byId = new LinkedHashMap<>();
+        for (org.openelisglobal.questionnaire.valueholder.Questionnaire entity : questionnaireService
+                .getAllMatching("identifierSystem", identifierSystem)) {
+            if (entity.getStatus() == QuestionnaireStatus.ACTIVE) {
+                Questionnaire questionnaire = toFhir(entity);
+                byId.put(idOf(questionnaire), questionnaire);
+            }
+        }
+        if (isFhirStoreConfigured()) {
+            try {
+                for (Questionnaire questionnaire : searchFhirStoreByIdentifierSystem(identifierSystem)) {
+                    byId.put(idOf(questionnaire), questionnaire);
+                }
+            } catch (RuntimeException e) {
+                LogEvent.logWarn(getClass().getSimpleName(), "getActiveQuestionnairesByIdentifierSystem",
+                        "FHIR store search failed, serving local questionnaires only: " + e.getMessage());
+            }
+        }
+        return new ArrayList<>(byId.values());
+    }
+
+    @Override
+    @Transactional
+    public QuestionnaireResponse saveQuestionnaireResponse(QuestionnaireResponse response) {
+        storeQuestionnaireResponseLocally(response);
+        pushToFhirStore(response);
+        return response;
+    }
+
+    @Override
+    @Transactional
+    public QuestionnaireResponse storeQuestionnaireResponseLocally(QuestionnaireResponse response) {
+        String id = requireId(response);
+        org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse entity = findLocalResponse(id)
+                .orElseGet(org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse::new);
+        entity.setFhirUuid(toStorageUuid(id));
+        entity.setStatus(toLocalStatus(response.getStatus()));
+        entity.setSubjectReference(
+                response.hasSubject() ? StringUtils.left(response.getSubject().getReference(), REFERENCE_LENGTH)
+                        : null);
+        entity.setAuthored(response.hasAuthored() ? new Timestamp(response.getAuthored().getTime()) : null);
+        UUID questionnaireUuid = questionnaireUuidOf(response);
+        entity.setQuestionnaireFhirUuid(questionnaireUuid);
+        entity.setQuestionnaire(questionnaireUuid == null ? null
+                : questionnaireService.getMatch("fhirUuid", questionnaireUuid).orElse(null));
+        entity.setResourceJson(parser.encodeResourceToString(response));
+        if (entity.getId() == null) {
+            questionnaireResponseService.insert(entity);
+        } else {
+            questionnaireResponseService.update(entity);
+        }
+        return response;
+    }
+
+    @Override
+    public Optional<QuestionnaireResponse> getQuestionnaireResponse(String uuid) {
+        if (StringUtils.isBlank(uuid)) {
+            return Optional.empty();
+        }
+        Optional<QuestionnaireResponse> remote = readFromFhirStore(QuestionnaireResponse.class, uuid);
+        if (remote.isPresent()) {
+            backfillLocally(uuid, findLocalResponse(uuid).isEmpty(),
+                    () -> storeQuestionnaireResponseLocally(remote.get()));
+            return remote;
+        }
+        return findLocalResponse(uuid).map(this::toFhir);
+    }
+
+    @Override
+    public Optional<QuestionnaireResponse> getQuestionnaireResponse(UUID uuid) {
+        return uuid == null ? Optional.empty() : getQuestionnaireResponse(uuid.toString());
+    }
+
+    private void storeQuestionnaireLocally(Questionnaire questionnaire) {
+        String id = requireId(questionnaire);
+        org.openelisglobal.questionnaire.valueholder.Questionnaire entity = findLocalQuestionnaire(id)
+                .orElseGet(org.openelisglobal.questionnaire.valueholder.Questionnaire::new);
+        entity.setFhirUuid(toStorageUuid(id));
+        entity.setQuestionnaireName(StringUtils
+                .left(StringUtils.firstNonBlank(questionnaire.getName(), questionnaire.getTitle(), id), TEXT_LENGTH));
+        entity.setDescription(StringUtils.left(questionnaire.getDescription(), TEXT_LENGTH));
+        entity.setPurpose(StringUtils.left(questionnaire.getPurpose(), TEXT_LENGTH));
+        entity.setStatus(toLocalStatus(questionnaire.getStatus()));
+        entity.setCode(
+                questionnaire.hasCode() ? StringUtils.left(questionnaire.getCodeFirstRep().getCode(), CODE_LENGTH)
+                        : null);
+        entity.setHasItem(questionnaire.hasItem());
+        entity.setIdentifierSystem(questionnaire.hasIdentifier()
+                ? StringUtils.left(questionnaire.getIdentifierFirstRep().getSystem(), TEXT_LENGTH)
+                : null);
+        entity.setIdentifierValue(questionnaire.hasIdentifier()
+                ? StringUtils.left(questionnaire.getIdentifierFirstRep().getValue(), TEXT_LENGTH)
+                : null);
+        entity.setResourceJson(parser.encodeResourceToString(questionnaire));
+        if (entity.getId() == null) {
+            questionnaireService.insert(entity);
+        } else {
+            questionnaireService.update(entity);
+        }
+    }
+
+    private Optional<org.openelisglobal.questionnaire.valueholder.Questionnaire> findLocalQuestionnaire(String id) {
+        return questionnaireService.getMatch("fhirUuid", toStorageUuid(id));
+    }
+
+    private Optional<org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse> findLocalResponse(String id) {
+        return questionnaireResponseService.getMatch("fhirUuid", toStorageUuid(id));
+    }
+
+    private Questionnaire toFhir(org.openelisglobal.questionnaire.valueholder.Questionnaire entity) {
+        if (StringUtils.isNotBlank(entity.getResourceJson())) {
+            return parser.parseResource(Questionnaire.class, entity.getResourceJson());
+        }
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId(entity.getFhirUuid().toString());
+        questionnaire.setName(entity.getQuestionnaireName());
+        questionnaire.setTitle(entity.getQuestionnaireName());
+        questionnaire.setDescription(entity.getDescription());
+        questionnaire.setPurpose(entity.getPurpose());
+        questionnaire.setStatus(toFhirStatus(entity.getStatus()));
+        return questionnaire;
+    }
+
+    private QuestionnaireResponse toFhir(org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse entity) {
+        if (StringUtils.isNotBlank(entity.getResourceJson())) {
+            return parser.parseResource(QuestionnaireResponse.class, entity.getResourceJson());
+        }
+        QuestionnaireResponse response = new QuestionnaireResponse();
+        response.setId(entity.getFhirUuid().toString());
+        response.setStatus(toFhirStatus(entity.getStatus()));
+        if (entity.getQuestionnaireFhirUuid() != null) {
+            response.setQuestionnaire("Questionnaire/" + entity.getQuestionnaireFhirUuid());
+        }
+        return response;
+    }
+
+    private <T extends IBaseResource> Optional<T> readFromFhirStore(Class<T> type, String id) {
+        if (!isFhirStoreConfigured()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.ofNullable(fhirUtil.getLocalFhirClient().read().resource(type).withId(id).execute());
+        } catch (RuntimeException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "readFromFhirStore", type.getSimpleName() + "/" + id
+                    + " not read from the FHIR store, using the local database: " + e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private List<Questionnaire> searchFhirStoreByIdentifierSystem(String identifierSystem) {
+        List<Questionnaire> found = new ArrayList<>();
+        IGenericClient client = fhirUtil.getLocalFhirClient();
+        Bundle bundle = client.search().forResource(Questionnaire.class)
+                .where(Questionnaire.IDENTIFIER.hasSystemWithAnyCode(identifierSystem))
+                .where(Questionnaire.STATUS.exactly().code("active")).returnBundle(Bundle.class).execute();
+        while (bundle != null) {
+            for (BundleEntryComponent entry : bundle.getEntry()) {
+                if (entry.getResource() instanceof Questionnaire) {
+                    found.add((Questionnaire) entry.getResource());
+                }
+            }
+            bundle = bundle.getLink(IBaseBundle.LINK_NEXT) != null ? client.loadPage().next(bundle).execute() : null;
+        }
+        return found;
+    }
+
+    private void pushToFhirStore(Resource resource) {
+        if (!isFhirStoreConfigured()) {
+            return;
+        }
+        try {
+            fhirPersistanceService.updateFhirResourceInFhirStore(resource);
+        } catch (FhirLocalPersistingException | RuntimeException e) {
+            LogEvent.logError(getClass().getSimpleName(), "pushToFhirStore", resource.fhirType() + "/" + idOf(resource)
+                    + " saved locally but not in the FHIR store: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Copies a resource that only exists in the FHIR store into the local database.
+     * Skipped inside a caller's transaction so a failed copy can never poison the
+     * caller's work; the plain controller reads are where it runs.
+     */
+    private void backfillLocally(String id, boolean missingLocally, Runnable store) {
+        if (!missingLocally || TransactionSynchronizationManager.isActualTransactionActive()) {
+            return;
+        }
+        try {
+            store.run();
+        } catch (RuntimeException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "backfillLocally",
+                    id + " read from the FHIR store but not copied locally: " + e.getMessage());
+        }
+    }
+
+    private static String requireId(Resource resource) {
+        String id = idOf(resource);
+        if (StringUtils.isBlank(id)) {
+            throw new IllegalArgumentException(resource.fhirType() + " must carry an id before it can be stored");
+        }
+        return id;
+    }
+
+    private static String idOf(Resource resource) {
+        return resource.getIdElement().getIdPart();
+    }
+
+    /**
+     * FHIR ids are normally UUIDs; anything else maps to a stable name-based UUID.
+     */
+    static UUID toStorageUuid(String id) {
+        try {
+            return UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            return UUID.nameUUIDFromBytes(id.getBytes());
+        }
+    }
+
+    private static UUID questionnaireUuidOf(QuestionnaireResponse response) {
+        if (!response.hasQuestionnaire()) {
+            return null;
+        }
+        String reference = response.getQuestionnaire();
+        String tail = reference.substring(reference.lastIndexOf('/') + 1);
+        try {
+            return UUID.fromString(tail);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static QuestionnaireStatus toLocalStatus(PublicationStatus status) {
+        if (status == null) {
+            return QuestionnaireStatus.UNKNOWN;
+        }
+        switch (status) {
+        case DRAFT:
+            return QuestionnaireStatus.DRAFT;
+        case ACTIVE:
+            return QuestionnaireStatus.ACTIVE;
+        case RETIRED:
+            return QuestionnaireStatus.RETIRED;
+        default:
+            return QuestionnaireStatus.UNKNOWN;
+        }
+    }
+
+    private static PublicationStatus toFhirStatus(QuestionnaireStatus status) {
+        if (status == null) {
+            return PublicationStatus.UNKNOWN;
+        }
+        switch (status) {
+        case DRAFT:
+            return PublicationStatus.DRAFT;
+        case ACTIVE:
+            return PublicationStatus.ACTIVE;
+        case RETIRED:
+            return PublicationStatus.RETIRED;
+        default:
+            return PublicationStatus.UNKNOWN;
+        }
+    }
+
+    private static QuestionnaireResponseStatus toLocalStatus(QuestionnaireResponse.QuestionnaireResponseStatus status) {
+        if (status == null || status == QuestionnaireResponse.QuestionnaireResponseStatus.NULL) {
+            return null;
+        }
+        for (QuestionnaireResponseStatus candidate : QuestionnaireResponseStatus.values()) {
+            if (candidate.getValue().equals(status.toCode())) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static QuestionnaireResponse.QuestionnaireResponseStatus toFhirStatus(QuestionnaireResponseStatus status) {
+        return status == null ? null : QuestionnaireResponse.QuestionnaireResponseStatus.fromCode(status.getValue());
+    }
+}

--- a/src/main/java/org/openelisglobal/questionnaire/valueholder/Questionnaire.java
+++ b/src/main/java/org/openelisglobal/questionnaire/valueholder/Questionnaire.java
@@ -27,12 +27,12 @@ public class Questionnaire extends BaseObject<Integer> {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "questionnaire_generator")
     @SequenceGenerator(name = "questionnaire_generator", sequenceName = "questionnaire_seq", allocationSize = 1)
-    private int id;
+    private Integer id;
 
     @Column(name = "fhir_uuid", nullable = false, unique = true)
     private UUID fhirUuid;
 
-    @Column(name = "code", nullable = false, length = 10)
+    @Column(name = "code", length = 10)
     private String code;
 
     @Column(name = "has_item")
@@ -53,7 +53,7 @@ public class Questionnaire extends BaseObject<Integer> {
     @Column(name = "description", length = 255)
     private String description;
 
-    @Column(name = "questionnaire_name", length = 36, nullable = false)
+    @Column(name = "questionnaire_name", length = 255)
     private String questionnaireName;
 
     @Column(name = "approval_date")
@@ -68,8 +68,21 @@ public class Questionnaire extends BaseObject<Integer> {
     @Column(name = "status_id", length = 10)
     private String statusId;
 
-    @Column(name = "purpose", nullable = false, length = 255)
+    @Column(name = "purpose", length = 255)
     private String purpose;
+
+    @Column(name = "identifier_system", length = 255)
+    private String identifierSystem;
+
+    @Column(name = "identifier_value", length = 255)
+    private String identifierValue;
+
+    /**
+     * Canonical FHIR JSON of the resource; the relational columns are metadata
+     * derived from it.
+     */
+    @Column(name = "resource_json")
+    private String resourceJson;
 
     public Questionnaire() {
     }
@@ -186,6 +199,30 @@ public class Questionnaire extends BaseObject<Integer> {
 
     public void setPurpose(String purpose) {
         this.purpose = purpose;
+    }
+
+    public String getIdentifierSystem() {
+        return identifierSystem;
+    }
+
+    public void setIdentifierSystem(String identifierSystem) {
+        this.identifierSystem = identifierSystem;
+    }
+
+    public String getIdentifierValue() {
+        return identifierValue;
+    }
+
+    public void setIdentifierValue(String identifierValue) {
+        this.identifierValue = identifierValue;
+    }
+
+    public String getResourceJson() {
+        return resourceJson;
+    }
+
+    public void setResourceJson(String resourceJson) {
+        this.resourceJson = resourceJson;
     }
 
     public enum QuestionnaireStatus {

--- a/src/main/java/org/openelisglobal/questionnaire/valueholder/QuestionnaireResponse.java
+++ b/src/main/java/org/openelisglobal/questionnaire/valueholder/QuestionnaireResponse.java
@@ -18,7 +18,6 @@ import java.sql.Timestamp;
 import java.util.Set;
 import java.util.UUID;
 import org.openelisglobal.common.valueholder.BaseObject;
-import org.openelisglobal.patient.valueholder.Patient;
 
 @Entity
 @Table(name = "questionnaire_response")
@@ -40,15 +39,32 @@ public class QuestionnaireResponse extends BaseObject<Integer> {
     @Column(name = "status")
     private QuestionnaireResponseStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "subject_id")
-    private Patient subject;
+    /**
+     * FHIR reference of the subject, e.g. {@code Patient/<uuid>}; null for
+     * patientless samples.
+     */
+    @Column(name = "subject_reference", length = 100)
+    private String subjectReference;
+
+    /**
+     * UUID of the answered Questionnaire, kept even when that questionnaire has no
+     * local row.
+     */
+    @Column(name = "questionnaire_fhir_uuid")
+    private UUID questionnaireFhirUuid;
 
     @Column(name = "authored")
     private Timestamp authored;
 
     @Column(name = "summary")
     private String summary;
+
+    /**
+     * Canonical FHIR JSON of the resource; the relational columns are metadata
+     * derived from it.
+     */
+    @Column(name = "resource_json")
+    private String resourceJson;
 
     @OneToMany(mappedBy = "questionnaireResponse", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<QuestionnaireResponseItem> items;
@@ -77,12 +93,28 @@ public class QuestionnaireResponse extends BaseObject<Integer> {
         this.status = status;
     }
 
-    public Patient getSubject() {
-        return subject;
+    public String getSubjectReference() {
+        return subjectReference;
     }
 
-    public void setSubject(Patient subject) {
-        this.subject = subject;
+    public void setSubjectReference(String subjectReference) {
+        this.subjectReference = subjectReference;
+    }
+
+    public UUID getQuestionnaireFhirUuid() {
+        return questionnaireFhirUuid;
+    }
+
+    public void setQuestionnaireFhirUuid(UUID questionnaireFhirUuid) {
+        this.questionnaireFhirUuid = questionnaireFhirUuid;
+    }
+
+    public String getResourceJson() {
+        return resourceJson;
+    }
+
+    public void setResourceJson(String resourceJson) {
+        this.resourceJson = resourceJson;
     }
 
     public Timestamp getAuthored() {

--- a/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
+++ b/src/main/java/org/openelisglobal/sample/controller/rest/OrderSearchRestController.java
@@ -42,7 +42,6 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.IdValuePair;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.observationhistory.service.ObservationHistoryService;
 import org.openelisglobal.observationhistory.service.ObservationHistoryServiceImpl.ObservationType;
 import org.openelisglobal.organization.service.OrganizationService;
@@ -68,6 +67,7 @@ import org.openelisglobal.program.valueholder.ProgramSample;
 import org.openelisglobal.provider.valueholder.Provider;
 import org.openelisglobal.qachecklist.service.SampleQaChecklistService;
 import org.openelisglobal.qc.dao.SampleItemQcProfileDAO;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
 import org.openelisglobal.referral.service.ReferralService;
 import org.openelisglobal.referral.valueholder.Referral;
 import org.openelisglobal.referral.valueholder.ReferralSubcontract;
@@ -165,7 +165,7 @@ public class OrderSearchRestController extends BaseRestController {
     private OrganizationService organizationService;
 
     @Autowired
-    private FhirUtil fhirUtil;
+    private QuestionnaireStorageService questionnaireStorageService;
 
     @Autowired
     private SampleStorageAssignmentDAO sampleStorageAssignmentDAO;
@@ -1098,9 +1098,9 @@ public class OrderSearchRestController extends BaseRestController {
                     // Load questionnaire response if available
                     if (programSample.getQuestionnaireResponseUuid() != null) {
                         try {
-                            QuestionnaireResponse qr = fhirUtil.getLocalFhirClient().read()
-                                    .resource(QuestionnaireResponse.class)
-                                    .withId(programSample.getQuestionnaireResponseUuid().toString()).execute();
+                            QuestionnaireResponse qr = questionnaireStorageService
+                                    .getQuestionnaireResponse(programSample.getQuestionnaireResponseUuid())
+                                    .orElse(null);
                             if (qr != null) {
                                 sampleOrderItems.put("additionalQuestions", qr);
                             }
@@ -1138,9 +1138,8 @@ public class OrderSearchRestController extends BaseRestController {
                         // Load questionnaire response if available
                         if (ps.getQuestionnaireResponseUuid() != null) {
                             try {
-                                QuestionnaireResponse qr = fhirUtil.getLocalFhirClient().read()
-                                        .resource(QuestionnaireResponse.class)
-                                        .withId(ps.getQuestionnaireResponseUuid().toString()).execute();
+                                QuestionnaireResponse qr = questionnaireStorageService
+                                        .getQuestionnaireResponse(ps.getQuestionnaireResponseUuid()).orElse(null);
                                 if (qr != null) {
                                     sampleOrderItems.put("additionalQuestions", qr);
                                 }

--- a/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
+++ b/src/main/java/org/openelisglobal/sample/service/SamplePatientEntryServiceImpl.java
@@ -150,6 +150,8 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
     private org.openelisglobal.referral.service.ReferralSetService referralSetService;
     @Autowired
     private OrderLabelRequestService orderLabelRequestService;
+    @Autowired
+    private org.openelisglobal.questionnaire.service.QuestionnaireStorageService questionnaireStorageService;
 
     @Transactional
     @Override
@@ -421,6 +423,12 @@ public class SamplePatientEntryServiceImpl implements SamplePatientEntryService 
                 immunohistochemistrySampleService.save((ImmunohistochemistrySample) updateData.getProgramSample());
             } else {
                 programSampleService.save(updateData.getProgramSample());
+            }
+            if (updateData.getProgramQuestionnaireResponse() != null) {
+                updateData.getProgramQuestionnaireResponse()
+                        .setId(updateData.getProgramSample().getQuestionnaireResponseUuid().toString());
+                questionnaireStorageService
+                        .storeQuestionnaireResponseLocally(updateData.getProgramQuestionnaireResponse());
             }
         }
 

--- a/src/main/resources/liquibase/3.6.x.x/002-questionnaire-local-storage.xml
+++ b/src/main/resources/liquibase/3.6.x.x/002-questionnaire-local-storage.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="questionnaire-008-questionnaire-local-storage" author="OGC">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="questionnaire"/>
+            <not>
+                <columnExists tableName="questionnaire" columnName="resource_json"/>
+            </not>
+        </preConditions>
+        <comment>
+            Store the canonical FHIR Questionnaire JSON in OpenELIS so programme forms no longer
+            depend on the FHIR store; relax the columns FHIR does not guarantee.
+        </comment>
+
+        <addColumn tableName="questionnaire">
+            <column name="resource_json" type="TEXT"/>
+            <column name="identifier_system" type="VARCHAR(255)"/>
+            <column name="identifier_value" type="VARCHAR(255)"/>
+        </addColumn>
+
+        <dropNotNullConstraint tableName="questionnaire" columnName="code" columnDataType="VARCHAR(10)"/>
+        <dropNotNullConstraint tableName="questionnaire" columnName="purpose" columnDataType="VARCHAR(255)"/>
+        <modifyDataType tableName="questionnaire" columnName="questionnaire_name" newDataType="VARCHAR(255)"/>
+        <dropNotNullConstraint tableName="questionnaire" columnName="questionnaire_name" columnDataType="VARCHAR(255)"/>
+
+        <createIndex indexName="idx_questionnaire_identifier_system" tableName="questionnaire">
+            <column name="identifier_system"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_questionnaire_identifier_system" tableName="questionnaire"/>
+            <dropColumn tableName="questionnaire" columnName="identifier_value"/>
+            <dropColumn tableName="questionnaire" columnName="identifier_system"/>
+            <dropColumn tableName="questionnaire" columnName="resource_json"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="questionnaire-009-questionnaire-response-local-storage" author="OGC">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="questionnaire_response"/>
+            <columnExists tableName="questionnaire_response" columnName="subject_id"/>
+        </preConditions>
+        <comment>
+            Store the canonical FHIR QuestionnaireResponse JSON locally. The subject becomes a FHIR
+            reference and is optional (environmental samples have no patient); the answered
+            questionnaire is tracked by UUID so responses survive without a local questionnaire row.
+        </comment>
+
+        <renameColumn tableName="questionnaire_response" oldColumnName="subject_id"
+            newColumnName="subject_reference" columnDataType="VARCHAR(20)"/>
+        <modifyDataType tableName="questionnaire_response" columnName="subject_reference" newDataType="VARCHAR(100)"/>
+        <dropNotNullConstraint tableName="questionnaire_response" columnName="subject_reference"
+            columnDataType="VARCHAR(100)"/>
+        <dropNotNullConstraint tableName="questionnaire_response" columnName="questionnaire_id"
+            columnDataType="INTEGER"/>
+        <dropNotNullConstraint tableName="questionnaire_response" columnName="status" columnDataType="VARCHAR(30)"/>
+
+        <addColumn tableName="questionnaire_response">
+            <column name="questionnaire_fhir_uuid" type="UUID"/>
+            <column name="resource_json" type="TEXT"/>
+        </addColumn>
+
+        <createIndex indexName="idx_questionnaire_response_questionnaire_fhir_uuid" tableName="questionnaire_response">
+            <column name="questionnaire_fhir_uuid"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_questionnaire_response_questionnaire_fhir_uuid" tableName="questionnaire_response"/>
+            <dropColumn tableName="questionnaire_response" columnName="resource_json"/>
+            <dropColumn tableName="questionnaire_response" columnName="questionnaire_fhir_uuid"/>
+            <renameColumn tableName="questionnaire_response" oldColumnName="subject_reference"
+                newColumnName="subject_id" columnDataType="VARCHAR(100)"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.6.x.x/base.xml
+++ b/src/main/resources/liquibase/3.6.x.x/base.xml
@@ -5,5 +5,6 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
   <include relativeToChangelogFile="true" file="001-questionnaire.xml"/>
+  <include relativeToChangelogFile="true" file="002-questionnaire-local-storage.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -173,6 +173,15 @@
         <class>org.openelisglobal.labelpreset.valueholder.TestLabelPresetLink</class>
         <class>org.openelisglobal.labelpreset.valueholder.OrderLabelRequest</class>
 
+        <!-- Questionnaire / QuestionnaireResponse local storage -->
+        <class>org.openelisglobal.questionnaire.valueholder.Questionnaire</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireItem</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireAnswerOption</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireItemInitial</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireResponseItem</class>
+        <class>org.openelisglobal.questionnaire.valueholder.QuestionnaireResponseAnswer</class>
+
         <properties>
             <property name="hibernate.cfg_xml_file"
                 value="classpath:hibernate/hibernate.cfg.xml" />

--- a/src/test/java/org/openelisglobal/program/ProgramAutocreateWithoutFhirStoreTest.java
+++ b/src/test/java/org/openelisglobal/program/ProgramAutocreateWithoutFhirStoreTest.java
@@ -1,0 +1,116 @@
+package org.openelisglobal.program;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.program.service.ProgramAutocreateService;
+import org.openelisglobal.program.service.ProgramService;
+import org.openelisglobal.program.valueholder.Program;
+import org.openelisglobal.questionnaire.service.QuestionnaireStorageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Programme seeding used to be skipped entirely when no FHIR store was
+ * configured; the bundled programmes and their questionnaires must now land in
+ * the OpenELIS database on their own.
+ */
+public class ProgramAutocreateWithoutFhirStoreTest extends BaseWebContextSensitiveTest {
+
+    private static final String[] QUESTIONNAIRE_TABLES = { "questionnaire_response_answer",
+            "questionnaire_response_item", "questionnaire_response", "questionnaire_item_initial",
+            "questionnaire_answer_option", "questionnaire_item", "questionnaire" };
+
+    @Autowired
+    private ProgramAutocreateService autocreateService;
+    @Autowired
+    private ProgramService programService;
+    @Autowired
+    private QuestionnaireStorageService storage;
+    @Autowired
+    private FhirConfig fhirConfig;
+    @Autowired
+    private FhirUtil fhirUtil;
+    @Autowired
+    private DataSource dataSource;
+
+    private List<JsonNode> bundledProgrammes;
+    private ProgramAutocreateService target;
+
+    @Before
+    public void setUp() throws Exception {
+        target = AopTestUtils.getUltimateTargetObject(autocreateService);
+        reset(fhirConfig, fhirUtil);
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn("");
+        when(fhirUtil.getFhirParser()).thenReturn(FhirContext.forR4Cached().newJsonParser());
+        bundledProgrammes = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        for (Resource resource : new PathMatchingResourcePatternResolver().getResources("classpath*:programs/*.json")) {
+            try (InputStream in = resource.getInputStream()) {
+                bundledProgrammes.add(mapper.readTree(in));
+            }
+        }
+        removeSeededRows();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ReflectionTestUtils.setField(target, "autocreateOn", false);
+        reset(fhirConfig, fhirUtil);
+        removeSeededRows();
+    }
+
+    @Test
+    public void autocreate_withoutFhirStore_seedsProgrammesAndStoresTheirQuestionnairesLocally() {
+        assertFalse("the bundled programme definitions must be on the classpath", bundledProgrammes.isEmpty());
+        ReflectionTestUtils.setField(target, "autocreateOn", true);
+
+        ReflectionTestUtils.invokeMethod(target, "doAutocreateProgram");
+
+        for (JsonNode definition : bundledProgrammes) {
+            String code = definition.path("program").path("code").asText();
+            UUID questionnaireUuid = UUID.fromString(definition.path("program").path("questionnaireUUID").asText());
+            Program program = programService.getMatch("code", code)
+                    .orElseThrow(() -> new AssertionError("programme " + code + " was not seeded"));
+            assertEquals(code, questionnaireUuid, program.getQuestionnaireUUID());
+
+            Questionnaire questionnaire = storage.getQuestionnaire(program.getQuestionnaireUUID())
+                    .orElseThrow(() -> new AssertionError("questionnaire for " + code + " is not in the database"));
+            assertEquals(questionnaireUuid.toString(), questionnaire.getIdElement().getIdPart());
+            assertEquals(definition.path("additionalOrderEntryQuestions").path("item").size(),
+                    questionnaire.getItem().size());
+            assertTrue(questionnaire.hasStatus());
+        }
+    }
+
+    private void removeSeededRows() throws Exception {
+        cleanRowsInCurrentConnection(QUESTIONNAIRE_TABLES);
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        for (JsonNode definition : bundledProgrammes) {
+            jdbc.update("DELETE FROM clinlims.program WHERE code = ?",
+                    definition.path("program").path("code").asText());
+        }
+    }
+}

--- a/src/test/java/org/openelisglobal/program/ProgramControllerLocalQuestionnaireTest.java
+++ b/src/test/java/org/openelisglobal/program/ProgramControllerLocalQuestionnaireTest.java
@@ -1,0 +1,99 @@
+package org.openelisglobal.program;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.program.controller.EditProgramForm;
+import org.openelisglobal.program.controller.ProgramController;
+import org.openelisglobal.program.service.ProgramService;
+import org.openelisglobal.program.valueholder.Program;
+import org.openelisglobal.questionnaire.service.QuestionnaireService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Admin → Programme entry and the Add Order questionnaire endpoint must work
+ * with no FHIR store configured. The controller package is excluded from the
+ * test component scan, so the controller is created against the live context.
+ */
+public class ProgramControllerLocalQuestionnaireTest extends BaseWebContextSensitiveTest {
+
+    private static final String CODE = "QLOCAL";
+    private static final String[] QUESTIONNAIRE_TABLES = { "questionnaire_response_answer",
+            "questionnaire_response_item", "questionnaire_response", "questionnaire_item_initial",
+            "questionnaire_answer_option", "questionnaire_item", "questionnaire" };
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+    @Autowired
+    private ProgramService programService;
+    @Autowired
+    private QuestionnaireService questionnaireService;
+    @Autowired
+    private FhirConfig fhirConfig;
+    @Autowired
+    private DataSource dataSource;
+
+    private ProgramController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        reset(fhirConfig);
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn("");
+        controller = webApplicationContext.getAutowireCapableBeanFactory().createBean(ProgramController.class);
+        removeRows();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        reset(fhirConfig);
+        removeRows();
+    }
+
+    @Test
+    public void saveProgramme_withoutFhirStore_storesQuestionnaireAndServesItToAddOrder() {
+        Program program = new Program();
+        program.setCode(CODE);
+        program.setProgramName("Local questionnaire programme");
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setStatus(PublicationStatus.ACTIVE);
+        questionnaire.addItem().setLinkId("site").setText("Sampling site").setType(QuestionnaireItemType.STRING);
+        EditProgramForm form = new EditProgramForm();
+        form.setProgram(program);
+        form.setAdditionalOrderEntryQuestions(questionnaire);
+
+        controller.createProgram(form);
+
+        Program saved = programService.getMatch("code", CODE).orElseThrow();
+        UUID questionnaireUuid = saved.getQuestionnaireUUID();
+        assertNotNull(questionnaireUuid);
+        assertTrue(questionnaireService.getMatch("fhirUuid", questionnaireUuid).isPresent());
+
+        Questionnaire served = controller.getAdditionalEntryQuestions(new MockHttpServletRequest(), saved.getId());
+        assertEquals(questionnaireUuid.toString(), served.getIdElement().getIdPart());
+        assertEquals("site", served.getItemFirstRep().getLinkId());
+
+        EditProgramForm edit = controller.createProgram(saved.getId());
+        assertEquals("site", edit.getAdditionalOrderEntryQuestions().getItemFirstRep().getLinkId());
+    }
+
+    private void removeRows() throws Exception {
+        cleanRowsInCurrentConnection(QUESTIONNAIRE_TABLES);
+        new JdbcTemplate(dataSource).update("DELETE FROM clinlims.program WHERE code = ?", CODE);
+    }
+}

--- a/src/test/java/org/openelisglobal/questionnaire/QuestionnaireResponseServiceTest.java
+++ b/src/test/java/org/openelisglobal/questionnaire/QuestionnaireResponseServiceTest.java
@@ -72,7 +72,7 @@ public class QuestionnaireResponseServiceTest extends BaseWebContextSensitiveTes
         response.setAuthored(new Timestamp(System.currentTimeMillis()));
 
         Patient patient = patientService.get("1");
-        response.setSubject(patient);
+        response.setSubjectReference("Patient/" + patient.getFhirUuidAsString());
 
         questionnaireResponseService.insert(response);
 
@@ -101,7 +101,7 @@ public class QuestionnaireResponseServiceTest extends BaseWebContextSensitiveTes
         response.setFhirUuid(UUID.randomUUID());
         response.setStatus(QuestionnaireResponseStatus.COMPLETED);
         response.setAuthored(new Timestamp(System.currentTimeMillis()));
-        response.setSubject(patient);
+        response.setSubjectReference("Patient/" + patient.getFhirUuidAsString());
 
         QuestionnaireResponseItem item = new QuestionnaireResponseItem();
         item.setQuestionnaireResponse(response);
@@ -144,7 +144,7 @@ public class QuestionnaireResponseServiceTest extends BaseWebContextSensitiveTes
         response.setFhirUuid(UUID.randomUUID());
         response.setStatus(QuestionnaireResponseStatus.COMPLETED);
         response.setAuthored(new Timestamp(System.currentTimeMillis()));
-        response.setSubject(patient);
+        response.setSubjectReference("Patient/" + patient.getFhirUuidAsString());
 
         QuestionnaireResponseItem parent = new QuestionnaireResponseItem();
         parent.setQuestionnaireResponse(response);
@@ -192,7 +192,7 @@ public class QuestionnaireResponseServiceTest extends BaseWebContextSensitiveTes
         response.setFhirUuid(UUID.randomUUID());
         response.setStatus(QuestionnaireResponseStatus.COMPLETED);
         response.setAuthored(new Timestamp(System.currentTimeMillis()));
-        response.setSubject(patient);
+        response.setSubjectReference("Patient/" + patient.getFhirUuidAsString());
 
         QuestionnaireResponseItem item = new QuestionnaireResponseItem();
         item.setQuestionnaireResponse(response);
@@ -237,7 +237,7 @@ public class QuestionnaireResponseServiceTest extends BaseWebContextSensitiveTes
         response.setFhirUuid(UUID.randomUUID());
         response.setStatus(QuestionnaireResponseStatus.IN_PROGRESS);
         response.setAuthored(new Timestamp(System.currentTimeMillis()));
-        response.setSubject(patient);
+        response.setSubjectReference("Patient/" + patient.getFhirUuidAsString());
 
         QuestionnaireResponseItem item = new QuestionnaireResponseItem();
         item.setQuestionnaireResponse(response);

--- a/src/test/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageServiceTest.java
+++ b/src/test/java/org/openelisglobal/questionnaire/service/QuestionnaireStorageServiceTest.java
@@ -1,0 +1,302 @@
+package org.openelisglobal.questionnaire.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IRead;
+import ca.uhn.fhir.rest.gclient.IReadExecutable;
+import ca.uhn.fhir.rest.gclient.IReadTyped;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.QuestionnaireResponse.QuestionnaireResponseStatus;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.dataexchange.fhir.FhirConfig;
+import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.questionnaire.valueholder.Questionnaire.QuestionnaireStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * The FHIR store is optional: everything must work from the local database, and
+ * when a store is configured it is read first and written alongside.
+ */
+public class QuestionnaireStorageServiceTest extends BaseWebContextSensitiveTest {
+
+    private static final String FHIR_STORE = "http://fhir.test/fhir";
+    private static final String IDENTIFIER_SYSTEM = "http://openelis-global.org/notebook_questionare";
+    private static final String[] TABLES = { "questionnaire_response_answer", "questionnaire_response_item",
+            "questionnaire_response", "questionnaire_item_initial", "questionnaire_answer_option", "questionnaire_item",
+            "questionnaire" };
+
+    @Autowired
+    private QuestionnaireStorageService storage;
+    @Autowired
+    private QuestionnaireService questionnaireService;
+    @Autowired
+    private QuestionnaireResponseService questionnaireResponseService;
+    @Autowired
+    private FhirConfig fhirConfig;
+    @Autowired
+    private FhirUtil fhirUtil;
+    @Autowired
+    private DataSource dataSource;
+
+    @Before
+    public void setUp() throws Exception {
+        cleanRowsInCurrentConnection(TABLES);
+        reset(fhirConfig, fhirUtil);
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn("");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        reset(fhirConfig, fhirUtil);
+        cleanRowsInCurrentConnection(TABLES);
+    }
+
+    @Test
+    public void saveQuestionnaire_withoutFhirStore_persistsLocallyAndRoundTrips() {
+        String uuid = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "Vector field survey", PublicationStatus.ACTIVE));
+
+        org.openelisglobal.questionnaire.valueholder.Questionnaire row = questionnaireService
+                .getMatch("fhirUuid", UUID.fromString(uuid)).orElseThrow();
+        assertEquals("VectorFieldSurvey", row.getQuestionnaireName());
+        assertEquals(QuestionnaireStatus.ACTIVE, row.getStatus());
+        assertEquals(IDENTIFIER_SYSTEM, row.getIdentifierSystem());
+        assertTrue(row.isHasItem());
+        assertTrue(row.getResourceJson().contains("\"linkId\":\"species\""));
+
+        Questionnaire loaded = storage.getQuestionnaire(uuid).orElseThrow();
+        assertEquals(uuid, loaded.getIdElement().getIdPart());
+        assertEquals("Vector field survey", loaded.getTitle());
+        assertEquals("species", loaded.getItemFirstRep().getLinkId());
+        assertEquals(QuestionnaireItemType.CHOICE, loaded.getItemFirstRep().getType());
+        assertEquals("Aedes", loaded.getItemFirstRep().getAnswerOptionFirstRep().getValueCoding().getCode());
+    }
+
+    @Test
+    public void saveQuestionnaire_existingUuid_updatesTheSameRow() {
+        String uuid = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "First title", PublicationStatus.DRAFT));
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "Second title", PublicationStatus.ACTIVE));
+
+        List<org.openelisglobal.questionnaire.valueholder.Questionnaire> rows = questionnaireService.getAll();
+        assertEquals(1, rows.size());
+        assertEquals(QuestionnaireStatus.ACTIVE, rows.get(0).getStatus());
+        assertEquals("Second title", storage.getQuestionnaire(uuid).orElseThrow().getTitle());
+    }
+
+    @Test
+    public void getQuestionnaire_unknownUuid_isEmpty() {
+        assertTrue(storage.getQuestionnaire(UUID.randomUUID().toString()).isEmpty());
+        assertTrue(storage.getQuestionnaire((UUID) null).isEmpty());
+        assertTrue(storage.getQuestionnaire("").isEmpty());
+    }
+
+    @Test
+    public void getQuestionnaire_withFhirStore_prefersTheStoreCopyAndCopiesItLocally() {
+        String uuid = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "Local title", PublicationStatus.ACTIVE));
+        Questionnaire remote = programmeQuestionnaire(uuid, "Store title", PublicationStatus.ACTIVE);
+        String remoteOnly = UUID.randomUUID().toString();
+        Questionnaire remoteOnlyQuestionnaire = programmeQuestionnaire(remoteOnly, "Only in store",
+                PublicationStatus.ACTIVE);
+
+        IGenericClient client = clientServing(Questionnaire.class,
+                Map.of(uuid, remote, remoteOnly, remoteOnlyQuestionnaire), null);
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn(FHIR_STORE);
+        when(fhirUtil.getLocalFhirClient()).thenReturn(client);
+
+        assertEquals("Store title", storage.getQuestionnaire(uuid).orElseThrow().getTitle());
+        assertEquals("Only in store", storage.getQuestionnaire(remoteOnly).orElseThrow().getTitle());
+        assertTrue("store-only questionnaire is copied into the local database",
+                questionnaireService.getMatch("fhirUuid", UUID.fromString(remoteOnly)).isPresent());
+    }
+
+    @Test
+    public void getQuestionnaire_whenFhirStoreIsDown_fallsBackToLocalCopy() {
+        String uuid = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "Local title", PublicationStatus.ACTIVE));
+
+        IGenericClient client = clientServing(Questionnaire.class, Map.of(),
+                new ResourceNotFoundException("store unavailable"));
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn(FHIR_STORE);
+        when(fhirUtil.getLocalFhirClient()).thenReturn(client);
+
+        assertEquals("Local title", storage.getQuestionnaire(uuid).orElseThrow().getTitle());
+    }
+
+    @Test
+    public void saveQuestionnaire_whenFhirStoreWriteFails_keepsTheLocalCopy() {
+        String uuid = UUID.randomUUID().toString();
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn(FHIR_STORE);
+
+        storage.saveQuestionnaire(programmeQuestionnaire(uuid, "Kept locally", PublicationStatus.ACTIVE));
+
+        assertTrue(questionnaireService.getMatch("fhirUuid", UUID.fromString(uuid)).isPresent());
+    }
+
+    @Test
+    public void storeQuestionnaireResponseLocally_withoutSubjectOrLocalQuestionnaire_persistsAnswers() {
+        String responseUuid = UUID.randomUUID().toString();
+        String questionnaireUuid = UUID.randomUUID().toString();
+        QuestionnaireResponse response = answers(responseUuid, questionnaireUuid, "Aedes");
+
+        storage.storeQuestionnaireResponseLocally(response);
+
+        org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse row = questionnaireResponseService
+                .getMatch("fhirUuid", UUID.fromString(responseUuid)).orElseThrow();
+        assertNull(row.getSubjectReference());
+        assertNull(row.getQuestionnaire());
+        assertEquals(UUID.fromString(questionnaireUuid), row.getQuestionnaireFhirUuid());
+        assertEquals(
+                org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED,
+                row.getStatus());
+
+        QuestionnaireResponse loaded = storage.getQuestionnaireResponse(responseUuid).orElseThrow();
+        assertEquals("Aedes", loaded.getItemFirstRep().getAnswerFirstRep().getValueStringType().getValue());
+        assertEquals("Questionnaire/" + questionnaireUuid, loaded.getQuestionnaire());
+    }
+
+    @Test
+    public void saveQuestionnaireResponse_linksTheLocalQuestionnaireAndKeepsTheSubject() {
+        String questionnaireUuid = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(questionnaireUuid, "Linked", PublicationStatus.ACTIVE));
+        String responseUuid = UUID.randomUUID().toString();
+        QuestionnaireResponse response = answers(responseUuid, questionnaireUuid, "Culex");
+        response.setSubject(new Reference("Patient/" + UUID.randomUUID()));
+
+        storage.saveQuestionnaireResponse(response);
+        storage.saveQuestionnaireResponse(answers(responseUuid, questionnaireUuid, "Anopheles"));
+
+        List<org.openelisglobal.questionnaire.valueholder.QuestionnaireResponse> rows = questionnaireResponseService
+                .getAll();
+        assertEquals(1, rows.size());
+        assertEquals(UUID.fromString(questionnaireUuid), rows.get(0).getQuestionnaireFhirUuid());
+        assertEquals(questionnaireUuid,
+                new JdbcTemplate(dataSource).queryForObject("SELECT q.fhir_uuid::text FROM clinlims.questionnaire q"
+                        + " JOIN clinlims.questionnaire_response r ON r.questionnaire_id = q.id"
+                        + " WHERE r.fhir_uuid = ?::uuid", String.class, responseUuid));
+        assertEquals("Anopheles", storage.getQuestionnaireResponse(responseUuid).orElseThrow().getItemFirstRep()
+                .getAnswerFirstRep().getValueStringType().getValue());
+    }
+
+    @Test
+    public void getQuestionnaireResponse_whenFhirStoreIsDown_fallsBackToLocalCopy() {
+        String responseUuid = UUID.randomUUID().toString();
+        storage.storeQuestionnaireResponseLocally(answers(responseUuid, UUID.randomUUID().toString(), "Aedes"));
+
+        IGenericClient client = clientServing(QuestionnaireResponse.class, Map.of(),
+                new ResourceNotFoundException("store unavailable"));
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn(FHIR_STORE);
+        when(fhirUtil.getLocalFhirClient()).thenReturn(client);
+
+        Optional<QuestionnaireResponse> loaded = storage.getQuestionnaireResponse(responseUuid);
+        assertEquals("Aedes",
+                loaded.orElseThrow().getItemFirstRep().getAnswerFirstRep().getValueStringType().getValue());
+    }
+
+    @Test
+    public void getActiveQuestionnairesByIdentifierSystem_withoutFhirStore_listsLocalActiveOnes() {
+        String active = UUID.randomUUID().toString();
+        storage.saveQuestionnaire(programmeQuestionnaire(active, "Active notebook form", PublicationStatus.ACTIVE));
+        storage.saveQuestionnaire(
+                programmeQuestionnaire(UUID.randomUUID().toString(), "Retired form", PublicationStatus.RETIRED));
+        Questionnaire otherSystem = programmeQuestionnaire(UUID.randomUUID().toString(), "Other system",
+                PublicationStatus.ACTIVE);
+        otherSystem.getIdentifier().clear();
+        otherSystem.addIdentifier(new Identifier().setSystem("http://elsewhere").setValue("x"));
+        storage.saveQuestionnaire(otherSystem);
+
+        List<Questionnaire> found = storage.getActiveQuestionnairesByIdentifierSystem(IDENTIFIER_SYSTEM);
+
+        assertEquals(1, found.size());
+        assertEquals(active, found.get(0).getIdElement().getIdPart());
+        assertFalse(storage.isFhirStoreConfigured());
+    }
+
+    @Test
+    public void toStorageUuid_acceptsUuidsAndMapsOtherIdsDeterministically() {
+        UUID uuid = UUID.randomUUID();
+        assertEquals(uuid, QuestionnaireStorageServiceImpl.toStorageUuid(uuid.toString()));
+        assertEquals(QuestionnaireStorageServiceImpl.toStorageUuid("generic-sample-logbook"),
+                QuestionnaireStorageServiceImpl.toStorageUuid("generic-sample-logbook"));
+        assertNotEquals(QuestionnaireStorageServiceImpl.toStorageUuid("a"),
+                QuestionnaireStorageServiceImpl.toStorageUuid("b"));
+    }
+
+    /**
+     * A FHIR client whose {@code read().resource(type).withId(id).execute()}
+     * returns the mapped resource, throws {@code failure} when given, and otherwise
+     * reports the id as not found.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends IBaseResource> IGenericClient clientServing(Class<T> type, Map<String, T> byId,
+            RuntimeException failure) {
+        IGenericClient client = mock(IGenericClient.class);
+        IRead read = mock(IRead.class);
+        IReadTyped<T> typed = mock(IReadTyped.class);
+        when(client.read()).thenReturn(read);
+        when(read.resource(type)).thenReturn(typed);
+        when(typed.withId(anyString())).thenAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            IReadExecutable<T> executable = mock(IReadExecutable.class);
+            if (failure != null) {
+                when(executable.execute()).thenThrow(failure);
+            } else if (byId.containsKey(id)) {
+                when(executable.execute()).thenReturn(byId.get(id));
+            } else {
+                when(executable.execute()).thenThrow(new ResourceNotFoundException(type.getSimpleName() + "/" + id));
+            }
+            return executable;
+        });
+        return client;
+    }
+
+    private static Questionnaire programmeQuestionnaire(String uuid, String title, PublicationStatus status) {
+        Questionnaire questionnaire = new Questionnaire();
+        questionnaire.setId(uuid);
+        questionnaire.setName("VectorFieldSurvey");
+        questionnaire.setTitle(title);
+        questionnaire.setStatus(status);
+        questionnaire.setDescription("Additional order entry questions");
+        questionnaire.addIdentifier(new Identifier().setSystem(IDENTIFIER_SYSTEM).setValue(title));
+        questionnaire.addItem().setLinkId("species").setText("Species").setType(QuestionnaireItemType.CHOICE)
+                .addAnswerOption().setValue(new Coding().setCode("Aedes").setDisplay("Aedes"));
+        return questionnaire;
+    }
+
+    private static QuestionnaireResponse answers(String responseUuid, String questionnaireUuid, String species) {
+        QuestionnaireResponse response = new QuestionnaireResponse();
+        response.setId(responseUuid);
+        response.setStatus(QuestionnaireResponseStatus.COMPLETED);
+        response.setQuestionnaire("Questionnaire/" + questionnaireUuid);
+        response.addItem().setLinkId("species").addAnswer().setValue(new StringType(species));
+        return response;
+    }
+}

--- a/src/test/resources/common.properties
+++ b/src/test/resources/common.properties
@@ -2,3 +2,6 @@
 org.openelisglobal.branding.dir=${java.io.tmpdir}/openelis-branding-test/
 org.openelisglobal.branding.config.dir=${java.io.tmpdir}/openelis-branding-config-test/
 org.openelisglobal.remote.source.updateStatus=true
+
+# Programme seeding is driven explicitly by ProgramAutocreateWithoutFhirStoreTest, never at context start-up.
+org.openelisglobal.program.autocreate=false

--- a/src/test/resources/testdata/questionnaire-response.xml
+++ b/src/test/resources/testdata/questionnaire-response.xml
@@ -84,18 +84,21 @@
 
     <questionnaire_response id="1"
         fhir_uuid="aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa" questionnaire_id="1"
-        subject_id="1" status="COMPLETED" authored="2026-05-20 09:00:00"
-        sys_user_id="1" last_updated="2026-05-20 09:10:00" />
+        subject_reference="Patient/b479ab79-5f53-4d1f-bc9b-10f19ce04635"
+        status="COMPLETED" authored="2026-05-20 09:00:00" sys_user_id="1"
+        last_updated="2026-05-20 09:10:00" />
 
     <questionnaire_response id="2"
         fhir_uuid="bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb" questionnaire_id="2"
-        subject_id="1" status="COMPLETED" authored="2026-05-20 09:30:00"
-        sys_user_id="1" last_updated="2026-05-20 09:40:00" />
+        subject_reference="Patient/b479ab79-5f53-4d1f-bc9b-10f19ce04635"
+        status="COMPLETED" authored="2026-05-20 09:30:00" sys_user_id="1"
+        last_updated="2026-05-20 09:40:00" />
 
     <questionnaire_response id="3"
         fhir_uuid="cccc3333-cccc-cccc-cccc-cccccccccccc" questionnaire_id="3"
-        subject_id="1" status="IN_PROGRESS" authored="2026-05-20 10:00:00"
-        sys_user_id="1" last_updated="2026-05-20 10:05:00" />
+        subject_reference="Patient/b479ab79-5f53-4d1f-bc9b-10f19ce04635"
+        status="IN_PROGRESS" authored="2026-05-20 10:00:00" sys_user_id="1"
+        last_updated="2026-05-20 10:05:00" />
 
     <questionnaire_response_item id="1"
         questionnaire_response_id="1" link_id="1" text="Maternal Assessment"


### PR DESCRIPTION
Follow-up to #3622. No Jira ticket exists for this work.

**What changed**
- New `QuestionnaireStorageService` fronts every Questionnaire / QuestionnaireResponse read and write. Writes land in the OpenELIS tables first (canonical FHIR JSON plus metadata columns) and are mirrored to the FHIR store when `org.openelisglobal.fhirstore.uri` is set; reads try the store first when configured and fall back to the local copy. A store-only resource is copied locally on first read, so existing deployments migrate on their own.
- Programme seeding at start-up and the `questionnaires/*.json` loader no longer require a FHIR store. Admin → Programme entry, Add Order, order search, Modify Order, programme dashboards, pathology/cytology/IHC case views, generic-sample orders, the notebook picker and `GET /rest/fhir/Questionnaire*` all use the facade.
- Order entry stores the programme answers synchronously with the order; the async FHIR transform keeps pushing them to the store.
- Schema (`3.6.x.x/002`): `resource_json` and identifier columns; `subject_reference` replaces the `subject_id` Patient join and is optional (environmental samples have no patient); `questionnaire_fhir_uuid`; relaxed NOT NULLs. Entities registered in the main persistence unit; `Integer` id; `daoimpl` package; DAO-level `@Transactional` removed.

**Why**
OpenELIS should depend on the FHIR store only for the EMR–LIS workflow. Without a store, programmes were never seeded, the admin save returned 500 after committing the programme row, and saved answers could not be shown.

**How it was tested**
- New backend tests: `QuestionnaireStorageServiceTest` (11), `ProgramAutocreateWithoutFhirStoreTest`, `ProgramControllerLocalQuestionnaireTest`; #3622 tests updated for the subject column. Each new behaviour was inverted once to confirm the tests catch it. Full backend suite: 5751 run, 0 failures, 0 errors, 8 skipped.
- Live on the dev stack, FHIR container stopped, then property blank: in both modes programme questionnaires load in Add Order, the admin save succeeds and stores the row, an order with answers lands in `questionnaire_response` (linked to its questionnaire, no subject), and order search returns the answers. With the store back: deleting a local questionnaire row and reading it through Add Order served it from the store and re-created the local copy.

**Notes**
- The FHIR store is authoritative on read when configured; a store write failure is logged, not surfaced.
- Test profile: `org.openelisglobal.program.autocreate=false` in `common.properties` keeps the seeding daemon out of the shared test context; the autocreate test drives it explicitly.
- The relational item tables from #3622 stay in place but are not populated yet; the JSON column is the source of truth.
- Pre-existing and unchanged: without a store the async order-entry FHIR transform still logs a null-client error; a store-less deployment that already recorded the `questionnaires/*.json` checksum needs one `POST /rest/configuration/domains/reload` with `force` to copy those files locally.
