### PR TITLE
fix(eqa): make the V2 rollback runnable on a database that used the feature (OGC-935)

### DIFF
--- a/docs/eqa/v1-distribution-absorption.md
+++ b/docs/eqa/v1-distribution-absorption.md
@@ -60,6 +60,69 @@ after the migration: a transition other than the backfill row, or a round,
 panel, roster entry, receipt, result, follow-up, or shipping box attached to it.
 Resolve those cycles by hand before rolling back.
 
+### Rolling the whole V2 set back
+
+The V2 set is a contiguous run of changesets. Two things about removing it are
+not obvious from the changelog.
+
+**Two housekeeping changesets sit above everything, always.**
+`2.8.x.x/panel_item_fix.xml::1` and `2.3.x.x/minor_fixes.xml::2` are
+`runAlways`, so they re-execute on every application start and are therefore the
+two most recently applied changesets on any running installation. Neither had an
+inverse: one deletes orphaned panel items, the other stamps null timestamps. So
+every rollback attempted on this product, of any feature, stopped on
+`No inverse to DeleteDataChange created` before it reached whatever was being
+removed, and had to be unblocked by hand from a stack trace.
+
+Both now declare an empty `<rollback />`, which is the truthful inverse as well
+as the convenient one: restoring orphaned panel items would restore broken
+references, and the next start would delete them again.
+
+**Say where to stop, do not count.** `liquibase rollbackToTag eqa-v2-start`
+names the point the set begins, written by `qa/040-eqa-v2-start-tag.xml`, which
+is included ahead of the first V2 changeset rather than in file order.
+
+The tag carries a precondition, which is the honest part. A tag marks the last
+changeset applied when it runs, so on a database that already carries the V2 set
+this file would execute after it and tag the wrong end: a tag that rolls back
+nothing, which is worse than no tag because an operator would trust it. There it
+is marked ran without tagging, and the route is `rollbackCount`. A database
+provisioned after this change gets the tag where it belongs.
+
+Counting, where you have to: the V2 set is 57 changesets, and the two
+`runAlways` rows above it are part of the count, so `rollbackCount 59` is the
+whole set on a running installation. Verify against `databasechangelog` ordered
+by `orderexecuted` before running it rather than trusting the number.
+
+**Widened CHECK constraints delete their own rows.** Four V2 changesets widened
+a CHECK precisely so the feature could write a new value, and their rollbacks
+restore the narrow definition. That cannot succeed while rows carrying the new
+value are on file, which on any installation that used EQA is all of them. Each
+of those rollbacks now deletes the rows it would otherwise fail on, in the same
+block:
+
+| Changeset | Constraint                                     | Rows removed on rollback                |
+| --------- | ---------------------------------------------- | --------------------------------------- |
+| `qa/024`  | `eqa_cycle_state_transition_trigger_event_chk` | `trigger_event = 'PANEL_RECEIPT'`       |
+| `qa/028`  | `eqa_cycle_state_transition_trigger_event_chk` | `trigger_event = 'FIRST_SHIPMENT_SENT'` |
+| `qa/022`  | `eqa_cycle_state_transition_trigger_event_chk` | `trigger_event = 'V1_BACKFILL'`         |
+| `qa/030`  | `chk_alert_type` on `clinlims.alert`           | `alert_type = 'EQA_SUBMISSION_FAILED'`  |
+
+The first three are audit rows on a table the rollback drops a few changesets
+later, so deleting them costs nothing that was not already going. The fourth is
+different: `clinlims.alert` survives the rollback, so those alerts are genuinely
+deleted. They name a feature that is being removed, and the constraint they
+violate belongs to `3.5.x.x/070-critical-result-alert-type.xml` rather than to
+EQA, so leaving them would block a core constraint from being restored.
+
+**The end state**, measured on a `pg_dump` copy of a participant database that
+had used the feature: eleven V2 tables gone, the eight V1 EQA tables standing,
+`shipping_box.eqa_cycle_id` removed, the one `EQA_SUBMISSION_FAILED` alert
+deleted with the other six untouched, `chk_alert_type` back to the definition
+`3.5.x.x/070-critical-result-alert-type.xml` owns, and 59 rows gone from
+`databasechangelog`. Liquibase reported "Rollback has been successful" with no
+manual step at any point.
+
 ## Why the legacy scores stay where they are
 
 V1 scores predate cycles, panels, and the V2 scoring fields. Copying them into

