### PR TITLE
fix(eqa): hide receipt and blinding actions from users lacking the grant, explain the 403 (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
+++ b/frontend/src/components/eqa/InHouse/InHousePanelsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   Button,
   Column,
@@ -19,6 +19,8 @@ import { Locked } from "@carbon/react/icons";
 import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
+import UserSessionDetailsContext from "../../../UserSessionDetailsContext";
+import { hasQaPermission } from "../../utils/Utils";
 import {
   downloadLabelSheet,
   fetchInHouseSchemes,
@@ -42,6 +44,9 @@ const STATUS_TAG = {
 };
 
 const InHousePanelsPage = () => {
+  const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  // Sealing a panel is a manage-grant write; the wizard's every step ends there.
+  const canManage = hasQaPermission(userSessionDetails, "qa.manage.eqa");
   const intl = useIntl();
   const history = useHistory();
   const [schemes, setSchemes] = useState([]);
@@ -150,9 +155,27 @@ const InHousePanelsPage = () => {
           </Select>
         </Column>
         <Column lg={8} md={4} sm={4}>
-          <Button onClick={() => history.push("/qa/eqa/in-house/new")}>
-            {label("eqa.inhouse.launchWizard", "Launch blinding wizard")}
-          </Button>
+          {canManage ? (
+            <Button onClick={() => history.push("/qa/eqa/in-house/new")}>
+              {label("eqa.inhouse.launchWizard", "Launch blinding wizard")}
+            </Button>
+          ) : (
+            // Four steps of panel design in front of a seal this persona cannot
+            // perform is worse than no launcher at all.
+            <InlineNotification
+              kind="info"
+              lowContrast
+              hideCloseButton
+              title={label(
+                "eqa.inhouse.readOnly.title",
+                "Read-only view of in-house panels",
+              )}
+              subtitle={label(
+                "eqa.inhouse.readOnly.body",
+                "Designing and sealing a blinded panel needs the manage grant. The panels below are the whole picture either way.",
+              )}
+            />
+          )}
         </Column>
 
         {panels.length > 0 &&

--- a/frontend/src/components/eqa/InHouse/__tests__/InHousePanelsPage.test.jsx
+++ b/frontend/src/components/eqa/InHouse/__tests__/InHousePanelsPage.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
+import messages from "../../../../languages/en.json";
+import InHousePanelsPage from "../InHousePanelsPage";
+import UserSessionDetailsContext from "../../../../UserSessionDetailsContext";
+import { fetchInHouseSchemes, fetchPanelsForScheme } from "../inHouseApi";
+
+vi.mock("../inHouseApi", () => ({
+  fetchInHouseSchemes: vi.fn(),
+  fetchPanelsForScheme: vi.fn(),
+  downloadLabelSheet: vi.fn(),
+  unblindPanel: vi.fn(),
+}));
+
+vi.mock("../../../common/PageBreadCrumb", () => ({
+  default: function MockBreadCrumb() {
+    return <div data-testid="breadcrumb">breadcrumb</div>;
+  },
+}));
+
+const renderPage = (permissions) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <UserSessionDetailsContext.Provider
+        value={{
+          userSessionDetails: { authenticated: true, roles: [], permissions },
+          errorLoadingSessionDetails: false,
+          isCheckingLogin: () => false,
+          logout: vi.fn(),
+        }}
+      >
+        <MemoryRouter>
+          <InHousePanelsPage />
+        </MemoryRouter>
+      </UserSessionDetailsContext.Provider>
+    </IntlProvider>,
+  );
+
+describe("InHousePanelsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchInHouseSchemes.mockImplementation((callback) =>
+      callback([{ id: "3", name: "In-house malaria RDT" }]),
+    );
+    fetchPanelsForScheme.mockImplementation((_schemeId, callback) =>
+      callback([]),
+    );
+  });
+
+  // F-27: the launcher opened four steps of panel design in front of a seal
+  // this persona cannot perform.
+  it("hides the wizard launcher from a persona without the manage grant", () => {
+    renderPage(["qa.view.eqa", "qa.eqa.participant"]);
+
+    expect(
+      screen.queryByRole("button", { name: "Launch blinding wizard" }),
+    ).toBeNull();
+    expect(
+      screen.getByText("Read-only view of in-house panels"),
+    ).toBeInTheDocument();
+  });
+
+  it("offers the launcher to a persona holding the manage grant", () => {
+    renderPage(["qa.view.eqa", "qa.manage.eqa"]);
+
+    expect(
+      screen.getByRole("button", { name: "Launch blinding wizard" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Read-only view of in-house panels")).toBeNull();
+  });
+});

--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import {
   Button,
   InlineNotification,
@@ -15,7 +15,12 @@ import {
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import { Link as RouterLink } from "react-router-dom";
-import { formatDateOnly, resolveApiErrorMessage } from "../../../utils/Utils";
+import {
+  formatDateOnly,
+  hasQaPermission,
+  resolveApiErrorMessage,
+} from "../../../utils/Utils";
+import UserSessionDetailsContext from "../../../../UserSessionDetailsContext";
 import { hintStyle } from "../../eqaCommon";
 import {
   distributeScores,
@@ -66,6 +71,13 @@ const dateCell = (value) =>
  */
 const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
   const intl = useIntl();
+  const { userSessionDetails } = useContext(UserSessionDetailsContext);
+  // Gate each action on the grant its own endpoint asks for, so what is on
+  // offer is what this user can actually do. Provider covers reception,
+  // repeats, provider-side result entry and score return; manage covers
+  // scoring the cycle and the audited override that opens submissions.
+  const isProvider = hasQaPermission(userSessionDetails, "qa.eqa.provider");
+  const canManage = hasQaPermission(userSessionDetails, "qa.manage.eqa");
   const t = (id, defaultMessage, values) =>
     intl.formatMessage({ id, defaultMessage }, values);
 
@@ -94,11 +106,31 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
    * {success: false, error} when the store refuses the bundle, and reporting
    * that as sent is the D-LIVE-1 mistake in a new place.
    */
-  const report = ({ ok, body }, successKey, successText, failKey) => {
+  const report = (
+    { ok, status, body },
+    successKey,
+    successText,
+    failKey,
+    grant,
+  ) => {
     setBusy(null);
     if (ok && body?.success !== false) {
       refresh();
       onNotice({ kind: "success", text: t(successKey, successText) });
+      return;
+    }
+    // A refusal names the action and the grant that carries it. The actions are
+    // hidden without the grant, so this is reachable only when one is revoked
+    // mid-session — which is exactly when "Forbidden" explains least.
+    if (status === 403) {
+      onNotice({
+        kind: "error",
+        text: t(
+          "eqa.action.forbidden",
+          "This action needs the {grant} permission, which your account does not have. Ask an administrator for it.",
+          { grant },
+        ),
+      });
       return;
     }
     onNotice({
@@ -115,6 +147,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.delivered",
         "Delivery recorded.",
         "eqa.receipt.deliveredFailed",
+        "qa.eqa.provider",
       ),
     );
   };
@@ -129,6 +162,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.repeatSent",
         "Repeat panel dispatched.",
         "eqa.receipt.repeatFailed",
+        "qa.eqa.provider",
       );
     });
   };
@@ -149,6 +183,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.submissionsOpened",
         "Submissions are open.",
         "eqa.receipt.submissionsOpenFailed",
+        "qa.manage.eqa",
       );
     });
   };
