### PR TITLE
fix(eqa): score late in-house results instead of discarding them (OGC-612)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
+++ b/src/main/java/org/openelisglobal/eqa/scheduler/EQADeadlineAlertScheduler.java
@@ -268,6 +268,25 @@ public class EQADeadlineAlertScheduler {
     }
 
     /**
+     * AC-V2.4-06: a result answered after its panel unblinded is scored on the next
+     * pass, keeping its lateness flag. Rides the sweep the unblind pass already
+     * runs on rather than adding a second scheduler (the house rule), and reads the
+     * missed rows rather than the scored panels, so the work shrinks as they are
+     * answered.
+     */
+    @Scheduled(fixedDelay = 300000)
+    public void scoreLateInHouseResults() {
+        try {
+            int scored = blindingService.scoreLateResults(SCHEDULER_USER);
+            if (scored > 0) {
+                logger.info("Scored {} in-house result(s) entered after unblind", scored);
+            }
+        } catch (RuntimeException e) {
+            logger.error("Late in-house result scoring failed", e);
+        }
+    }
+
+    /**
      * FR-V2.2-05 automatic submission: bridge each participant cycle's validated
      * results onto its own rows, advance the participant state machine, and post to
      * the provider once the review window has elapsed. Per-cycle calls in a

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingService.java
@@ -47,4 +47,23 @@ public interface EQABlindingService {
      * (FR-V2.4-08 — never auto-NCE for in-house). The panel ends SCORED.
      */
     EQAPanel unblindAndScore(Long panelId, String sysUserId, EQAUnblindMethod method);
