### PR TITLE
fix(eqa): let the QA Officer follow the non-conformity links, and filter the queue by source (OGC-935)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -683,6 +683,7 @@ export default function App() {
                   exact
                   component={() => <NonConformIndex form="NceDashboard" />}
                   role={[Roles.RECEPTION, Roles.VALIDATION]}
+                  permission="qa.view.eqa"
                 />
                 <SecureRoute
                   path="/ReportNonConformingEvent"
@@ -691,6 +692,7 @@ export default function App() {
                     <NonConformIndex form="ReportNonConformingEvent" />
                   )}
                   role={[Roles.RECEPTION, Roles.VALIDATION]}
+                  permission="qa.view.eqa"
                 />
                 <SecureRoute
                   path="/ViewNonConformingEvent"
@@ -699,6 +701,7 @@ export default function App() {
                     <NonConformIndex form="ViewNonConformingEvent" />
                   )}
                   role={[Roles.RECEPTION, Roles.VALIDATION]}
+                  permission="qa.view.eqa"
                 />
 
                 <SecureRoute
@@ -708,6 +711,7 @@ export default function App() {
                     <NonConformIndex form="NCECorrectiveAction" />
                   )}
                   role={[Roles.RECEPTION, Roles.VALIDATION]}
+                  permission="qa.view.eqa"
                 />
 
                 <SecureRoute
@@ -1010,6 +1014,7 @@ export default function App() {
                     <NonConformIndex form="ViewNonConformingEvent" />
                   )}
                   role={[Roles.RECEPTION, Roles.VALIDATION]}
+                  permission="qa.view.qms"
                 />
                 <SecureRoute
                   path="/qa/qms/audit-trail"

--- a/frontend/src/components/eqa/FollowUp/FollowUpQueuePage.jsx
+++ b/frontend/src/components/eqa/FollowUp/FollowUpQueuePage.jsx
@@ -50,6 +50,10 @@ const SOURCE_TAG = {
   inter_lab_split: "cyan",
 };
 