--- a/src/main/resources/liquibase/2.3.x.x/minor_fixes.xml
+++ b/src/main/resources/liquibase/2.3.x.x/minor_fixes.xml
@@ -30,6 +30,13 @@
               <column name="last_updated" valueComputed="${now}"/>
               <where>last_updated is null</where>
           </update>
+        <!--
+            No-op inverse, for the same reason as 2.8.x.x/panel_item_fix.xml: an
+            update has none, this changeset is runAlways so it sits above every
+            rollback that is ever attempted, and putting the timestamps back to
+            null would only have them stamped again on the next start.
+        -->
+        <rollback />
     </changeSet>
 
     <changeSet author="csteele" id="3">

--- a/src/main/resources/liquibase/2.8.x.x/panel_item_fix.xml
+++ b/src/main/resources/liquibase/2.8.x.x/panel_item_fix.xml
@@ -17,6 +17,22 @@
         <delete tableName="panel_item" schemaName="clinlims">
             <where>test_id NOT IN (SELECT id FROM clinlims.test)</where>
         </delete>
+        <!--
+            Rolling this back is a no-op, declared rather than left to fail.
+
+            A delete has no inverse, so without this any rollback stops here with
+            "No inverse to DeleteDataChange created" and has to be unblocked by
+            hand. That is not an occasional collision: the changeset is
+            runAlways, so it re-executes on every start and is therefore always
+            among the most recently applied changesets, above whatever is
+            actually being rolled back. Every rollback on this product had to
+            pass it.
+
+            A no-op is also the truthful inverse. The rows this deletes are panel
+            items whose test no longer exists; restoring them would restore
+            broken references, and the next start would delete them again.
+        -->
+        <rollback />
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -68,6 +68,12 @@
   <!-- QA Phase D.2 — OGC-686: accreditation page menu row -->
   <include file="liquibase/qa/014-add-accreditation-menu.xml" />
 
+  <!-- A name for the point the EQA V2 set begins, so a rollback can say where to
+       stop rather than counting backwards through whatever core changesets sit
+       above it. Included here rather than in file order for that reason: the tag
+       has to be applied before the first EQA V2 changeset, not after the last. -->
+  <include file="liquibase/qa/040-eqa-v2-start-tag.xml" />
+
   <!-- EQA V2.1 T-08 — OGC-609: cycle/round/state-transition-audit spine -->
   <include file="liquibase/qa/015-create-eqa-cycle-tables.xml" />
 

--- a/src/main/resources/liquibase/qa/022-backfill-v1-distribution-cycles.xml
+++ b/src/main/resources/liquibase/qa/022-backfill-v1-distribution-cycles.xml
@@ -36,6 +36,13 @@
         </sql>
         <rollback>
             <sql>
+                <!-- The backfill's own rollback removes the V1_BACKFILL rows with the
+                     synthetic cycles they mark, and it runs before this one. This is
+                     the belt: if it refused (a backfilled cycle that has since been
+                     used), those rows are still here and the narrow CHECK would fail
+                     on them with a constraint name rather than an explanation. -->
+                DELETE FROM clinlims.eqa_cycle_state_transition WHERE trigger_event = 'V1_BACKFILL';
+
                 ALTER TABLE clinlims.eqa_cycle_state_transition
                 DROP CONSTRAINT eqa_cycle_state_transition_trigger_event_chk;
 

--- a/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
+++ b/src/main/resources/liquibase/qa/024-extend-eqa-trigger-event-check.xml
@@ -31,6 +31,14 @@
         </sql>
         <rollback>
             <sql>
+                <!-- The narrow CHECK cannot come back over rows carrying the value
+                     this changeset widened it for, and the table is full of them on
+                     any installation that used the feature. Those rows belong to the
+                     feature being removed, so deleting them is the rollback rather
+                     than collateral damage, and the table itself is dropped later
+                     in the same rollback anyway. -->
+                DELETE FROM clinlims.eqa_cycle_state_transition WHERE trigger_event = 'PANEL_RECEIPT';
+
                 ALTER TABLE clinlims.eqa_cycle_state_transition
                 DROP CONSTRAINT eqa_cycle_state_transition_trigger_event_chk;
 

