### PR TITLE
fix(eqa): make the review gate and the submission retry budget reachable (OGC-935)

### DIFF
--- a/frontend/src/components/alerts/AlertsDashboard.jsx
+++ b/frontend/src/components/alerts/AlertsDashboard.jsx
@@ -115,6 +115,12 @@ const AlertsDashboard = () => {
               text={intl.formatMessage({ id: "alerts.type.eqa_deadline" })}
             />
             <SelectItem
+              value="EQA_SUBMISSION_FAILED"
+              text={intl.formatMessage({
+                id: "alerts.type.eqa_submission_failed",
+              })}
+            />
+            <SelectItem
               value="SAMPLE_EXPIRATION"
               text={intl.formatMessage({ id: "alerts.type.sample_expiration" })}
             />

--- a/frontend/src/components/alerts/__tests__/AlertsDashboard.test.jsx
+++ b/frontend/src/components/alerts/__tests__/AlertsDashboard.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
@@ -53,8 +53,16 @@ const mockDashboard = {
       message: "Sample expiring soon",
       startTime: "2026-01-15T11:00:00Z",
     },
+    {
+      id: 3,
+      alertType: "EQA_SUBMISSION_FAILED",
+      severity: "CRITICAL",
+      status: "OPEN",
+      message: "Automatic EQA submission failed 5 times",
+      startTime: "2026-01-15T12:00:00Z",
+    },
   ],
-  totalCount: 2,
+  totalCount: 3,
   page: 0,
   pageSize: 25,
 };
