### PR TITLE
fix(eqa): stamp a cycle's actual start and end dates (OGC-935)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -216,6 +216,32 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         return Optional.of(cycle);
     }
 
+    /**
+     * When the cycle actually ran, as opposed to when it was planned to.
+     *
+     * <p>
+     * Both columns have existed since the spine and nothing ever wrote either — a
+     * grep for {@code setActualEndDate} came back empty — so a scored cycle
+     * recorded no scoring date at all, and anything wanting to print one had
+     * nothing to read. Stamped here rather than in the scoring service so every
+     * machine and every caller gets it from the one place they all route through.
+     *
+     * <p>
+     * Neither is ever overwritten: the first time a cycle leaves PLANNED is when it
+     * started, and the first time it reaches SCORED is when it was judged. A
+     * re-score cannot move the date.
+     */
+    private static void stampActualDates(EQACycle cycle, EQACycleStatus priorState, EQACycleStatus newState) {
+        // The columns are DATE, and the cycle's own dates are days elsewhere too.
+        Date today = new Date(System.currentTimeMillis());
+        if (priorState == PLANNED && cycle.getActualStartDate() == null) {
+            cycle.setActualStartDate(today);
+        }
+        if (newState == SCORED && cycle.getActualEndDate() == null) {
+            cycle.setActualEndDate(today);
+        }
+    }
+
     private static Set<EQACycleStatus> legalNextStates(EQACycleStatus from, EQAStateMachine machine) {
         Map<EQACycleStatus, Set<EQACycleStatus>> edges = machine == EQAStateMachine.PROVIDER ? PROVIDER_EDGES
                 : PARTICIPANT_EDGES;
@@ -252,6 +278,7 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         enforcePrepGate(cycle, priorState, newState, machine);
 
         cycle.setStatus(newState);
+        stampActualDates(cycle, priorState, newState);
         cycle.setSysUserId(sysUserId);
         EQACycle updated = eqaCycleDAO.update(cycle);
 

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
+import java.sql.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -93,6 +94,44 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
 
         assertEquals(EQACycleStatus.CLOSED, readBack(cycle.getId()).getStatus());
         assertEquals(path.length, cycleService.getTransitions(cycle.getId()).size());
+    }
+
+    /**
+     * A cycle records when it actually ran, not only when it was planned to.
+     * Nothing had ever written either column, so a scored cycle carried no scoring
+     * date and anything wanting to print one had nothing to read.
+     */
+    @Test
+    public void aCycleRecordsWhenItStartedAndWhenItWasScored() {
+        EQACycle cycle = newCycle();
+        assertNull("a planned cycle has not started", readBack(cycle.getId()).getActualStartDate());
+        assertNull("nor been scored", readBack(cycle.getId()).getActualEndDate());
+
+        cycleService.transition(cycle.getId(), EQACycleStatus.PANEL_RECEIVED, EQAStateMachine.PARTICIPANT,
+                EQATriggerType.AUTO, EQATriggerEvent.PANEL_RECEIPT, null, null, USER);
+
+        Date started = readBack(cycle.getId()).getActualStartDate();
+        assertNotNull("leaving PLANNED is when it started", started);
+        assertNull("and it is not scored yet", readBack(cycle.getId()).getActualEndDate());
+
+        for (EQACycleStatus next : new EQACycleStatus[] { EQACycleStatus.TESTING, EQACycleStatus.READY_TO_SUBMIT,
+                EQACycleStatus.SUBMITTED, EQACycleStatus.SCORED }) {
+            cycleService.transition(cycle.getId(), next, EQAStateMachine.PARTICIPANT, EQATriggerType.AUTO,
+                    EQATriggerEvent.LAST_VALIDATED_RESULT, null, null, USER);
+        }
+
+        EQACycle scored = readBack(cycle.getId());
+        assertNotNull("reaching SCORED is when it was judged", scored.getActualEndDate());
+        assertEquals("and the start date is not moved by later transitions", started.toString(),
+                scored.getActualStartDate().toString());
+
+        // Closing it afterwards must not restamp either date: they record when the
+        // cycle ran, not when it was last touched.
+        cycleService.transition(cycle.getId(), EQACycleStatus.CLOSED, EQAStateMachine.PARTICIPANT, EQATriggerType.AUTO,
+                EQATriggerEvent.SCHEDULED_JOB, null, null, USER);
+        EQACycle closed = readBack(cycle.getId());
+        assertEquals(scored.getActualEndDate().toString(), closed.getActualEndDate().toString());
+        assertEquals(started.toString(), closed.getActualStartDate().toString());
     }
 
     @Test


### PR DESCRIPTION
## Problem

`eqa_cycle` has carried `actual_start_date` and `actual_end_date` since the V2 schema landed, but no code ever wrote either one. Both columns stay null for the entire life of every cycle, so anything reading them — a report, a filter, a duration calculation — sees a cycle that never started and never finished. UAT found it while checking what a scored cycle records about itself.

## Fix

`EQACycleServiceImpl.transition(...)` now stamps the two dates on the same write that moves the status:

- `actual_start_date` when a cycle first leaves `PLANNED`, on either state machine — that is the point work begins, whether the participant received a panel or the provider started preparation.
- `actual_end_date` when a cycle reaches `SCORED`.

Each is written only when still null, so a later transition cannot move a date already on file. That matters for the two paths that can revisit a state: a re-score, and the move to `CLOSED`, which must not overwrite the end date with the closing day.

Both columns are `DATE`, and the cycle's planned dates are days rather than instants, so the stamp is a day too.

## Tests

`EQACycleStateMachineIntegrationTest.aCycleRecordsWhenItStartedAndWhenItWasScored` — asserts both columns are null on a fresh cycle, that the start date appears on leaving `PLANNED` while the end date is still null, that the end date appears at `SCORED`, and that walking on to `CLOSED` moves neither.

Inversion check: commenting out the `stampActualDates(...)` call fails the test at the "leaving PLANNED is when it started" assertion.

Full EQA suite: 561 tests, 0 failures (560 on the branch point plus the one new test).

## Follow-on

The provider's per-participant performance report drops its "Scored on" column because that date was never available. Restoring it belongs on top of #4208 now that the dates exist, and is recorded on the delivery plan rather than folded in here.