--- a/src/main/resources/liquibase/qa/028-eqa-shipment-workbench.xml
+++ b/src/main/resources/liquibase/qa/028-eqa-shipment-workbench.xml
@@ -64,6 +64,10 @@
         </sql>
         <rollback>
             <sql>
+                <!-- Same trap as qa/024: the value this changeset widened the CHECK
+                     for has to go before the narrow definition returns. -->
+                DELETE FROM clinlims.eqa_cycle_state_transition WHERE trigger_event = 'FIRST_SHIPMENT_SENT';
+
                 ALTER TABLE clinlims.eqa_cycle_state_transition
                 DROP CONSTRAINT eqa_cycle_state_transition_trigger_event_chk;
 

--- a/src/main/resources/liquibase/qa/030-add-eqa-cycle-submission-retry.xml
+++ b/src/main/resources/liquibase/qa/030-add-eqa-cycle-submission-retry.xml
@@ -74,6 +74,13 @@
         </sql>
         <rollback>
             <sql>
+                <!-- These alerts name a feature that is being removed, and the narrow
+                     CHECK 3.5.x.x/070 owns cannot come back while they are on file.
+                     Unlike the state-transition rows, the alert table survives the
+                     rollback, so this is a real deletion: it is scoped to the one
+                     alert type this changeset introduced. -->
+                DELETE FROM clinlims.alert WHERE alert_type = 'EQA_SUBMISSION_FAILED';
+
                 ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
                 ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
                 CHECK (alert_type IN (

--- a/src/main/resources/liquibase/qa/040-eqa-v2-start-tag.xml
+++ b/src/main/resources/liquibase/qa/040-eqa-v2-start-tag.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <!--
+        A name for the point the EQA V2 set begins, so a rollback can say where to
+        stop instead of counting backwards.
+
+        Counting is what the rollback drill had to do, and the count is not a
+        property of the EQA set. Core changesets land above it as releases go by,
+        and reaching the first EQA changeset by count means passing through
+        whatever happens to sit above it that day. One of those, the panel-item
+        fix, is a deleteData with no inverse, so the count-based rollback cannot
+        reach a single EQA changeset without stopping on it.
+
+        With the tag: liquibase rollbackToTag eqa-v2-start.
+
+        The precondition is the honest part. A tag marks the last changeset
+        applied when it runs, so on a database that already carries the V2 set
+        this file would execute after it and tag the wrong end: a tag that rolls
+        back nothing, which is worse than no tag at all because an operator would
+        trust it. There it is marked ran without tagging, and the rollback route
+        stays the counted one documented in docs/eqa/v1-distribution-absorption.md.
+        A database provisioned after this change gets the tag where it belongs.
+    -->
+    <changeSet author="openelisglobal" id="qa-079-tag-eqa-v2-start">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists schemaName="clinlims" tableName="eqa_cycle" />
+            </not>
+        </preConditions>
+        <!-- The schema makes tagDatabase an exclusive choice: a changeset holds
+             either a tag or ordinary changes, so this one cannot carry a
+             <comment> element alongside it. -->
+        <tagDatabase tag="eqa-v2-start" />
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
The rollback smoke was driven for real: a participant database `pg_dump`ed into a copy beside it, and Liquibase 4.8 (the jar the webapp already ships) running `rollbackCount` against the copy. The **end state was correct** — eleven V2 tables gone, the eight V1 EQA tables standing, `shipping_box.eqa_cycle_id` removed. But it stopped three times, each needing a statement written by hand from a stack trace. The rollback path worked on an installation that had never used EQA, which is the one installation that would never roll back.

Three causes, all fixed, and the first turned out to be worse than the finding recorded.

## 1. Two housekeeping changesets sit above everything, always

The finding said `2.8.x.x/panel_item_fix.xml` "sits above the EQA block", so a rollback could not reach a single EQA changeset without passing it. Driving the drill again showed why that is not a coincidence of ordering:

```
orderexecuted | filename                            | id
--------------+-------------------------------------+----
         1094 | liquibase/2.8.x.x/panel_item_fix.xml | 1
         1093 | liquibase/2.3.x.x/minor_fixes.xml    | 2
          952 | liquibase/qa/039-eqa-result-text.xml | qa-078-eqa-result-text
```

Both are `runAlways="true"`. They re-execute on **every application start**, so they are always the two most recently applied changesets on any running installation, above whatever is actually being rolled back. And neither had an inverse: one is a `delete` of orphaned panel items, the other an `update` stamping null timestamps.

So this was never an EQA problem. **Every rollback attempted on this product, of any feature, stopped here.**

Both now declare an empty `<rollback />`. That is the truthful inverse as well as the convenient one: restoring panel items whose test no longer exists would restore broken references, and the next start would delete them again. This is the only part of the change outside the EQA lane, and it is deliberate — documenting a hand-written `DELETE` as the workaround would have left the trap in place for the next person.

## 2. Four rollbacks re-add a CHECK over the rows that made them necessary

Each of these widened a CHECK precisely so the feature could write a new value; each rollback restores the narrow definition, which cannot succeed while rows carrying the new value are on file. On any installation that used EQA, that is all of them.

| Changeset | Constraint | Rows removed on rollback |
| --- | --- | --- |
| `qa/024` | `eqa_cycle_state_transition_trigger_event_chk` | `trigger_event = 'PANEL_RECEIPT'` |
| `qa/028` | same | `trigger_event = 'FIRST_SHIPMENT_SENT'` |
| `qa/022` | same | `trigger_event = 'V1_BACKFILL'` |
| `qa/030` | `chk_alert_type` on `clinlims.alert` | `alert_type = 'EQA_SUBMISSION_FAILED'` |

Each rollback now deletes those rows first, in the same block. The data belongs to the feature being removed, so deleting it is the rollback rather than collateral damage.

The first three are audit rows on `eqa_cycle_state_transition`, which the rollback drops a few changesets later, so they were going regardless. **The fourth is different** and the block says so: `clinlims.alert` survives the rollback, so those alerts are genuinely deleted. They name a feature being removed, and the constraint they violate belongs to `3.5.x.x/070-critical-result-alert-type.xml` rather than to EQA — leaving them would block a core constraint from being restored.

`qa/022`'s is a belt to its own braces: the backfill's rollback already removes the `V1_BACKFILL` rows with the synthetic cycles they mark, and runs first — but it *refuses* if a backfilled cycle has been used since, and then those rows are still there and the CHECK fails with a constraint name instead of an explanation.

## 3. A name for where the set begins

`qa/040-eqa-v2-start-tag.xml` writes the tag `eqa-v2-start`, included ahead of the first V2 changeset rather than in file order, so `liquibase rollbackToTag eqa-v2-start` names the boundary rather than counting backwards through whatever sits above it.

**The precondition is the honest part.** A tag marks the last changeset applied when it runs, so on a database that already carries the V2 set this file would execute *after* it and tag the wrong end — a tag that rolls back nothing, which is worse than no tag at all because an operator would trust it. There it is marked ran without tagging, and the documented route stays `rollbackCount`. A database provisioned after this change gets the tag where it belongs, which every integration test now exercises.

(The XSD makes `tagDatabase` an exclusive choice, so that changeset cannot also carry a `<comment>` element; the explanation is an XML comment instead.)

## Verified end to end

Same method as the original smoke — `pg_dump` copy of a participant database that had used the feature, Liquibase 4.8, `rollbackCount 59` (the 57 V2 changesets plus the two `runAlways` rows above them):

```
Rolling Back Changeset: liquibase/qa/015-create-eqa-cycle-tables.xml::eqa-cycle-001-create-eqa-cycle
Liquibase: Rollback has been successful.
```

**No manual step at any point.** Measured afterwards:

- 0 of the 11 V2 tables remain; the 8 V1 EQA tables stand.
- `shipping_box.eqa_cycle_id` gone.
- The 1 `EQA_SUBMISSION_FAILED` alert deleted; the other 6 alerts untouched.
- `chk_alert_type` restored to exactly the definition `070-critical-result-alert-type.xml` owns — `CRITICAL_RESULT` present, `EQA_SUBMISSION_FAILED` absent.
- 59 rows gone from `databasechangelog` (952 → 893).

Before the change, the same command against the same dump ended on `No inverse to DeleteDataChange created` without rolling back anything.

Full EQA suite: 560 tests, 0 failures — unchanged from the branch point, as this card adds no application code. The new changeset is exercised on the fresh-install path by every integration test, which is where the tag is actually written.

`docs/eqa/v1-distribution-absorption.md` gains a "Rolling the whole V2 set back" section carrying all of the above: the `runAlways` trap, the deletion table, the tag's precondition, the count to use, and the measured end state.