### PR TITLE
fix: refresh database and FHIR runtime images off Bullseye

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official PostgreSQL 14.4 image as base
-FROM postgres:14.4
+# Keep the PostgreSQL major version on a supported operating-system base.
+FROM postgres:14.24-bookworm
 
 RUN apt-get update && apt-get install -y gettext-base && rm -rf /var/lib/apt/lists/*
 # Copy initialization scripts and data files into the container

--- a/docs/service-image-maintenance.md
+++ b/docs/service-image-maintenance.md
@@ -1,0 +1,47 @@
+# Database and FHIR Image Maintenance
+
+The database image uses PostgreSQL 14.24 on Debian Bookworm. The FHIR image runs
+the unchanged HAPI 6.6.0 WAR on Tomcat 9 with Java 17 on Ubuntu Noble. The old
+HAPI image supplies only the WAR during the build, not the final operating
+system, Tomcat installation, or entrypoint. Configuration stays at
+`/opt/openelis/config/hapi_application.yaml`; TLS settings and runtime user 8443
+are preserved. The Tomcat installation is now `/usr/local/tomcat`.
+
+This addresses the expired Bullseye package metadata that prevented clean image
+builds. It does not constitute a HAPI application upgrade or a PostgreSQL
+major-version upgrade. Both still need their own planned upgrades; pinning
+versions does not replace regular dependency maintenance.
+
+## Validate Images
+
+Run from the repository root with Docker and jq available:
+
+```bash
+docker build --platform linux/amd64 -f db/Dockerfile -t openelis-base-refresh-db:local .
+docker build --platform linux/amd64 -f fhir/Dockerfile -t openelis-base-refresh-fhir:local .
+bash scripts/smoke-test-service-images.sh
+```
+
+The smoke test creates only uniquely named containers, a network, and a
+certificate volume. It exposes no host ports, removes its resources on exit, and
+prints the directory containing its logs and response evidence. It checks fresh
+OpenELIS database initialization, non-root FHIR startup, mutual TLS, FHIR R4
+metadata, and saving/reading a synthetic patient across both services' restart.
+It is an infrastructure test, not browser acceptance or a new CI pipeline. The
+existing end-to-end workflow remains the application gate.
+
+## Existing Deployments
+
+Back up and rehearse the update on a copy before replacing an existing database
+container. Keep the database volume; do not reset production data. An
+operating-system change also changes locale libraries. Existing indexes that
+depend on locale-sensitive text ordering may need rebuilding before normal
+traffic resumes. Review both the database's default locale and any explicit
+column/index collations. Refreshing a recorded collation version alone does not
+rebuild affected indexes. Follow the PostgreSQL
+[collation maintenance guidance](https://www.postgresql.org/docs/14/sql-altercollation.html).
+
+The fresh-database smoke test does not establish that an existing site's indexes
+are safe after that library change. Site-specific backup, index maintenance,
+restore, and rollback validation are deployment responsibilities. Do not disable
+package signature or expiration checks to retain an obsolete base image.

--- a/fhir/Dockerfile
+++ b/fhir/Dockerfile
@@ -1,45 +1,30 @@
-FROM hapiproject/hapi:v6.6.0-tomcat
+# Retain the HAPI application without inheriting its retired Bullseye runtime.
+FROM hapiproject/hapi:v6.6.0-tomcat AS hapi
+
+FROM tomcat:9.0.121-jre17-temurin-noble
 
 USER root
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY ./tomcat/hapi_server.xml /opt/bitnami/tomcat/conf/server.xml
+RUN groupadd tomcat \
+    && groupadd -g 8443 tomcat-ssl-cert \
+    && useradd -M -s /bin/bash -u 8443 -g tomcat -G tomcat-ssl-cert tomcat_admin \
+    && mkdir -p "$CATALINA_HOME/target" /opt/openelis/config \
+    && printf '\norg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.Digester$EnvironmentPropertySource\n' >> "$CATALINA_HOME/conf/catalina.properties"
 
-RUN chown tomcat:tomcat /opt/bitnami/tomcat/conf/server.xml \
-    && chmod 640 /opt/bitnami/tomcat/conf/server.xml
+COPY --from=hapi --chown=tomcat_admin:tomcat /opt/bitnami/tomcat/webapps/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+COPY --chown=tomcat_admin:tomcat ./tomcat/hapi_server.xml /usr/local/tomcat/conf/server.xml
+COPY --chown=tomcat_admin:tomcat ./fhir/hapi_application.yaml /opt/openelis/config/hapi_application.yaml
 
-# Create groups and custom user, set ownership and folder permissions
-RUN groupadd tomcat; \
-    groupadd tomcat-ssl-cert -g 8443; \
-    useradd -M -s /bin/bash -u 8443 tomcat_admin; \
-    usermod -a -G tomcat,tomcat-ssl-cert tomcat_admin; \
-    chown -R tomcat_admin:tomcat /opt/bitnami/tomcat; \
-    chown -R tomcat_admin:tomcat /target; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf; \
-    chmod o-rwx /opt/bitnami/tomcat/logs; \
-    chmod o-rwx /opt/bitnami/tomcat/temp; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/bin; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/webapps; \
-    chmod 770 /opt/bitnami/tomcat/conf/catalina.policy; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/catalina.properties; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/context.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/logging.properties; \
-    chmod 640 /opt/bitnami/tomcat/conf/server.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/tomcat-users.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/web.xml;\
-    chown -R tomcat_admin:tomcat /bitnami/tomcat/
-
-# Ensure the target directory exists
-RUN mkdir -p /opt/openelis/config
-
-# Copy your HAPI application YAML into the image
-COPY ./fhir/hapi_application.yaml /opt/openelis/config/hapi_application.yaml
-
-# Ensure proper permissions so tomcat can read it
-RUN chown tomcat_admin:tomcat /opt/openelis/config/hapi_application.yaml \
+RUN chown -R tomcat_admin:tomcat "$CATALINA_HOME" \
+    && chmod g-w,o-rwx "$CATALINA_HOME" "$CATALINA_HOME/conf" "$CATALINA_HOME/bin" "$CATALINA_HOME/webapps" \
+    && chmod o-rwx "$CATALINA_HOME/logs" "$CATALINA_HOME/temp" "$CATALINA_HOME/work" "$CATALINA_HOME/target" \
+    && chmod g-w,o-rwx "$CATALINA_HOME"/conf/* \
+    && chmod 640 "$CATALINA_HOME/conf/server.xml" \
     && chmod 600 /opt/openelis/config/hapi_application.yaml
 
-# Optionally, set SPRING_CONFIG_LOCATION so the container automatically picks it up
 ENV SPRING_CONFIG_LOCATION=file:///opt/openelis/config/hapi_application.yaml
+EXPOSE 8443
 USER tomcat_admin

--- a/scripts/smoke-test-service-images.sh
+++ b/scripts/smoke-test-service-images.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Run after building db/Dockerfile and fhir/Dockerfile with the tags below.
+set -euo pipefail
+
+DOCKER=${DOCKER:-docker}
+DB_IMAGE=${DB_IMAGE:-openelis-base-refresh-db:local}
+FHIR_IMAGE=${FHIR_IMAGE:-openelis-base-refresh-fhir:local}
+export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
+evidence=$(mktemp -d "${TMPDIR:-/tmp}/oe-service-images.XXXXXXXX")
+name=$(basename "$evidence" | tr . -)
+
+cleanup() {
+  result=$?
+  trap - EXIT
+  "$DOCKER" logs "$name-db" > "$evidence/database.log" 2>&1 || true
+  "$DOCKER" logs "$name-fhir" > "$evidence/fhir.log" 2>&1 || true
+  "$DOCKER" rm -f -v "$name-fhir" "$name-db" >/dev/null 2>&1 || true
+  "$DOCKER" volume rm "$name-certs" >/dev/null 2>&1 || true
+  "$DOCKER" network rm "$name" >/dev/null 2>&1 || true
+  printf 'Smoke-test logs: %s\n' "$evidence"
+  exit "$result"
+}
+trap cleanup EXIT
+
+"$DOCKER" network create "$name" >/dev/null
+"$DOCKER" volume create "$name-certs" >/dev/null
+"$DOCKER" run --rm --user root -v "$name-certs:/certs" "$FHIR_IMAGE" sh -ec '
+  keytool -genkeypair -alias smoke -keyalg RSA -validity 2 -dname CN=localhost \
+    -ext SAN=dns:localhost -ext EKU=serverAuth,clientAuth -storetype PKCS12 \
+    -keystore /certs/smoke.p12 -storepass smoke-password -noprompt
+  keytool -exportcert -rfc -alias smoke -keystore /certs/smoke.p12 \
+    -storepass smoke-password -file /certs/smoke.crt
+  keytool -importcert -alias smoke -file /certs/smoke.crt -storetype PKCS12 \
+    -keystore /certs/trust.p12 -storepass smoke-password -noprompt
+  chgrp 8443 /certs/*
+  chmod 640 /certs/*
+'
+
+"$DOCKER" run -d --name "$name-db" --network "$name" --network-alias db \
+  --memory 512m --cpus 1 \
+  -e POSTGRES_PASSWORD=smoke-password -e POSTGRES_DB=clinlims \
+  -e POSTGRES_INITDB_ARGS=--auth-host=md5 -e DB_PASSWORD=smoke-password \
+  -e DB_SUPERUSER_PASSWORD=smoke-password "$DB_IMAGE" >/dev/null
+
+db_ready() {
+  "$DOCKER" exec -e PGPASSWORD=smoke-password "$name-db" psql \
+    -h 127.0.0.1 -U clinlims -d clinlims -Atc \
+    "SELECT count(*) FROM clinlims.site_information" >/dev/null 2>&1
+}
+wait_for() {
+  deadline=$((SECONDS + 300))
+  until "$@"; do
+    if (( SECONDS >= deadline )); then
+      printf 'Timed out waiting for %s\n' "$*" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+wait_for db_ready
+"$DOCKER" exec "$name-db" postgres --version
+
+"$DOCKER" run -d --name "$name-fhir" --network "$name" --memory 2g --cpus 2 \
+  -v "$name-certs:/certs:ro" \
+  -e JAVA_OPTS='-Xms256m -Xmx1024m' \
+  -e CATALINA_OPTS='-Dhapi.ssl.keystorepath=/certs/smoke.p12 -Dhapi.ssl.keystorepassword=smoke-password -Dhapi.ssl.truststorepath=/certs/trust.p12 -Dhapi.ssl.truststorepassword=smoke-password' \
+  -e 'FHIR_DATASOURCE_URL=jdbc:postgresql://db:5432/clinlims?currentSchema=clinlims' \
+  -e FHIR_DATASOURCE_USERNAME=clinlims -e FHIR_DATASOURCE_PASSWORD=smoke-password \
+  -e FHIR_SERVER_ADRESS=https://localhost:8443/fhir/ "$FHIR_IMAGE" >/dev/null
+
+fhir() {
+  "$DOCKER" exec "$name-fhir" curl --fail --silent --show-error --max-time 15 \
+    --cacert /certs/smoke.crt --cert-type P12 \
+    --cert /certs/smoke.p12:smoke-password "$@"
+}
+fhir_ready() {
+  fhir 'https://localhost:8443/fhir/metadata?_format=json' \
+    > "$evidence/metadata.json" 2> "$evidence/readiness.log"
+}
+wait_for fhir_ready
+jq -e '.resourceType == "CapabilityStatement" and .fhirVersion == "4.0.1"' \
+  "$evidence/metadata.json" >/dev/null
+test "$("$DOCKER" exec "$name-fhir" id -u)" = 8443
+if "$DOCKER" exec "$name-fhir" curl --fail --silent --show-error --max-time 15 \
+  --cacert /certs/smoke.crt https://localhost:8443/fhir/metadata \
+  > "$evidence/no-client-cert.log" 2>&1; then
+  printf 'FHIR unexpectedly accepted a request without a client certificate.\n' >&2
+  exit 1
+fi
+
+fhir -X PUT -H 'Content-Type: application/fhir+json' \
+  --data '{"resourceType":"Patient","id":"service-image-smoke","active":true}' \
+  https://localhost:8443/fhir/Patient/service-image-smoke \
+  > "$evidence/created.json"
+jq -e '.resourceType == "Patient" and .id == "service-image-smoke"' \
+  "$evidence/created.json" >/dev/null
+
+"$DOCKER" stop "$name-fhir" "$name-db" >/dev/null
+"$DOCKER" start "$name-db" >/dev/null
+wait_for db_ready
+"$DOCKER" start "$name-fhir" >/dev/null
+wait_for fhir_ready
+fhir https://localhost:8443/fhir/Patient/service-image-smoke \
+  > "$evidence/persisted.json"
+jq -e '.resourceType == "Patient" and .id == "service-image-smoke" and .active == true' \
+  "$evidence/persisted.json" >/dev/null
+printf 'PASS: database initialization, non-root FHIR, mutual TLS, R4 metadata, write/read across restart.\n'


### PR DESCRIPTION
## Why

The normal end-to-end image build fails before tests start because both the PostgreSQL and HAPI images use Bullseye security metadata that expired on September 7. Evidence: [failed Shared Build](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/34163136921/job/101870584318). This shared infrastructure failure blocked every PR until #4209 landed a stopgap (bullseye packages from archive.debian.org with the expiry check relaxed); this PR is the durable fix and removes that stopgap.

## Changes

- PostgreSQL 14.4 -> 14.24 on Debian Bookworm; retain the PostgreSQL major version and existing initialization scripts.
- Run the unchanged HAPI 6.6.0 WAR on Tomcat 9.0.121 / Java 17 / Ubuntu Noble. The old HAPI image supplies the WAR only, not the final runtime OS.
- Preserve the checked-in FHIR configuration, mutual TLS settings, UID 8443, and certificate group 8443.
- Add a focused, isolated container smoke test and document existing-database deployment precautions.

No CI workflow changes, manually posted statuses, alternate end-to-end path, analyzer changes, or disabled package authenticity/expiration checks. This is a standalone PR targeting develop, not a new analyzer milestone.

## Validation

Passed locally using linux/amd64 images in OrbStack:

- Clean PostgreSQL image build, including apt update/install.
- Clean HAPI runtime image build, including apt update/install.
- `bash scripts/smoke-test-service-images.sh`: fresh OpenELIS database initialization; FHIR R4 metadata over mutual TLS; runtime UID 8443; rejection without a client certificate; synthetic Patient write/read surviving both services restarting.
- Original and replacement HAPI WAR SHA-256 match: `6b4d61ef8394a8abe47607f99812aba80a67da2d109ed6fc081c95d3a71e200f`.
- Full `mvn spotless:apply` and uncached `mvn clean spotless:check`, shell syntax check, and `git diff --check`.
- Inspected database/FHIR logs and response evidence. The run contains Hibernate schema-initialization constraint-drop messages and connection warnings during the deliberate simultaneous service shutdown; startup and post-restart persistence assertions passed.
- Smoke-test containers, network, and certificate volume were cleaned up; existing local stacks were untouched.

The existing normal GitHub end-to-end workflow remains the application gate.

## Deployment Risks

This is not a full HAPI application upgrade or PostgreSQL major-version upgrade. Existing database volumes need backup and rehearsal: changing operating-system locale libraries can require rebuilding text-ordering indexes. See `docs/service-image-maintenance.md`. Fresh-database smoke evidence does not establish existing-site collation safety.

No deployment or merge is performed by this PR.

## Why this is still needed after #4209

#4209 kept the CI build alive by pointing the two Debian 11 (bullseye) images at `archive.debian.org` and telling apt to accept the archive's expired Release files. That was the right move for the night the pipeline broke, and it is the wrong place to stay:

- **End of life means no more fixes, not just a broken mirror.** Debian 11's LTS ended on 2026-08-31. From that date no security update is published for anything in the image: glibc, OpenSSL, libpq, curl, the JVM's native dependencies. The expired Release file that broke CI on 2026-09-07 was the first visible symptom; every CVE from now on is the invisible one. Keeping `postgres:14.4` and `hapiproject/hapi:v6.6.0-tomcat` means shipping a database and a FHIR server on an operating system nobody patches.
- **The archive is a museum, not a mirror.** `archive.debian.org` serves frozen snapshots on a best-effort basis: the `bullseye-security` suite is not there yet (404), package pools get pruned (the current `security.debian.org` pool already 404s on `libcurl4 deb11u16`), and `Acquire::Check-Valid-Until=false` only papers over the fact that the metadata is no longer maintained. It can break again on any day, with the same symptom.
- **`postgres:14.4` is 20 minor releases behind.** 14.24 carries two years of data-corruption and security fixes for the same major version; nothing in OpenELIS depends on 14.4 specifically.

This PR moves both images onto supported bases and stops depending on the archive: PostgreSQL 14.24 on Debian 12 (bookworm), and the unchanged HAPI 6.6.0 WAR on Tomcat 9 / Java 17 / Ubuntu 24.04. The CI build compose needs no change: it never mounted `server.xml` (the image bakes `tomcat/hapi_server.xml`) and already passes the `-Dhapi.ssl.*` properties that file expects.

## Existing databases: what changes and what to do

Data compatibility is intact: 14.4 → 14.24 is a minor upgrade of the same major, in place, no dump or `pg_upgrade`. What does change is the operating system's collation library (glibc 2.31 → 2.36), and PostgreSQL 14 does not warn about the database's default collation. Measured on a copy of a real OpenELIS database (en_US.utf8, 914 indexes, 11 MB):

- `pg_collation` records `en_US.utf8` at version 2.31; the new image reports 2.36.
- `REINDEX DATABASE clinlims` as superuser took 1.0 s on that copy; it scales with index size.
- `ALTER COLLATION "en_US.utf8" REFRESH VERSION` (and `"en_US"`) then records 2.36.

Deployment step for every existing site (testing included): back up, start on the new image, run `REINDEX DATABASE clinlims` and the two `REFRESH VERSION` statements during the maintenance window, then open the site. `docs/service-image-maintenance.md` carries the same instructions.

## Verified

- Both images build from this branch (no archive, no relaxed apt checks).
- `scripts/smoke-test-service-images.sh`: fresh database initialization, non-root FHIR (uid 8443), mutual TLS, R4 metadata, Patient write/read across a restart of both services.
- OpenELIS dev stack on these images with fresh volumes: Liquibase initialised PostgreSQL 14.24, OpenELIS wrote to HAPI over mutual TLS at start-up (5 Questionnaires, 1 QuestionnaireResponse in `hfj_resource` after the checks), admin programme save and Add Order questionnaire 9/9, browser patient search on the Results page 15/15.
- OpenELIS dev stack on these images against a byte-for-byte copy of an existing 14.4 volume (in-place, no conversion): data intact (samples, patients, programmes, 1089 changesets), clean start, browser patient-search flow 15/15 before remediation, `REINDEX DATABASE clinlims` 1.04 s and `REFRESH VERSION` to 2.36 applied in place, 15/15 again afterwards.
