### PR TITLE
fix(eqa): require receipt notes and cycle deadlines, pick enrollment schemes, correct shipment dates (OGC-935)

### DIFF
--- a/frontend/src/components/addOrder/Index.jsx
+++ b/frontend/src/components/addOrder/Index.jsx
@@ -24,7 +24,7 @@ import {
 import OrderEntryAdditionalQuestions from "./OrderEntryAdditionalQuestions";
 import OrderSuccessMessage from "./OrderSuccessMessage";
 import EQASampleEntry from "../eqa/EQASampleEntry";
-import EQAOrderForm from "../eqa/EQAOrderForm";
+import EQAOrderForm, { eqaReceiptNoteMissing } from "../eqa/EQAOrderForm";
 import { FormattedMessage, useIntl } from "react-intl";
 import { createOrderEntryValidationSchema } from "../formModel/validationSchema/OrderEntryValidationSchema";
 import config from "../../config.json";
@@ -954,6 +954,10 @@ const Index = () => {
                 <Button
                   kind="primary"
                   className="forwardButton"
+                  disabled={
+                    page === programPageNumber &&
+                    eqaReceiptNoteMissing(orderFormValues)
+                  }
                   onClick={() => navigateForward()}
                 >
                   <FormattedMessage id="next.action.button" />

--- a/frontend/src/components/eqa/EQAOrderForm.jsx
+++ b/frontend/src/components/eqa/EQAOrderForm.jsx
@@ -11,6 +11,20 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../utils/Utils";
 import CustomDatePicker from "../common/CustomDatePicker";
 
+/**
+ * A receipt marked not-intact needs the note that says what was wrong with the
+ * material (AC-V2.2-13). Exported so the wizard's Next button holds on the same
+ * rule the receipt service enforces, rather than a second copy of it.
+ */
+export const eqaReceiptNoteMissing = (orderFormValues) => {
+  const order = orderFormValues?.sampleOrderItems || {};
+  return (
+    !!order.isEQASample &&
+    order.eqaIntegrityOk === false &&
+    !(order.eqaIntegrityNotes || "").trim()
+  );
+};
+
 const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
   const intl = useIntl();
   const componentMounted = useRef(false);
@@ -336,6 +350,10 @@ const EQAOrderForm = ({ orderFormValues, setOrderFormValues }) => {
                       id="eqa-integrity-notes"
                       labelText={intl.formatMessage({
                         id: "eqa.order.receipt.notes",
+                      })}
+                      invalid={eqaReceiptNoteMissing(orderFormValues)}
+                      invalidText={intl.formatMessage({
+                        id: "eqa.order.receipt.notes.required",
                       })}
                       value={sampleOrder.eqaIntegrityNotes || ""}
                       onChange={(e) =>

--- a/frontend/src/components/eqa/InlineEnrollmentForm.jsx
+++ b/frontend/src/components/eqa/InlineEnrollmentForm.jsx
@@ -13,7 +13,16 @@ import {
 import { useIntl } from "react-intl";
 import { getFromOpenElisServer } from "../utils/Utils";
 
-const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
+// The "my scheme is not on this list" option: an enrollment may name a provider
+// whose schemes this instance does not carry, so free text stays available.
+const NOT_LISTED = "__notListed__";
+
+const InlineEnrollmentForm = ({
+  enrollment,
+  enrollments = [],
+  onSave,
+  onCancel,
+}) => {
   const intl = useIntl();
   const isEdit = !!enrollment;
 
@@ -38,6 +47,13 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
   const [testAnalytes, setTestAnalytes] = useState({});
   const [dataReady, setDataReady] = useState(false);
 
+  // The schemes this instance carries, and this laboratory's cycles. The first
+  // is what the picker offers; the second is why the pair freezes — a renamed
+  // enrollment detaches from every cycle that matched it by name.
+  const [schemes, setSchemes] = useState([]);
+  const [myCycles, setMyCycles] = useState([]);
+  const [schemeChoice, setSchemeChoice] = useState(NOT_LISTED);
+
   const [labUnits, setLabUnits] = useState([]);
   const [tests, setTests] = useState([]);
   const [panels, setPanels] = useState([]);
@@ -49,6 +65,18 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
       loaded++;
       if (loaded >= 4) setDataReady(true);
     };
+
+    getFromOpenElisServer("/rest/eqa/programs", (data) => {
+      const items = (data || []).filter((scheme) => scheme.name);
+      setSchemes(items);
+      if (enrollment && items.some((s) => s.name === enrollment.programName)) {
+        setSchemeChoice(enrollment.programName);
+      }
+    });
+
+    getFromOpenElisServer("/rest/eqa/cycles/mine", (data) => {
+      setMyCycles(Array.isArray(data) ? data : []);
+    });
 
     getFromOpenElisServer("/rest/displayList/TEST_SECTION_ACTIVE", (data) => {
       if (data) {
@@ -129,6 +157,35 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
     onSave(payload);
   };
 
+  // A scheme already enrolled is not on offer, deactivated enrollments included:
+  // reactivating one through Edit is the way back, not a second row for the same
+  // scheme. The enrollment being edited keeps its own scheme, or the picker would
+  // drop what it is showing.
+  const offeredSchemes = schemes.filter(
+    (scheme) =>
+      !enrollments.some(
+        (other) =>
+          other.id !== (enrollment ? enrollment.id : null) &&
+          (other.programName || "") === scheme.name,
+      ),
+  );
+
+  // Cycles are matched to an enrollment by programme name — there is no scheme
+  // foreign key — so renaming one silently detaches it from its own cycles.
+  const frozen =
+    isEdit &&
+    myCycles.some((cycle) => cycle.schemeName === enrollment.programName);
+
+  const pickScheme = (value) => {
+    setSchemeChoice(value);
+    if (value === NOT_LISTED) {
+      return;
+    }
+    const scheme = schemes.find((s) => s.name === value);
+    setProgramName(value);
+    setProvider(scheme && scheme.provider ? scheme.provider : "");
+  };
+
   const isValid = programName.trim() !== "" && provider.trim() !== "";
 
   return (
@@ -150,12 +207,39 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
 
       <Grid condensed>
         <Column lg={5} md={4} sm={4}>
+          <Select
+            id="enrollment-scheme"
+            labelText={intl.formatMessage({ id: "eqa.enrollment.scheme" })}
+            helperText={intl.formatMessage({
+              id: frozen
+                ? "eqa.enrollment.scheme.frozen"
+                : "eqa.enrollment.scheme.helper",
+            })}
+            value={schemeChoice}
+            disabled={frozen}
+            onChange={(e) => pickScheme(e.target.value)}
+          >
+            {offeredSchemes.map((scheme) => (
+              <SelectItem
+                key={scheme.id}
+                value={scheme.name}
+                text={scheme.name}
+              />
+            ))}
+            <SelectItem
+              value={NOT_LISTED}
+              text={intl.formatMessage({ id: "eqa.enrollment.scheme.other" })}
+            />
+          </Select>
+        </Column>
+        <Column lg={5} md={4} sm={4}>
           <TextInput
             id="enrollment-program-name"
             labelText={intl.formatMessage({
               id: "eqa.enrollment.programName",
             })}
             value={programName}
+            disabled={frozen}
             onChange={(e) => setProgramName(e.target.value)}
             placeholder={intl.formatMessage({
               id: "eqa.enrollment.programName.placeholder",
@@ -167,6 +251,7 @@ const InlineEnrollmentForm = ({ enrollment, onSave, onCancel }) => {
             id="enrollment-provider"
             labelText={intl.formatMessage({ id: "eqa.enrollment.provider" })}
             value={provider}
+            disabled={frozen}
             onChange={(e) => setProvider(e.target.value)}
             placeholder={intl.formatMessage({
               id: "eqa.enrollment.provider.placeholder",

--- a/frontend/src/components/eqa/MyProgramsPage.jsx
+++ b/frontend/src/components/eqa/MyProgramsPage.jsx
@@ -214,6 +214,7 @@ const MyProgramsPage = () => {
             <div style={{ marginBottom: "1rem" }}>
               <InlineEnrollmentForm
                 enrollment={null}
+                enrollments={enrollments}
                 onSave={handleCreate}
                 onCancel={() => setShowNewForm(false)}
               />
@@ -374,6 +375,7 @@ const MyProgramsPage = () => {
                               >
                                 <InlineEnrollmentForm
                                   enrollment={enrollment}
+                                  enrollments={enrollments}
                                   onSave={(payload) =>
                                     handleUpdate(enrollment.id, payload)
                                   }

--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -138,11 +138,12 @@ const CycleWizard = () => {
   const samplesComplete = samples.every(
     (sample) => sample.sampleCode.trim() && sample.testId,
   );
-  // Per step, what must be filled in to move on. Step 1 is the only one the
-  // server can reject outright, so it is the only one gated hard here; cycle
-  // details and distribution are all optional columns.
+  // Per step, what must be filled in to move on: whatever the server will
+  // refuse. Step 0's date pair is the cycle's distribution date and submission
+  // deadline, and a cycle without the deadline is invisible to the reminder
+  // digest, so both are required rather than optional columns.
   const canAdvance = [
-    true,
+    !!cycleName.trim() && !!plannedStartDate && !!plannedEndDate,
     !!panelName.trim() &&
       samplesComplete &&
       (!vendorRequired || !!vendorName.trim()),
@@ -271,6 +272,11 @@ const CycleWizard = () => {
                   id="cycle-name"
                   labelText={t("eqa.provider.wizard.cycleName", "Cycle name")}
                   value={cycleName}
+                  invalid={!cycleName.trim()}
+                  invalidText={t(
+                    "eqa.provider.wizard.cycleName.required",
+                    "A cycle needs a name.",
+                  )}
                   onChange={(e) => setCycleName(e.target.value)}
                 />
               </Column>
@@ -312,6 +318,11 @@ const CycleWizard = () => {
                       "Submission deadline",
                     )}
                     placeholder="dd/mm/yyyy"
+                    invalid={!plannedStartDate || !plannedEndDate}
+                    invalidText={t(
+                      "eqa.provider.wizard.dates.required",
+                      "A cycle needs both a distribution date and a submission deadline; the deadline is what its reminders are sent against.",
+                    )}
                   />
                 </DatePicker>
               </Column>

--- a/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
@@ -15,7 +15,11 @@ import {
   TextInput,
 } from "@carbon/react";
 import { useIntl } from "react-intl";
-import { resolveApiErrorMessage, toLocalIsoDate } from "../../../utils/Utils";
+import {
+  formatDateOnly,
+  resolveApiErrorMessage,
+  toLocalIsoDate,
+} from "../../../utils/Utils";
 import { hintStyle } from "../../eqaCommon";
 import {
   generateLabelPDF,
@@ -349,7 +353,11 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                       <DatePicker
                         datePickerType="single"
                         dateFormat="d/m/Y"
-                        value={draft.estimatedDeliveryDate}
+                        // The draft holds the ISO date the API takes; the
+                        // picker parses its value with dateFormat, so a bare
+                        // ISO string reads as nonsense under d/m/Y and
+                        // flatpickr normalises every row to the same day.
+                        value={formatDateOnly(draft.estimatedDeliveryDate)}
                         onChange={(dates) =>
                           setDraft(row.organizationId, {
                             estimatedDeliveryDate: dates[0]

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
@@ -19,6 +19,10 @@ vi.mock("../../../../utils/Utils", () => ({
   resolveApiErrorMessage: (_intl, payload, fallbackId) =>
     payload?.error || fallbackId,
   toLocalIsoDate: (d) => (d ? "2026-09-01" : ""),
+  // The workbench renders the stored ISO date through this, so the picker
+  // parses what its own dateFormat says it will.
+  formatDateOnly: (value) =>
+    value ? String(value).slice(0, 10).split("-").reverse().join("/") : "",
 }));
 
 vi.mock("../../../../common/PageBreadCrumb", () => ({

--- a/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
@@ -70,8 +70,30 @@ const renderWizard = () => {
 const next = () =>
   fireEvent.click(screen.getByRole("button", { name: "Next" }));
 
+/**
+ * Step 0's required fields: a cycle needs a name, and the date pair its
+ * reminders are sent against. A name already typed is left alone.
+ */
+const completeCycleStep = () => {
+  const name = screen.getByLabelText("Cycle name");
+  if (!name.value) {
+    fireEvent.change(name, { target: { value: "2026 Round 4" } });
+  }
+  // flatpickr only publishes a typed date on Enter (its blur path sets the
+  // date without firing onChange), so each half of the range needs both events.
+  typeDate("Distribution date", "01/09/2026");
+  typeDate("Submission deadline", "01/10/2026");
+};
+
+const typeDate = (label, value) => {
+  const input = screen.getByLabelText(label);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter", keyCode: 13 });
+};
+
 /** Steps 0 → 2, with the panel step completed on the way through. */
 const throughPanelStep = () => {
+  completeCycleStep();
   next();
   fireEvent.change(screen.getByLabelText("Panel name"), {
     target: { value: "HIV VL panel" },
@@ -95,8 +117,35 @@ describe("CycleWizard", () => {
     vi.clearAllMocks();
   });
 
+  test("step 1 holds until the cycle has a name and both its dates", () => {
+    renderWizard();
+    const nextButton = () => screen.getByRole("button", { name: "Next" });
+
+    expect(nextButton()).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Cycle name"), {
+      target: { value: "2026 Round 4" },
+    });
+    expect(nextButton()).toBeDisabled();
+
+    typeDate("Distribution date", "01/09/2026");
+    // The submission deadline is what the reminder digest keys on, so the step
+    // is still incomplete with only the distribution date on it.
+    expect(nextButton()).toBeDisabled();
+
+    typeDate("Submission deadline", "01/10/2026");
+    expect(nextButton()).toBeEnabled();
+
+    // And a name cleared after the fact closes the step again.
+    fireEvent.change(screen.getByLabelText("Cycle name"), {
+      target: { value: "  " },
+    });
+    expect(nextButton()).toBeDisabled();
+  });
+
   test("only tests that carry an analyte are offered", () => {
     renderWizard();
+    completeCycleStep();
     next();
 
     // A panel target is stored against an analyte, so a test without one is a
@@ -107,6 +156,7 @@ describe("CycleWizard", () => {
 
   test("the panel step cannot be left until a panel name and a full sample exist", () => {
     renderWizard();
+    completeCycleStep();
     next();
 
     expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();

--- a/frontend/src/components/eqa/__tests__/EQAOrderForm.test.jsx
+++ b/frontend/src/components/eqa/__tests__/EQAOrderForm.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import messages from "../../../languages/en.json";
-import EQAOrderForm from "../EQAOrderForm";
+import EQAOrderForm, { eqaReceiptNoteMissing } from "../EQAOrderForm";
 import { getFromOpenElisServer } from "../../utils/Utils";
 
 vi.mock("../../utils/Utils", async (importOriginal) => {
@@ -183,5 +183,98 @@ describe("EQAOrderForm inbound consignment", () => {
     expect(
       screen.queryByLabelText(messages["eqa.order.receipt.consignment"]),
     ).toBeNull();
+  });
+});
+
+describe("EQAOrderForm panel integrity", () => {
+  const PROGRAMS = [{ id: 7, programName: "CPHL National HIV Viral Load EQA" }];
+  const CYCLES = [
+    {
+      id: 12,
+      cycleName: "Round 1",
+      schemeName: "CPHL National HIV Viral Load EQA",
+    },
+  ];
+
+  const Harness = () => {
+    const [orderFormValues, setOrderFormValues] = useState({
+      sampleOrderItems: {
+        isEQASample: true,
+        eqaProgramId: "7",
+        eqaCycleId: "12",
+      },
+    });
+    return (
+      <EQAOrderForm
+        orderFormValues={orderFormValues}
+        setOrderFormValues={setOrderFormValues}
+      />
+    );
+  };
+
+  const renderForm = () => {
+    window.history.pushState({}, "", "/SamplePatientEntry?isEQA=true");
+    getFromOpenElisServer.mockImplementation((url, cb) => {
+      if (url.startsWith("/rest/eqa/my-programs")) cb(PROGRAMS);
+      else if (url.startsWith("/rest/eqa/cycles/mine")) cb(CYCLES);
+      else if (url.startsWith("/rest/shipping-box/by-state/IN_TRANSIT")) cb([]);
+    });
+    return render(
+      <IntlProvider locale="en" messages={messages}>
+        <Harness />
+      </IntlProvider>,
+    );
+  };
+
+  // AC-V2.2-13: the one receipt an accreditation record needs prose on is the
+  // one saying the material arrived compromised.
+  test("unticking intact demands the note, and filling it clears the alert", async () => {
+    renderForm();
+    const alert = messages["eqa.order.receipt.notes.required"];
+
+    expect(await screen.findByLabelText("Integrity notes")).toBeInTheDocument();
+    expect(screen.queryByText(alert)).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Panel arrived intact"));
+    expect(screen.getByText(alert)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Integrity notes"), {
+      target: { value: "Two vials cracked in transit" },
+    });
+    expect(screen.queryByText(alert)).toBeNull();
+
+    // Whitespace is not an explanation.
+    fireEvent.change(screen.getByLabelText("Integrity notes"), {
+      target: { value: "   " },
+    });
+    expect(screen.getByText(alert)).toBeInTheDocument();
+  });
+});
+
+describe("eqaReceiptNoteMissing", () => {
+  const order = (sampleOrderItems) => ({ sampleOrderItems });
+
+  test("holds only an EQA receipt that says not-intact with no note", () => {
+    expect(
+      eqaReceiptNoteMissing(
+        order({ isEQASample: true, eqaIntegrityOk: false }),
+      ),
+    ).toBe(true);
+    expect(
+      eqaReceiptNoteMissing(
+        order({
+          isEQASample: true,
+          eqaIntegrityOk: false,
+          eqaIntegrityNotes: "Cracked",
+        }),
+      ),
+    ).toBe(false);
+    // Intact, unanswered, and non-EQA orders are none of this rule's business.
+    expect(
+      eqaReceiptNoteMissing(order({ isEQASample: true, eqaIntegrityOk: true })),
+    ).toBe(false);
+    expect(eqaReceiptNoteMissing(order({ isEQASample: true }))).toBe(false);
+    expect(eqaReceiptNoteMissing(order({ eqaIntegrityOk: false }))).toBe(false);
+    expect(eqaReceiptNoteMissing(undefined)).toBe(false);
   });
 });

--- a/frontend/src/components/eqa/__tests__/InlineEnrollmentForm.test.jsx
+++ b/frontend/src/components/eqa/__tests__/InlineEnrollmentForm.test.jsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import messages from "../../../languages/en.json";
+import InlineEnrollmentForm from "../InlineEnrollmentForm";
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+vi.mock("../../utils/Utils", () => ({
+  getFromOpenElisServer: vi.fn(),
+}));
+
+const SCHEMES = [
+  { id: 5, name: "Chemistry PT", provider: "WHO" },
+  { id: 6, name: "Virology PT", provider: "NHLS" },
+];
+
+const ENROLLED = [{ id: 1, programName: "Chemistry PT", provider: "WHO" }];
+
+const mockServer = (cycles = []) =>
+  getFromOpenElisServer.mockImplementation((url, callback) => {
+    if (url === "/rest/eqa/programs") callback(SCHEMES);
+    else if (url === "/rest/eqa/cycles/mine") callback(cycles);
+    else if (url === "/rest/displayList/TEST_SECTION_ACTIVE")
+      callback([{ id: 10, value: "Chemistry" }]);
+    else if (url === "/rest/displayList/ALL_TESTS")
+      callback([{ id: 100, value: "Glucose" }]);
+    else if (url === "/rest/displayList/PANELS")
+      callback([{ id: 200, value: "Basic Metabolic Panel" }]);
+    else if (url === "/rest/eqa/my-programs/analytes")
+      callback([{ id: 900, value: "Glucose (serum)" }]);
+    else callback([]);
+  });
+
+const renderForm = (props) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <InlineEnrollmentForm onSave={vi.fn()} onCancel={vi.fn()} {...props} />
+    </IntlProvider>,
+  );
+
+describe("InlineEnrollmentForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("the scheme picker offers the loaded schemes and leaves out the enrolled one", () => {
+    mockServer();
+    renderForm({ enrollment: null, enrollments: ENROLLED });
+
+    const options = Array.from(
+      screen.getByLabelText("Scheme").querySelectorAll("option"),
+    ).map((option) => option.textContent);
+
+    expect(options).toEqual(["Virology PT", "Not listed - type the name"]);
+  });
+
+  test("picking a scheme fills the programme name and its provider", () => {
+    mockServer();
+    const onSave = vi.fn();
+    renderForm({ enrollment: null, enrollments: ENROLLED, onSave });
+
+    fireEvent.change(screen.getByLabelText("Scheme"), {
+      target: { value: "Virology PT" },
+    });
+
+    expect(screen.getByLabelText("Program Name")).toHaveValue("Virology PT");
+    expect(screen.getByLabelText("Provider")).toHaveValue("NHLS");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Enrollment" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      programName: "Virology PT",
+      provider: "NHLS",
+    });
+  });
+
+  test("free text stays available for a provider this instance does not carry", () => {
+    mockServer();
+    const onSave = vi.fn();
+    renderForm({ enrollment: null, enrollments: [], onSave });
+
+    fireEvent.change(screen.getByLabelText("Program Name"), {
+      target: { value: "Regional TB PT" },
+    });
+    fireEvent.change(screen.getByLabelText("Provider"), {
+      target: { value: "SANAS" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Enrollment" }));
+    expect(onSave.mock.calls[0][0]).toMatchObject({
+      programName: "Regional TB PT",
+      provider: "SANAS",
+    });
+  });
+
+  test("an enrollment with cycles against it cannot be renamed", () => {
+    // Cycles are matched to an enrollment by programme name, so a rename would
+    // silently detach this enrollment from the cycle below.
+    mockServer([{ id: 9, schemeName: "Chemistry PT" }]);
+    renderForm({
+      enrollment: {
+        id: 1,
+        programName: "Chemistry PT",
+        provider: "WHO",
+        isActive: true,
+      },
+      enrollments: ENROLLED,
+    });
+
+    expect(screen.getByLabelText("Scheme")).toBeDisabled();
+    expect(screen.getByLabelText("Program Name")).toBeDisabled();
+    expect(screen.getByLabelText("Provider")).toBeDisabled();
+    expect(
+      screen.getByText(
+        "This enrollment has cycles against it, so its scheme and provider cannot be changed.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("an enrollment with no cycles is still editable", () => {
+    mockServer([{ id: 9, schemeName: "Virology PT" }]);
+    renderForm({
+      enrollment: {
+        id: 1,
+        programName: "Chemistry PT",
+        provider: "WHO",
+        isActive: true,
+      },
+      enrollments: ENROLLED,
+    });
+
+    expect(screen.getByLabelText("Scheme")).toBeEnabled();
+    expect(screen.getByLabelText("Program Name")).toBeEnabled();
+    expect(screen.getByLabelText("Provider")).toBeEnabled();
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8566,5 +8566,12 @@
   "eqa.cycle.importScores.unmapped": "Not recognised here: {names}",
   "eqa.cycle.importScores.failed": "Could not import the scores",
   "eqa.program.schemeType": "Scheme type",
-  "eqa.program.schemeType.helper": "In-house schemes are run by this laboratory and need no provider; every other type does."
+  "eqa.program.schemeType.helper": "In-house schemes are run by this laboratory and need no provider; every other type does.",
+  "eqa.order.receipt.notes.required": "Say what was wrong with the material. A receipt marked not intact needs the note that explains it.",
+  "eqa.provider.wizard.cycleName.required": "A cycle needs a name.",
+  "eqa.provider.wizard.dates.required": "A cycle needs both a distribution date and a submission deadline; the deadline is what its reminders are sent against.",
+  "eqa.enrollment.scheme": "Scheme",
+  "eqa.enrollment.scheme.helper": "Pick a scheme this instance carries, or choose Not listed and type the name.",
+  "eqa.enrollment.scheme.frozen": "This enrollment has cycles against it, so its scheme and provider cannot be changed.",
+  "eqa.enrollment.scheme.other": "Not listed - type the name"
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -364,6 +364,16 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         if (request == null || request.schemeId() == null) {
             throw new IllegalArgumentException("A cycle needs a scheme");
         }
+        if (GenericValidator.isBlankOrNull(request.cycleName())) {
+            throw new IllegalArgumentException("A cycle needs a name");
+        }
+        // The distribution date and the submission deadline are what the cycle is
+        // scheduled by: the deadline is the only thing the 7/3/1-day digest can key
+        // on, so a cycle created without one would be invisible to every reminder
+        // for its whole life. Refusing it here is cheaper than explaining later.
+        if (request.plannedStartDate() == null || request.plannedEndDate() == null) {
+            throw new IllegalArgumentException("A cycle needs a distribution date and a submission deadline");
+        }
         if (GenericValidator.isBlankOrNull(request.panelName())) {
             throw new IllegalArgumentException("A cycle needs a panel name");
         }
@@ -422,26 +432,18 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         // so a cycle with no round is invisible to it however close its deadline is.
         // The planned end date is that deadline, and this is the only place it is
         // known, so round 1 is written here rather than left to blinding.
-        //
-        // Only when a deadline was actually given: with none, there is nothing to
-        // remind anyone about, and leaving the row out keeps the existing behaviour
-        // where blinding creates round 1 and derives the deadline from the panel's
-        // unblind date.
-        if (request.plannedEndDate() != null) {
-            EQARound round = new EQARound();
-            round.setFhirUuid(UUID.randomUUID());
-            round.setCycle(cycle);
-            round.setRoundNumber(1);
-            // Step 1's date pair IS the FRS's "distribution date, submission deadline"
-            // (FR-V2.5-02); the cycle keeps them as planned_start/planned_end, the
-            // round carries them under their real names for the digest and reports.
-            if (request.plannedStartDate() != null) {
-                round.setDistributionDate(new Timestamp(request.plannedStartDate().getTime()));
-            }
-            round.setSubmissionDeadline(new Timestamp(request.plannedEndDate().getTime()));
-            round.setSysUserId(sysUserId);
-            eqaRoundDAO.insert(round);
-        }
+        EQARound round = new EQARound();
+        round.setFhirUuid(UUID.randomUUID());
+        round.setCycle(cycle);
+        round.setRoundNumber(1);
+        // Step 1's date pair IS the FRS's "distribution date, submission deadline"
+        // (FR-V2.5-02); the cycle keeps them as planned_start/planned_end, the round
+        // carries them under their real names for the digest and reports. Both are
+        // required above, so the round is unconditional.
+        round.setDistributionDate(new Timestamp(request.plannedStartDate().getTime()));
+        round.setSubmissionDeadline(new Timestamp(request.plannedEndDate().getTime()));
+        round.setSysUserId(sysUserId);
+        eqaRoundDAO.insert(round);
 
         // Step 5 is "confirm & begin prep", so the wizard leaves the cycle where the
         // prep workbench expects it. A person clicked this, so it is recorded as a

--- a/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAPanelReceiptServiceImpl.java
@@ -5,6 +5,7 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
 import org.openelisglobal.eqa.valueholder.EQACycle;
@@ -64,6 +65,14 @@ public class EQAPanelReceiptServiceImpl extends BaseObjectServiceImpl<EQAPanelRe
             BigDecimal receivedTempC, Boolean integrityOk, String integrityNotes, Long receivedBy, String sysUserId) {
         if (receivedBy == null) {
             throw new IllegalArgumentException("A receipt requires the receiving user");
+        }
+
+        // A receipt saying the material arrived compromised is the one receipt
+        // that needs prose, so the note is required exactly there — the same
+        // shape as the write-off a failed homogeneity QC already demands.
+        if (Boolean.FALSE.equals(integrityOk) && GenericValidator.isBlankOrNull(integrityNotes)) {
+            throw new IllegalArgumentException(
+                    "The panel was not received intact, so the receipt requires a written note");
         }
 
         // Idempotency: the DB unique constraint is the backstop; this read is what

--- a/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAPanelReceiptIntegrationTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.eqa;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -175,6 +176,41 @@ public class EQAPanelReceiptIntegrationTest extends EQASpineTestBase {
                 "SELECT count(*) FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ?", Integer.class, cycleId));
         assertEquals("the ignored shipment stays untouched", "IN_TRANSIT",
                 jdbc.queryForObject("SELECT status FROM clinlims.shipment WHERE id = 9952", String.class));
+    }
+
+    /**
+     * AC-V2.2-13. A receipt saying the panel arrived compromised is the one receipt
+     * an accreditation record needs prose on, so the note is required exactly there
+     * — and nothing about the receipt is written without it.
+     */
+    @Test
+    public void aReceiptMarkedNotIntactWithoutANote_isRefusedAndWritesNothing() {
+        seedEnrollment(ENROLLMENT, "Compromised panel");
+        EQAProgram scheme = insertScheme("Integrity scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> receiptService.recordReceipt(cycleId, ENROLLMENT, null, null, false, "   ", ADMIN_USER_ID, USER));
+
+        assertTrue(refused.getMessage(), refused.getMessage().contains("written note"));
+        assertEquals("no receipt row", Integer.valueOf(0), jdbc.queryForObject(
+                "SELECT count(*) FROM clinlims.eqa_panel_receipt WHERE cycle_id = ?", Integer.class, cycleId));
+        assertEquals("the cycle stays where it was", EQACycleStatus.PLANNED, readBack(cycleId).getStatus());
+    }
+
+    /** The same receipt with the note behind it is taken, note and all. */
+    @Test
+    public void aReceiptMarkedNotIntactWithANote_isRecordedWithIt() {
+        seedEnrollment(ENROLLMENT, "Compromised panel, explained");
+        EQAProgram scheme = insertScheme("Integrity noted scheme", EQASchemeType.INTERNATIONAL_PT, "NHLS");
+        Long cycleId = insertCycle(scheme, 1);
+
+        EQAPanelReceipt receipt = receiptService.recordReceipt(cycleId, ENROLLMENT, null, null, false,
+                "Two vials cracked in transit", ADMIN_USER_ID, USER);
+
+        assertEquals(Boolean.FALSE, receipt.getIntegrityOk());
+        assertEquals("Two vials cracked in transit", receipt.getIntegrityNotes());
+        assertEquals(EQACycleStatus.PANEL_RECEIVED, readBack(cycleId).getStatus());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderCycleWizardIntegrationTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.eqa;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -234,9 +235,10 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
 
     @Test
     public void aVendorSourcedPanelWithoutAVendorIsRefused() {
-        ProviderCycleRequest request = new ProviderCycleRequest(scheme.getId(), 4, "2026 Round 4", null, null,
-                "Vendor panel", EQAPanelSourceType.VENDOR_SOURCED, "LOT-1", null, null, null, twoSamples(),
-                List.of(ORG_A), null, null, EQADistributionMethod.FHIR);
+        ProviderCycleRequest request = new ProviderCycleRequest(scheme.getId(), 4, "2026 Round 4",
+                Date.valueOf("2026-09-01"), Date.valueOf("2026-10-01"), "Vendor panel",
+                EQAPanelSourceType.VENDOR_SOURCED, "LOT-1", null, null, null, twoSamples(), List.of(ORG_A), null, null,
+                EQADistributionMethod.FHIR);
 
         try {
             cycleService.createProviderCycle(request, USER);
@@ -349,36 +351,46 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
     }
 
     /**
-     * With no deadline there is nothing to remind anyone about, and writing an
-     * empty round would take the reuse branch in blinding's findOrCreateRound,
-     * costing the deadline it derives from the panel's unblind date.
+     * The submission deadline is the only thing the reminder digest can key on, so
+     * a cycle created without one would be invisible to every reminder for its
+     * whole life. It is refused rather than written and left silent.
      */
     @Test
-    public void aCycleWithNoPlannedEndDateWritesNoRound() {
-        EQACycle created = cycleService.createProviderCycle(withCycleNumber(11), USER);
+    public void aCycleWithNoSubmissionDeadlineIsRefused() {
+        ProviderCycleRequest noDeadline = new ProviderCycleRequest(scheme.getId(), 11, "2026 Round",
+                Date.valueOf("2026-09-01"), null, "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null,
+                null, null, twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR);
 
-        assertEquals(Integer.valueOf(0), jdbc.queryForObject(
-                "SELECT count(*) FROM clinlims.eqa_round WHERE cycle_id = ?", Integer.class, created.getId()));
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> cycleService.createProviderCycle(noDeadline, USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("submission deadline"));
+        assertEquals("nothing written", Integer.valueOf(0),
+                jdbc.queryForObject("SELECT count(*) FROM clinlims.eqa_cycle WHERE cycle_number = 11 AND scheme_id = ?",
+                        Integer.class, scheme.getId()));
     }
 
-    /**
-     * The deadline alone is enough for a round — a missing distribution date must
-     * not cost the digest its reminder, and must not invent a date either.
-     */
+    /** The distribution date is half of the pair FR-V2.5-02 step 1 collects. */
     @Test
-    public void aDeadlineWithoutADistributionDateStillWritesTheRound() {
-        EQACycle created = cycleService
-                .createProviderCycle(
-                        new ProviderCycleRequest(scheme.getId(), 12, "2026 Round", null, Date.valueOf("2026-10-01"),
-                                "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null, null,
-                                twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR),
-                        USER);
+    public void aCycleWithNoDistributionDateIsRefused() {
+        ProviderCycleRequest noStart = new ProviderCycleRequest(scheme.getId(), 12, "2026 Round", null,
+                Date.valueOf("2026-10-01"), "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null,
+                null, twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR);
 
-        assertEquals(Timestamp.valueOf("2026-10-01 00:00:00"),
-                jdbc.queryForObject("SELECT submission_deadline FROM clinlims.eqa_round WHERE cycle_id = ?",
-                        Timestamp.class, created.getId()));
-        assertNull(jdbc.queryForObject("SELECT distribution_date FROM clinlims.eqa_round WHERE cycle_id = ?",
-                Timestamp.class, created.getId()));
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> cycleService.createProviderCycle(noStart, USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("distribution date"));
+    }
+
+    /** A cycle nobody can name is refused too (AC-V2.5-02's step 1 fields). */
+    @Test
+    public void aCycleWithNoNameIsRefused() {
+        ProviderCycleRequest unnamed = new ProviderCycleRequest(scheme.getId(), 13, "   ", Date.valueOf("2026-09-01"),
+                Date.valueOf("2026-10-01"), "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null,
+                null, twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR);
+
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> cycleService.createProviderCycle(unnamed, USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("name"));
     }
 
     private ProviderCycleRequest request(List<Long> participants) {
@@ -386,9 +398,9 @@ public class EQAProviderCycleWizardIntegrationTest extends EQASpineTestBase {
     }
 
     private ProviderCycleRequest withCycleNumber(Integer cycleNumber) {
-        return new ProviderCycleRequest(scheme.getId(), cycleNumber, "2026 Round", null, null, "HIV VL panel",
-                EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null, null, twoSamples(), List.of(ORG_A),
-                EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR);
+        return new ProviderCycleRequest(scheme.getId(), cycleNumber, "2026 Round", Date.valueOf("2026-09-01"),
+                Date.valueOf("2026-10-01"), "HIV VL panel", EQAPanelSourceType.IN_HOUSE_ALIQUOTED, "LOT-1", null, null,
+                null, twoSamples(), List.of(ORG_A), EQAStorageTemp.DRY_ICE, null, EQADistributionMethod.FHIR);
     }
 
     private ProviderCycleRequest with(List<PanelSampleRequest> samples, List<Long> participants) {


### PR DESCRIPTION
Issues:

## 1. A saved expected-delivery date redisplayed as the same day for every row

`ShipmentWorkbench.jsx` set `dateFormat="d/m/Y"` on the Carbon `DatePicker` and handed it the stored ISO date. Flatpickr parsed `2026-09-06` under `d/m/Y`, got nonsense, and normalised it — to the *same* date for every row on the page. Display only: writes already went through `toLocalIsoDate`, and the read-only Receipt Monitor rendered both dates correctly.

The draft still holds the ISO date the API takes; only the value handed to the picker is formatted, through the existing `formatDateOnly` helper. That keeps one representation in state and one on screen, and leaves the lane's other pickers on the format they already use.

## 2. A compromised panel needed no explanation

Unticking **Panel arrived intact** on the EQA Add Order receipt left **Next** enabled with the integrity notes empty and showed no field alert, and `EQAPanelReceiptServiceImpl` stored a null note without objection. For an accreditation record that is the wrong way round: the one receipt that needs prose is the one saying the material arrived compromised.

The note is now required in three places that agree with each other:

- the notes field carries an alert while it is empty and the box is unticked,
- the wizard's **Next** holds on the same rule (exported as `eqaReceiptNoteMissing`, so there is one copy of it),
- and `recordReceipt` refuses it, so the API cannot be walked around. The receipt rides the order's transaction on purpose, so the refusal takes the whole order down rather than leaving a half-saved one.

Whitespace does not count as an explanation on either side.

## 3. A cycle could be created that no reminder could ever reach

The provider cycle wizard accepted a blank name and blank dates and marked step 1 **Complete**; `createProviderCycle` required neither. That mattered more than it looked: the deadline reminder digest keys on `eqa_round.submission_deadline`, and the wizard wrote round 1 *only* when a deadline was given — so a cycle created without one was invisible to every 7/3/1-day reminder for its whole life, by construction.

- Step 1 holds until the cycle has a name and both dates, with the reason on the fields rather than only in a disabled button.
- `createProviderCycle` refuses a blank name, a missing distribution date and a missing submission deadline, each by name.
- Round 1 is now written unconditionally, and the branch that used to skip it is gone along with the case it existed for.

## 4. Participant enrollment named its programme in free text

**My Programs → Enroll** took **Program Name** and **Provider** as free-text boxes with no picker, and Edit kept both writable. `eqa_lab_program_enrollment` has no scheme foreign key — cycles are matched to an enrollment by programme *name* — so a typo silently detached a laboratory's enrollment from the cycles it should see.

The form now:

- offers the schemes this instance carries, leaving out those already enrolled (an enrollment being edited keeps its own, or the picker would drop what it is showing),
- fills the provider from the chosen scheme,
- keeps the free-text pair for a provider this instance does not carry,
- and freezes both fields once cycles exist against the enrollment, saying why.

Deactivated enrollments still occupy their scheme: reactivating one through Edit is the way back, not a second row for the same scheme.

Not in scope: suspend / resume / withdraw with a reason and effective date is genuinely unbuilt (the row's Options menu offers only Edit and Deactivate) and wants its own change, not a corner of this one.

## Tests

Backend, full EQA suite: **563 tests, 0 failures** (560 on the branch point, plus three net new).

- `EQAPanelReceiptIntegrationTest` — a not-intact receipt with a blank note is refused and writes no receipt row and no cycle transition; the same receipt with a note is recorded with it.
- `EQAProviderCycleWizardIntegrationTest` — a missing deadline, a missing distribution date and a blank name are each refused by name, and the deadline case leaves no cycle behind. The two tests that asserted the old "no deadline, no round" behaviour are replaced by the refusals, since the case they covered can no longer arise.

Frontend, 192 tests across the EQA and Add Order suites, 0 failures.

- `CycleWizard.test.jsx` — step 1 holds with a name and only one date, opens with both, and closes again if the name is cleared.
- `InlineEnrollmentForm.test.jsx` (new) — the picker's options are exactly the unenrolled schemes plus "Not listed"; picking one fills the name and provider and both reach the payload; free text still saves; an enrollment with a cycle against it has all three controls disabled and says why; one with no cycle stays editable.
- `EQAOrderForm.test.jsx` — unticking intact raises the alert, a note clears it, whitespace raises it again; plus the shared predicate over every combination that is and is not this rule's business.

Each new assertion was inverted against the change it covers and fails without it.