### PR TITLE
fix(eqa): let a triage verdict decide how its sample counts (OGC-935)

### DIFF
--- a/docs/eqa/analyst-competency-rules.md
+++ b/docs/eqa/analyst-competency-rules.md
@@ -31,9 +31,34 @@ before any counting. This matters because an unacceptable score that is then
 escalated writes **two** events about **one** sample; counting both would fail
 the analyst twice for it.
 
-The collapsed fact counts if any of its rows count, fails if any of its rows
-fail, and carries the worst outcome of its rows. An event with no result behind
-it (a cross-cycle event) is its own fact.
+**The latest statement about a sample decides how it counts.** Scoring is the
+instrument's verdict; a triage verdict is the supervisor's finding _about_ that
+verdict, and it is recorded afterwards, so it replaces the score's counting
+decision rather than being OR-ed with it. FR-V2.3-06 says as much — "the event
+is the canonical row" — and one canonical row per result is not the same thing
+as the OR across every row about it.
+
+An escalation is not a counting decision: the score it escalates is already the
+evaluable row, so it contributes the failure and the open-non-conformity flag
+and leaves the denominator alone.
+
+The collapsed fact carries the **worst** outcome of its rows and the latest of
+their dates, so the evidence table still shows what happened. An event with no
+result behind it (a cross-cycle event) is its own fact.
+
+A sample's whole history, then:
+
+| Sample's history                                                            | In `evaluable_n` | In `failure_n`              |
+| --------------------------------------------------------------------------- | ---------------- | --------------------------- |
+| scored acceptable, no triage                                                | yes              | no                          |
+| scored badly, no triage                                                     | yes              | yes                         |
+| scored badly → dismissed equipment / pending re-test / acceptable on review | no               | no                          |
+| scored badly → dismissed transcription / other                              | yes              | yes (once, not twice)       |
+| scored badly → escalated                                                    | yes              | yes, plus the open-NCE band |
+
+Two events about one sample very often share a date — a bad score and the triage
+answering it usually land the same day — so triage verdicts are ordered by date
+**and then by event id**.
 
 ## Counted, failing, excused
 
@@ -58,9 +83,20 @@ into one sample anyway.
 
 `DISMISSED_EQUIPMENT` and `DISMISSED_ACCEPTABLE_ON_REVIEW` leave **both**
 totals. Equipment fault is not the analyst's, and acceptable-on-review means
-triage found nothing to answer for. An excused sample therefore does not drag
-the denominator down, which would otherwise make an analyst look under-evidenced
-for someone else's broken analyser.
+triage found nothing to answer for.
+
+Because these are triage verdicts, they excuse the sample they dismiss —
+including one that had already failed, which is the only case that arises in
+production: a queue row exists only after a bad score. An excused sample
+therefore **does** pull the denominator down, and that is the intended outcome
+rather than a side effect. A broken analyser means less evidence about the
+person, not more, so an analyst whose only failures were equipment faults bands
+**Under review** for thin evidence rather than Competent. FR-V2.3-06's own
+worked example is exactly that case: one unacceptable, three equipment
+dismissals and two acceptables gives `evaluable_n` 3 and `failure_n` 1 — Under
+review by the evidence floor, which is the answer the example states. Counting
+the excused samples would give `evaluable_n` 6 and `failure_n` 1, which is
+Competent, and the example is built to show the denominator falling below four.
 
 ## The bands, in precedence order
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
@@ -77,6 +77,21 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
             EQACompetencyEventType.IN_HOUSE_MISSED_DEADLINE, EQACompetencyEventType.DISMISSED_TRANSCRIPTION,
             EQACompetencyEventType.DISMISSED_OTHER, EQACompetencyEventType.ESCALATED_TO_NCE);
 
+    /**
+     * The triage verdicts: a supervisor's finding <i>about</i> a score, recorded
+     * after it. Whichever of these lands last decides how the sample counts,
+     * because triage is the later and better-informed statement -- which is what
+     * lets the two excusing categories excuse anything at all.
+     *
+     * <p>
+     * ESCALATED_TO_NCE is deliberately not one of them. An escalation is an extra
+     * fact about a sample the score already made evaluable, not a decision about
+     * whether it counts.
+     */
+    private static final Set<EQACompetencyEventType> TRIAGE_VERDICT = Set.of(EQACompetencyEventType.DISMISSED_EQUIPMENT,
+            EQACompetencyEventType.DISMISSED_TRANSCRIPTION, EQACompetencyEventType.DISMISSED_ACCEPTABLE_ON_REVIEW,
+            EQACompetencyEventType.DISMISSED_OTHER);
+
     private static final Map<EQAPerformanceStatus, String> VERDICT = Map.of(EQAPerformanceStatus.ACCEPTABLE,
             EQACompetencyRow.ACCEPTABLE, EQAPerformanceStatus.QUESTIONABLE, EQACompetencyRow.QUESTIONABLE,
             EQAPerformanceStatus.UNACCEPTABLE, EQACompetencyRow.UNACCEPTABLE);
