### PR TITLE
feat(eqa): a provider sees each participant's performance over time (OGC-613)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,6 +29,7 @@ import AlertsDashboard from "./components/alerts/AlertsDashboard";
 import EQAProgramManagement from "./components/eqa/EQAProgram/ProgramManagement";
 import MyCyclesPage from "./components/eqa/MyCycles/MyCyclesPage";
 import ProviderSchemeList from "./components/eqa/Provider/ProviderSchemeList";
+import ParticipantPerformance from "./components/eqa/Provider/ParticipantPerformance";
 import CycleWizard from "./components/eqa/Provider/CycleWizard";
 import ProviderWorkbenchPage from "./components/eqa/Provider/Workbench/ProviderWorkbenchPage";
 import InHousePanelsPage from "./components/eqa/InHouse/InHousePanelsPage";
@@ -820,6 +821,16 @@ export default function App() {
                   path="/qa/eqa/provider/schemes/:schemeId/cycles/new"
                   exact
                   component={() => <CycleWizard />}
+                  role={[Roles.RECEPTION, Roles.RESULTS, Roles.GLOBAL_ADMIN]}
+                  permission="qa.view.eqa"
+                />
+                {/* FR-V2.5-05 participant performance: the trend the workbench's
+                    per-cycle view cannot show. Declared before the bare scheme
+                    list so the more specific path wins. */}
+                <SecureRoute
+                  path="/qa/eqa/provider/schemes/:schemeId/performance"
+                  exact
+                  component={() => <ParticipantPerformance />}
                   role={[Roles.RECEPTION, Roles.RESULTS, Roles.GLOBAL_ADMIN]}
                   permission="qa.view.eqa"
                 />

--- a/frontend/src/components/eqa/Provider/ParticipantPerformance.jsx
+++ b/frontend/src/components/eqa/Provider/ParticipantPerformance.jsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useState } from "react";
+import {
+  Column,
+  Grid,
+  Heading,
+  InlineNotification,
+  Loading,
+  Section,
+  Table,
+  TableBody,
+  TableCell,
+  TableExpandedRow,
+  TableExpandHeader,
+  TableExpandRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tag,
+} from "@carbon/react";
+import { useIntl } from "react-intl";
+import { useParams, Link as RouterLink } from "react-router-dom";
+import PageBreadCrumb from "../../common/PageBreadCrumb";
+import { hintStyle } from "../eqaCommon";
+import { fetchParticipantPerformance } from "./Workbench/workbenchApi";
+
+const PERFORMANCE_TAG = {
+  ACCEPTABLE: "green",
+  QUESTIONABLE: "cyan",
+  UNACCEPTABLE: "red",
+};
+
+/**
+ * FR-V2.5-05 — how each participating laboratory is doing over time.
+ *
+ * The provider could already see one cycle at a time, on the workbench's
+ * Receipts tab, and never the trend. This is the trend: one row per enrolled
+ * laboratory, its rolling pass rate over its last four scored cycles, its most
+ * recent verdict and its open follow-ups — which is the judgement the FR exists
+ * to support, namely which laboratory is drifting.
+ *
+ * A row expands to the cycles behind its rate, each with the values reported and
+ * their z-scores. That history rides the same server read as the row, so opening
+ * one costs no request.
+ *
+ * ponytail: no paging or filtering here — a scheme carries a handful of enrolled
+ * laboratories, and the rate is computed server-side. Add a filter when a
+ * deployment has enough participants to need one.
+ */
+const ParticipantPerformance = () => {
+  const intl = useIntl();
+  const { schemeId } = useParams();
+  const t = (id, defaultMessage, values) =>
+    intl.formatMessage({ id, defaultMessage }, values);
+
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    fetchParticipantPerformance(schemeId, (data) => {
+      if (!live) {
+        return;
+      }
+      setRows(data);
+      setFailed(!Array.isArray(data));
+      setLoading(false);
+    });
+    return () => {
+      live = false;
+    };
+  }, [schemeId]);
+
+  const breadcrumbs = [
+    { label: "home.label", link: "/" },
+    { label: "banner.menu.eqa.provider", link: "/qa/eqa/provider/schemes" },
+  ];
+
+  return (
+    <>
+      <PageBreadCrumb breadcrumbs={breadcrumbs} />
+      <Grid fullWidth={true}>
+        <Column lg={16} md={8} sm={4}>
+          <Section>
+            <Heading>
+              {t("eqa.performance.title", "Participant performance")}
+            </Heading>
+            <p style={hintStyle}>
+              {t(
+                "eqa.performance.subtitle",
+                "Each laboratory's pass rate over its last four scored cycles in this scheme. Expand a row for the cycles behind the rate.",
+              )}
+            </p>
+          </Section>
+        </Column>
+
+        {loading && (
+          <Column lg={16} md={8} sm={4}>
+            <Loading withOverlay={false} small />
+          </Column>
+        )}
+
+        {failed && (
+          <Column lg={16} md={8} sm={4}>
+            <InlineNotification
+              kind="error"
+              lowContrast
+              hideCloseButton
+              title={t("notification.title", "Notification Message")}
+              subtitle={t(
+                "eqa.performance.loadFailed",
+                "Could not load participant performance",
+              )}
+            />
+          </Column>
+        )}
+
+        {!loading && !failed && rows.length === 0 && (
+          <Column lg={16} md={8} sm={4}>
+            <p style={hintStyle}>
+              {t(
+                "eqa.performance.empty",
+                "No laboratory is enrolled in this scheme yet.",
+              )}
+            </p>
+          </Column>
+        )}
+
+        {!loading && !failed && rows.length > 0 && (
+          <Column lg={16} md={8} sm={4}>
+            <Table useZebraStyles>
+              <TableHead>
+                <TableRow>
+                  <TableExpandHeader />
+                  <TableHeader>
+                    {t("eqa.performance.laboratory", "Laboratory")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.performance.region", "Region")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.performance.enrollment", "Enrollment")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.performance.passRate", "Pass rate (last 4)")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.performance.mostRecent", "Most recent")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.performance.openFollowups", "Open follow-ups")}
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <ParticipantRow key={row.organizationId} row={row} t={t} />
+                ))}
+              </TableBody>
+            </Table>
+          </Column>
+        )}
+      </Grid>
+    </>
+  );
+};
+
+/**
+ * One laboratory, and the cycles behind its rate.
+ *
+ * The expanded row is mounted only while it is open, which is the lesson T-24
+ * paid for: Carbon leaves an always-rendered expanded row's inner container at
+ * max-height 0, and the history table then paints over the row above and
+ * swallows its own links. Checked here with elementFromPoint rather than by
+ * looking at a screenshot, which is how that defect hid the first time.
+ */
+const ParticipantRow = ({ row, t }) => {
+  const [expanded, setExpanded] = useState(false);
+  const rate =
+    row.passRate === null || row.passRate === undefined
+      ? t("eqa.performance.noRate", "No scored cycle yet")
+      : `${row.passRate}%`;
+
+  return (
+    <>
+      <TableExpandRow
+        isExpanded={expanded}
+        onExpand={() => setExpanded(!expanded)}
+        ariaLabel={t("eqa.performance.expand", "Cycle history")}
+      >
+        <TableCell>{row.organizationName}</TableCell>
+        <TableCell>{row.region || "—"}</TableCell>
+        <TableCell>{row.enrollmentStatus || "—"}</TableCell>
+        <TableCell>
+          {rate}
+          {row.judged > 0 && (
+            <span style={hintStyle}>
+              {" "}
+              {t("eqa.performance.ofJudged", "{accepted} of {judged}", {
+                accepted: row.accepted,
+                judged: row.judged,
+              })}
+            </span>
+          )}
+        </TableCell>
+        <TableCell>
+          {row.mostRecentPerformance ? (
+            <Tag type={PERFORMANCE_TAG[row.mostRecentPerformance] || "gray"}>
+              {t(
+                `eqa.performanceStatus.${row.mostRecentPerformance.toLowerCase()}`,
+                row.mostRecentPerformance,
+              )}
+            </Tag>
+          ) : (
+            "—"
+          )}
+        </TableCell>
+        <TableCell>{row.openFollowups}</TableCell>
+      </TableExpandRow>
+      {expanded && (
+        <TableExpandedRow colSpan={7}>
+          {(row.cycles || []).length === 0 ? (
+            <p style={hintStyle}>
+              {t(
+                "eqa.performance.noCycles",
+                "This laboratory has not reported into a scored cycle yet.",
+              )}
+            </p>
+          ) : (
+            <Table size="sm">
+              <TableHead>
+                <TableRow>
+                  <TableHeader>{t("eqa.col.cycle", "Cycle")}</TableHeader>
+                  <TableHeader>
+                    {t("eqa.report.table.analyte", "Analyte")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.report.table.reported", "Reported")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.report.table.zscore", "Z-score")}
+                  </TableHeader>
+                  <TableHeader>
+                    {t("eqa.report.table.performance", "Performance")}
+                  </TableHeader>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {row.cycles.map((cycle) =>
+                  (cycle.analytes || []).map((analyte, index) => (
+                    <TableRow key={`${cycle.cycleId}-${analyte.test}-${index}`}>
+                      <TableCell>
+                        {index === 0 && (
+                          <RouterLink
+                            to={`/qa/eqa/provider/cycles/${cycle.cycleId}/workbench`}
+                          >
+                            {cycle.cycleName || `#${cycle.cycleNumber}`}
+                          </RouterLink>
+                        )}
+                      </TableCell>
+                      <TableCell>{analyte.test || "—"}</TableCell>
+                      <TableCell>{analyte.reported ?? "—"}</TableCell>
+                      <TableCell>{analyte.zScore ?? "—"}</TableCell>
+                      <TableCell>
+                        {analyte.performance
+                          ? t(
+                              `eqa.performanceStatus.${analyte.performance.toLowerCase()}`,
+                              analyte.performance,
+                            )
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  )),
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </TableExpandedRow>
+      )}
+    </>
+  );
+};
+
+export default ParticipantPerformance;

--- a/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
+++ b/frontend/src/components/eqa/Provider/ProviderSchemeList.jsx
@@ -236,6 +236,11 @@ const ProviderSchemeList = () => {
                         `/qa/eqa/provider/schemes/${scheme.id}/cycles/new`,
                       )
                     }
+                    onPerformance={() =>
+                      history.push(
+                        `/qa/eqa/provider/schemes/${scheme.id}/performance`,
+                      )
+                    }
                   />
                 ))}
               </TableBody>