+// FR-V2.3-02 gives the queue a Source filter. The keys are the ones the rows
+// already carry, so the tag colours above and this list cannot drift apart.
+const SOURCE_KEYS = Object.keys(SOURCE_TAG);
+
 const REASON_TAG = {
   questionable: "warm-gray",
   inHouseFailure: "red",
@@ -134,6 +138,7 @@ const FollowUpQueuePage = () => {
   const [notice, setNotice] = useState(null);
   const [dismissing, setDismissing] = useState(null);
   const [category, setCategory] = useState(DISMISSAL_CATEGORIES[0]);
+  const [sourceFilter, setSourceFilter] = useState("all");
   const [notes, setNotes] = useState("");
   const [busy, setBusy] = useState(false);
 
@@ -162,6 +167,14 @@ const FollowUpQueuePage = () => {
       `eqa.queue.reason.${reason}`,
       reason === "inHouseFailure" ? "In-house fail" : "Questionable",
     );
+
+  // The KPI tiles below describe the whole queue on purpose; only the table and
+  // its export follow the filter, so a laboratory cannot mistake a filtered
+  // view for its real backlog.
+  const visibleRows =
+    sourceFilter === "all"
+      ? rows
+      : rows.filter((row) => row.sourceKey === sourceFilter);
 
   const questionableCount = rows.filter(
     (row) => row.reason === "questionable",
@@ -319,11 +332,41 @@ const FollowUpQueuePage = () => {
               marginBottom: "0.5rem",
             }}
           >
-            <strong>
-              {t("eqa.queue.count", "Queue · {count} items", {
-                count: rows.length,
-              })}
-            </strong>
+            <div
+              style={{
+                display: "flex",
+                gap: "1rem",
+                alignItems: "flex-end",
+              }}
+            >
+              <strong>
+                {sourceFilter === "all"
+                  ? t("eqa.queue.count", "Queue · {count} items", {
+                      count: rows.length,
+                    })
+                  : t(
+                      "eqa.queue.countFiltered",
+                      "Queue · {count} of {total} items",
+                      { count: visibleRows.length, total: rows.length },
+                    )}
+              </strong>
+              <Select
+                id="queue-source-filter"
+                size="sm"
+                labelText={t("eqa.queue.source", "Source")}
+                hideLabel
+                value={sourceFilter}
+                onChange={(e) => setSourceFilter(e.target.value)}
+              >
+                <SelectItem
+                  value="all"
+                  text={t("eqa.queue.source.all", "Every source")}
+                />
+                {SOURCE_KEYS.map((key) => (
+                  <SelectItem key={key} value={key} text={sourceLabelOf(key)} />
+                ))}
+              </Select>
+            </div>
             <div>
               <Button
                 kind="ghost"
@@ -337,10 +380,10 @@ const FollowUpQueuePage = () => {
                 kind="ghost"
                 size="sm"
                 renderIcon={Download}
-                disabled={rows.length === 0}
+                disabled={visibleRows.length === 0}
                 onClick={() =>
                   downloadCsv(
-                    queueCsv(rows, sourceLabelOf, reasonLabelOf),
+                    queueCsv(visibleRows, sourceLabelOf, reasonLabelOf),
                     "eqa-follow-up-queue.csv",
                   )
                 }
@@ -359,6 +402,14 @@ const FollowUpQueuePage = () => {
                 "Nothing awaiting triage. Questionable scores and in-house failures land here as cycles are scored.",
               )}
             </Tile>
+          ) : visibleRows.length === 0 ? (
+            <Tile>
+              {t(
+                "eqa.queue.emptyForSource",
+                "Nothing from this source is awaiting triage. The queue holds {total} items from other sources.",
+                { total: rows.length },
+              )}
+            </Tile>
           ) : (
             <Table useZebraStyles>
               <TableHead>
@@ -375,7 +426,7 @@ const FollowUpQueuePage = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {rows.map((row) => (
+                {visibleRows.map((row) => (
                   <React.Fragment key={row.id}>
                     <TableRow>
                       <TableCell>

--- a/frontend/src/components/eqa/FollowUp/__tests__/FollowUpQueuePage.test.jsx
+++ b/frontend/src/components/eqa/FollowUp/__tests__/FollowUpQueuePage.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
@@ -121,10 +121,13 @@ describe("FollowUpQueuePage", () => {
     expect(await screen.findByText("2026 Round 2")).toBeInTheDocument();
     expect(screen.getByText("HIV-1 viral load")).toBeInTheDocument();
     expect(screen.getByText("2.4")).toBeInTheDocument();
-    expect(screen.getByText("External provider")).toBeInTheDocument();
+    // The source filter above the table offers the same three labels, so the
+    // row tags are read out of the table itself.
+    const table = within(document.querySelector("table"));
+    expect(table.getByText("External provider")).toBeInTheDocument();
     // Two analytes on one cycle stay one register row — triage acts on the row.
     expect(screen.getByText("Malaria RDT +1 more")).toBeInTheDocument();
-    expect(screen.getByText("In-house")).toBeInTheDocument();
+    expect(table.getByText("In-house")).toBeInTheDocument();
   });
 
   it("tags the triage band from the scheme, not from the verdict", async () => {
@@ -151,6 +154,43 @@ describe("FollowUpQueuePage", () => {
     expect(screen.getByTestId("kpi-queued")).toHaveTextContent("2");
     expect(screen.getByTestId("kpi-questionable")).toHaveTextContent("1");
     expect(screen.getByTestId("kpi-inhouse")).toHaveTextContent("1");
+  });
+
+  // F-24: the page rendered a Source column and counted in-house rows for its
+  // own KPI tile, and offered no way to filter on it.
+  it("filters the table by source and says how much of the queue is showing", async () => {
+    renderPage();
+    await screen.findByText("2026 Round 2");
+
+    const filter = document.getElementById("queue-source-filter");
+    expect(
+      Array.from(filter.querySelectorAll("option")).map((o) => o.textContent),
+    ).toEqual([
+      "Every source",
+      "External provider",
+      "In-house",
+      "Inter-lab split",
+    ]);
+    expect(screen.getByText("Queue · 2 items")).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "in_house" } });
+
+    expect(screen.getByText("Blind run 1")).toBeInTheDocument();
+    expect(screen.queryByText("2026 Round 2")).toBeNull();
+    expect(screen.getByText("Queue · 1 of 2 items")).toBeInTheDocument();
+    // The tiles describe the whole queue, not the filtered view.
+    expect(screen.getByTestId("kpi-queued")).toHaveTextContent("2");
+
+    fireEvent.change(filter, { target: { value: "inter_lab_split" } });
+    expect(
+      screen.getByText(
+        "Nothing from this source is awaiting triage. The queue holds 2 items from other sources.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "all" } });
+    expect(screen.getByText("2026 Round 2")).toBeInTheDocument();
+    expect(screen.getByText("Blind run 1")).toBeInTheDocument();
   });
 
   it("escalates a row and reports the NCE the server raised", async () => {

--- a/frontend/src/components/security/nonConformityRoutePermissions.test.js
+++ b/frontend/src/components/security/nonConformityRoutePermissions.test.js
@@ -1,0 +1,45 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * The non-conformity routes are shared: the EQA lane's coverage tile deep-links
+ * the dashboard, and the dashboard's own row actions push to the other three. A
+ * QA Officer holds neither Reception nor Validation, so with a role list alone
+ * every one of them answered Access Denied — the data permission was never the
+ * problem, only the route declaration.
+ *
+ * SecureRoute ORs role and permission, so this is a declaration-level check, the
+ * frontend counterpart of the backend's guard matrix: the routes a lane links
+ * must name a permission, or the wall comes back the next time a role list is
+ * written without one.
+ */
+const APP = readFileSync(resolve(__dirname, "../../App.jsx"), "utf8");
+
+/**
+ * The `<SecureRoute …>` block declaring a given path. It ends at the element's
+ * own self-closing tag, which is the one sitting on its own line — a bare search
+ * for "/>" finds the inline component element first and cuts the block short.
+ */
+const routeBlock = (path) => {
+  const at = APP.indexOf(`path="${path}"`);
+  expect(at).toBeGreaterThan(-1);
+  const opened = APP.lastIndexOf("<SecureRoute", at);
+  const closed = APP.indexOf("\n                />", at);
+  expect(closed).toBeGreaterThan(at);
+  return APP.slice(opened, closed);
+};
+
+describe("non-conformity route permissions", () => {
+  test.each([
+    ["/NceDashboard", "qa.view.eqa"],
+    ["/ReportNonConformingEvent", "qa.view.eqa"],
+    ["/ViewNonConformingEvent", "qa.view.eqa"],
+    ["/NCECorrectiveAction", "qa.view.eqa"],
+    ["/qa/qms/nce-register", "qa.view.qms"],
+  ])("%s is reachable by permission, not by role alone", (path, permission) => {
+    const block = routeBlock(path);
+    expect(block).toContain(`permission="${permission}"`);
+    // The roles stay: this widens access, it does not move it.
+    expect(block).toContain("Roles.RECEPTION");
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8584,5 +8584,8 @@
   "eqa.labperf.kpi.submitted": "Submitted cycles",
   "eqa.labperf.acceptableOf": "Acceptable of scored",
   "eqa.labperf.kpi.lateCount": "Late submissions",
-  "eqa.labperf.kpi.nceOpenCount": "Of those, still open"
+  "eqa.labperf.kpi.nceOpenCount": "Of those, still open",
+  "eqa.queue.source.all": "Every source",
+  "eqa.queue.countFiltered": "Queue · {count} of {total} items",
+  "eqa.queue.emptyForSource": "Nothing from this source is awaiting triage. The queue holds {total} items from other sources."
 }


### PR DESCRIPTION
Two oversight-navigation defects: a deep link into a wall, and a filter the mockup specifies that never shipped.

## The coverage tile deep-linked the QA Officer into Access Denied

Everything the criterion measures was already right. The tile's href is exactly `/NceDashboard?source=eqa`, `GET /rest/nce/dashboard?source=eqa` answers 200 for the QA Officer with precisely the two `EQA_*` non-conformities the tile counts, and the tile's number equals the row count. Clicking it landed on **Access Denied**.

The block was the SPA route declaration and nothing else: `/NceDashboard` named `role={[Roles.RECEPTION, Roles.VALIDATION]}` with no `permission`, and a QA Officer holds neither role. The data permission was never the problem — the NonConformity module is granted to Reception, Results and Validation, and the persona holds Results. `SecureRoute` ORs `role` and `permission`, so naming one widens access without moving it.

**Scope: four routes, not one.** Fixing only the dashboard would have moved the wall one click deeper — the dashboard's own row actions push to `/ReportNonConformingEvent`, `/ViewNonConformingEvent` and `/NCECorrectiveAction`, so a user who can open it has to be able to follow them. All four now carry `permission="qa.view.eqa"` alongside their existing roles.

While there: `/qa/qms/nce-register` had the same gap, and it sits in a lane where every sibling route names a permission. It gets `qa.view.qms`, matching them.

## The follow-up queue had no Source filter

The page knew about `source` twice over — it rendered a Source column as a Tag and counted in-house rows for one of its own KPI tiles — and exposed no way to filter on it, which the requirement and the mockup both give it. A DOM sweep of the rendered page found no select, combobox or search input anywhere in `main`.

It has one now, over the same three keys the rows carry (derived from the tag-colour map, so the two cannot drift apart). Three decisions worth stating:

- **The table and its CSV export follow the filter.** Exporting the unfiltered queue from a filtered view would be the more surprising behaviour.
- **The KPI tiles keep describing the whole queue.** They are the laboratory's backlog, and a filtered view must not be mistakable for it. The count beside the table says "1 of 2 items" when a filter is on, so the difference is visible rather than implied.
- **A filter matching nothing says how much is waiting elsewhere**, instead of rendering an empty table under populated tiles.

## Tests

Frontend, 1211 tests, 0 failures across the whole suite.

- `nonConformityRoutePermissions.test.js` (new) — each of the five routes declares the permission it needs and keeps its roles. This is a declaration-level check, the frontend counterpart of the backend's REST guard matrix: `SecureRoute`'s own OR behaviour is already covered by its unit tests, and what actually broke here was a route written with a role list and no permission. Without such a test the wall comes back the next time one is.
- `FollowUpQueuePage.test.jsx` — the filter offers every source plus "Every source"; picking one hides the other rows and reports "1 of 2 items" while the tiles still read 2; a source with nothing in it explains itself; returning to "Every source" restores both rows. One pre-existing assertion was scoped to the table, because the filter above it now legitimately renders the same three labels.

Both changes were inverted against their tests and fail without them.