### PR TITLE
fix(eqa): export both Lab Performance views (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/Performance/LabPerformancePage.jsx
+++ b/frontend/src/components/eqa/Performance/LabPerformancePage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import {
+  Button,
   ClickableTile,
   Column,
   ContentSwitcher,
@@ -22,8 +23,11 @@ import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
 import { formatDateOnly } from "../../utils/Utils";
+import { Download } from "@carbon/icons-react";
 import {
+  csvCell,
   CycleStatusTag,
+  downloadCsv,
   hintStyle,
   kpiLabelStyle,
   kpiValueStyle,
@@ -72,6 +76,122 @@ const percent = (value) =>
  * it (Recent Cycles). Both views read one rollup, so the KPI row cannot
  * disagree with the table under it.
  */
+/**
+ * The KPI block both exports carry above their rows. These are the numbers being
+ * attested for ISO 15189 §7.7.2, so a file that omitted them would invite a
+ * screenshot beside it — which is what this export exists to replace.
+ */
+const kpiLines = (kpis, labelOf) => [
+  [
+    labelOf("acceptance", "Acceptance rate (12 mo)"),
+    percent(kpis.acceptanceRate),
+  ],
+  [labelOf("onTime", "On-time submission rate"), percent(kpis.onTimeRate)],
+  // The tiles' own "late of total" and "open" lines are parameterised
+  // sentences, so the file uses plain column names for those two counts.
+  [labelOf("lateCount", "Late submissions"), kpis.lateCount ?? 0],
+  [labelOf("submitted", "Submitted cycles"), kpis.submittedCount ?? 0],
+  [labelOf("nce", "EQA-triggered NCEs (12 mo)"), kpis.eqaNceCount ?? 0],
+  [labelOf("nceOpenCount", "Of those, still open"), kpis.eqaNceOpenCount ?? 0],
+  [
+    labelOf("uncovered", "Accredited tests without EQA"),
+    kpis.uncoveredTestCount ?? 0,
+  ],
+];
+
+/**
+ * One row per section × scheme, its cycle cells and its acceptance rate — the
+ * matrix on screen, cell for cell. Cells are right-aligned on the most recent
+ * cycle exactly as the table pads them, so a scheme with fewer than four cycles
+ * lines up with the header rather than against another scheme's oldest.
+ */
+export const coverageCsv = (
+  kpis,
+  coverage,
+  gaps,
+  columns,
+  labelOf,
+  headerOf,
+) => {
+  const lines = kpiLines(kpis, labelOf).map((pair) =>
+    pair.map(csvCell).join(","),
+  );
+  lines.push("");
+  const header = [headerOf("section", "Section"), headerOf("scheme", "Scheme")];
+  for (let i = 0; i < columns; i++) {
+    header.push(
+      i === columns - 1
+        ? headerOf("mostRecent", "Most recent")
+        : `${headerOf("cycle", "Cycle")} -${columns - 1 - i}`,
+    );
+  }
+  header.push(headerOf("acceptanceRate", "Acceptance rate"));
+  lines.push(header.map(csvCell).join(","));
+
+  coverage.forEach((row) => {
+    const offset = columns - row.cells.length;
+    const cells = Array.from({ length: columns }, (_, i) => {
+      const cell = i < offset ? null : row.cells[i - offset];
+      return cell ? `${cell.cycleLabel}: ${cell.verdict}` : "";
+    });
+    lines.push(
+      [row.section || "", row.schemeName, ...cells, percent(row.acceptanceRate)]
+        .map(csvCell)
+        .join(","),
+    );
+  });
+
+  if (gaps.length > 0) {
+    lines.push("");
+    lines.push(
+      [
+        headerOf("gapTitle", "Accredited without EQA cover:"),
+        gaps.map((gap) => gap.testName).join("; "),
+      ]
+        .map(csvCell)
+        .join(","),
+    );
+  }
+  return lines.join("\n");
+};
+
+/** The Recent Cycles table, honouring whatever scheme filter is applied. */
+export const recentCyclesCsv = (kpis, cycles, labelOf, headerOf) => {
+  const lines = kpiLines(kpis, labelOf).map((pair) =>
+    pair.map(csvCell).join(","),
+  );
+  lines.push("");
+  lines.push(
+    [
+      headerOf("scheme", "Scheme"),
+      headerOf("cycle", "Cycle"),
+      headerOf("status", "Status"),
+      headerOf("acceptableOf", "Acceptable of scored"),
+      headerOf("performance", "Performance"),
+      headerOf("submitted", "Submitted"),
+    ]
+      .map(csvCell)
+      .join(","),
+  );
+  cycles.forEach((cycle) => {
+    lines.push(
+      [
+        cycle.schemeName || "",
+        cycle.cycleLabel,
+        cycle.status,
+        cycle.scoredCount
+          ? `${cycle.acceptableCount} of ${cycle.scoredCount}`
+          : "",
+        cycle.performance || "",
+        cycle.submittedAt ? formatDateOnly(cycle.submittedAt) : "",
+      ]
+        .map(csvCell)
+        .join(","),
+    );
+  });
+  return lines.join("\n");
+};
+
 const LabPerformancePage = ({ view = "coverage" }) => {
   const intl = useIntl();
   const t = (id, defaultMessage, values) =>
@@ -103,6 +223,23 @@ const LabPerformancePage = ({ view = "coverage" }) => {
   const sectionLabel = (section) =>
     section || t("eqa.labperf.unassignedSection", "Unassigned section");
   const cycleColumns = Math.max(0, ...coverage.map((row) => row.cells.length));
+
+  // The export reads its headings from the same message ids as the table, so a
+  // renamed column cannot leave the file describing the old one.
+  const kpiLabelOf = (key, fallback) => t(`eqa.labperf.kpi.${key}`, fallback);
+  const headerOf = (key, fallback) => t(`eqa.labperf.${key}`, fallback);
+
+  const exportButton = (onClick) => (
+    <Button
+      kind="ghost"
+      size="sm"
+      renderIcon={Download}
+      style={{ marginBottom: "0.5rem" }}
+      onClick={onClick}
+    >
+      {t("eqa.labperf.exportCsv", "Export CSV")}
+    </Button>
+  );
 
   return (
     <>
@@ -239,6 +376,19 @@ const LabPerformancePage = ({ view = "coverage" }) => {
 
           {view === "coverage" ? (
             <>
+              {exportButton(() =>
+                downloadCsv(
+                  coverageCsv(
+                    kpis,
+                    coverage,
+                    gaps,
+                    cycleColumns,
+                    kpiLabelOf,
+                    headerOf,
+                  ),
+                  "eqa-coverage.csv",
+                ),
+              )}
               <p style={{ ...hintStyle, marginBottom: "0.5rem" }}>
                 {t(
                   "eqa.labperf.legendIntro",
@@ -349,6 +499,12 @@ const LabPerformancePage = ({ view = "coverage" }) => {
             </>
           ) : (
             <>
+              {exportButton(() =>
+                downloadCsv(
+                  recentCyclesCsv(kpis, cycles, kpiLabelOf, headerOf),
+                  "eqa-recent-cycles.csv",
+                ),
+              )}
               <Search
                 size="sm"
                 labelText={t("eqa.labperf.filterScheme", "Filter scheme")}

--- a/frontend/src/components/eqa/Performance/__tests__/LabPerformancePage.test.jsx
+++ b/frontend/src/components/eqa/Performance/__tests__/LabPerformancePage.test.jsx
@@ -1,10 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
 import messages from "../../../../languages/en.json";
-import LabPerformancePage from "../LabPerformancePage";
+import LabPerformancePage, {
+  coverageCsv,
+  recentCyclesCsv,
+} from "../LabPerformancePage";
 import { getFromOpenElisServer } from "../../../utils/Utils";
 
 vi.mock("../../../utils/Utils", async () => {
@@ -151,6 +154,114 @@ describe("LabPerformancePage", () => {
     expect(screen.getByText("3 of 4")).toBeInTheDocument();
     expect(screen.getByText("14/07/2026")).toBeInTheDocument();
     expect(screen.getByText("pending")).toBeInTheDocument();
+  });
+
+  // F-25: the two sibling pages in this lane already export, and these two
+  // views -- the section x scheme matrix and the cycles behind it -- are the
+  // laboratory's ISO 15189 evidence, which until now left the screen only as a
+  // screenshot.
+  it("exports the coverage matrix cell for cell, with the attested numbers above it", async () => {
+    renderPage("coverage");
+    await screen.findByText("National HIV PT");
+
+    const csv = coverageCsv(
+      ROLLUP.kpis,
+      ROLLUP.coverage,
+      ROLLUP.gaps,
+      4,
+      (_key, fallback) => fallback,
+      (_key, fallback) => fallback,
+    );
+    const lines = csv.split("\n");
+
+    // The KPI block: the numbers being attested, not just the grid.
+    expect(lines[0]).toBe('"Acceptance rate (12 mo)","84%"');
+    expect(lines).toContain('"On-time submission rate","92%"');
+    expect(lines).toContain('"Late submissions","2"');
+    expect(lines).toContain('"EQA-triggered NCEs (12 mo)","3"');
+    expect(lines).toContain('"Accredited tests without EQA","1"');
+
+    const header = lines.find((line) => line.startsWith('"Section"'));
+    expect(header).toBe(
+      '"Section","Scheme","Cycle -3","Cycle -2","Cycle -1","Most recent","Acceptance rate"',
+    );
+    // Four cycles: every column filled, each carrying its cycle and verdict.
+    expect(lines).toContain(
+      '"Serology","National HIV PT","2025 R1: acceptable","2025 R2: questionable","2026 R1: acceptable","2026 R2: acceptable","75%"',
+    );
+    // Two cycles: padded on the LEFT, exactly as the table pads them, so the
+    // newest cycle stays under "Most recent".
+    expect(lines).toContain(
+      '"Haematology","Regional FBC PT","","","2026 R1: unacceptable","2026 R2: acceptable","50%"',
+    );
+    // The uncovered tests travel with the file they justify.
+    expect(lines).toContain(
+      '"Accredited without EQA cover:","TB smear microscopy"',
+    );
+  });
+
+  it("exports recent cycles honouring the scheme filter on screen", async () => {
+    renderPage("recent");
+    await screen.findByText("National HIV PT");
+
+    const all = recentCyclesCsv(
+      ROLLUP.kpis,
+      ROLLUP.recentCycles,
+      (_key, fallback) => fallback,
+      (_key, fallback) => fallback,
+    ).split("\n");
+    expect(all).toContain(
+      '"National HIV PT","2026 R2","SCORED","3 of 4","questionable","14/07/2026"',
+    );
+    // Nothing scored and nothing submitted reads as empty, not as "pending"
+    // or an em dash -- a spreadsheet cell is not a screen.
+    expect(all).toContain('"Regional FBC PT","2026 R2","SUBMITTED","","",""');
+
+    const filtered = recentCyclesCsv(
+      ROLLUP.kpis,
+      ROLLUP.recentCycles.filter((cycle) =>
+        cycle.schemeName.toLowerCase().includes("hiv"),
+      ),
+      (_key, fallback) => fallback,
+      (_key, fallback) => fallback,
+    ).split("\n");
+    expect(filtered.some((line) => line.includes("National HIV PT"))).toBe(
+      true,
+    );
+    expect(filtered.some((line) => line.includes("Regional FBC PT"))).toBe(
+      false,
+    );
+  });
+
+  it("offers the export on both views", async () => {
+    renderPage("coverage");
+    await screen.findByText("National HIV PT");
+    expect(
+      screen.getByRole("button", { name: /Export CSV/ }),
+    ).toBeInTheDocument();
+
+    renderPage("recent");
+    expect(
+      screen.getAllByRole("button", { name: /Export CSV/ }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("hands the browser a file when the export is clicked", async () => {
+    const createObjectURL = vi.fn(() => "blob:eqa");
+    const revokeObjectURL = vi.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    renderPage("coverage");
+    await screen.findByText("National HIV PT");
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/ }));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledTimes(1);
+    click.mockRestore();
   });
 
   it("reads both views from one rollup call", async () => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8579,5 +8579,10 @@
   "eqa.receipt.readOnly.body": "Recording a delivery, dispatching a repeat, entering results and returning scores all need the provider grant; scoring the cycle needs the manage grant. The table below is the whole cycle either way.",
   "eqa.inhouse.readOnly.title": "Read-only view of in-house panels",
   "eqa.inhouse.readOnly.body": "Designing and sealing a blinded panel needs the manage grant. The panels below are the whole picture either way.",
-  "eqa.score.downloadReport": "Report PDF"
+  "eqa.score.downloadReport": "Report PDF",
+  "eqa.labperf.exportCsv": "Export CSV",
+  "eqa.labperf.kpi.submitted": "Submitted cycles",
+  "eqa.labperf.acceptableOf": "Acceptable of scored",
+  "eqa.labperf.kpi.lateCount": "Late submissions",
+  "eqa.labperf.kpi.nceOpenCount": "Of those, still open"
 }


### PR DESCRIPTION
Neither Lab Performance view offered a download. A DOM sweep of both routes listed every control they render — the tab strip, plus the search box's clear button on Recent Cycles — and nothing else. `LabPerformancePage.jsx` imported neither `downloadCsv` nor `csvCell`, and neither the component nor its API module mentioned CSV at all.

The two sibling pages in the same lane already do it: the follow-up queue and analyst competency both import the shared helpers and render an **Export CSV** button. So this is the third page catching up with a pattern that exists, not a new capability, and there is no backend change — the rollup endpoint already returns everything both views render.

It matters because of what the page holds. The section × scheme coverage matrix and the acceptance, on-time and NCE tiles are the laboratory's ISO 15189 §7.7.2 evidence for an external assessor, and until now they left the screen only as a screenshot.

## What each file contains

**Both** open with the KPI block — acceptance rate, on-time rate, late count, submitted count, EQA-triggered NCEs, how many are still open, and accredited tests without EQA. Those are the numbers being attested; a file that omitted them would invite a screenshot beside it, which is the thing this replaces. The two tiles whose captions are parameterised sentences ("2 late of 24", "1 open → NCE register") get plain column names in the file instead.

**Coverage**: one row per section and scheme, then one column per cycle carrying that cycle's own label and verdict together (`"2025 R2: questionable"`), then the acceptance rate. Cells pad on the **left**, exactly as the table pads them, so a scheme with fewer than four cycles lines up under "Most recent" rather than under another scheme's oldest — getting this wrong would silently misdate every verdict in a short row. The accredited-tests-without-cover callout is appended, because it travels with the evidence it qualifies.

**Recent Cycles**: scheme, cycle, status, acceptable-of-scored, verdict and submitted date, honouring whatever scheme filter is applied on screen. A cycle with nothing scored reads as empty cells rather than "pending" or an em dash — a spreadsheet cell is not a screen.

Column headings are resolved from the same message ids the table uses, so a renamed column cannot leave the file describing the old one.

## Tests

Frontend, 170 tests across the EQA suite, 0 failures.

- The coverage export is asserted line for line: the KPI block, the exact header row including the negative cycle offsets, a four-cycle row with every column filled, a two-cycle row padded on the left, and the uncovered-test line.
- The recent-cycles export is asserted for a scored row and for one with nothing scored, and then re-derived through the same filter the search box applies to prove the file follows it.
- Both views render the button, and clicking it hands the browser exactly one blob.

Inverted: dropping the KPI block, or padding the coverage cells from the left instead of the right, fails the coverage assertion.