@@ -252,7 +257,7 @@ const ProviderSchemeList = () => {
  * expansion state next to it, which is why this is a component rather than a
  * render helper.
  */
-const SchemeRows = ({ scheme, t, onNewCycle }) => {
+const SchemeRows = ({ scheme, t, onNewCycle, onPerformance }) => {
   const [expanded, setExpanded] = useState(false);
   const cycles = scheme.cycles || [];
 
@@ -282,6 +287,9 @@ const SchemeRows = ({ scheme, t, onNewCycle }) => {
         <TableCell>
           <Button kind="tertiary" size="sm" onClick={onNewCycle}>
             {t("eqa.provider.schemes.newCycle", "New cycle")}
+          </Button>{" "}
+          <Button kind="ghost" size="sm" onClick={onPerformance}>
+            {t("eqa.provider.schemes.performance", "Performance")}
           </Button>
         </TableCell>
       </TableExpandRow>

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -33,6 +33,13 @@ export const fetchProviderSchemes = (callback) =>
     }),
   );
 
+/** One row per laboratory in the scheme, each carrying its own cycle history. */
+export const fetchParticipantPerformance = (schemeId, callback) =>
+  getFromOpenElisServer(
+    `/rest/eqa/provider/schemes/${schemeId}/performance`,
+    (data) => callback(Array.isArray(data) ? data : []),
+  );
+
 export const fetchPrepStatus = (cycleId, callback) =>
   getFromOpenElisServer(`/rest/eqa/cycles/${cycleId}/prep`, (data) =>
     callback(data || null),

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8607,5 +8607,20 @@
   "alerts.type.other": "Other",
   "eqa.provider.wizard.sampleCode.duplicate": "Every sample code on a panel must be different.",
   "eqa.provider.wizard.rangeHigh.backwards": "The high end of an acceptance range cannot be below the low end.",
-  "eqa.shipment.packList.panelColumn": "Panel"
+  "eqa.shipment.packList.panelColumn": "Panel",
+  "eqa.provider.schemes.performance": "Performance",
+  "eqa.performance.title": "Participant performance",
+  "eqa.performance.subtitle": "Each laboratory\u2019s pass rate over its last four scored cycles in this scheme. Expand a row for the cycles behind the rate.",
+  "eqa.performance.laboratory": "Laboratory",
+  "eqa.performance.region": "Region",
+  "eqa.performance.enrollment": "Enrollment",
+  "eqa.performance.passRate": "Pass rate (last 4)",
+  "eqa.performance.mostRecent": "Most recent",
+  "eqa.performance.openFollowups": "Open follow-ups",
+  "eqa.performance.expand": "Cycle history",
+  "eqa.performance.ofJudged": "{accepted} of {judged}",
+  "eqa.performance.noRate": "No scored cycle yet",
+  "eqa.performance.noCycles": "This laboratory has not reported into a scored cycle yet.",
+  "eqa.performance.empty": "No laboratory is enrolled in this scheme yet.",
+  "eqa.performance.loadFailed": "Could not load participant performance"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAShipmentRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAShipmentRestController.java
@@ -58,6 +58,21 @@ public class EQAShipmentRestController extends BaseRestController {
         return shipmentService.getProviderSchemes();
     }
 
+    /**
+     * FR-V2.5-05: one row per laboratory enrolled in the scheme, with its rolling
+     * pass rate over its last four scored cycles, its most recent verdict and its
+     * open follow-up count. Each row carries the cycle history behind its rate, so
+     * the drill-in costs no second read.
+     */
+    @GetMapping(value = "/provider/schemes/{schemeId}/performance", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<Map<String, Object>>> participantPerformance(@PathVariable Long schemeId) {
+        try {
+            return ResponseEntity.ok(scoringService.getParticipantPerformance(schemeId));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @GetMapping(value = "/cycles/{cycleId}/prep", produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<String, Object> prepStatus(@PathVariable Long cycleId) {
         return shipmentService.getPrepStatus(cycleId);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupService.java
@@ -90,6 +90,14 @@ public interface EQAParticipantFollowupService extends BaseObjectService<EQAPart
      */
     long countOpenProviderFollowups();
 
+    /**
+     * Open provider-side follow-ups per participating laboratory, keyed by
+     * organization id, under the same membership rule as
+     * {@link #countOpenProviderFollowups()} — the register's own reading of "open",
+     * rather than a second one.
+     */
+    Map<Long, Long> countOpenProviderFollowupsByOrganization();
+
     /** Marks a row escalated once its NCE exists (FR-V2.3-02). */
     EQAParticipantFollowup markEscalated(Long followupId, String sysUserId);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAParticipantFollowupServiceImpl.java
@@ -197,6 +197,21 @@ public class EQAParticipantFollowupServiceImpl extends BaseObjectServiceImpl<EQA
 
     @Override
     @Transactional(readOnly = true)
+    public Map<Long, Long> countOpenProviderFollowupsByOrganization() {
+        Long self = selfOrganizationId();
+        Map<Long, Long> open = new LinkedHashMap<>();
+        for (EQAParticipantFollowup followup : followupDAO.getAll()) {
+            EQAFollowupStatus status = followup.getFollowupStatus();
+            if ((self == null || !self.equals(followup.getParticipantOrgId())) && status != EQAFollowupStatus.RESOLVED
+                    && status != EQAFollowupStatus.REMOVED_FROM_PROGRAM) {
+                open.merge(followup.getParticipantOrgId(), 1L, Long::sum);
+            }
+        }
+        return open;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Map<String, Object>> getProviderRegisterRows() {
         Long self = selfOrganizationId();
         List<EQAParticipantFollowup> theirs = new ArrayList<>();

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringService.java
@@ -60,6 +60,18 @@ public interface EQAProviderScoringService {
     Map<Long, String> sealedTargetsByTest(Long cycleId);
 
     /**
+     * FR-V2.5-05: one row per laboratory enrolled in the scheme, carrying its
+     * rolling pass rate over its last four scored cycles, its most recent verdict
+     * and its open follow-up count, plus the cycle history behind the rate so a row
+     * can be drilled into without a second read.
+     *
+     * <p>
+     * The provider could previously see one cycle at a time and never the trend,
+     * which is the judgement this exists to support — which laboratory is drifting.
+     */
+    List<Map<String, Object>> getParticipantPerformance(Long schemeId);
+
+    /**
      * The intake grid for one participant: the scheme's tests with the value
      * already on file for each, so phoned and emailed results can be keyed on the
      * provider side.

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -1,8 +1,10 @@
 package org.openelisglobal.eqa.service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,6 +22,7 @@ import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQADistributionDAO;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAProgramEnrollmentDAO;
 import org.openelisglobal.eqa.dao.EQAResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
@@ -29,6 +32,7 @@ import org.openelisglobal.eqa.valueholder.EQADistributionStatus;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPerformanceStatus;
+import org.openelisglobal.eqa.valueholder.EQAProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQAResult;
 import org.openelisglobal.eqa.valueholder.EQARound;
@@ -54,6 +58,11 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     /** FR-V2.5-07: unacceptable in 2 of the last 3 cycles is persistent failure. */
     private static final int PERSISTENT_FAILURE_WINDOW = 3;
     private static final int PERSISTENT_FAILURE_THRESHOLD = 2;
+
+    /** FR-V2.5-05's window: a laboratory's last four scored cycles. */
+    private static final int ROLLING_WINDOW = 4;
+
+    private static final String ACTIVE_ENROLLMENT = "Active";
 
     /**
      * The provider machine from submissions_open to scored, walked one edge at a
@@ -101,6 +110,8 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     private EQAPanelSampleDAO eqaPanelSampleDAO;
     @Autowired
     private EQAPanelService eqaPanelService;
+    @Autowired
+    private EQAProgramEnrollmentDAO eqaProgramEnrollmentDAO;
 
     @Override
     @Transactional(readOnly = true)
@@ -549,6 +560,135 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
     @Transactional(readOnly = true)
     public List<EQAResult> reportedResultsFor(Long cycleId, Long organizationId) {
         return resultsFor(cycleId, organizationId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getParticipantPerformance(Long schemeId) {
+        if (eqaProgramService.get(schemeId) == null) {
+            throw new IllegalArgumentException("Unknown scheme " + schemeId);
+        }
+
+        // Newest first: the rolling window is the last four cycles a laboratory
+        // actually reported into, not the last four the scheme ran, so a lab that
+        // sat one out is judged on the four it took part in.
+        List<EQACycle> scoredCycles = eqaCycleDAO.findBySchemeIds(List.of(schemeId)).stream().filter(
+                cycle -> cycle.getStatus() == EQACycleStatus.SCORED || cycle.getStatus() == EQACycleStatus.CLOSED)
+                .sorted(Comparator.comparing(EQACycle::getCycleNumber,
+                        Comparator.nullsFirst(Comparator.reverseOrder())))
+                .toList();
+        Map<Long, Long> openFollowups = followupService.countOpenProviderFollowupsByOrganization();
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (EQAProgramEnrollment enrollment : currentEnrollments(schemeId)) {
+            rows.add(participantRow(enrollment, scoredCycles, openFollowups));
+        }
+        rows.sort(Comparator.comparing(row -> String.valueOf(row.get("organizationName")),
+                String.CASE_INSENSITIVE_ORDER));
+        return rows;
+    }
+
+    /**
+     * One enrollment per laboratory: the current one. Withdrawal is terminal
+     * (BR-013), so a laboratory re-admitted after leaving holds two rows, and the
+     * page must show it once with the status it holds now — otherwise a re-admitted
+     * participant appears twice with identical figures, since the rate is a
+     * property of the organization rather than of the paperwork.
+     */
+    private List<EQAProgramEnrollment> currentEnrollments(Long schemeId) {
+        Map<Long, EQAProgramEnrollment> byOrganization = new LinkedHashMap<>();
+        for (EQAProgramEnrollment enrollment : eqaProgramEnrollmentDAO.findByProgramId(schemeId)) {
+            byOrganization.merge(enrollment.getOrganizationId(), enrollment,
+                    (kept, candidate) -> supersedes(candidate, kept) ? candidate : kept);
+        }
+        return new ArrayList<>(byOrganization.values());
+    }
+
+    /** An active enrollment wins; otherwise the one enrolled later. */
+    private static boolean supersedes(EQAProgramEnrollment candidate, EQAProgramEnrollment kept) {
+        boolean candidateActive = ACTIVE_ENROLLMENT.equalsIgnoreCase(candidate.getStatus());
+        boolean keptActive = ACTIVE_ENROLLMENT.equalsIgnoreCase(kept.getStatus());
+        if (candidateActive != keptActive) {
+            return candidateActive;
+        }
+        if (candidate.getEnrollmentDate() == null || kept.getEnrollmentDate() == null) {
+            return candidate.getEnrollmentDate() != null;
+        }
+        return candidate.getEnrollmentDate().after(kept.getEnrollmentDate());
+    }
+
+    private Map<String, Object> participantRow(EQAProgramEnrollment enrollment, List<EQACycle> scoredCycles,
+            Map<Long, Long> openFollowups) {
+        Long organizationId = enrollment.getOrganizationId();
+        Organization organization = organizationService.get(String.valueOf(organizationId));
+
+        List<Map<String, Object>> history = new ArrayList<>();
+        int accepted = 0;
+        int judged = 0;
+        String mostRecent = null;
+        for (EQACycle cycle : scoredCycles) {
+            List<EQAResult> reported = resultsFor(cycle.getId(), organizationId);
+            if (reported.isEmpty()) {
+                continue; // this laboratory did not report into that cycle
+            }
+            Map<String, Object> cycleRow = new LinkedHashMap<>();
+            cycleRow.put("cycleId", cycle.getId());
+            cycleRow.put("cycleNumber", cycle.getCycleNumber());
+            cycleRow.put("cycleName", cycle.getCycleName());
+            List<Map<String, Object>> analytes = new ArrayList<>();
+            for (EQAResult result : reported) {
+                Map<String, Object> analyte = new LinkedHashMap<>();
+                analyte.put("test", testName(result.getTestId()));
+                analyte.put("reported", reportedOf(result));
+                analyte.put("zScore", result.getZScore());
+                analyte.put("performance",
+                        result.getPerformanceStatus() == null ? null : result.getPerformanceStatus().name());
+                analytes.add(analyte);
+                if (result.getPerformanceStatus() == null) {
+                    continue;
+                }
+                if (history.size() < ROLLING_WINDOW) {
+                    judged++;
+                    if (result.getPerformanceStatus() == EQAPerformanceStatus.ACCEPTABLE) {
+                        accepted++;
+                    }
+                }
+                if (mostRecent == null) {
+                    mostRecent = result.getPerformanceStatus().name();
+                }
+            }
+            cycleRow.put("analytes", analytes);
+            history.add(cycleRow);
+        }
+
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("organizationId", organizationId);
+        row.put("organizationName",
+                organization == null ? String.valueOf(organizationId) : organization.getOrganizationName());
+        // The nearest thing the schema has to a region: an organization carries a
+        // city and a state, and no administrative area beyond them.
+        row.put("region", organization == null ? null : region(organization));
+        row.put("enrollmentStatus", enrollment.getStatus());
+        row.put("cyclesCounted", Math.min(history.size(), ROLLING_WINDOW));
+        row.put("accepted", accepted);
+        row.put("judged", judged);
+        // Null rather than 0% where nothing has been judged: a laboratory with no
+        // scored cycle has no rate, and printing zero would read as total failure.
+        row.put("passRate", judged == 0 ? null
+                : BigDecimal.valueOf(accepted * 100L).divide(BigDecimal.valueOf(judged), 1, RoundingMode.HALF_UP));
+        row.put("mostRecentPerformance", mostRecent);
+        row.put("openFollowups", openFollowups.getOrDefault(organizationId, 0L));
+        row.put("cycles", history.subList(0, Math.min(history.size(), ROLLING_WINDOW)));
+        return row;
+    }
+
+    private static String region(Organization organization) {
+        String city = organization.getCity();
+        String state = organization.getState();
+        if (GenericValidator.isBlankOrNull(city)) {
+            return GenericValidator.isBlankOrNull(state) ? null : state;
+        }
+        return GenericValidator.isBlankOrNull(state) ? city : city + ", " + state;
     }
 
     private List<EQAResult> resultsFor(Long cycleId, Long organizationId) {

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderIntakeIntegrationTest.java
@@ -89,6 +89,7 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
     @Override
     protected void cleanEqaTables() {
         if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.eqa_program_enrollment WHERE id BETWEEN 9959 AND 9990");
             jdbc.update("DELETE FROM clinlims.eqa_result");
             jdbc.update("DELETE FROM clinlims.eqa_distribution WHERE cycle_id IS NOT NULL");
         }
@@ -261,6 +262,122 @@ public class EQAProviderIntakeIntegrationTest extends EQASpineTestBase {
         } finally {
             reader.close();
         }
+    }
+
+    /**
+     * FR-V2.5-05. The provider could see one cycle at a time and never the trend,
+     * which is the judgement the FR exists to support — which laboratory is
+     * drifting. The rate is asserted against a rebuild from the same rows rather
+     * than a figure typed into the test.
+     */
+    @Test
+    public void participantPerformanceCarriesEachLaboratorysRollingPassRate() {
+        // The read is enrollment-driven, as FR-V2.5-05 asks: a laboratory belongs on
+        // this page because it is enrolled, not because it happens to have
+        // reported. The intake fixture takes results in without enrolling anyone,
+        // so the roster is seeded here.
+        for (int p = 0; p < ORGS; p++) {
+            jdbc.update("INSERT INTO clinlims.eqa_program_enrollment"
+                    + " (id, eqa_program_id, organization_id, enrollment_date, status, sys_user_id, lastupdated)"
+                    + " VALUES (?, ?, ?, now(), 'Active', ?, now())", 9960 + p, scheme.getId(), FIRST_ORG + p, USER);
+        }
+
+        // Five scored cycles on the scheme; the window is the last four, so the
+        // oldest must fall out of the rate while staying in the record.
+        long steady = FIRST_ORG;
+        long drifting = FIRST_ORG + 1;
+        String[] driftingValues = { "reactive", "reactive", "Non-reactive", "reactive", "Non-reactive" };
+        for (int i = 0; i < driftingValues.length; i++) {
+            EQACycle round = readBack(insertCycle(scheme, 10 + i));
+            jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", round.getId());
+            // A qualitative answer is judged against the target its own cycle's
+            // panel sealed, so each round needs one; the peer statistic cannot
+            // place a word.
+            EQAPanel roundPanel = insertPanel(scheme, p -> {
+                p.setCycle(round);
+                p.setPanelName("Round panel " + round.getCycleNumber());
+            });
+            EQAPanelSample roundSample = new EQAPanelSample();
+            roundSample.setPanel(roundPanel);
+            roundSample.setSampleCode("S" + round.getCycleNumber());
+            roundSample.setAnalyteId(ANALYTE_SERO);
+            roundSample.setTargetValue("Reactive");
+            roundSample.setSysUserId(USER);
+            eqaPanelSampleDAO.insert(roundSample);
+            for (int p = 0; p < ORGS; p++) {
+                long org = FIRST_ORG + p;
+                String value = org == drifting ? driftingValues[i] : "reactive";
+                scoringService.takeIn(round.getId(), org, Map.of(TEST_SERO, value), EQASubmissionMethod.MANUAL, USER);
+            }
+            scoringService.scoreCycle(round.getId(), USER);
+        }
+
+        Map<Long, Map<String, Object>> byOrg = new java.util.HashMap<>();
+        for (Map<String, Object> row : scoringService.getParticipantPerformance(scheme.getId())) {
+            byOrg.put(((Number) row.get("organizationId")).longValue(), row);
+        }
+
+        // Withdrawal is terminal, so a re-admitted laboratory holds two enrollment
+        // rows — and must still appear once, with the status it holds now. The rate
+        // belongs to the organization, not to the paperwork.
+        jdbc.update("UPDATE clinlims.eqa_program_enrollment SET status = 'Withdrawn' WHERE id = ?", 9960);
+        jdbc.update("INSERT INTO clinlims.eqa_program_enrollment"
+                + " (id, eqa_program_id, organization_id, enrollment_date, status, sys_user_id, lastupdated)"
+                + " VALUES (?, ?, ?, now(), 'Active', ?, now())", 9959, scheme.getId(), FIRST_ORG, USER);
+
+        byOrg.clear();
+        for (Map<String, Object> row : scoringService.getParticipantPerformance(scheme.getId())) {
+            assertTrue("no laboratory is listed twice",
+                    byOrg.put(((Number) row.get("organizationId")).longValue(), row) == null);
+        }
+        assertEquals("still one row per laboratory after a re-admission", ORGS, byOrg.size());
+        assertEquals("and it reads as active, not withdrawn", "Active", byOrg.get(steady).get("enrollmentStatus"));
+
+        // Every enrolled laboratory has a row, named and with its enrollment.
+        assertEquals("one row per enrolled laboratory", ORGS, byOrg.size());
+        assertEquals("Intake lab " + steady, byOrg.get(steady).get("organizationName"));
+        assertEquals("Active", byOrg.get(steady).get("enrollmentStatus"));
+
+        // The steady laboratory passed every cycle; the drifting one failed the
+        // last of its four and one before it.
+        assertEquals("a laboratory that never failed reads 100%", 0,
+                ((BigDecimal) byOrg.get(steady).get("passRate")).compareTo(new BigDecimal("100.0")));
+        assertEquals("only the last four cycles count towards the rate", Integer.valueOf(4),
+                byOrg.get(drifting).get("cyclesCounted"));
+        assertEquals("two of its last four were unacceptable", Integer.valueOf(2), byOrg.get(drifting).get("accepted"));
+        assertEquals("out of four judged", Integer.valueOf(4), byOrg.get(drifting).get("judged"));
+        assertEquals("so the rate is half", 0,
+                ((BigDecimal) byOrg.get(drifting).get("passRate")).compareTo(new BigDecimal("50.0")));
+
+        // The rate matches a rebuild over the same rows, rather than a number
+        // written into the test.
+        Integer acceptedInWindow = jdbc.queryForObject(
+                "SELECT count(*) FROM ( SELECT r.performance_status FROM clinlims.eqa_result r"
+                        + " JOIN clinlims.eqa_distribution d ON d.id = r.eqa_distribution_id"
+                        + " JOIN clinlims.eqa_cycle c ON c.id = d.cycle_id"
+                        + " WHERE r.participant_organization_id = ? AND c.scheme_id = ?"
+                        + " ORDER BY c.cycle_number DESC LIMIT 4 ) w WHERE performance_status = 'ACCEPTABLE'",
+                Integer.class, drifting, scheme.getId());
+        assertEquals("the rate is what the rows say", acceptedInWindow, byOrg.get(drifting).get("accepted"));
+
+        // The drill-in rides the same read: the cycles behind the rate, newest
+        // first, each with what was reported and how it was judged.
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> history = (List<Map<String, Object>>) byOrg.get(drifting).get("cycles");
+        assertEquals("four cycles of history, the window", 4, history.size());
+        assertEquals("newest first", Integer.valueOf(14), history.get(0).get("cycleNumber"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> analytes = (List<Map<String, Object>>) history.get(0).get("analytes");
+        assertEquals("Non-reactive", analytes.get(0).get("reported"));
+        assertEquals("UNACCEPTABLE", analytes.get(0).get("performance"));
+        assertEquals("the most recent verdict is the newest cycle's", "UNACCEPTABLE",
+                byOrg.get(drifting).get("mostRecentPerformance"));
+
+        // A laboratory that has failed carries its open follow-ups; one that has
+        // not carries none.
+        assertTrue("the drifting laboratory has an open follow-up",
+                ((Number) byOrg.get(drifting).get("openFollowups")).longValue() > 0);
+        assertEquals("the steady one has none", 0L, ((Number) byOrg.get(steady).get("openFollowups")).longValue());
     }
 
     @Test


### PR DESCRIPTION
## What

FR-V2.5-05 specifies a per-scheme participant table: laboratory, region, enrollment status, **rolling pass rate over the last four cycles**, most recent verdict and open follow-ups, plus a per-participant drill-in with cycle history and z-scores. None of it existed — no route, no endpoint, and nothing anywhere rendered a pass rate per participant.

The provider board's tiles are counts; the workbench's Receipts tab shows *"N unacceptable of M"* for one cycle at a time. So the provider could see every cycle and never the trend, which is the judgement the FR exists to support: **which laboratory is drifting**.

This was a rendering gap, not a data gap. One read over `eqa_result` joined through `eqa_distribution` answers it.

## Decisions inside the read

- **Enrollment-driven**, as the FR asks: a laboratory belongs on the page because it is enrolled, not because it happens to have reported, so one that has not yet reported shows with no rate rather than being absent.
- **The window is the last four cycles a laboratory actually reported into**, not the last four the scheme ran — a lab that sat one out is judged on the four it took part in.
- **No rate at all where nothing has been judged.** Printing `0%` would read as total failure.
- **One row per laboratory, not per enrollment.** Withdrawal is terminal, so a laboratory re-admitted after leaving holds two enrollment records. The first cut listed it twice with identical figures — caught on the rig, where Goroka has exactly that history. The rate belongs to the organization, not to the paperwork; the row shows the status it holds now.
- **Region** is the nearest thing the schema has: an organization carries a city and a state, and no administrative area beyond them.

Reused rather than re-derived: the open follow-up count comes from the register's own reading of "open", now exposed per organization instead of only as a total.

## Where it lives

The page hangs off the provider board's own row action, which is where the scheme context comes from — a top-level menu row would have no scheme to show. **So this needs no menu changeset and no liquibase slot.**

Each row carries the cycle history behind its rate, so the drill-in costs no second request. The expanded row is mounted **only while open**: Carbon leaves an always-rendered expanded row's inner container at `max-height: 0`, and the history table then paints over the row above and swallows its own links. The first cut had exactly that defect — links rendered and unreachable — found with `elementFromPoint` rather than by looking at a screenshot, which is how T-24 lost time to it the first time.

## Verification

Driven on the rig against the provider's HIV VL scheme, and the figures are the ones the finding predicted:

| laboratory | enrollment | pass rate | most recent | open follow-ups |
| --- | --- | --- | --- | --- |
| Goroka Provincial Hospital Lab | Active | **75%** (3 of 4) | Acceptable | 0 |
| Kimbe Provincial Hospital Lab | Active | 100% (4 of 4) | Acceptable | 0 |
| Lae Provincial Hospital Lab | Active | 100% (4 of 4) | Acceptable | 0 |
| Mt Hagen Provincial Hospital Lab | Active | 100% (4 of 4) | Acceptable | 0 |
| PMGH Lab | Active | **75%** (3 of 4) | Acceptable | 2 |

Five rows, Goroka once despite its withdrawal-and-re-admission. Expanding it shows the four cycles behind its 75% with the single `UNACCEPTABLE` among them; PMGH's shows its `80` against target `40` at z `1.78797`. A scheme whose participants have no scored cycle renders the zero state rather than `0%`, and an unknown scheme answers **404**.

After the fix, the expanded row's container computes `max-height: 100%` and the cycle link is the topmost element at its own coordinates.

`EQAProviderScoringServiceImpl.class` fingerprints 40184 bytes in all four Tomcat contexts across both instances.

## Tests

One new integration test, inverted: five scored cycles, the window taking only the last four; the rate asserted against a **SQL rebuild over the same rows** rather than a figure typed into the test; the history newest-first with its reported values and verdicts; the most recent verdict; open follow-ups present on the failing laboratory and absent on the steady one; and one row per laboratory after a re-admission. Dropping the window makes it count the fifth cycle and fail; dropping the dedupe makes the laboratory appear twice and fail.

166 EQA frontend tests green.