### PR TITLE
fix(eqa): cosmetic and copy defects from the acceptance walkthrough (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/EQAParticipantsPage.jsx
+++ b/frontend/src/components/eqa/EQAParticipantsPage.jsx
@@ -105,13 +105,16 @@ const EQAParticipantsPage = () => {
       `/rest/eqa/programs/${selectedProgramId}/enrollments`,
       JSON.stringify({ organizationIds: [Number(selectedOrgId)] }),
       (response) => {
-        if (response && !response.error) {
+        // The count comes from what the server says it wrote, not from what was
+        // asked for: an already-enrolled laboratory writes nothing, and reporting
+        // that as a success is worse than reporting nothing at all.
+        if (Array.isArray(response) && response.length > 0) {
           setSelectedOrgId("");
           setNotification({
             kind: "success",
             message: intl.formatMessage(
               { id: "eqa.enrollment.success" },
-              { count: 1 },
+              { count: response.length },
             ),
           });
         } else {

--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -138,6 +138,34 @@ const CycleWizard = () => {
   const samplesComplete = samples.every(
     (sample) => sample.sampleCode.trim() && sample.testId,
   );
+  // What the server refuses by name, held here instead of shown as a 422 with
+  // nothing pointing at the field that caused it.
+  const duplicateSampleCode = (index) => {
+    const code = samples[index].sampleCode.trim().toUpperCase();
+    return (
+      !!code &&
+      samples.some(
+        (other, i) =>
+          i < index && other.sampleCode.trim().toUpperCase() === code,
+      )
+    );
+  };
+  const rangeBackwards = (sample) => {
+    const low = Number(sample.acceptanceRangeLow);
+    const high = Number(sample.acceptanceRangeHigh);
+    return (
+      sample.acceptanceRangeLow !== "" &&
+      sample.acceptanceRangeHigh !== "" &&
+      Number.isFinite(low) &&
+      Number.isFinite(high) &&
+      low > high
+    );
+  };
+  const samplesValid =
+    samplesComplete &&
+    !samples.some(
+      (sample, index) => duplicateSampleCode(index) || rangeBackwards(sample),
+    );
   // Per step, what must be filled in to move on: whatever the server will
   // refuse. Step 0's date pair is the cycle's distribution date and submission
   // deadline, and a cycle without the deadline is invisible to the reminder
@@ -145,7 +173,7 @@ const CycleWizard = () => {
   const canAdvance = [
     !!cycleName.trim() && !!plannedStartDate && !!plannedEndDate,
     !!panelName.trim() &&
-      samplesComplete &&
+      samplesValid &&
       (!vendorRequired || !!vendorName.trim()),
     selectedOrgs.length > 0,
     true,
@@ -447,6 +475,11 @@ const CycleWizard = () => {
                           )}
                           hideLabel
                           value={sample.sampleCode}
+                          invalid={duplicateSampleCode(index)}
+                          invalidText={t(
+                            "eqa.provider.wizard.sampleCode.duplicate",
+                            "Every sample code on a panel must be different.",
+                          )}
                           onChange={(e) =>
                             setSample(index, { sampleCode: e.target.value })
                           }
@@ -532,6 +565,11 @@ const CycleWizard = () => {
                           )}
                           hideLabel
                           value={sample.acceptanceRangeHigh}
+                          invalid={rangeBackwards(sample)}
+                          invalidText={t(
+                            "eqa.provider.wizard.rangeHigh.backwards",
+                            "The high end of an acceptance range cannot be below the low end.",
+                          )}
                           onChange={(e) =>
                             setSample(index, {
                               acceptanceRangeHigh: e.target.value,

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -90,10 +90,13 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
   const [openingSubmissions, setOpeningSubmissions] = useState(false);
   const [openReason, setOpenReason] = useState("");
 
+  // The cycle status is a dependency, not decoration: dispatching from the
+  // sibling Shipments tab moves the cycle, and without it this tab kept
+  // reporting "Not shipped" until the page was reloaded.
   const load = useCallback(() => {
     fetchReceiptRows(cycleId, setRows);
     fetchScoreRows(cycleId, setScores);
-  }, [cycleId]);
+  }, [cycleId, cycleStatus]);
 
   useEffect(load, [load]);
 

--- a/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
@@ -127,6 +127,16 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
     });
   };
 
+  /** Aliquots per panel: what the box holds, keyed the way the label prints it. */
+  const panelCounts = () =>
+    (prep?.panels || []).reduce(
+      (counts, panel) => ({
+        ...counts,
+        [panel.panelName]: (counts[panel.panelName] || 0) + panel.sampleCount,
+      }),
+      {},
+    );
+
   const handleLabel = (row) =>
     generateLabelPDF(
       {
@@ -137,6 +147,8 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
           (sum, panel) => sum + panel.sampleCount,
           0,
         ),
+        sampleTypeCounts: panelCounts(),
+        createdDate: row.boxCreatedDate,
       },
       intl.formatMessage,
     );
@@ -193,6 +205,14 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
           destinationFacility: row.organizationName,
           state: row.boxState,
           temperature: row.temperatureRequirement,
+          // The three header facts the shipment module reads off the box on the
+          // server; this document is built here, so they travel with the row.
+          serviceLocation: row.serviceLocation,
+          createdDate: row.boxCreatedDate,
+          createdBy: row.boxCreatedBy,
+          // Panel material has no specimen type, and calling the panel one was
+          // the wrong label rather than the wrong value.
+          typeColumnLabel: t("eqa.shipment.packList.panelColumn", "Panel"),
           samples: samples,
           notes: t(
             "eqa.shipment.packList.notes",

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -115,6 +115,31 @@ describe("ReceiptMonitor", () => {
     expect(screen.getByText("1 unacceptable of 3")).toBeInTheDocument();
   });
 
+  // Dispatching from the sibling Shipments tab moves the cycle, and this tab
+  // kept reporting the pre-dispatch state until the page was reloaded.
+  it("refetches when the cycle moves under it", async () => {
+    const { rerender } = renderTab("SHIPPED");
+    await screen.findByText("Overdue");
+    const readsAfterFirstLoad = getFromOpenElisServer.mock.calls.length;
+
+    rerender(
+      <IntlProvider locale="en" messages={messages}>
+        <MemoryRouter>
+          <ReceiptMonitor
+            cycleId="9"
+            cycleStatus="SUBMISSIONS_OPEN"
+            onChanged={vi.fn()}
+            onNotice={vi.fn()}
+          />
+        </MemoryRouter>
+      </IntlProvider>,
+    );
+
+    expect(getFromOpenElisServer.mock.calls.length).toBeGreaterThan(
+      readsAfterFirstLoad,
+    );
+  });
+
   it("records a delivery for one participant", async () => {
     postToOpenElisServerFullResponse.mockImplementation((_url, _body, cb) =>
       cb(jsonResponse(true, { receiptStatus: "DELIVERED" })),

--- a/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
@@ -192,6 +192,70 @@ describe("CycleWizard", () => {
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
   });
 
+  // The server refuses both of these by name; the wizard used to let them
+  // through to a 422 with nothing pointing at the field that caused it.
+  test("the panel step holds on a repeated sample code", () => {
+    renderWizard();
+    completeCycleStep();
+    next();
+    fireEvent.change(screen.getByLabelText("Panel name"), {
+      target: { value: "HIV VL panel" },
+    });
+    fireEvent.change(screen.getByLabelText("Sample code"), {
+      target: { value: "PS-1" },
+    });
+    fireEvent.change(screen.getByLabelText("Test"), { target: { value: "55" } });
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add sample" }));
+    const codes = screen.getAllByLabelText("Sample code");
+    fireEvent.change(codes[1], { target: { value: "ps-1" } });
+    fireEvent.change(screen.getAllByLabelText("Test")[1], {
+      target: { value: "56" },
+    });
+
+    // Case is not a difference the server would accept either.
+    expect(
+      screen.getByText("Every sample code on a panel must be different."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+
+    fireEvent.change(codes[1], { target: { value: "PS-2" } });
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+  });
+
+  test("the panel step holds on an acceptance range that runs backwards", () => {
+    renderWizard();
+    completeCycleStep();
+    next();
+    fireEvent.change(screen.getByLabelText("Panel name"), {
+      target: { value: "HIV VL panel" },
+    });
+    fireEvent.change(screen.getByLabelText("Sample code"), {
+      target: { value: "PS-1" },
+    });
+    fireEvent.change(screen.getByLabelText("Test"), { target: { value: "55" } });
+
+    fireEvent.change(screen.getByLabelText("Acceptance low"), {
+      target: { value: "46.3" },
+    });
+    fireEvent.change(screen.getByLabelText("Acceptance high"), {
+      target: { value: "41.1" },
+    });
+
+    expect(
+      screen.getByText(
+        "The high end of an acceptance range cannot be below the low end.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Acceptance high"), {
+      target: { value: "51.1" },
+    });
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+  });
+
   test("only actively enrolled labs are offered as participants", async () => {
     renderWizard();
     throughPanelStep();

--- a/frontend/src/components/shipment/utils/pdfGenerator.js
+++ b/frontend/src/components/shipment/utils/pdfGenerator.js
@@ -153,7 +153,11 @@ export const generateManifestPDF = async (manifestData, formatMessage) => {
         formatMessage({ id: "shipment.manifest.number" }) || "#",
         formatMessage({ id: "sample.label.accessionNumber" }) ||
           "Accession Number",
-        formatMessage({ id: "sample.label.typeOfSample" }) || "Type",
+        // What the middle column holds depends on the document: a specimen type
+        // for a patient consignment, the panel for EQA material.
+        manifestData.typeColumnLabel ||
+          formatMessage({ id: "sample.label.typeOfSample" }) ||
+          "Type",
         formatMessage({ id: "shipment.label.tests" }) || "Tests",
         formatMessage({ id: "sample.label.collectionDate" }) ||
           "Collection Date",

--- a/frontend/src/components/utils/Utils.ts
+++ b/frontend/src/components/utils/Utils.ts
@@ -626,9 +626,14 @@ export const convertAlphaNumLabNumForDisplay = (
       labNumberForDisplay +
       labNumberParts[0].slice(labNumberParts[0].length - 3);
   }
-  //re-add dash
+  // Re-add every remaining part, not just the first: keeping only one dropped
+  // the tail of anything with a second dash in it (an EQA blind code such as
+  // IH-2-04 rendered as IH-2, the same for every row on the page).
   if (isAnalysisLabNumber) {
-    labNumberForDisplay = labNumberForDisplay + "-" + labNumberParts[1];
+    labNumberForDisplay = [
+      labNumberForDisplay,
+      ...labNumberParts.slice(1),
+    ].join("-");
   }
   return labNumberForDisplay.toUpperCase();
 };

--- a/frontend/src/components/utils/__tests__/Utils.test.ts
+++ b/frontend/src/components/utils/__tests__/Utils.test.ts
@@ -1,4 +1,4 @@
-import { formatDateOnly } from "../Utils";
+import { convertAlphaNumLabNumForDisplay, formatDateOnly } from "../Utils";
 
 describe("formatDateOnly", () => {
   test("keeps the entered calendar date for an end-of-day deadline", () => {
@@ -15,5 +15,30 @@ describe("formatDateOnly", () => {
     expect(formatDateOnly(null)).toBe("");
     expect(formatDateOnly("")).toBe("");
     expect(formatDateOnly("not a date")).toBe("");
+  });
+});
+
+describe("convertAlphaNumLabNumForDisplay", () => {
+  test("keeps every part of a lab number carrying more than one dash", () => {
+    // An EQA blind code is IH-<cycle>-<sample>. Keeping only the first part
+    // after the split rendered every row on the workplan as "IH-2".
+    expect(convertAlphaNumLabNumForDisplay("IH-2-04")).toBe("IH-2-04");
+    expect(convertAlphaNumLabNumForDisplay("IH-12-07-1")).toBe("IH-12-07-1");
+  });
+
+  test("still formats a legacy dashed lab number the same way", () => {
+    expect(convertAlphaNumLabNumForDisplay("20260900123-1")).toBe(
+      "20-260-900-123-1",
+    );
+    expect(convertAlphaNumLabNumForDisplay("20260900123")).toBe(
+      "20-260-900-123",
+    );
+  });
+
+  test("passes absent and opaque values straight through", () => {
+    expect(convertAlphaNumLabNumForDisplay(null)).toBeNull();
+    expect(convertAlphaNumLabNumForDisplay("DEV01263000000000001")).toBe(
+      "DEV01263000000000001",
+    );
   });
 });

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8604,5 +8604,8 @@
   "alerts.type.inventory_low": "Inventory Low",
   "alerts.type.sample_tracking": "Sample Tracking",
   "alerts.type.critical_result": "Critical Result",
-  "alerts.type.other": "Other"
+  "alerts.type.other": "Other",
+  "eqa.provider.wizard.sampleCode.duplicate": "Every sample code on a panel must be different.",
+  "eqa.provider.wizard.rangeHigh.backwards": "The high end of an acceptance range cannot be below the low end.",
+  "eqa.shipment.packList.panelColumn": "Panel"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAEnrollmentRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAEnrollmentRestController.java
@@ -64,6 +64,15 @@ public class EQAEnrollmentRestController extends ControllerUtills {
             String sysUserId = getSysUserId(request);
 
             List<EQAProgramEnrollment> enrolled = enrollmentService.bulkEnroll(programId, organizationIds, sysUserId);
+            // Nothing was written because every laboratory named is already enrolled.
+            // Answering Created with an empty list let the caller report a success that
+            // never happened, which is the one thing a roster screen must not do.
+            if (enrolled.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.CONFLICT)
+                        .body(Map.of("error",
+                                organizationIds.size() == 1 ? "That laboratory is already enrolled in this scheme"
+                                        : "Every laboratory named is already enrolled in this scheme"));
+            }
             List<Map<String, Object>> dtos = enrolled.stream().map(this::toDto).collect(Collectors.toList());
 
             return ResponseEntity.status(HttpStatus.CREATED).body(dtos);

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabelPDFServiceImpl.java
@@ -5,6 +5,7 @@ import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Font;
 import com.itextpdf.text.PageSize;
 import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.ColumnText;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfWriter;
@@ -46,6 +47,8 @@ public class EQALabelPDFServiceImpl implements EQALabelPDFService {
     private static final int COLUMNS = 3;
     private static final int ROWS = 10;
     private static final float PAD = 8f;
+
+    private static final String ELLIPSIS = "...";
 
     /** Sealed and distributed only — see generateLabelSheet. */
     private static final Set<EQAPanelStatus> PRINTABLE_STATES = EnumSet.of(EQAPanelStatus.SEALED,
@@ -123,21 +126,57 @@ public class EQALabelPDFServiceImpl implements EQALabelPDFService {
 
         // Blind code large and first; cycle + analyte small underneath. Target
         // values and acceptance ranges are deliberately never read here.
-        show(canvas, new Phrase(sample.getBlindCode(), CODE_FONT), left, top - 24);
-        show(canvas, new Phrase(cycleIdentifier, META_FONT), left, top - 42);
-        show(canvas, new Phrase(analyteName(sample.getAnalyteId()), META_FONT), left, top - 54);
+        show(canvas, oneLine(sample.getBlindCode(), CODE_FONT), left, top - 24);
+        show(canvas, oneLine(cycleIdentifier, META_FONT), left, top - 42);
+        show(canvas, oneLine(analyteName(sample.getAnalyteId()), META_FONT), left, top - 54);
+    }
+
+    /** The width one line of label text has to live in. */
+    private static final float TEXT_WIDTH = LABEL_WIDTH - 2f * PAD;
+
+    /**
+     * One line, shortened with an ellipsis if it does not fit the label's width. A
+     * label box holds a single line, and a value long enough to wrap used to lose
+     * every line of itself rather than the tail — so the cycle identifier and the
+     * analyte name printed on nothing but the shortest fixtures. A truncated
+     * analyte name on a tube is still useful; a missing one is not.
+     */
+    private static Phrase oneLine(String text, Font font) {
+        String fitted = text == null ? "" : text.trim();
+        BaseFont base = font.getCalculatedBaseFont(false);
+        if (base.getWidthPoint(fitted, font.getSize()) <= TEXT_WIDTH) {
+            return new Phrase(fitted, font);
+        }
+        while (!fitted.isEmpty() && base.getWidthPoint(fitted + ELLIPSIS, font.getSize()) > TEXT_WIDTH) {
+            fitted = fitted.substring(0, fitted.length() - 1);
+        }
+        return new Phrase(fitted.trim() + ELLIPSIS, font);
     }
 
     /**
      * Clipped to the label box: showTextAligned draws a single unwrapped line, so a
      * long blind code would otherwise run into the neighbouring label.
+     *
+     * <p>
+     * The box has to hold a whole line of leading, not just the glyphs: sized to
+     * the font alone it was a fraction too short and iText dropped the text without
+     * a word. The baseline still lands on {@code y}, because that is where a column
+     * places its first line.
      */
     private void show(PdfContentByte canvas, Phrase phrase, float x, float y) {
+        float leading = phrase.getFont().getSize() + 1f;
         ColumnText column = new ColumnText(canvas);
-        column.setSimpleColumn(x, y - 2f, x + LABEL_WIDTH - 2f * PAD, y + phrase.getFont().getSize() + 2f);
+        column.setLeading(leading);
+        column.setSimpleColumn(x, y - 3f, x + TEXT_WIDTH, y + leading);
         column.addText(phrase);
         try {
-            column.go();
+            // go() reports what it could not fit rather than throwing, so an
+            // unchecked call is how a line goes missing silently. Everything drawn
+            // here is one line wide by construction, so this cannot fire without a
+            // bug above it.
+            if ((column.go() & ColumnText.NO_MORE_TEXT) == 0) {
+                throw new IllegalStateException("Label text did not fit its box: " + phrase.getContent());
+            }
         } catch (DocumentException e) {
             throw new IllegalStateException("Label text layout failed", e);
         }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
+import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQACycleParticipantDAO;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
@@ -817,6 +818,15 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         row.put("shippedDate",
                 shipment == null || shipment.getShippedDate() == null ? null : shipment.getShippedDate().toString());
         row.put("shipmentStatus", shipment == null ? null : shipment.getStatus().name());
+        // The pack list and shipping label are built in the browser, so the three
+        // header facts the shipment module reads off the box server-side have to
+        // travel with the row; without them both documents printed "-" where the
+        // sending laboratory, the date and the packer belong.
+        row.put("boxCreatedDate", box == null || box.getCreatedDate() == null ? null : box.getCreatedDate().toString());
+        row.put("boxCreatedBy",
+                box == null || box.getCreatedBy() == null ? null : box.getCreatedBy().getNameForDisplay());
+        row.put("serviceLocation",
+                ConfigurationProperties.getInstance().getPropertyValue(ConfigurationProperties.Property.SiteName));
         return row;
     }
 

--- a/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
+++ b/src/main/java/org/openelisglobal/result/action/util/ResultsLoadUtility.java
@@ -311,15 +311,20 @@ public class ResultsLoadUtility {
             currentPatient = sampleService.getPatient(sample);
 
             String patientName = "";
-            String patientInfo;
-            String nationalId = patientService.getNationalId(currentPatient);
-            if (depersonalize) {
+            String patientInfo = "";
+            // A blinded EQA order has no patient at all. Reading identity off a null
+            // one used to render the literal words "null" into the Sample Info cell
+            // — "nullnull, null, N" — which reads like corrupt data.
+            String nationalId = currentPatient == null ? null : patientService.getNationalId(currentPatient);
+            if (currentPatient == null) {
+                patientInfo = "";
+            } else if (depersonalize) {
                 patientInfo = GenericValidator.isBlankOrNull(nationalId) ? patientService.getExternalId(currentPatient)
                         : nationalId;
             } else {
                 patientName = patientService.getLastFirstName(currentPatient);
-                patientInfo = nationalId + ", " + patientService.getGender(currentPatient) + ", "
-                        + patientService.getBirthdayForDisplay(currentPatient);
+                patientInfo = joinPatientInfo(nationalId, patientService.getGender(currentPatient),
+                        patientService.getBirthdayForDisplay(currentPatient));
             }
 
             currSample = analysis.getSampleItem().getSample();
@@ -416,6 +421,24 @@ public class ResultsLoadUtility {
     public List<Test> getTestsInSection(String id) {
 
         return testService.getTestsByTestSection(id);
+    }
+
+    /**
+     * The three-part patient line, with absent parts dropped rather than printed as
+     * the word "null". A sample with no identity on file should read as blank, not
+     * as a record that lost its contents.
+     */
+    private String joinPatientInfo(String nationalId, String gender, String birthday) {
+        StringBuilder info = new StringBuilder();
+        for (String part : new String[] { nationalId, gender, birthday }) {
+            if (!GenericValidator.isBlankOrNull(part)) {
+                if (info.length() > 0) {
+                    info.append(", ");
+                }
+                info.append(part);
+            }
+        }
+        return info.toString();
     }
 
     private List<TestResultItem> getTestResultItemFromAnalysis(Analysis analysis, String patientName,

--- a/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByPanelRestController.java
+++ b/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByPanelRestController.java
@@ -120,6 +120,7 @@ public class WorkplanByPanelRestController extends WorkplanRestController {
                     testResultItem.setTestId(analysis.getTest().getId());
                     Sample sample = analysis.getSampleItem().getSample();
                     testResultItem.setAccessionNumber(sample.getAccessionNumber());
+                    markEqaSample(testResultItem, sample);
                     testResultItem.setPatientInfo(getSubjectNumber(analysis));
                     testResultItem.setNextVisitDate(SpringContext.getBean(ObservationHistoryService.class)
                             .getValueForSample(ObservationType.NEXT_VISIT_DATE, sample.getId()));

--- a/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByPriorityRestController.java
+++ b/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByPriorityRestController.java
@@ -85,6 +85,7 @@ public class WorkplanByPriorityRestController extends WorkplanRestController {
                 testResultItem.setTestId(analysis.getTest().getId());
                 Sample sample = analysis.getSampleItem().getSample();
                 testResultItem.setAccessionNumber(sample.getAccessionNumber());
+                markEqaSample(testResultItem, sample);
                 testResultItem.setReceivedDate(getReceivedDateDisplay(sample));
                 testResultItem.setTestName(TestServiceImpl.getUserLocalizedTestName(analysis.getTest()));
                 boolean nonConforming = QAService.isAnalysisParentNonConforming(analysis);

--- a/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByTestRestController.java
+++ b/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByTestRestController.java
@@ -98,6 +98,7 @@ public class WorkplanByTestRestController extends WorkplanRestController {
                 testResultItem.setTestId(testType);
                 Sample sample = analysis.getSampleItem().getSample();
                 testResultItem.setAccessionNumber(sample.getAccessionNumber());
+                markEqaSample(testResultItem, sample);
                 testResultItem.setReceivedDate(getReceivedDateDisplay(sample));
                 boolean nonConforming = QAService.isAnalysisParentNonConforming(analysis);
                 if (FormFields.getInstance().useField(Field.QaEventsBySection)) {
@@ -157,6 +158,7 @@ public class WorkplanByTestRestController extends WorkplanRestController {
                 testResultItem = new TestResultItem();
                 testResultItem.setTestId(testType);
                 testResultItem.setAccessionNumber(currentAccessionNumber);
+                markEqaSample(testResultItem, sample);
                 testResultItem.setReceivedDate(sample.getReceivedDateForDisplay());
                 testResultItem.setSampleGroupingNumber(sampleGroupingNumber);
                 testResultItem.setNonconforming(QAService.isAnalysisParentNonConforming(analysis));

--- a/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByTestSectionRestController.java
+++ b/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanByTestSectionRestController.java
@@ -152,6 +152,7 @@ public class WorkplanByTestSectionRestController extends WorkplanRestController 
                 testResultItem = new TestResultItem();
                 testResultItem.setTestName(analysisService.getTestDisplayName(analysis));
                 testResultItem.setAccessionNumber(currentAccessionNumber);
+                markEqaSample(testResultItem, sample);
                 testResultItem.setReceivedDate(getReceivedDateDisplay(sample));
                 testResultItem.setSampleGroupingNumber(sampleGroupingNumber);
                 testResultItem.setTestId(analysis.getTest().getId());

--- a/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanRestController.java
+++ b/src/main/java/org/openelisglobal/workplan/controller/rest/WorkplanRestController.java
@@ -15,6 +15,8 @@ import org.openelisglobal.common.util.ConfigurationProperties;
 import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.common.util.IdValuePair;
 import org.openelisglobal.common.util.StringUtil;
+import org.openelisglobal.eqa.service.SampleEQAService;
+import org.openelisglobal.eqa.valueholder.SampleEQA;
 import org.openelisglobal.observationhistory.service.ObservationHistoryService;
 import org.openelisglobal.observationhistory.service.ObservationHistoryServiceImpl.ObservationType;
 import org.openelisglobal.patient.service.PatientService;
@@ -22,6 +24,7 @@ import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.spring.util.SpringContext;
+import org.openelisglobal.test.beanItems.TestResultItem;
 import org.openelisglobal.test.service.TestService;
 import org.openelisglobal.test.valueholder.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +35,9 @@ public class WorkplanRestController extends BaseRestController {
 
     @Autowired
     protected TestService testService;
+
+    @Autowired
+    protected SampleEQAService sampleEQAService;
 
     protected static List<String> statusList;
     protected static boolean useReceptionTime = FormFields.getInstance().useField(Field.SampleEntryUseReceptionHour);
@@ -117,6 +123,26 @@ public class WorkplanRestController extends BaseRestController {
 
         } else {
             return "";
+        }
+    }
+
+    /**
+     * Flag a workplan row that belongs to an EQA order, so the bench sees the same
+     * badge here that result entry shows. Every workplan variant builds its rows by
+     * hand, and none of them carried the flag, so the badge component was fed
+     * nothing on every one of them.
+     */
+    protected void markEqaSample(TestResultItem testResultItem, Sample sample) {
+        if (sample == null || sample.getId() == null) {
+            return;
+        }
+        SampleEQA sampleEQA = sampleEQAService.findBySampleId(Long.valueOf(sample.getId())).orElse(null);
+        if (sampleEQA == null || !Boolean.TRUE.equals(sampleEQA.getIsEqaSample())) {
+            return;
+        }
+        testResultItem.setEqaSample(true);
+        if (sampleEQA.getEqaPriority() != null) {
+            testResultItem.setEqaPriority(sampleEQA.getEqaPriority().name());
         }
     }
 

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -99,6 +99,15 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
                 + "   WHERE name = 'Entered' AND status_type = 'SAMPLE')");
         statusService.refreshCache();
 
+        // The label sheet prints the analyte's name under each blind code, so the
+        // two analytes this class uses need names to print.
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated)"
+                + " SELECT 9801, 'EQA Numeric Analyte', 'Y', now()"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.analyte WHERE id = 9801)");
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated)"
+                + " SELECT 9802, 'EQA Categorical Analyte', 'Y', now()"
+                + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.analyte WHERE id = 9802)");
+
         jdbc.update("INSERT INTO clinlims.localization (id, description)" + " SELECT 9807, 'EQA Blinding Test'"
                 + " WHERE NOT EXISTS (SELECT 1 FROM clinlims.localization WHERE id = 9807)");
         jdbc.update("INSERT INTO clinlims.test_section (id, name, description, is_external, sort_order,"
@@ -780,9 +789,50 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         String extracted = text.toString();
 
         assertTrue("every blind code prints", extracted.contains("IHBLIND-P1") && extracted.contains("IHBLIND-P2"));
+        // AC-V2.4-14 also asks for the cycle and the analyte under each code. Both
+        // are 8pt, and a box sized to the glyphs alone silently dropped them.
+        String cycleIdentifier = cycle.getCycleName() != null ? cycle.getCycleName() : panel.getPanelName();
+        assertTrue("the cycle identifier prints under each code", extracted.contains(cycleIdentifier));
+        // Whatever the catalog calls these two analytes, both must appear: the
+        // 8pt meta lines were being dropped by a box sized to the glyphs alone.
+        for (long analyteId : new long[] { NUMERIC_ANALYTE, CATEGORICAL_ANALYTE }) {
+            String name = jdbc.queryForObject("SELECT name FROM clinlims.analyte WHERE id = ?", String.class,
+                    analyteId);
+            assertTrue("the analyte prints under its blind code: " + name, extracted.contains(name));
+        }
         assertFalse("numeric target must not leak (AC-V2.4-14)", extracted.contains("43.7"));
         assertFalse("acceptance range must not leak", extracted.contains("41.1") || extracted.contains("46.3"));
         assertFalse("categorical target must not leak", extracted.contains("SecretPositive77"));
+    }
+
+    /**
+     * The rig's real names are long: a scheme cycle called "CPHL National HIV Viral
+     * Load EQA 2026 Round 1" and an analyte called "HIV-1 Viral Load (plasma, RNA
+     * copies/mL)" are what the sheet has to carry, not the short fixture strings.
+     */
+    @Test
+    public void labelSheet_printsLongCycleAndAnalyteNames() throws Exception {
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated)"
+                + " VALUES (9811, 'HIV-1 Viral Load (plasma, RNA copies/mL)', 'Y', now())"
+                + " ON CONFLICT (id) DO UPDATE SET name = excluded.name");
+        EQAProgram scheme = inHouseScheme("IH Long Label Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        cycle.setCycleName("CPHL National HIV Viral Load EQA 2026 Round 1");
+        cycle.setSysUserId(USER);
+        eqaCycleDAO.update(cycle);
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.SEALED, LocalDate.now().plusDays(7));
+        insertPanelSample(panel, "IH-01", "IHLONG-P1", 9811L, "5000", null, null);
+
+        PdfReader reader = new PdfReader(labelPDFService.generateLabelSheet(panel.getId()));
+        String extracted = PdfTextExtractor.getTextFromPage(reader, 1);
+        reader.close();
+
+        assertTrue("the blind code prints", extracted.contains("IHLONG-P1"));
+        // Shortened to the label's width rather than dropped: on the old build the
+        // sheet printed the blind code and nothing else for names this long.
+        assertTrue("the cycle identifier prints: " + extracted, extracted.contains("CPHL National HIV Viral Load"));
+        assertTrue("the analyte prints: " + extracted, extracted.contains("HIV-1 Viral Load (plasma"));
+        assertTrue("what did not fit is marked, not silently lost", extracted.contains("..."));
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/EQAWorkplanBadgeIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAWorkplanBadgeIntegrationTest.java
@@ -1,0 +1,112 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.SampleEQAService;
+import org.openelisglobal.sample.valueholder.Sample;
+import org.openelisglobal.test.beanItems.TestResultItem;
+import org.openelisglobal.workplan.controller.rest.WorkplanRestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The EQA badge on the workplan. Every workplan variant builds its rows by hand
+ * and none of them set the flag the badge reads, so the bench saw no marker on
+ * any of them; they now all route through one method on the shared base
+ * controller, which is what this exercises against real rows.
+ *
+ * <p>
+ * The workplan package is outside the test component scan (its controllers pull
+ * in the whole result-entry stack), so the base controller is built by hand
+ * with the one collaborator this path uses — the same pattern the blinding test
+ * uses for the scheduler.
+ */
+public class EQAWorkplanBadgeIntegrationTest extends EQASpineTestBase {
+
+    private static final long EQA_SAMPLE_ID = 98132L;
+    private static final long PLAIN_SAMPLE_ID = 98133L;
+    private static final long WITHDRAWN_SAMPLE_ID = 98134L;
+
+    @Autowired
+    private SampleEQAService sampleEQAService;
+
+    private WorkplanRestController workplan;
+
+    @Before
+    public void seedOrdersAndController() {
+        jdbc.update("DELETE FROM clinlims.sample_eqa WHERE sample_id IN (?, ?, ?)", EQA_SAMPLE_ID, PLAIN_SAMPLE_ID,
+                WITHDRAWN_SAMPLE_ID);
+        jdbc.update("DELETE FROM clinlims.sample WHERE id IN (?, ?, ?)", EQA_SAMPLE_ID, PLAIN_SAMPLE_ID,
+                WITHDRAWN_SAMPLE_ID);
+
+        insertSample(EQA_SAMPLE_ID, "EQAWP98132");
+        insertSample(PLAIN_SAMPLE_ID, "EQAWP98133");
+        insertSample(WITHDRAWN_SAMPLE_ID, "EQAWP98134");
+        jdbc.update("INSERT INTO clinlims.sample_eqa (id, sample_id, is_eqa_sample, eqa_priority, sys_user_id,"
+                + " last_updated) VALUES (?, ?, true, 'URGENT', ?, NOW())", 98135L, EQA_SAMPLE_ID, USER);
+        // A row that exists but says this is not an EQA sample: the flag is the
+        // fact, not the presence of the row.
+        jdbc.update(
+                "INSERT INTO clinlims.sample_eqa (id, sample_id, is_eqa_sample, eqa_priority, sys_user_id,"
+                        + " last_updated) VALUES (?, ?, false, 'STANDARD', ?, NOW())",
+                98136L, WITHDRAWN_SAMPLE_ID, USER);
+
+        workplan = new WorkplanRestController();
+        ReflectionTestUtils.setField(workplan, "sampleEQAService", sampleEQAService);
+    }
+
+    @Test
+    public void anEqaOrderIsFlaggedWithItsPriority() {
+        TestResultItem row = new TestResultItem();
+
+        ReflectionTestUtils.invokeMethod(workplan, "markEqaSample", row, sample(EQA_SAMPLE_ID));
+
+        assertTrue("the badge reads this flag", row.isEqaSample());
+        assertEquals("URGENT", row.getEqaPriority());
+    }
+
+    @Test
+    public void anOrdinaryOrderIsLeftAlone() {
+        TestResultItem row = new TestResultItem();
+
+        ReflectionTestUtils.invokeMethod(workplan, "markEqaSample", row, sample(PLAIN_SAMPLE_ID));
+
+        assertFalse(row.isEqaSample());
+        assertNull(row.getEqaPriority());
+    }
+
+    @Test
+    public void anOrderWhoseEqaFlagIsOffIsLeftAlone() {
+        TestResultItem row = new TestResultItem();
+
+        ReflectionTestUtils.invokeMethod(workplan, "markEqaSample", row, sample(WITHDRAWN_SAMPLE_ID));
+
+        assertFalse(row.isEqaSample());
+        assertNull(row.getEqaPriority());
+    }
+
+    @Test
+    public void aRowWithNoSampleBehindItIsNotAnError() {
+        TestResultItem row = new TestResultItem();
+
+        ReflectionTestUtils.invokeMethod(workplan, "markEqaSample", row, (Sample) null);
+
+        assertFalse(row.isEqaSample());
+    }
+
+    private void insertSample(long id, String accession) {
+        jdbc.update("INSERT INTO clinlims.sample (id, accession_number, entered_date, received_date,"
+                + " is_confirmation, lastupdated) VALUES (?, ?, NOW(), NOW(), false, NOW())", id, accession);
+    }
+
+    private Sample sample(long id) {
+        Sample sample = new Sample();
+        sample.setId(String.valueOf(id));
+        return sample;
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAEnrollmentRestControllerTest.java
@@ -102,6 +102,39 @@ public class EQAEnrollmentRestControllerTest {
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
     }
 
+    /**
+     * A laboratory already on the roster writes nothing, and Created with an empty
+     * list let the caller report a success that never happened.
+     */
+    @Test
+    public void testCreateEnrollments_AlreadyEnrolledIsAConflictNotACreation() {
+        when(enrollmentService.bulkEnroll(eq(1L), anyList(), eq("1"))).thenReturn(List.of());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("organizationIds", List.of(100));
+
+        ResponseEntity<?> response = controller.createEnrollments(request, 1L, body);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("That laboratory is already enrolled in this scheme",
+                ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    /** The same refusal, worded for a batch. */
+    @Test
+    public void testCreateEnrollments_EveryLabAlreadyEnrolledIsAConflict() {
+        when(enrollmentService.bulkEnroll(eq(1L), anyList(), eq("1"))).thenReturn(List.of());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("organizationIds", List.of(100, 200));
+
+        ResponseEntity<?> response = controller.createEnrollments(request, 1L, body);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("Every laboratory named is already enrolled in this scheme",
+                ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
     @Test
     public void testCreateEnrollments_NonNumericOrgIds() {
         Map<String, Object> body = new HashMap<>();


### PR DESCRIPTION
The cosmetic sweep from the acceptance walkthrough: seven small defects, one PR. Two of them had real logic behind them and are covered below in more detail than their size suggests.

## The label sheet printed only the blind code

`EQALabelPDFServiceImpl` draws a cycle identifier and an analyte name under each blind code. Neither appeared on the rig, and the cause was not the font size — it was the box. Each line was drawn into a column exactly `fontSize + 4` tall, which cannot hold a line of leading, so a value long enough to wrap lost **every** line of itself rather than its tail. `column.go()`'s status was never checked, so the loss was silent.

Reproduced in a test before fixing: with the rig's real names ("CPHL National HIV Viral Load EQA 2026 Round 1", "HIV-1 Viral Load (plasma, RNA copies/mL)") the sheet printed the blind code and nothing else. The short fixture strings in the existing test fitted, which is why it had been passing.

Each line is now shortened to the label's width with an ellipsis and drawn in a box that holds one line of leading, with the baseline still where it was. The layout call checks what it could not place, which cannot now fire — everything drawn is one line wide by construction — so it stands as an assertion rather than a fallback. A truncated analyte name on a tube is still useful; a missing one is not.

## The workplan truncated blind codes and showed no badge

Two separate causes.

`convertAlphaNumLabNumForDisplay` split the lab number on `-` and re-added **only the first** part afterwards, so anything carrying a second dash lost its tail: `IH-2-04` rendered as `IH-2`, identically for every row on the page, while the link href carried the true code. Fixed at the root — every remaining part is re-added — which is a smaller diff than a guard per caller and fixes the six other callers of the same helper. Legacy dashed lab numbers format exactly as before.

Separately, no workplan variant set the flag the `EQABadge` reads, so the component was fed nothing on all four of them. All four now call one `markEqaSample` on the shared `WorkplanRestController` base, which resolves the order's `sample_eqa` row and carries its priority across — the same facts result entry already shows.

## Result entry rendered the word "null" for a blinded order

A blinded in-house order has no patient. `ResultsLoadUtility` read identity off the null one anyway, so the Sample Info cell printed `nullnull, null, N` — name, national id and date of birth alike. Absent identity now reads as blank, and the three-part patient line drops the parts it does not have instead of printing them as the word "null".

Not changed: an EQA order created through **Add Order** shows `NULL, NULL NULL, M, 01/01/1900`, which is the placeholder patient that flow actually creates. That is real data, and suppressing patient identity on EQA rows generally is a product decision rather than a null-handling bug.

## A duplicate enrollment reported a success that never happened

`bulkEnroll` skips a laboratory already actively enrolled, and the controller returned that empty list as `201 Created`. The Participants page reported "Enrollment successful" for any non-error response, so a stale picker could confirm a write that did not occur.

It is a `409` now, naming the case (one laboratory, or all of them), and the page reports the count the server says it wrote rather than assuming one.

## The cycle wizard let through what its own server refuses

A repeated sample code and an acceptance range that runs backwards both reach a 422 with no field alert. The wizard now holds its panel step on both, with the reason on the field that caused it. Sample codes are compared case-insensitively, because the server does not accept case as a difference either.

## The receipts tab went stale after a dispatch

`ReceiptMonitor` kept reporting "Not shipped" after the sibling Shipments tab dispatched, until the page was reloaded. The cycle status was missing from the fetch dependencies — it is a dependency, not decoration.

## The pack list and shipping label printed "-" for their header

Both documents are generated in the browser (the shipment module's backend PDF services are deprecated for removal), so the three header facts the shipment module reads off the box server-side never reached them: Service Location, Created Date, Created By. Those now travel with the shipment row — the site name, and the box's own created date and creator — and the label carries its per-panel aliquot counts, where SAMPLE TYPES had read "-".

The pack list's middle column showed the panel name under a "Type" heading. Panel material has no specimen type, so this was the wrong *label*, not the wrong value: the manifest generator now takes an optional column label and the EQA caller names it "Panel". The shipment module's own manifests are unchanged.

## Two items that did not become code

**The pack list's empty Specimen Barcodes block** is not reproduced from the code. The box id's own barcode renders through the same helper, every row supplies the `accessionNumber` the block keys on, and failures there are swallowed by design. Without an isolated cause I have left it alone rather than guess at a fix; it needs a browser session with the console open.

**Genie III missing from the Serum order list is not a defect.** On the rig the three `Genie III` rows (tests 44, 45, 46) all carry `orderable = false`, and the order list filters on exactly that (`TestDAOImpl`: `isActive = 'Y' and orderable = true`). Every Genie II row that renders is `orderable = true`. So the list is correct and the catalog data is what differs — with a second observation for whoever owns the catalog: there are three rows all named "Genie III".

## Tests

Backend, full EQA suite: **567 tests, 0 failures** (560 on the branch point plus seven new).

- `EQABlindingIntegrationTest` — a new test drives the long real-world names and asserts the cycle identifier and analyte print and that what did not fit is marked; the existing sheet test now also asserts both meta lines, reading each analyte's name from the catalog rather than a literal.
- `EQAWorkplanBadgeIntegrationTest` (new) — an EQA order is flagged with its priority; an ordinary order, an order whose EQA flag is off, and a row with no sample behind it are each left alone. The workplan package sits outside the test component scan, so the base controller is built by hand with the one collaborator this path uses.
- `EQAEnrollmentRestControllerTest` — the already-enrolled case is a conflict with its message, for one laboratory and for a batch.

Frontend, 193 tests, 0 failures.

- `Utils.test.ts` — every part of a multi-dash lab number survives; legacy dashed numbers are unchanged; absent and opaque values pass through.
- `CycleWizard.test.jsx` — the panel step holds on a repeated code (including one differing only in case) and on a backwards range, and opens again once corrected.
- `ReceiptMonitor.test.jsx` — moving the cycle under the tab refetches.

Each new assertion was inverted against the change it covers and fails without it.

## Overlap

Touches `CycleWizard.jsx` and `en.json` alongside #4212, which gates the same wizard's first step. The two gate different steps and merge cleanly by keeping both.