@@ -108,6 +116,18 @@ describe("AlertsDashboard", () => {
     renderWithIntl(<AlertsDashboard />);
     expect(screen.getByText("EQA deadline approaching")).toBeTruthy();
     expect(screen.getByText("Sample expiring soon")).toBeTruthy();
+  });
+
+  // Every alert type the enum can produce needs a label, or the Type column
+  // prints the raw enum beside rows that read as English.
+  test("every alert type reads as a label, not as its enum", () => {
+    renderWithIntl(<AlertsDashboard />);
+
+    // The filter's own options carry the same labels, so read the table.
+    const table = document.querySelector("table");
+    expect(within(table).getByText("EQA Deadline")).toBeTruthy();
+    expect(within(table).getByText("EQA Submission Failed")).toBeTruthy();
+    expect(within(table).queryByText("EQA_SUBMISSION_FAILED")).toBeNull();
   });
 
   test("renders filter controls", () => {

--- a/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
+++ b/frontend/src/components/eqa/EQAProgram/ProgramForm.jsx
@@ -35,6 +35,9 @@ const ProgramForm = ({ program, onClose }) => {
   const [description, setDescription] = useState(program?.description || "");
   const [isActive, setIsActive] = useState(program?.isActive !== false);
   const [perAnalyst, setPerAnalyst] = useState(program?.perAnalyst === true);
+  const [requiresCycleReview, setRequiresCycleReview] = useState(
+    program?.requiresCycleReview === true,
+  );
   const [schemeType, setSchemeType] = useState(
     program?.schemeType || "INTERNATIONAL_PT",
   );
@@ -158,6 +161,7 @@ const ProgramForm = ({ program, onClose }) => {
       provider: providerRequired ? provider : "",
       description,
       perAnalyst,
+      requiresCycleReview,
       schemeType,
     };
 
@@ -293,6 +297,21 @@ const ProgramForm = ({ program, onClose }) => {
           labelB={intl.formatMessage({ id: "eqa.program.perAnalyst.on" })}
           toggled={perAnalyst}
           onToggle={(toggled) => setPerAnalyst(toggled)}
+        />
+        <Toggle
+          id="program-requires-cycle-review"
+          labelText={intl.formatMessage({
+            id: "eqa.program.requiresCycleReview",
+            defaultMessage: "Hold each cycle for review before submitting",
+          })}
+          labelA={intl.formatMessage({
+            id: "eqa.program.requiresCycleReview.off",
+          })}
+          labelB={intl.formatMessage({
+            id: "eqa.program.requiresCycleReview.on",
+          })}
+          toggled={requiresCycleReview}
+          onToggle={(toggled) => setRequiresCycleReview(toggled)}
         />
         {isEditing && (
           <Toggle

--- a/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
+++ b/frontend/src/components/eqa/EQAProgram/__tests__/ProgramManagement.test.jsx
@@ -216,6 +216,49 @@ describe("ProgramForm", () => {
     expect(JSON.parse(payload).schemeType).toBe("REGIONAL_PT");
   });
 
+  // F-21: the review gate is read by the auto-submit sweep, the cycle DTO and My
+  // Cycles, and no screen could set it — so outside the test suite it could only
+  // ever be its column default of false.
+  test("the review gate is reachable from the dialog and rides the payload", () => {
+    const { container } = renderWithIntl(
+      <ProgramForm program={null} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector("#program-name"), {
+      target: { value: "Regional serology" },
+    });
+    fireEvent.change(container.querySelector("#program-scheme-type"), {
+      target: { value: "REGIONAL_PT" },
+    });
+    fireEvent.change(container.querySelector("#program-provider"), {
+      target: { value: "CPHL" },
+    });
+    fireEvent.click(container.querySelector("#program-requires-cycle-review"));
+    fireEvent.click(screen.getByText("Add Program"));
+
+    const [, payload] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(JSON.parse(payload).requiresCycleReview).toBe(true);
+  });
+
+  test("a scheme already holding for review opens with the toggle on", () => {
+    const { container } = renderWithIntl(
+      <ProgramForm
+        program={{
+          id: 1,
+          name: "Chemistry PT",
+          provider: "CAP",
+          isActive: true,
+          requiresCycleReview: true,
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      container.querySelector("#program-requires-cycle-review"),
+    ).toBeChecked();
+  });
+
   test("renders create mode with correct heading", () => {
     renderWithIntl(<ProgramForm program={null} onClose={vi.fn()} />);
     expect(screen.getByText("Add New EQA Program")).toBeTruthy();

--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -41,6 +41,7 @@ import {
   fetchMyPrograms,
   importScoresCsv,
   submitCycle,
+  submitCycleManually,
 } from "./cyclesApi";
 
 const breadcrumbs = [
@@ -90,6 +91,14 @@ const resultEntryUrl = (labNo) =>
 // only while a review-gated scheme sits at ready_to_submit.
 const reviewGateOpen = (cycle) =>
   cycle.requiresCycleReview && cycle.status === "ready_to_submit";
+
+// The automatic channel gives up after five attempts and never tries again, so
+// from here on the only way out is a submission recorded by hand. The alert the
+// sweep raises says exactly that; this is where it can now be acted on.
+const MAX_SUBMISSION_ATTEMPTS = 5;
+const retriesSpent = (cycle) =>
+  cycle.status === "ready_to_submit" &&
+  (cycle.submissionAttempts || 0) >= MAX_SUBMISSION_ATTEMPTS;
 
 // A validation is a real instant, so it renders in the viewer's timezone —
 // unlike deadlines, which are end-of-day values read as UTC (formatDateOnly).
@@ -148,6 +157,7 @@ const MyCyclesPage = () => {
   // Scores from a provider that is not an OpenELIS arrive as a file; a provider
   // OpenELIS delivers them through the FHIR store on its own.
   const [scoreImport, setScoreImport] = useState(null);
+  const [manualSubmit, setManualSubmit] = useState(null);
   const [importNotice, setImportNotice] = useState(null);
 
   const handleImportScores = () => {
@@ -272,6 +282,40 @@ const MyCyclesPage = () => {
     });
   };
 
+  const handleManualSubmit = () => {
+    setManualSubmit({ ...manualSubmit, busy: true, error: null });
+    submitCycleManually(
+      manualSubmit.cycle.id,
+      manualSubmit.reference,
+      (result) => {
+        if (!result.ok) {
+          setManualSubmit({
+            ...manualSubmit,
+            busy: false,
+            error: result.error,
+          });
+          return;
+        }
+        setManualSubmit(null);
+        setCycles((prev) =>
+          prev.map((c) =>
+            c.id === manualSubmit.cycle.id ? { ...c, status: "submitted" } : c,
+          ),
+        );
+        setSubmitNotice({
+          kind: "success",
+          text: t(
+            "eqa.cycle.submitManual.success",
+            "Recorded as submitted by hand, with the provider's reference.",
+          ),
+        });
+      },
+    );
+  };
+
+  const openManualSubmit = (cycle) =>
+    setManualSubmit({ cycle, reference: "", error: null, busy: false });
+
   // Lab-wide KPIs — deliberately NOT filtered; they describe the whole lab.
   const activeCount = cycles.filter((c) =>
     BUCKETS.active.includes(c.status),
@@ -321,6 +365,15 @@ const MyCyclesPage = () => {
             {t("eqa.cycle.importScores", "Import scores (CSV)")}
           </Button>
         )}
+        {cycle.status === "ready_to_submit" && (
+          <Button
+            kind="ghost"
+            size="sm"
+            onClick={() => openManualSubmit(cycle)}
+          >
+            {t("eqa.cycle.submitManual", "Submit by hand")}
+          </Button>
+        )}
         <Button
           kind="ghost"
           size="sm"
@@ -330,6 +383,25 @@ const MyCyclesPage = () => {
           {t("eqa.report.download", "Download performance report")}
         </Button>
       </div>
+      {retriesSpent(cycle) && (
+        <ActionableNotification
+          kind="error"
+          lowContrast
+          hideCloseButton
+          inline
+          title={t(
+            "eqa.cycle.retriesSpent.title",
+            "Automatic submission has stopped for this cycle.",
+          )}
+          subtitle={t(
+            "eqa.cycle.retriesSpent.body",
+            "It failed {attempts} times and will not be retried. Send the results to the provider yourself — the export bundle is on the scheme's page — and record their reference here.",
+            { attempts: cycle.submissionAttempts },
+          )}
+          actionButtonLabel={t("eqa.cycle.submitManual", "Submit by hand")}
+          onActionButtonClick={() => openManualSubmit(cycle)}
+        />
+      )}
       {cycle.hasNce && (
         <InlineNotification
           kind="error"
@@ -1004,6 +1076,51 @@ const MyCyclesPage = () => {
               setScoreImport({ ...scoreImport, csv: e.target.value })
             }
             rows={5}
+          />
+        </Modal>
+      )}
+      {manualSubmit && (
+        <Modal
+          open
+          size="sm"
+          modalHeading={t(
+            "eqa.cycle.submitManual.heading",
+            "Record a submission made by hand",
+          )}
+          primaryButtonText={t("eqa.cycle.submitManual", "Submit by hand")}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={
+            manualSubmit.busy || !manualSubmit.reference.trim()
+          }
+          onRequestClose={() => setManualSubmit(null)}
+          onSecondarySubmit={() => setManualSubmit(null)}
+          onRequestSubmit={handleManualSubmit}
+        >
+          <p style={{ color: "#525252", marginBottom: "1rem" }}>
+            {t(
+              "eqa.cycle.submitManual.help",
+              "Use this once the results have reached the provider some other way. The reference they gave you is what makes this a record rather than a claim, so it is required.",
+            )}
+          </p>
+          {manualSubmit.error && (
+            <InlineNotification
+              kind="error"
+              lowContrast
+              hideCloseButton
+              title={manualSubmit.error}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          <TextInput
+            id="manual-submission-reference"
+            labelText={t(
+              "eqa.cycle.submitManual.reference",
+              "Provider's reference",
+            )}
+            value={manualSubmit.reference}
+            onChange={(e) =>
+              setManualSubmit({ ...manualSubmit, reference: e.target.value })
+            }
           />
         </Modal>
       )}

--- a/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
+++ b/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
@@ -204,6 +204,82 @@ describe("MyCyclesPage", () => {
     ).toBeInTheDocument();
   });
 
+  // F-22: the automatic channel gives up after five attempts and never tries
+  // again, and the alert it raises says "submit manually" — which nothing in
+  // the UI could do.
+  test("a cycle whose retries are spent offers a manual submission and records the reference", async () => {
+    const stuck = {
+      ...MOCK_CYCLES[0],
+      id: 31,
+      status: "READY_TO_SUBMIT",
+      participantState: "READY_TO_SUBMIT",
+      requiresCycleReview: false,
+      submissionAttempts: 5,
+      samples: [],
+    };
+    renderPage(UNCYCLED_ORDERS, [stuck]);
+    fireEvent.click(screen.getByTestId("cycle-row-31"));
+
+    expect(
+      screen.getByText("Automatic submission has stopped for this cycle."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed 5 times and will not be retried/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Submit by hand" })[0],
+    );
+    // The provider's reference is what makes this a record rather than a claim,
+    // so the action holds until there is one.
+    const dialog = screen.getByRole("dialog");
+    const confirm = within(dialog).getByRole("button", {
+      name: "Submit by hand",
+    });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Provider's reference"), {
+      target: { value: "NHLS-2026-0099" },
+    });
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb({ ok: true, json: () => Promise.resolve({ status: "SUBMITTED" }) }),
+    );
+    fireEvent.click(confirm);
+
+    const [url, body] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(url).toBe("/rest/eqa/cycles/31/submit-manual");
+    expect(JSON.parse(body)).toEqual({
+      manualSubmissionReference: "NHLS-2026-0099",
+    });
+    expect(
+      await screen.findByText(
+        "Recorded as submitted by hand, with the provider's reference.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("a cycle with retries left is not told automatic submission has stopped", () => {
+    const trying = {
+      ...MOCK_CYCLES[0],
+      id: 32,
+      status: "READY_TO_SUBMIT",
+      participantState: "READY_TO_SUBMIT",
+      requiresCycleReview: false,
+      submissionAttempts: 2,
+      samples: [],
+    };
+    renderPage(UNCYCLED_ORDERS, [trying]);
+    fireEvent.click(screen.getByTestId("cycle-row-32"));
+
+    expect(
+      screen.queryByText("Automatic submission has stopped for this cycle."),
+    ).toBeNull();
+    // The manual route is still offered — it is the fallback, not a last rite.
+    expect(
+      screen.getByRole("button", { name: "Submit by hand" }),
+    ).toBeInTheDocument();
+  });
+
   test("row expansion reveals sample progress with result-entry deep links", () => {
     renderPage();
     fireEvent.click(screen.getByTestId("cycle-row-1"));

--- a/frontend/src/components/eqa/MyCycles/cyclesApi.js
+++ b/frontend/src/components/eqa/MyCycles/cyclesApi.js
@@ -46,6 +46,31 @@ export const submitCycle = (cycleId, callback) => {
   );
 };
 
+// FR-V2.2-06 manual fallback, reachable at last. The automatic channel spends a
+// finite retry budget and then stops for good, and the alert it raises says
+// "submit manually" — this is what that sentence now points at. The provider's
+// reference is mandatory server-side: without it a manual submission is a claim
+// rather than a record.
+export const submitCycleManually = (cycleId, reference, callback) => {
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/submit-manual`,
+    JSON.stringify({ manualSubmissionReference: reference }),
+    (response) => {
+      response
+        .json()
+        .catch(() => ({}))
+        .then((payload) => {
+          callback({
+            ok: response.ok,
+            error: response.ok
+              ? null
+              : payload?.error || payload?.message || response.statusText,
+          });
+        });
+    },
+  );
+};
+
 // Programmes this lab has enrolled in (My Programs); the "New cycle" form
 // offers exactly these, by name, because the participant-created cycle is
 // matched to a local programme of the same name on the server.

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8587,5 +8587,22 @@
   "eqa.labperf.kpi.nceOpenCount": "Of those, still open",
   "eqa.queue.source.all": "Every source",
   "eqa.queue.countFiltered": "Queue · {count} of {total} items",
-  "eqa.queue.emptyForSource": "Nothing from this source is awaiting triage. The queue holds {total} items from other sources."
+  "eqa.queue.emptyForSource": "Nothing from this source is awaiting triage. The queue holds {total} items from other sources.",
+  "eqa.program.requiresCycleReview": "Hold each cycle for review before submitting",
+  "eqa.program.requiresCycleReview.off": "Submit automatically",
+  "eqa.program.requiresCycleReview.on": "Hold for review",
+  "eqa.cycle.submitManual": "Submit by hand",
+  "eqa.cycle.submitManual.heading": "Record a submission made by hand",
+  "eqa.cycle.submitManual.help": "Use this once the results have reached the provider some other way. The reference they gave you is what makes this a record rather than a claim, so it is required.",
+  "eqa.cycle.submitManual.reference": "Provider's reference",
+  "eqa.cycle.submitManual.success": "Recorded as submitted by hand, with the provider's reference.",
+  "eqa.cycle.retriesSpent.title": "Automatic submission has stopped for this cycle.",
+  "eqa.cycle.retriesSpent.body": "It failed {attempts} times and will not be retried. Send the results to the provider yourself - the export bundle is on the scheme's page - and record their reference here.",
+  "alerts.type.eqa_submission_failed": "EQA Submission Failed",
+  "alerts.type.freezer_temperature": "Freezer Temperature",
+  "alerts.type.equipment_failure": "Equipment Failure",
+  "alerts.type.inventory_low": "Inventory Low",
+  "alerts.type.sample_tracking": "Sample Tracking",
+  "alerts.type.critical_result": "Critical Result",
+  "alerts.type.other": "Other"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQACycleRestController.java
@@ -622,6 +622,9 @@ public class EQACycleRestController extends BaseRestController {
         }
         dto.put("distributionMethod",
                 cycle.getDistributionMethod() == null ? null : cycle.getDistributionMethod().name());
+        // What the automatic channel has spent. My Cycles offers a manual
+        // submission from the point the sweep gives up, and says why.
+        dto.put("submissionAttempts", cycle.getSubmissionAttempts() == null ? 0 : cycle.getSubmissionAttempts());
         dto.put("plannedStartDate",
                 cycle.getPlannedStartDate() == null ? null : cycle.getPlannedStartDate().toString());
         dto.put("plannedEndDate", cycle.getPlannedEndDate() == null ? null : cycle.getPlannedEndDate().toString());

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAProgramRestController.java
@@ -71,6 +71,10 @@ public class EQAProgramRestController extends ControllerUtills {
             program.setSchemeType(schemeTypeOf(schemeType));
             program.setProvider(blankToNull((String) body.get("provider")));
             program.setPerAnalyst(Boolean.TRUE.equals(body.get("perAnalyst")));
+            // FR-V2.2-07's review gate. Read at three layers — the auto-submit sweep,
+            // the cycle DTO and My Cycles — and until now written nowhere, so outside
+            // the test suite it could only ever be its column default of false.
+            program.setRequiresCycleReview(Boolean.TRUE.equals(body.get("requiresCycleReview")));
             program.setIsActive(true);
             program.setSysUserId(getSysUserId(request));
 
@@ -145,6 +149,10 @@ public class EQAProgramRestController extends ControllerUtills {
 
             if (body.containsKey("perAnalyst")) {
                 program.setPerAnalyst(Boolean.TRUE.equals(body.get("perAnalyst")));
+            }
+
+            if (body.containsKey("requiresCycleReview")) {
+                program.setRequiresCycleReview(Boolean.TRUE.equals(body.get("requiresCycleReview")));
             }
 
             program = programService.update(program);
@@ -290,6 +298,9 @@ public class EQAProgramRestController extends ControllerUtills {
         // FR-V2.3-04: result entry reads this to decide whether to show the
         // Analyst column, so the scheme list has to carry it.
         dto.put("perAnalyst", Boolean.TRUE.equals(program.getPerAnalyst()));
+        // FR-V2.2-07: with this on, a participant's cycle holds at ready-to-submit
+        // for a human to review rather than submitting itself.
+        dto.put("requiresCycleReview", Boolean.TRUE.equals(program.getRequiresCycleReview()));
         dto.put("fhirUuid", program.getFhirUuid() != null ? program.getFhirUuid().toString() : null);
         dto.put("participantCount", enrollmentService.countActiveEnrollments(program.getId()));
         return dto;

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -496,6 +496,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             for (Long enrollmentId : enrollments) {
                 markSent(cycle.getId(), enrollmentId, EQASubmissionChannel.FHIR, null, SCHEDULER_USER);
             }
+            clearRetryBudget(cycle, SCHEDULER_USER);
             advanceTo(cycle, SUBMITTED, EQATriggerType.AUTO, EQATriggerEvent.FHIR_SUBMIT_SUCCESS, null, null,
                     SCHEDULER_USER);
             return true;
@@ -517,6 +518,23 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             }
         }
         return readyAt;
+    }
+
+    /**
+     * A submission that got through spends none of the budget. The counter had only
+     * ever been incremented, so a cycle that failed its way to the ceiling once
+     * could never be submitted automatically again for the rest of its life — and
+     * the same would have been true of the next cycle to reach the ceiling after a
+     * transient outage.
+     */
+    private void clearRetryBudget(EQACycle cycle, String sysUserId) {
+        if (cycle.getSubmissionAttempts() == null || cycle.getSubmissionAttempts() == 0) {
+            return;
+        }
+        cycle.setSubmissionAttempts(0);
+        cycle.setLastSubmissionAttemptAt(null);
+        cycle.setSysUserId(sysUserId);
+        cycleDAO.update(cycle);
     }
 
     private void recordFailedAttempt(EQACycle cycle, int attempts) {
@@ -581,6 +599,7 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
         if (sent == 0) {
             throw new IllegalArgumentException("No validated result to submit for cycle " + cycleId);
         }
+        clearRetryBudget(cycle, sysUserId);
         advanceTo(cycle, SUBMITTED, EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE, actingUser(sysUserId),
                 "Manual submission, provider reference " + reference.trim(), sysUserId);
         return cycleDAO.get(cycleId).orElseThrow();

--- a/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQAProgramRestControllerTest.java
@@ -15,6 +15,7 @@ import org.hibernate.ObjectNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -89,6 +90,60 @@ public class EQAProgramRestControllerTest {
         Map<String, Object> dto = (Map<String, Object>) response.getBody();
         assertEquals("Chemistry PT", dto.get("name"));
         assertEquals(true, dto.get("isActive"));
+    }
+
+    /**
+     * FR-V2.2-07's review gate. It is read by the auto-submit sweep, the cycle DTO
+     * and My Cycles, and was written by nothing, so outside the test suite it could
+     * only ever be its column default of false.
+     */
+    @Test
+    public void testCreateProgram_CarriesTheReviewGate() {
+        ArgumentCaptor<EQAProgram> written = ArgumentCaptor.forClass(EQAProgram.class);
+        when(programService.insert(any(EQAProgram.class))).thenReturn(1L);
+        program1.setRequiresCycleReview(true);
+        when(programService.get(1L)).thenReturn(program1);
+
+        ResponseEntity<?> response = controller.createProgram(request, Map.of("name", "Chemistry PT", "schemeType",
+                "INTERNATIONAL_PT", "provider", "NHLS", "requiresCycleReview", true));
+
+        verify(programService).insert(written.capture());
+        assertEquals("the gate reaches the row", Boolean.TRUE, written.getValue().getRequiresCycleReview());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dto = (Map<String, Object>) response.getBody();
+        assertEquals("and comes back to the client", true, dto.get("requiresCycleReview"));
+    }
+
+    /** Left out of the request, a new scheme submits automatically as before. */
+    @Test
+    public void testCreateProgram_ReviewGateDefaultsOff() {
+        ArgumentCaptor<EQAProgram> written = ArgumentCaptor.forClass(EQAProgram.class);
+        when(programService.insert(any(EQAProgram.class))).thenReturn(1L);
+        when(programService.get(1L)).thenReturn(program1);
+
+        controller.createProgram(request,
+                Map.of("name", "Chemistry PT", "schemeType", "INTERNATIONAL_PT", "provider", "NHLS"));
+
+        verify(programService).insert(written.capture());
+        assertEquals(Boolean.FALSE, written.getValue().getRequiresCycleReview());
+    }
+
+    @Test
+    public void testUpdateProgram_TogglesTheReviewGateBothWays() {
+        program1.setRequiresCycleReview(false);
+        when(programService.get(1L)).thenReturn(program1);
+        when(programService.update(any(EQAProgram.class))).thenAnswer(call -> call.getArgument(0));
+
+        controller.updateProgram(request, 1L, Map.of("requiresCycleReview", true));
+        assertEquals(Boolean.TRUE, program1.getRequiresCycleReview());
+
+        controller.updateProgram(request, 1L, Map.of("requiresCycleReview", false));
+        assertEquals(Boolean.FALSE, program1.getRequiresCycleReview());
+
+        // A request that does not mention it leaves it where it was.
+        controller.updateProgram(request, 1L, Map.of("requiresCycleReview", true));
+        controller.updateProgram(request, 1L, Map.of("description", "unrelated edit"));
+        assertEquals(Boolean.TRUE, program1.getRequiresCycleReview());
     }
 
     @Test

--- a/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
@@ -409,6 +410,68 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
         cycleSubmissionService.advanceCycle(cycle.getId());
         assertEquals(5, attempts(cycle.getId()));
         assertEquals(1, failureAlerts(cycle.getId()));
+    }
+
+    /**
+     * The counter had only ever been incremented, so a cycle that failed its way to
+     * the ceiling could never be submitted automatically again. A submission that
+     * gets through spends none of the budget, which is also what makes the ceiling
+     * a limit on consecutive failures rather than on a cycle's whole life.
+     */
+    @Test
+    public void aSubmissionThatSucceeds_givesTheRetryBudgetBack() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 21));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(false);
+        windowElapsed();
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(3)));
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        assertEquals("two of five spent", 2, attempts(cycle.getId()));
+
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(5)));
+        cycleSubmissionService.advanceCycle(cycle.getId());
+
+        assertEquals(EQACycleStatus.SUBMITTED, readBack(cycle.getId()).getStatus());
+        assertEquals("the budget is whole again", 0, attempts(cycle.getId()));
+        assertNull("and nothing is holding the next attempt off",
+                jdbc.queryForObject("SELECT last_submission_attempt_at FROM clinlims.eqa_cycle WHERE id = ?",
+                        Timestamp.class, cycle.getId()));
+    }
+
+    /**
+     * The dead end F-22 recorded: with the budget spent the sweep never tries
+     * again, so the manual endpoint is the only way out — and it has to leave the
+     * cycle able to submit automatically next time.
+     */
+    @Test
+    public void aManualSubmission_recoversACycleWhoseRetriesAreSpent() {
+        EQAProgram scheme = externalScheme(false);
+        EQACycle cycle = readBack(insertCycle(scheme, 22));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(false);
+
+        long[] hoursOut = { 2, 3, 5, 8, 12 };
+        for (long hours : hoursOut) {
+            target.setClock(Clock.offset(Clock.systemDefaultZone(), Duration.ofHours(hours)));
+            cycleSubmissionService.advanceCycle(cycle.getId());
+        }
+        assertEquals(5, attempts(cycle.getId()));
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+
+        EQACycle submitted = cycleSubmissionService.submitManually(cycle.getId(), ENROLLMENT, "NHLS-2026-0099", USER);
+
+        assertEquals(EQACycleStatus.SUBMITTED, submitted.getStatus());
+        assertEquals("MANUAL", participantResults(cycle.getId()).get(0).get("submission_channel"));
+        assertEquals("NHLS-2026-0099", participantResults(cycle.getId()).get(0).get("manual_submission_reference"));
+        assertEquals("the spent budget does not follow the cycle around", 0, attempts(cycle.getId()));
     }
 
     @Test


### PR DESCRIPTION
Two switches a laboratory could not reach, and a label that read as an enum.

## The review gate could never be switched on

`eqa_program.requires_cycle_review` is read at three layers and was written at none.

The read side is complete and correct: the auto-submit sweep stands down when a scheme sets it, the cycle DTO puts it on the row, and My Cycles renders **Review & submit** from it. But `grep -rn "setRequiresCycleReview" src frontend/src` returned exactly one hit, in a test. The programme create handler and the update handler read `perAnalyst` and no other flag, and the configuration handler parses name, description, provider, schemeType, frequency, testSection and active. The column arrived with its migration carrying `defaultValueBoolean="false"`, so outside the test suite it could only ever be false — and the acceptance criterion for the gate was blocked, because testing it would have meant an `UPDATE` against a table the feature only reads, which would have hidden the finding rather than tested it.

Now: the create and update endpoints accept `requiresCycleReview` beside `perAnalyst`, the DTO returns it, and the EQA Programs dialog carries a toggle next to the per-analyst one. No schema change. A request that does not mention the flag leaves it where it was, so an unrelated edit cannot switch a scheme's gate off.

The configuration CSV could take a column too, but the dialog is the path a laboratory would actually use, and it is the one that was missing.

## A cycle that spent its retry budget was unrecoverable

Two independent halves of one dead end.

**The counter only ever went up.** Automatic submission stops once attempts reach five, and `recordFailedAttempt` was its single writer — no successful submission reset it. So a cycle that failed its way to the ceiling could never be submitted automatically again for the rest of its life, and a cycle that hit the ceiling during a transient outage was in the same position as one whose endpoint was genuinely gone. A submission that gets through now spends none of the budget, on the automatic path and the manual one, which makes five a limit on *consecutive* failures rather than on a cycle's whole history.

**The alert had nowhere to go.** The alert raised at the fifth attempt says "submit manually before the deadline", and the two endpoints that would do it had no frontend caller at all. My Cycles now offers **Submit by hand** for any cycle sitting at ready-to-submit, and for one whose retries are spent it says so in as many words, with the count and the reason, and puts the action on that notice. The provider's reference stays mandatory — server-side as before — because without it a manual submission is a claim rather than a record.

Either change alone breaks the dead end. Together they also make the alert's own instruction true, which it was not.

The cycle DTO now carries `submissionAttempts` so the page can tell the difference between a cycle still being retried and one the sweep has given up on. Both get the manual route; only the second is told automatic submission has stopped.

## The Alerts dashboard printed a raw enum

The Type column showed `EQA_SUBMISSION_FAILED` beside rows reading "EQA Deadline", because that type had no label and the formatter falls back to the enum name.

Every `AlertType` value now has a label — the EQA submission failure and the six others that were also missing one, since it is the same defect for each — and the type filter offers the EQA submission failure alongside the deadline it sits next to.

## Tests

Backend, full EQA suite: **565 tests, 0 failures** (560 on the branch point plus five new).

- `EQAProgramRestControllerTest` — creating a scheme with the gate on writes it to the row and returns it; leaving it out defaults to off; update toggles it both ways and a request that does not name it leaves it alone.
- `EQAAutoSubmissionIntegrationTest` — a cycle two attempts down that then succeeds comes back to zero attempts with nothing holding off the next one; a cycle whose five attempts are genuinely spent (each pass jumping the clock past that attempt's backoff) is recovered by a manual submission, which records the channel and the reference and leaves the budget whole.

Frontend, 207 tests, 0 failures.

- `ProgramManagement.test.jsx` — the toggle is in the dialog and rides the payload; a scheme already holding for review opens with it on.
- `MyCyclesPage.test.jsx` — a cycle with five spent attempts shows the notice with its count, holds the action until a reference is entered, posts to the manual endpoint with exactly that reference, and reports the outcome; a cycle with attempts left is not told submission has stopped but is still offered the manual route.
- `AlertsDashboard.test.jsx` — every alert type in the table reads as a label, and the raw enum appears nowhere.

Each new assertion was inverted against the change it covers and fails without it.