### PR TITLE
fix(eqa): an unblinded in-house cycle reads as scored, with the count it earned (OGC-612)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -281,9 +281,15 @@ public class EQACycleRestController extends BaseRestController {
     }
 
     /**
-     * Progress and per-sample entry state for a cycle, at analysis grain: an
-     * analyte counts as entered once its analysis is finalized in the standard
-     * pipeline — the same gate T-14 will auto-submit on.
+     * Progress and per-sample entry state for a cycle, at analysis grain.
+     *
+     * <p>
+     * What counts as entered depends on the lane, because the two lanes have
+     * different gates. An external analyte counts once its analysis is finalized in
+     * the standard pipeline, which is what auto-submit waits on (FR-V2.2-07). An
+     * in-house one counts as soon as a result exists: that lane scores from the
+     * unblind and never goes through validation at all, so the Finalized rule left
+     * a fully answered and scored panel reading <i>0 of 6</i>.
      *
      * <p>
      * When the scheme's review gate is on, each analyte also carries what the lab
@@ -303,6 +309,7 @@ public class EQACycleRestController extends BaseRestController {
         String finalizedId = statusService.getStatusID(AnalysisStatus.Finalized);
         String notStartedId = statusService.getStatusID(AnalysisStatus.NotStarted);
         boolean withReportedValues = Boolean.TRUE.equals(dto.get("requiresCycleReview"));
+        boolean inHouse = EQASchemeType.IN_HOUSE.name().equals(dto.get("schemeType"));
 
         int entered = 0;
         int total = 0;
@@ -319,12 +326,18 @@ public class EQACycleRestController extends BaseRestController {
             List<Map<String, Object>> analytes = new ArrayList<>();
             boolean allFinalized = !analyses.isEmpty();
             boolean anyStarted = false;
+            int enteredHere = 0;
             for (Analysis analysis : analyses) {
                 total++;
                 boolean finalized = finalizedId.equals(analysis.getStatusId());
-                if (finalized) {
+                // In-house: answered is the gate, and an answer is a result. Reading
+                // the status instead would count a cancelled analysis as entered.
+                boolean answered = inHouse ? hasResult(analysis) : finalized;
+                if (answered) {
                     entered++;
-                } else {
+                    enteredHere++;
+                }
+                if (!finalized) {
                     allFinalized = false;
                 }
                 if (!notStartedId.equals(analysis.getStatusId())) {
@@ -339,11 +352,28 @@ public class EQACycleRestController extends BaseRestController {
             sampleDto.put("id", link.getEqaProviderSampleId());
             sampleDto.put("labNo", order.getAccessionNumber());
             sampleDto.put("analytes", analytes);
-            sampleDto.put("entryStatus", allFinalized ? "entered" : anyStarted ? "in_progress" : "empty");
+            sampleDto.put("entryStatus",
+                    (inHouse ? enteredHere == analyses.size() && !analyses.isEmpty() : allFinalized) ? "entered"
+                            : anyStarted ? "in_progress" : "empty");
             sampleDtos.add(sampleDto);
         }
         dto.put("progress", Map.of("entered", entered, "total", total));
         dto.put("samples", sampleDtos);
+    }
+
+    /**
+     * Whether the bench has answered this analysis. One query per in-house
+     * analysis, which is the same order of cost as the surrounding loop already
+     * pays per order; an in-house panel carries a handful of samples.
+     */
+    private boolean hasResult(Analysis analysis) {
+        for (Result result : resultService.getResultsByAnalysis(analysis)) {
+            String rendered = resultService.getSimpleResultValue(result);
+            if (rendered != null && !rendered.isBlank()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -22,6 +22,8 @@ import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
@@ -31,7 +33,10 @@ import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
 import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
+import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
+import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
+import org.openelisglobal.eqa.valueholder.EQATriggerType;
 import org.openelisglobal.eqa.valueholder.EQAUnblindMethod;
 import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.openelisglobal.patient.service.PatientService;
@@ -75,6 +80,8 @@ public class EQABlindingServiceImpl implements EQABlindingService {
     private EQAPanelDAO panelDAO;
     @Autowired
     private EQAPanelSampleDAO panelSampleDAO;
+    @Autowired
+    private EQACycleService cycleService;
     @Autowired
     private EQARoundDAO roundDAO;
     @Autowired
@@ -182,7 +189,22 @@ public class EQABlindingServiceImpl implements EQABlindingService {
 
         panel.setStatus(EQAPanelStatus.SCORED);
         panel.setSysUserId(sysUserId);
-        return panelDAO.update(panel);
+        EQAPanel scored = panelDAO.update(panel);
+
+        // The cycle follows its panel. Without this an unblinded and scored
+        // in-house cycle stayed at PLANNED and My Cycles read it as untouched
+        // while its own report showed the verdicts. A second panel unblinding in
+        // the same cycle finds it already scored and leaves it alone.
+        markCycleScored(panel.getCycle(), sysUserId);
+        return scored;
+    }
+
+    private void markCycleScored(EQACycle cycle, String sysUserId) {
+        if (cycle == null || cycle.getStatus() == EQACycleStatus.SCORED || cycle.getStatus() == EQACycleStatus.CLOSED) {
+            return;
+        }
+        cycleService.transition(cycle.getId(), EQACycleStatus.SCORED, EQAStateMachine.PARTICIPANT, EQATriggerType.AUTO,
+                EQATriggerEvent.PANEL_UNBLIND, null, null, sysUserId);
     }
 
     // ---- seal helpers ----

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -50,6 +50,7 @@ import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQARound;
+import org.openelisglobal.eqa.valueholder.EQASchemeType;
 import org.openelisglobal.eqa.valueholder.EQAStateMachine;
 import org.openelisglobal.eqa.valueholder.EQASubmissionStatus;
 import org.openelisglobal.eqa.valueholder.EQATriggerEvent;
@@ -76,6 +77,17 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
     /** FR-V2.1-18. Terminal: CLOSED. */
     private static final Map<EQACycleStatus, Set<EQACycleStatus>> PROVIDER_EDGES = new EnumMap<>(EQACycleStatus.class);
 
+    /**
+     * The in-house lane's own edges. Its cycle-level events are the unblind and the
+     * close: a blinded panel is dealt to the bench, answered through standard
+     * result entry and scored at the unblind, so the external lane's intermediate
+     * states — panel received, ready to submit, submitted — describe nothing that
+     * happens here. Walking them to reach SCORED would write five audit rows for
+     * one act, and leaving the cycle at PLANNED is what made a fully scored panel
+     * read as untouched on My Cycles.
+     */
+    private static final Map<EQACycleStatus, Set<EQACycleStatus>> IN_HOUSE_EDGES = new EnumMap<>(EQACycleStatus.class);
+
     static {
         PARTICIPANT_EDGES.put(PLANNED, EnumSet.of(PANEL_RECEIVED));
         PARTICIPANT_EDGES.put(PANEL_RECEIVED, EnumSet.of(TESTING));
@@ -99,6 +111,9 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         PROVIDER_EDGES.put(SUBMISSIONS_CLOSED, EnumSet.of(SCORING));
         PROVIDER_EDGES.put(SCORING, EnumSet.of(SCORED));
         PROVIDER_EDGES.put(SCORED, EnumSet.of(CLOSED));
+
+        IN_HOUSE_EDGES.put(PLANNED, EnumSet.of(SCORED));
+        IN_HOUSE_EDGES.put(SCORED, EnumSet.of(CLOSED));
     }
 
     @Autowired
@@ -242,10 +257,21 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         }
     }
 
-    private static Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {
-        Map<EQACycleStatus, Set<EQACycleStatus>> edges = machine == EQAStateMachine.PROVIDER ? PROVIDER_EDGES
-                : PARTICIPANT_EDGES;
+    private static Set<EQACycleStatus> legalNextStates(EQACycle cycle, EQACycleStatus from, EQAStateMachine machine) {
+        Map<EQACycleStatus, Set<EQACycleStatus>> edges;
+        if (machine == EQAStateMachine.PROVIDER) {
+            edges = PROVIDER_EDGES;
+        } else if (isInHouse(cycle)) {
+            edges = IN_HOUSE_EDGES;
+        } else {
+            edges = PARTICIPANT_EDGES;
+        }
         return edges.getOrDefault(from, EnumSet.noneOf(EQACycleStatus.class));
+    }
+
+    private static boolean isInHouse(EQACycle cycle) {
+        return cycle != null && cycle.getScheme() != null
+                && cycle.getScheme().getSchemeType() == EQASchemeType.IN_HOUSE;
     }
 
     @Override
@@ -258,7 +284,7 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
                 .orElseThrow(() -> new ObjectNotFoundException(cycleId, EQACycle.class.getName()));
 
         EQACycleStatus priorState = cycle.getStatus();
-        if (!legalNextStates(priorState, machine).contains(newState)) {
+        if (!legalNextStates(cycle, priorState, machine).contains(newState)) {
             throw new EQAInvalidTransitionException(priorState, newState,
                     "Cannot move a " + machine + " cycle from " + priorState + " to " + newState);
         }

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -29,6 +29,7 @@ import org.openelisglobal.eqa.service.EQABlindingService.BlindOrderSpec;
 import org.openelisglobal.eqa.service.EQALabelPDFService;
 import org.openelisglobal.eqa.service.EQAPanelService;
 import org.openelisglobal.eqa.valueholder.EQACycle;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPanelStatus;
@@ -422,6 +423,51 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         java.util.Set<String> reported = new java.util.HashSet<>();
         summary.get("unacceptable").forEach(node -> reported.add(node.get("reported").asText()));
         assertEquals(java.util.Set.of("92", "140", "Negative"), reported);
+    }
+
+    /**
+     * The cycle follows its panel. An unblinded and scored in-house cycle used to
+     * stay at PLANNED, so My Cycles read a finished round as untouched while the
+     * same cycle's performance report showed every verdict.
+     */
+    @Test
+    public void unblind_movesTheInHouseCycleToScoredAndLeavesASecondPanelAlone() {
+        seedEnrollment(9901, "IH Cycle State Scheme");
+        EQAProgram scheme = inHouseScheme("IH Cycle State Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQAPanel first = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long firstSample = insertPanelSample(first, "IH-01", "IHSTATE-1", NUMERIC_ANALYTE, "100", "95", "105");
+        insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "102", 1L, firstSample);
+        EQAPanel second = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long secondSample = insertPanelSample(second, "IH-02", "IHSTATE-2", NUMERIC_ANALYTE, "100", "95", "105");
+        insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.SUBMITTED, "99", 1L, secondSample);
+
+        assertEquals("the cycle starts where the wizard leaves it", EQACycleStatus.PLANNED,
+                readBack(cycle.getId()).getStatus());
+
+        blindingService.unblindAndScore(first.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        assertEquals("the cycle follows its panel", EQACycleStatus.SCORED, readBack(cycle.getId()).getStatus());
+        List<Map<String, Object>> audit = jdbc
+                .queryForList("SELECT prior_state, new_state, trigger_type, trigger_event, triggered_by"
+                        + " FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ?", cycle.getId());
+        assertEquals("one audit row for one act, not a walk through the external lane's states", 1, audit.size());
+        assertEquals("PLANNED", audit.get(0).get("prior_state"));
+        assertEquals("SCORED", audit.get(0).get("new_state"));
+        assertEquals("AUTO", audit.get(0).get("trigger_type"));
+        assertEquals("PANEL_UNBLIND", audit.get(0).get("trigger_event"));
+        assertNull("the system acted, so no actor", audit.get(0).get("triggered_by"));
+
+        // A cycle may carry several panels; the second one finds it already scored.
+        blindingService.unblindAndScore(second.getId(), USER, EQAUnblindMethod.MANUAL);
+
+        assertEquals("still scored", EQACycleStatus.SCORED, readBack(cycle.getId()).getStatus());
+        assertEquals("and no second audit row", 1,
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ?",
+                        Integer.class, cycle.getId()).intValue());
+        assertEquals("both panels scored", EQAPanelStatus.SCORED,
+                eqaPanelDAO.get(second.getId()).orElseThrow(AssertionError::new).getStatus());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleEnrichmentIntegrationTest.java
@@ -86,7 +86,8 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
      * SampleEQAOrderStatusIntegrationTest.
      */
     private void ensureStatusRows() {
-        String[][] canonical = { { "9604", "Not Tested" }, { "9606", "Finalized" } };
+        String[][] canonical = { { "9604", "Not Tested" }, { "9606", "Finalized" },
+                { "9605", "Technical Acceptance" } };
         for (String[] row : canonical) {
             jdbc.update("INSERT INTO clinlims.status_of_sample (id, code, status_type, name, description)"
                     + " SELECT ?::numeric, 1, 'ANALYSIS', ?, 'restored by EQACycleEnrichmentIntegrationTest'"
@@ -102,7 +103,7 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
     }
 
     private void cleanupSeed() {
-        jdbc.update("DELETE FROM clinlims.result WHERE id = ?", RESULT_ID);
+        jdbc.update("DELETE FROM clinlims.result WHERE id IN (?, ?)", RESULT_ID, RESULT_ID + 1);
         jdbc.update("DELETE FROM clinlims.sample_eqa WHERE id = ?", SAMPLE_EQA_ID);
         jdbc.update("DELETE FROM clinlims.analysis WHERE id IN (?, ?)", ANALYSIS_FINALIZED_ID, ANALYSIS_NOT_STARTED_ID);
         jdbc.update("DELETE FROM clinlims.sample_item WHERE id = ?", SAMPLE_ITEM_ID);
@@ -194,6 +195,51 @@ public class EQACycleEnrichmentIntegrationTest extends EQASpineTestBase {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> after = (List<Map<String, Object>>) row.get("samples");
         assertEquals("entered", after.get(0).get("entryStatus"));
+    }
+
+    /**
+     * The two lanes count progress by different gates, because they have different
+     * gates. The in-house lane scores from the unblind and never goes through
+     * validation, so counting only Finalized analyses left a fully answered and
+     * scored panel reading 0 of 2 on My Cycles while its own report showed the
+     * verdicts.
+     */
+    @Test
+    public void anInHouseCycleCountsAnsweredSamplesRatherThanValidatedOnes() {
+        EQAProgram scheme = insertScheme("In-house progress " + System.nanoTime(), EQASchemeType.IN_HOUSE, null);
+        Long cycleId = insertCycle(scheme, 5);
+
+        int technicalAcceptance = Integer.parseInt(statusService.getStatusID(AnalysisStatus.TechnicalAcceptance));
+        int notStartedId = Integer.parseInt(statusService.getStatusID(AnalysisStatus.NotStarted));
+        seedLinkedOrder(cycleId, technicalAcceptance, notStartedId);
+        // The answered analysis carries a result; the silent one does not. That is
+        // the difference, not the status: reading the status would count a
+        // cancelled analysis as answered.
+        jdbc.update("INSERT INTO clinlims.result (id, analysis_id, result_type, value, sort_order, is_reportable,"
+                + " lastupdated) VALUES (?, ?, 'N', '102', '1', 'Y', NOW())", RESULT_ID, ANALYSIS_FINALIZED_ID);
+
+        Map<String, Object> row = findCycleRow(cycleId);
+
+        assertEquals("the answered sample counts although nothing was validated", Map.of("entered", 1, "total", 2),
+                row.get("progress"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> samples = (List<Map<String, Object>>) row.get("samples");
+        assertEquals("one answered of two reads as in progress", "in_progress", samples.get(0).get("entryStatus"));
+
+        // Answer the second one and the order reads as entered, still unvalidated.
+        jdbc.update("UPDATE clinlims.analysis SET status_id = ? WHERE id = ?", technicalAcceptance,
+                ANALYSIS_NOT_STARTED_ID);
+        jdbc.update(
+                "INSERT INTO clinlims.result (id, analysis_id, result_type, value, sort_order, is_reportable,"
+                        + " lastupdated) VALUES (?, ?, 'N', '99', '1', 'Y', NOW())",
+                RESULT_ID + 1, ANALYSIS_NOT_STARTED_ID);
+        row = findCycleRow(cycleId);
+
+        assertEquals(Map.of("entered", 2, "total", 2), row.get("progress"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> after = (List<Map<String, Object>>) row.get("samples");
+        assertEquals("entered", after.get(0).get("entryStatus"));
+        jdbc.update("DELETE FROM clinlims.result WHERE id = ?", RESULT_ID + 1);
     }
 
     /**


### PR DESCRIPTION
## What

A scored in-house cycle read **Planned · 0 / 6** on My Cycles while the same cycle's performance report showed 6 results, 4 scored and 50% acceptable, and its panel was `SCORED`. A completed round looked untouched, so a supervisor checking progress there would conclude the bench had not started.

Two independent causes, both definitional.

## 1. Progress counted the wrong gate

`addSampleProgress` counted an analysis as entered only once it was `Finalized`. That is right for the external lane, where validation is what auto-submit waits on (FR-V2.2-07) — but the in-house lane scores from the unblind and never goes through validation, so the counter never advanced however much bench work was done. On the rig all four answered in-house analyses sat at Technical Acceptance.

An in-house sample now counts once **a result exists**, which is what answering it means. The external rule is untouched. The check is the result rather than the analysis status deliberately: reading the status would count a cancelled analysis as answered.

## 2. Nothing moved the cycle

Panels reached `SCORED` while their cycles sat at `PLANNED` for ever — four such cycles on the rig. The cycle now follows its panel at the unblind, in one audited transition.

**The in-house lane gets its own edge set to do it.** Its cycle-level events are the unblind and the close, so the external lane's intermediate states — panel received, ready to submit, submitted — describe nothing that happens here, and walking them to reach `SCORED` would write five audit rows for one act. The card suggested this was an existing edge; from `PLANNED` it is not, and a lane-specific edge map is the honest way to say why. It also stops an in-house cycle being walked through states that mean nothing for it.

A second panel unblinding in the same cycle finds it already scored and leaves it alone.

## Verification

**The progress half is a page load**, because the rig still holds the state that produced the finding:

| cycle | before | after |
| --- | --- | --- |
| 2 · In-house round 1 | `0 / 6` | **`5 / 6`** — five answered, the silent control still empty |
| 3, 4, 13 | `0 / 1` | **`1 / 1`** |

**The transition half needed a fresh unblind**, since it fires at the unblind rather than retroactively. A one-sample in-house cycle was built through the wizard (`IH-16-01`, target `Positif`, unblind date tomorrow so the scheduler stayed out), answered through standard result entry, then unblinded:

```
eqa_cycle 14                      PLANNED  ->  SCORED
eqa_cycle_state_transition        PLANNED | SCORED | PARTICIPANT | AUTO | PANEL_UNBLIND | (no actor)
eqa_participant_result 10         SCORED | Positif | ACCEPTABLE
My Cycles                         Scored · 1 / 1
```

One audit row, not five. **The external lane is unchanged**: the participant instance's fifteen cycles with linked orders report exactly the progress they did before, and the cycle deliberately parked at `READY_TO_SUBMIT` stayed there.

`EQACycleServiceImpl.class` fingerprints 28268 bytes in all four Tomcat contexts across both instances.

## Tests

561 → 563 EQA tests, two new, each inverted:

- an in-house cycle counts answered samples rather than validated ones — reverting the gate fails it with `entered=0`
- the unblind moves the in-house cycle to `SCORED`, writes one audit row with no actor, and leaves a second panel's cycle alone — reverting the transition fails it with `expected:<SCORED> but was:<PLANNED>`

No schema change: `PANEL_UNBLIND` has been in the trigger-event vocabulary since the spine.