@@ -186,6 +201,7 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
         row.cycleId = event.getCycleId();
         row.participantResultId = event.getParticipantResultId();
         row.date = date;
+        row.eventId = event.getId();
         row.eventType = event.getEventType();
         row.counted = EVALUABLE.contains(event.getEventType());
         row.failure = FAILING.contains(event.getEventType());
@@ -343,39 +359,84 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
 
     /**
      * The de-duplication FR-V2.3-06 asks for: rows about one sample collapse to one
-     * fact. An escalated unacceptable score is a single failed sample, and a
-     * dismissal that does not count against the analyst clears the sample it
-     * dismisses rather than sitting beside it.
+     * fact, and the FRS names the winner -- "the event is the canonical row".
      */
     private List<EQACompetencyRow> facts(List<EQACompetencyRow> rows) {
-        Map<String, EQACompetencyRow> byFact = new LinkedHashMap<>();
+        Map<String, List<EQACompetencyRow>> byFact = new LinkedHashMap<>();
         int index = 0;
         for (EQACompetencyRow row : rows) {
-            String key = row.factKey(index++);
-            EQACompetencyRow known = byFact.get(key);
-            if (known == null) {
-                byFact.put(key, copy(row));
-                continue;
-            }
-            known.counted |= row.counted;
-            known.failure |= row.failure;
-            known.escalation |= row.escalation;
-            if (row.date.isAfter(known.date)) {
-                known.date = row.date;
-            }
-            if (severity(row.outcome) > severity(known.outcome)) {
-                known.outcome = row.outcome;
-            }
+            byFact.computeIfAbsent(row.factKey(index++), key -> new ArrayList<>()).add(row);
         }
 
         List<EQACompetencyRow> facts = new ArrayList<>();
-        for (EQACompetencyRow row : byFact.values()) {
-            // A sample only excused by a non-counting dismissal leaves both totals.
-            if (row.counted || row.failure) {
-                facts.add(row);
+        for (List<EQACompetencyRow> group : byFact.values()) {
+            EQACompetencyRow fact = collapse(group);
+            // A sample excused by a non-counting dismissal leaves both totals.
+            if (fact.counted || fact.failure) {
+                facts.add(fact);
             }
         }
         return facts;
+    }
+
+    /**
+     * One sample is one fact, and the latest statement about it decides how it
+     * counts. Scoring is the instrument's verdict; a triage verdict is the
+     * supervisor's finding about that verdict and is recorded after it, so it
+     * replaces the score's counting decision rather than being OR-ed with it.
+     *
+     * <p>
+     * OR-ing them was the defect: the score event always lands first, so its flags
+     * survived whatever triage decided, and the two categories the FRS says do not
+     * count against the analyst could only ever excuse a sample that had not
+     * failed. An equipment fault was never lifted off the analyst who happened to
+     * run the sample.
+     *
+     * <p>
+     * Nothing leaves the record. The evidence table under each analyst still lists
+     * every event with its date and category, so an assessor sees that the sample
+     * failed and sees why it was excused; only the counts move. Excusing pulls the
+     * denominator down, which can band an analyst Under Review for thin evidence
+     * rather than Competent -- a broken analyser means less evidence about the
+     * person, not more, and FR-V2.3-06's own worked example is exactly that case.
+     */
+    private EQACompetencyRow collapse(List<EQACompetencyRow> group) {
+        EQACompetencyRow fact = copy(group.get(0));
+        for (EQACompetencyRow row : group) {
+            fact.escalation |= row.escalation;
+            if (row.date.isAfter(fact.date)) {
+                fact.date = row.date;
+            }
+            if (severity(row.outcome) > severity(fact.outcome)) {
+                fact.outcome = row.outcome;
+            }
+        }
+
+        EQACompetencyRow verdict = latestTriageVerdict(group);
+        if (verdict != null) {
+            fact.counted = verdict.counted;
+            fact.failure = verdict.failure;
+        } else {
+            // No triage: the score rows speak for the sample, and an escalation
+            // beside one of them adds the failure without a second denominator.
+            fact.counted = group.stream().anyMatch(row -> row.counted);
+            fact.failure = group.stream().anyMatch(row -> row.failure);
+        }
+        return fact;
+    }
+
+    /**
+     * The last triage verdict about a sample, ordered by date and then by event id
+     * -- a bad score and the triage answering it usually land on the same day, so
+     * the date alone cannot order them.
+     */
+    private static EQACompetencyRow latestTriageVerdict(List<EQACompetencyRow> group) {
+        // Set.of throws on a null probe, and a row derived from a result has no
+        // event type at all.
+        return group.stream().filter(row -> row.eventType != null && TRIAGE_VERDICT.contains(row.eventType))
+                .max(Comparator.<EQACompetencyRow, LocalDate>comparing(row -> row.date)
+                        .thenComparing(row -> row.eventId == null ? 0L : row.eventId))
+                .orElse(null);
     }
 
     /**
@@ -393,6 +454,7 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
         clone.cycleId = row.cycleId;
         clone.participantResultId = row.participantResultId;
         clone.date = row.date;
+        clone.eventId = row.eventId;
         clone.eventType = row.eventType;
         clone.outcome = row.outcome;
         clone.counted = row.counted;

--- a/src/main/java/org/openelisglobal/eqa/service/EQACompetencyRow.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACompetencyRow.java
@@ -30,6 +30,14 @@ class EQACompetencyRow {
     Long cycleId;
     Long participantResultId;
     LocalDate date;
+
+    /**
+     * The logged event's own id, or null for a row derived from a result. Two
+     * events about one sample very often share a date -- a bad score and the triage
+     * that answers it usually land the same day -- so the id is what orders them.
+     */
+    Long eventId;
+
     EQACompetencyEventType eventType;
     String outcome;
 

--- a/src/test/java/org/openelisglobal/eqa/EQAAnalystCompetencyIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAAnalystCompetencyIntegrationTest.java
@@ -167,6 +167,83 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         assertEquals("excused samples are not assessed samples", 4, analyst.get("sampleCount"));
     }
 
+    /**
+     * FR-V2.3-06's own worked example, seeded the way production writes it: the
+     * score event lands first and triage answers it. OR-ing the two let the score
+     * event's flags survive whatever triage decided, so an equipment fault was
+     * never lifted off the analyst who happened to run the sample -- the excusing
+     * categories could only ever excuse a sample that had not failed.
+     */
+    @Test
+    public void anEquipmentFaultIsLiftedOffTheAnalystWhoRanTheSample() {
+        for (int i = 0; i < 2; i++) {
+            scoredResult(EQAPerformanceStatus.ACCEPTABLE, ANALYTE);
+        }
+        recordOn(EQAPerformanceStatus.UNACCEPTABLE, EQACompetencyEventType.UNACCEPTABLE_SCORE, ANALYTE);
+        for (int i = 0; i < 3; i++) {
+            scoredThenTriaged(EQAPerformanceStatus.UNACCEPTABLE, EQACompetencyEventType.DISMISSED_EQUIPMENT, ANALYTE);
+        }
+
+        Map<String, Object> analyst = onlyAnalyst();
+        // Two acceptables plus the one unanswered failure. The three equipment
+        // faults leave both totals, which pulls the denominator below the
+        // evidence floor -- a broken analyser means less evidence about the
+        // person, not more.
+        assertEquals("the excused samples leave the denominator", 3, analyst.get("evaluableCount"));
+        assertEquals("and the numerator", 1, analyst.get("failureCount"));
+        assertEquals(UNDER_REVIEW, analyst.get("status"));
+    }
+
+    /** Acceptable-on-review is the other excusing verdict, and behaves the same. */
+    @Test
+    public void acceptableOnReviewExcusesTheSampleItReviewed() {
+        for (int i = 0; i < 4; i++) {
+            scoredResult(EQAPerformanceStatus.ACCEPTABLE, ANALYTE);
+        }
+        scoredThenTriaged(EQAPerformanceStatus.QUESTIONABLE, EQACompetencyEventType.DISMISSED_ACCEPTABLE_ON_REVIEW,
+                ANALYTE);
+
+        Map<String, Object> analyst = onlyAnalyst();
+        assertEquals(4, analyst.get("evaluableCount"));
+        assertEquals("triage found nothing to answer for", 0, analyst.get("failureCount"));
+        assertEquals(COMPETENT, analyst.get("status"));
+    }
+
+    /**
+     * The counting categories are unaffected either way -- the point is that they
+     * count once, not twice, for a sample that carries both events.
+     */
+    @Test
+    public void aTranscriptionDismissalCountsOnceForASampleThatAlsoHasItsScore() {
+        for (int i = 0; i < 3; i++) {
+            scoredResult(EQAPerformanceStatus.ACCEPTABLE, ANALYTE);
+        }
+        scoredThenTriaged(EQAPerformanceStatus.UNACCEPTABLE, EQACompetencyEventType.DISMISSED_TRANSCRIPTION, ANALYTE);
+
+        Map<String, Object> analyst = onlyAnalyst();
+        assertEquals("one sample, one denominator entry", 4, analyst.get("evaluableCount"));
+        assertEquals("one sample, one failure", 1, analyst.get("failureCount"));
+        assertEquals(COMPETENT, analyst.get("status"));
+    }
+
+    /**
+     * An escalation is not a counting decision: the score it escalates is already
+     * the evaluable row, so it must not take the sample out of the denominator the
+     * way a triage verdict does.
+     */
+    @Test
+    public void anEscalationLeavesTheSampleInTheDenominator() {
+        for (int i = 0; i < 3; i++) {
+            scoredResult(EQAPerformanceStatus.ACCEPTABLE, ANALYTE);
+        }
+        Long failed = recordOn(EQAPerformanceStatus.UNACCEPTABLE, EQACompetencyEventType.UNACCEPTABLE_SCORE, ANALYTE);
+        escalate(failed, insertNce("Closed"));
+
+        Map<String, Object> analyst = onlyAnalyst();
+        assertEquals("the escalated sample is still an assessed sample", 4, analyst.get("evaluableCount"));
+        assertEquals("and fails once, not twice", 1, analyst.get("failureCount"));
+    }
+
     @Test
     public void transcriptionAndOtherDismissalsDoCountAgainstTheAnalyst() {
         for (int i = 0; i < 2; i++) {
@@ -353,6 +430,30 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         };
         EQAAnalystCompetencyEvent event = competencyService.record(result, type, null, category, null, USER);
         assertTrue("the writer must produce an event for an assigned analyst", event != null);
+        return result.getId();
+    }
+
+    /**
+     * The shape that actually arises in production: a bad score writes its own
+     * event, and triage answers that same result afterwards. Two events, one sample
+     * -- which is the case no acceptance criterion seeds, because they all seed
+     * bare events.
+     */
+    private Long scoredThenTriaged(EQAPerformanceStatus performance, EQACompetencyEventType triageType,
+            long analyteId) {
+        EQAParticipantResult result = result(performance, analyteId);
+        EQACompetencyEventType scoreType = performance == EQAPerformanceStatus.UNACCEPTABLE
+                ? EQACompetencyEventType.UNACCEPTABLE_SCORE
+                : EQACompetencyEventType.QUESTIONABLE_SCORE;
+        competencyService.record(result, scoreType, null, null, null, USER);
+        EQADismissalCategory category = switch (triageType) {
+        case DISMISSED_EQUIPMENT -> EQADismissalCategory.KNOWN_EQUIPMENT_ISSUE;
+        case DISMISSED_TRANSCRIPTION -> EQADismissalCategory.TRANSCRIPTION_ERROR;
+        case DISMISSED_ACCEPTABLE_ON_REVIEW -> EQADismissalCategory.ACCEPTABLE_ON_REVIEW;
+        case DISMISSED_OTHER -> EQADismissalCategory.OTHER;
+        default -> null;
+        };
+        competencyService.record(result, triageType, null, category, null, USER);
         return result.getId();
     }
 


### PR DESCRIPTION
## What happened

A bad EQA result writes two facts about one sample. At scoring, `recordScore` writes `UNACCEPTABLE_SCORE` or `QUESTIONABLE_SCORE` — the in-house lane included, since blinding scores through the same service. At triage, dismissing the queue row writes a second event, and for **Known equipment issue**, **Pending re-test** and **Acceptable on review** the FRS says that second event does not count against the analyst.

`facts()` collapsed rows about one sample — correctly — and then merged them with `counted |=` and `failure |=`. The score event always lands first, so its flags survived whatever triage decided. A sample left the totals only when nothing else ever spoke for it.

Measured on the rig with one analyst and two equipment dismissals. Same category, opposite outcome, decided only by whether a score event came first:

| result | cycle | events | counted | failure |
| --- | --- | --- | --- | --- |
| 8 | 10 | `QUESTIONABLE_SCORE` + `DISMISSED_EQUIPMENT` | t | t |
| 9 | 11 | `DISMISSED_EQUIPMENT` | f | f |

So the two "does not count against the analyst" categories could only ever excuse a sample that was **not** a failure — an acceptable result queued for |Z| > 2 — where they removed a passing sample from the denominator instead. An equipment fault was never lifted off the analyst who happened to run the sample. And the second row is the case no acceptance criterion ever seeds; in production the first row is the only one that arises, because a queue row exists only after a bad score.

## What the specs say

FR-V2.3-02's mapping table asks "Counts against analyst in the rollup?" and answers about the **item**, not the event: "No — equipment fault, not analyst", "No — deferred pending re-test", "No — was a false positive on triage".

FR-V2.3-06's de-duplication rule names a winner: rows where the same underlying result appears in both sources "are de-duplicated on `(scheme_id, cycle_id, participant_result_id)`; **the event is the canonical row**." One canonical row per result is not the same thing as the OR across every row about it.

And AC-V2.3-17's seeded scenario only works under the excusing reading — "analyst with 1 unacceptable + 3 dismissed_equipment + 2 acceptable returns Under Review, not Not Competent". Excluding the three: `evaluable_n` 3, `failure_n` 1 → Under Review by the evidence floor, which is what it asserts. Counting them: `evaluable_n` 6, `failure_n` 1 → **Competent**. The scenario is built to show the denominator falling below four.

What no spec addresses is a dismissal landing on a result that already carries a score event, because every criterion seeds bare events. The rules document fell into the same gap: it stated the OR merge under "One sample is one fact" and called a dismissed sample "excused" two sections later. Only one could survive.

## The rule now implemented

One sample is one fact, and **the latest statement about it decides how it counts**. Scoring is the instrument's verdict; a triage verdict is the supervisor's finding *about* that verdict, and it is recorded afterwards.

| Sample's history | In `evaluable_n` | In `failure_n` |
| --- | --- | --- |
| scored acceptable, no triage | yes | no |
| scored badly, no triage | yes | yes |
| scored badly → dismissed equipment / pending re-test / acceptable on review | no | no |
| scored badly → dismissed transcription / other | yes | yes (once, not twice) |
| scored badly → escalated | yes | yes, plus the open-NCE band |

An escalation is deliberately **not** a triage verdict: the score it escalates is already the evaluable row, so it contributes the failure and the open-non-conformity flag and leaves the denominator alone.

Triage verdicts are ordered by date **and then by event id**, because a bad score and the triage answering it usually land on the same day and the date alone cannot order them.

Nothing stored changes — the bands are derived on every read. The rules document is corrected in the same commit, and now states which reading holds and why.

## Two things worth saying out loud

**Nothing disappears from the record.** The evidence table under each analyst still lists every event with its date and category, so an assessor sees that the sample failed and sees why it was excused. Only the counts move.

**Excusing pulls the denominator down**, which can move an analyst to Under Review for thin evidence rather than Competent. That is the FRS's intended outcome, not a side effect: a broken analyser means less evidence about the person, not more, and AC-V2.3-17 is exactly that case.

## Tests

Full EQA suite: **564 tests, 0 failures** (560 on the branch point plus four new).

The existing dismissal tests all seed *bare* events, which is why they passed under either reading and still pass now. The new ones seed the production shape — a score event, then triage answering that same result:

- `anEquipmentFaultIsLiftedOffTheAnalystWhoRanTheSample` — FR-V2.3-06's worked example, written the way production writes it: `evaluable_n` 3, `failure_n` 1, Under Review.
- `acceptableOnReviewExcusesTheSampleItReviewed` — the other excusing verdict behaves the same.
- `aTranscriptionDismissalCountsOnceForASampleThatAlsoHasItsScore` — the counting categories are unaffected, and count once rather than twice.
- `anEscalationLeavesTheSampleInTheDenominator` — an escalation does not take the sample out of it the way a triage verdict does.

Inverted by restoring the OR merge, which produces exactly the numbers the analysis predicts: `evaluable_n` 6 instead of 3 for the worked example, and 5 instead of 4 for acceptable-on-review.

Register: AC-V2.3-17 keeps its PASS under either decision; its note is what changes.