@@ -264,6 +299,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.score.scored",
         "Cycle scored. Unacceptable participants are in the follow-up register.",
         "eqa.score.scoreFailed",
+        "qa.manage.eqa",
       ),
     );
   };
@@ -276,6 +312,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.score.distributed",
         "Scores placed in the FHIR store for the participant to collect.",
         "eqa.score.distributeFailed",
+        "qa.eqa.provider",
       ),
     );
   };
@@ -298,6 +335,22 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         />
       ) : (
         <>
+          {!isProvider && !canManage && (
+            <InlineNotification
+              kind="info"
+              lowContrast
+              hideCloseButton
+              title={t(
+                "eqa.receipt.readOnly.title",
+                "Read-only view of receipts and scores",
+              )}
+              subtitle={t(
+                "eqa.receipt.readOnly.body",
+                "Recording a delivery, dispatching a repeat, entering results and returning scores all need the provider grant; scoring the cycle needs the manage grant. The table below is the whole cycle either way.",
+              )}
+              style={{ marginBottom: "0.75rem" }}
+            />
+          )}
           <div
             style={{
               display: "flex",
@@ -306,12 +359,13 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
               marginBottom: "0.75rem",
             }}
           >
-            {SCORABLE.includes(cycleStatus) && (
+            {canManage && SCORABLE.includes(cycleStatus) && (
               <Button size="sm" disabled={busy !== null} onClick={handleScore}>
                 {t("eqa.score.scoreCycle", "Score cycle")}
               </Button>
             )}
-            {["SHIPPED", "DELIVERED"].includes(cycleStatus) &&
+            {canManage &&
+              ["SHIPPED", "DELIVERED"].includes(cycleStatus) &&
               rows.some(
                 (row) =>
                   row.receiptStatus === "DELIVERED" ||
@@ -419,7 +473,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                         : "—"}
                     </TableCell>
                     <TableCell>
-                      {!delivered && row.shipmentId && (
+                      {isProvider && !delivered && row.shipmentId && (
                         <Button
                           kind="ghost"
                           size="sm"
@@ -429,7 +483,7 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                           {t("eqa.receipt.markReceived", "Mark received")}
                         </Button>
                       )}
-                      {row.shipmentId && (
+                      {isProvider && row.shipmentId && (
                         <Button
                           kind="ghost"
                           size="sm"
@@ -442,24 +496,28 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
                           {t("eqa.receipt.sendRepeat", "Send repeat")}
                         </Button>
                       )}
-                      <Button
-                        kind="ghost"
-                        size="sm"
-                        disabled={busy !== null}
-                        onClick={() => openIntake(row)}
-                      >
-                        {t("eqa.intake.enterResults", "Enter results")}
-                      </Button>
+                      {isProvider && (
+                        <Button
+                          kind="ghost"
+                          size="sm"
+                          disabled={busy !== null}
+                          onClick={() => openIntake(row)}
+                        >
+                          {t("eqa.intake.enterResults", "Enter results")}
+                        </Button>
+                      )}
                       {score && score.resultCount > 0 && (
                         <>
-                          <Button
-                            kind="ghost"
-                            size="sm"
-                            disabled={busy === row.organizationId}
-                            onClick={() => handleDistribute(row)}
-                          >
-                            {t("eqa.score.sendScores", "Send scores")}
-                          </Button>
+                          {isProvider && (
+                            <Button
+                              kind="ghost"
+                              size="sm"
+                              disabled={busy === row.organizationId}
+                              onClick={() => handleDistribute(row)}
+                            >
+                              {t("eqa.score.sendScores", "Send scores")}
+                            </Button>
+                          )}
                           <Button
                             kind="ghost"
                             size="sm"

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
@@ -23,6 +23,8 @@ vi.mock("../../../../utils/Utils", () => ({
   // parses what its own dateFormat says it will.
   formatDateOnly: (value) =>
     value ? String(value).slice(0, 10).split("-").reverse().join("/") : "",
+  // This suite is about dispatch and the manifest, not about grants.
+  hasQaPermission: () => true,
 }));
 
 vi.mock("../../../../common/PageBreadCrumb", () => ({

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -6,6 +6,7 @@ import { IntlProvider } from "react-intl";
 import { MemoryRouter } from "react-router-dom";
 import messages from "../../../../../languages/en.json";
 import ReceiptMonitor from "../ReceiptMonitor";
+import UserSessionDetailsContext from "../../../../../UserSessionDetailsContext";
 import {
   getFromOpenElisServer,
   postToOpenElisServerFullResponse,
@@ -64,17 +65,35 @@ const SCORES = [
 
 const jsonResponse = (ok, body) => ({ ok, json: () => Promise.resolve(body) });
 
-const renderTab = (cycleStatus = "SUBMISSIONS_OPEN") =>
+const PROVIDER_AND_MANAGER = [
+  "qa.view.eqa",
+  "qa.eqa.provider",
+  "qa.manage.eqa",
+];
+
+const renderTab = (
+  cycleStatus = "SUBMISSIONS_OPEN",
+  { permissions = PROVIDER_AND_MANAGER, onNotice = vi.fn() } = {},
+) =>
   render(
     <IntlProvider locale="en" messages={messages}>
-      <MemoryRouter>
-        <ReceiptMonitor
-          cycleId="9"
-          cycleStatus={cycleStatus}
-          onChanged={vi.fn()}
-          onNotice={vi.fn()}
-        />
-      </MemoryRouter>
+      <UserSessionDetailsContext.Provider
+        value={{
+          userSessionDetails: { authenticated: true, roles: [], permissions },
+          errorLoadingSessionDetails: false,
+          isCheckingLogin: () => false,
+          logout: vi.fn(),
+        }}
+      >
+        <MemoryRouter>
+          <ReceiptMonitor
+            cycleId="9"
+            cycleStatus={cycleStatus}
+            onChanged={vi.fn()}
+            onNotice={onNotice}
+          />
+        </MemoryRouter>
+      </UserSessionDetailsContext.Provider>
     </IntlProvider>,
   );
 
@@ -149,18 +168,7 @@ describe("ReceiptMonitor", () => {
       ),
     );
     const onNotice = vi.fn();
-    render(
-      <IntlProvider locale="en" messages={messages}>
-        <MemoryRouter>
-          <ReceiptMonitor
-            cycleId="9"
-            cycleStatus="SCORED"
-            onChanged={vi.fn()}
-            onNotice={onNotice}
-          />
-        </MemoryRouter>
-      </IntlProvider>,
-    );
+    renderTab("SCORED", { onNotice });
 
     await screen.findByText("Iringa District Lab");
     fireEvent.click(screen.getByRole("button", { name: "Send scores" }));
@@ -169,6 +177,70 @@ describe("ReceiptMonitor", () => {
       expect(onNotice).toHaveBeenCalledWith(
         expect.objectContaining({ kind: "error" }),
       ),
+    );
+  });
+
+  // F-27: as a persona with the read umbrella and the participant grant only,
+  // every write action on this tab rendered and was enabled, and pressing one
+  // answered 403 with the single word "Forbidden".
+  it("offers no write action to a persona without either grant", async () => {
+    renderTab("SUBMISSIONS_OPEN", {
+      permissions: ["qa.view.eqa", "qa.eqa.participant"],
+    });
+
+    await screen.findByText("Mbeya Regional Lab");
+    for (const action of [
+      "Mark received",
+      "Send repeat",
+      "Enter results",
+      "Send scores",
+      "Score cycle",
+    ]) {
+      expect(screen.queryByRole("button", { name: action })).toBeNull();
+    }
+    // Read value is kept, and the missing actions are explained rather than
+    // silently absent -- the pattern the provider scheme board already uses.
+    expect(
+      screen.getByText("Read-only view of receipts and scores"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Iringa District Lab")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Scores CSV" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers the provider actions but not scoring to a provider without the manage grant", async () => {
+    renderTab("SUBMISSIONS_OPEN", {
+      permissions: ["qa.view.eqa", "qa.eqa.provider"],
+    });
+
+    await screen.findByText("Mbeya Regional Lab");
+    expect(
+      screen.getAllByRole("button", { name: "Send repeat" }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Score cycle" })).toBeNull();
+    expect(
+      screen.queryByText("Read-only view of receipts and scores"),
+    ).toBeNull();
+  });
+
+  it("names the grant when a refusal still reaches the user", async () => {
+    // Reachable when a grant is revoked mid-session, which is exactly when
+    // "Forbidden" explains least.
+    postToOpenElisServerFullResponse.mockImplementation((_url, _body, cb) =>
+      cb({ ok: false, status: 403, json: () => Promise.resolve({}) }),
+    );
+    const onNotice = vi.fn();
+    renderTab("SCORED", { onNotice });
+
+    await screen.findByText("Iringa District Lab");
+    fireEvent.click(screen.getByRole("button", { name: "Send scores" }));
+
+    await waitFor(() =>
+      expect(onNotice).toHaveBeenCalledWith({
+        kind: "error",
+        text: "This action needs the qa.eqa.provider permission, which your account does not have. Ask an administrator for it.",
+      }),
     );
   });
 

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -48,15 +48,21 @@ export const fetchShipmentRows = (cycleId, callback) =>
  * Every write answers with {ok, body}: on failure the body is the server's
  * own {error: "..."} so the operator reads the actual refusal, not a guess.
  */
+// The status travels with the body: a 403 needs a sentence naming the grant the
+// action wanted, and Spring's own body for one says only "Forbidden".
 const withBody = (callback) => (response) => {
   if (!response) {
-    callback({ ok: false, body: null });
+    callback({ ok: false, status: 0, body: null });
     return;
   }
   response
     .json()
-    .then((body) => callback({ ok: response.ok, body }))
-    .catch(() => callback({ ok: response.ok, body: null }));
+    .then((body) =>
+      callback({ ok: response.ok, status: response.status, body }),
+    )
+    .catch(() =>
+      callback({ ok: response.ok, status: response.status, body: null }),
+    );
 };
 
 /**

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8573,5 +8573,10 @@
   "eqa.enrollment.scheme": "Scheme",
   "eqa.enrollment.scheme.helper": "Pick a scheme this instance carries, or choose Not listed and type the name.",
   "eqa.enrollment.scheme.frozen": "This enrollment has cycles against it, so its scheme and provider cannot be changed.",
-  "eqa.enrollment.scheme.other": "Not listed - type the name"
+  "eqa.enrollment.scheme.other": "Not listed - type the name",
+  "eqa.action.forbidden": "This action needs the {grant} permission, which your account does not have. Ask an administrator for it.",
+  "eqa.receipt.readOnly.title": "Read-only view of receipts and scores",
+  "eqa.receipt.readOnly.body": "Recording a delivery, dispatching a repeat, entering results and returning scores all need the provider grant; scoring the cycle needs the manage grant. The table below is the whole cycle either way.",
+  "eqa.inhouse.readOnly.title": "Read-only view of in-house panels",
+  "eqa.inhouse.readOnly.body": "Designing and sealing a blinded panel needs the manage grant. The panels below are the whole picture either way."
 }


### PR DESCRIPTION
As a Reception-only persona — the read umbrella and the participant grant, nothing else — the provider workbench rendered **Send scores**, **Send repeat** and **Enter results** on its Receipts & scoring tab, five sets of them, every one `disabled === false` and visible once the tab was open. Pressing **Send scores** fired `POST /rest/eqa/cycles/5/scores/29/distribute` → **403**, and the user was told "Forbidden" and nothing else. **In-House Blinding** rendered **Launch blinding wizard**, and it opened: four steps of panel design in front of a seal the same persona cannot perform.

The guards hold. That is what makes this a usability defect and not a security one — and the contrast is in the same lane: the follow-up queue renders no triage buttons for a persona without the grant, and the provider scheme board replaces its whole board with "Participant view only". Two surfaces were simply missed.

## Each action gated on the grant it actually calls

Read off the endpoints rather than assumed:

| Action | Endpoint | Grant |
| --- | --- | --- |
| Mark received | `receipts/{org}/delivered` | `qa.eqa.provider` |
| Send repeat | `receipts/{org}/repeat` | `qa.eqa.provider` |
| Enter results | `cycles/{id}/results`, `results/import` | `qa.eqa.provider` |
| Send scores | `scores/{org}/distribute` | `qa.eqa.provider` |
| Score cycle | `cycles/{id}/score` | `qa.manage.eqa` |
| Open submissions | `cycles/{id}/transition` | `qa.manage.eqa` |
| Scores CSV | `scores/{org}/csv` | read — stays |

**One correction to the plan for this card:** it proposed `qa.manage.eqa` for Enter results. The endpoint behind it (`EQAResultRestController`, both the keyed entry and the CSV import) is guarded with `EQAGuards.PROVIDER`, so that is what the button is gated on. Gating on the wrong grant would have hidden the action from the people who can perform it.

## Hide or explain, not both inconsistently

The card asked for one pattern to be picked. The tab takes the **scheme board's**, not the queue's, because it keeps real read value: the receipt table, the score summary and the scores CSV are all still there, and a notice names the two grants that carry the missing actions. The in-house launcher is replaced by the same kind of notice, since a wizard whose last step is a seal has nothing to offer someone who cannot seal.

A persona holding only the provider grant sees the provider actions and no **Score cycle**, and gets no notice at all — it is not read-only for them.

## The 403 now says something

`withBody` carries the response status alongside the body, so a 403 can be told from a 4xx that has something to say. A refusal names the action's grant in a sentence: "This action needs the qa.eqa.provider permission, which your account does not have. Ask an administrator for it."

With the actions hidden this is reachable only when a grant is revoked mid-session — which is exactly when a single word explains least.

## Tests

Frontend, 1210 tests across the whole suite, 0 failures.

- `ReceiptMonitor.test.jsx` — a persona with neither grant sees none of the five write actions, sees the notice, and still sees the table and the CSV link; a provider without the manage grant sees the provider actions, no **Score cycle** and no notice; a 403 produces the sentence naming `qa.eqa.provider`.
- `InHousePanelsPage.test.jsx` (new) — the launcher is absent with a notice in its place for a persona without the manage grant, and present without the notice for one holding it.

The existing ReceiptMonitor suite needed a session context to render at all once the grants were read, which is the honest consequence of gating on them; its one test that built its own tree was moved onto the shared harness.

Inverted: forcing both grants true, and dropping the 403 branch, fails all four new tests.