+
+    /**
+     * AC-V2.4-06: scores results answered <i>after</i> their panel was unblinded.
+     *
+     * <p>
+     * A late answer is real bench work. It used to leave no trace in the EQA record
+     * — the row stayed {@code MISSED_DEADLINE} with no value and no verdict, the
+     * report printed it blank and "Not scored", and nothing could score it, because
+     * the unblind is guarded by the {@code DISTRIBUTED → UNBLINDED} edge and cannot
+     * be re-run. This pass re-resolves those rows instead of re-running the
+     * unblind, so the panel's own idempotency guard is left alone.
+     *
+     * <p>
+     * The status stays {@code MISSED_DEADLINE}: lateness and the verdict are two
+     * separate facts about one sample.
+     *
+     * @return how many late results were scored
+     */
+    int scoreLateResults(String sysUserId);
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -403,6 +403,32 @@ public class EQABlindingServiceImpl implements EQABlindingService {
 
     // ---- unblind helpers ----
 
+    @Override
+    public int scoreLateResults(String sysUserId) {
+        // Driven from the missed rows rather than from panels: the set shrinks as
+        // they are answered, where a scan of every scored panel would grow for
+        // ever. ponytail: one query for the rows, one per row for its panel
+        // sample; an in-house panel carries a handful of samples.
+        int scored = 0;
+        for (EQAParticipantResult result : participantResultDAO.getAllMatching("submissionStatus",
+                EQASubmissionStatus.MISSED_DEADLINE)) {
+            if (result.getPanelSampleId() == null || result.getPerformanceStatus() != null) {
+                continue; // external PT, or already given its verdict on an earlier pass
+            }
+            EQAPanelSample target = panelSampleDAO.get(result.getPanelSampleId()).orElse(null);
+            if (target == null || target.getPanel() == null || target.getPanel().getUnblindedAt() == null) {
+                continue; // the panel is still blinded, so nothing is late yet
+            }
+            String reported = reportedValueOf(result);
+            if (GenericValidator.isBlankOrNull(reported)) {
+                continue; // still unanswered — genuinely a missed deadline
+            }
+            participantResultService.recordLateScore(result.getId(), reported, verdictFor(target, reported), sysUserId);
+            scored++;
+        }
+        return scored;
+    }
+
     private void resolveResult(EQAParticipantResult result, EQAPanelSample target, String sysUserId) {
         if (result.getSubmissionStatus() == EQASubmissionStatus.SCORED
                 || result.getSubmissionStatus() == EQASubmissionStatus.MISSED_DEADLINE) {

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultService.java
@@ -51,6 +51,21 @@ public interface EQAParticipantResultService extends BaseObjectService<EQAPartic
      */
     EQAParticipantResult markMissedDeadline(Long resultId, String sysUserId);
 
+    /**
+     * Records the verdict for a result answered after its panel was unblinded,
+     * keeping {@code MISSED_DEADLINE} as the lateness flag rather than replacing it
+     * with SCORED. The two are separate facts: the row was late, and it was also
+     * right or wrong, and a supervisor reviewing the cycle needs to be able to tell
+     * a technologist who was late from one who never tested at all.
+     *
+     * <p>
+     * No competency event is written. The analyst's lateness was already recorded
+     * as {@code IN_HOUSE_MISSED_DEADLINE} when the panel unblinded, and counting
+     * the same sample twice would band them on one act.
+     */
+    EQAParticipantResult recordLateScore(Long resultId, String reportedValue, EQAPerformanceStatus performance,
+            String sysUserId);
+
     /** Results for one cycle, optionally narrowed to one lab enrollment. */
     List<Map<String, Object>> getResultDtos(Long cycleId, Long labEnrollmentId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantResultServiceImpl.java
@@ -150,6 +150,28 @@ public class EQAParticipantResultServiceImpl extends BaseObjectServiceImpl<EQAPa
     }
 
     @Override
+    public EQAParticipantResult recordLateScore(Long resultId, String reportedValue, EQAPerformanceStatus performance,
+            String sysUserId) {
+        EQAParticipantResult result = get(resultId);
+        if (result.getSubmissionStatus() != EQASubmissionStatus.MISSED_DEADLINE) {
+            throw new IllegalStateException(
+                    "A late score belongs to a MISSED_DEADLINE result; this one is " + result.getSubmissionStatus());
+        }
+        if (performance == null) {
+            throw new IllegalArgumentException("A score needs a performance verdict");
+        }
+
+        // The status stays MISSED_DEADLINE: it is the lateness flag, not a
+        // "resolved, do not look again" marker. Only the verdict and the value
+        // the bench reported are added.
+        result.setResultValue(reportedValue);
+        result.setPerformanceStatus(performance);
+        result.setScoreReceivedAt(now());
+        result.setSysUserId(sysUserId);
+        return eqaParticipantResultDAO.update(result);
+    }
+
+    @Override
     public EQAParticipantResult markMissedDeadline(Long resultId, String sysUserId) {
         EQAParticipantResult result = get(resultId);
         EQASubmissionStatus from = result.getSubmissionStatus();

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -14,6 +14,7 @@ import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.parser.PdfTextExtractor;
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -603,6 +604,59 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         } catch (IllegalArgumentException | IllegalStateException expected) {
             // the service refuses before writing anything
         }
+    }
+
+    /**
+     * AC-V2.4-06. A result answered after the unblind used to leave no trace: the
+     * row stayed MISSED_DEADLINE with no value and no verdict, and nothing could
+     * score it, because {@code resolveResult} returns early for that status and the
+     * unblind itself is guarded by the DISTRIBUTED → UNBLINDED edge. The re-resolve
+     * pass scores it and keeps the lateness, which are two separate facts.
+     */
+    @Test
+    public void lateResults_areScoredAndStillReadAsHavingMissedTheDeadline() {
+        seedEnrollment(9901, "IH Late Scheme");
+        EQAProgram scheme = inHouseScheme("IH Late Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long lateSample = insertPanelSample(panel, "IH-01", "IHLATE-1", NUMERIC_ANALYTE, "100", "95", "105");
+        Long silentSample = insertPanelSample(panel, "IH-02", "IHLATE-2", NUMERIC_ANALYTE, "100", "95", "105");
+        Long late = insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.DRAFT, null, 1L,
+                lateSample);
+        Long silent = insertResult(cycle, roundId, 9901, NUMERIC_ANALYTE, EQASubmissionStatus.DRAFT, null, 1L,
+                silentSample);
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+        assertEquals("both start as missed", "MISSED_DEADLINE", resultRow(late).get("submission_status"));
+        assertNull("and unverdicted", resultRow(late).get("performance_status"));
+
+        // The bench answers one of them after the panel has been scored.
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET result_value = '102' WHERE id = ?", late);
+        int scored = blindingService.scoreLateResults(USER);
+
+        assertEquals("only the answered one is scored", 1, scored);
+        Map<String, Object> lateRow = resultRow(late);
+        assertEquals("the verdict is recorded", "ACCEPTABLE", lateRow.get("performance_status"));
+        assertEquals("the reported value is on the row the report reads", "102", lateRow.get("result_value"));
+        assertEquals("and it still reads as late", "MISSED_DEADLINE", lateRow.get("submission_status"));
+        assertNotNull("scored-at is stamped", jdbc.queryForObject(
+                "SELECT score_received_at FROM clinlims.eqa_participant_result WHERE id = ?", Timestamp.class, late));
+
+        assertNull("a result nobody ever entered keeps no verdict", resultRow(silent).get("performance_status"));
+        assertEquals("MISSED_DEADLINE", resultRow(silent).get("submission_status"));
+
+        // The lateness was already counted against the analyst at the unblind, so
+        // scoring it now must not band them twice on one sample.
+        assertEquals("no second competency event for the late score", Integer.valueOf(1), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                Integer.class, late));
+        assertEquals("IN_HOUSE_MISSED_DEADLINE", jdbc.queryForObject(
+                "SELECT event_type FROM clinlims.eqa_analyst_competency_event" + " WHERE participant_result_id = ?",
+                String.class, late));
+
+        // A second pass finds it already verdicted and does nothing.
+        assertEquals("the pass is idempotent", 0, blindingService.scoreLateResults(USER));
     }
 
     @Test


### PR DESCRIPTION
## The problem

An in-house EQA result submitted after its panel unblinds is discarded instead of scored.

Once the deadline passes, the row is marked `MISSED_DEADLINE`. If the participant then enters a value, nothing ever scores it:

- `resolveResult` returns early for rows in that status, so the value never meets its target.
- The unblind pass cannot re-run to pick it up, because the `DISTRIBUTED → UNBLINDED` transition is its own idempotency guard.

The row keeps no value and no verdict. The performance report prints the cell blank and *"Not scored"*, which is exactly how it prints a sample nobody ever tested.

That loses real bench work. A supervisor reviewing a cycle cannot tell a technologist who tested late from one who never tested at all, and the acceptance criteria for late submissions ask for the opposite: score the result, and keep the lateness on the record.

## The change

`MISSED_DEADLINE` was carrying two meanings at once: *this was late*, and *this is resolved, stop looking at it*. The fix separates them.

A new `scoreLateResults` pass re-resolves the missed rows of a panel that has already unblinded. It records the value the bench reported and the verdict against the sealed target, and leaves `MISSED_DEADLINE` in place as the lateness flag. The panel's own unblind guard is untouched, so nothing re-runs the unblind.

Two deliberate choices:

- **The pass rides the existing unblind sweep** rather than adding a second scheduler.
- **It reads the missed rows**, not scored panels, so the work shrinks as rows are answered instead of growing without bound.

**No competency event is written for a late score.** The analyst's lateness was already recorded as `IN_HOUSE_MISSED_DEADLINE` when the panel unblinded. Counting the same sample twice would band an analyst on a single act. Agreed with the epic before building.

## Verification

Run against a standing fixture: `IH-2-03` carried a value of `100` entered after cycle 2 unblinded, with `IH-2-06` as an untouched control.

Nothing was clicked. On the next sweep:

```
Scored 1 in-house result(s) entered after unblind

id | submission_status | result_value | performance_status | score_received_at
 3 | MISSED_DEADLINE   | 100.00       | ACCEPTABLE         | 2026-09-07 16:43:00
 6 | MISSED_DEADLINE   |              |                    |
```

The late row is scored and still reads as late. The control row is untouched.

The performance report follows. Cycle 2 moved from **6 results / 4 scored / 50% acceptable** to **6 / 5 / 60%**, and the row that printed blank and *"Not scored"* now prints `100.00` against target `100 %` with **Acceptable**. The one row still reading *"Not scored"* is the sample nobody ever answered.

`EQABlindingServiceImpl.class` fingerprints 27504 bytes in all four Tomcat contexts across both instances.

## Tests

One new integration test in `EQABlindingIntegrationTest`, asserting that:

- the answered row is scored, carries its value and verdict, and still reads `MISSED_DEADLINE`;
- the unanswered row stays unverdicted;
- exactly one competency event exists for the late row, and it is `IN_HOUSE_MISSED_DEADLINE`;
- a second pass is a no-op.

Inverted: with the score call removed, it fails on `expected:<1> but was:<0>`.

## Not in scope

The performance report does not yet *say* that a scored row was late. Only its empty Submitted cell hints at it. That marker belongs in the report service, which the delta-column work already rewrites, so it goes there rather than opening a third branch on the same file.

## Note for reviewers

This shares `EQABlindingServiceImpl` with [#4206](https://github.com/DIGI-UW/OpenELIS-Global-2/pull/4206), in a different method. Whichever lands second needs a trivial rebase.
