### PR TITLE
feat(fhir): answer every facade search from the OpenELIS database

### DIFF
--- a/src/main/java/org/openelisglobal/address/daoimpl/PersonAddressDAOImpl.java
+++ b/src/main/java/org/openelisglobal/address/daoimpl/PersonAddressDAOImpl.java
@@ -39,7 +39,8 @@ public class PersonAddressDAOImpl extends BaseDAOImpl<PersonAddress, AddressPK> 
         if (personId == null || personId.trim().isEmpty()) {
             return new ArrayList<>();
         }
-        String sql = "from PersonAddress pa where pa.compoundId.targetId = :personId";
+        String sql = "from PersonAddress pa where pa.compoundId.targetId = :personId"
+                + " order by pa.compoundId.addressPartId";
 
         try {
             Query<PersonAddress> query = entityManager.unwrap(Session.class).createQuery(sql, PersonAddress.class);

--- a/src/main/java/org/openelisglobal/common/fhir/dao/BaseFhirDao.java
+++ b/src/main/java/org/openelisglobal/common/fhir/dao/BaseFhirDao.java
@@ -641,48 +641,25 @@ public abstract class BaseFhirDao {
     }
 
     /**
-     * Creates a last updated date range predicate.
+     * {@code _lastUpdated} over the entity's lastupdated column, with FHIR period
+     * semantics: a day-precision value spans the whole day, {@code gt}/{@code lt}
+     * exclude the period and {@code ge}/{@code le}/{@code eq} include it.
      */
     protected <T, R> Optional<Predicate> createLastUpdatedPredicate(FhirCriteriaContext<T, R> context,
             DateRangeParam lastUpdated) {
-
         if (context == null || lastUpdated == null) {
             return Optional.empty();
         }
-
-        DateParam lowerBound = lastUpdated.getLowerBound();
-        DateParam upperBound = lastUpdated.getUpperBound();
-
-        if (!hasDateValue(lowerBound) && !hasDateValue(upperBound)) {
-            return Optional.empty();
-        }
-
-        CriteriaBuilder criteriaBuilder = context.getCriteriaBuilder();
         Expression<Date> lastUpdatedExpression = resolveExpression(context, FhirConstants.LAST_UPDATED_PROPERTY,
                 Date.class);
-
-        Predicate lowerPredicate = createLowerDatePredicate(criteriaBuilder, lastUpdatedExpression, lowerBound);
-
-        Predicate upperPredicate = createUpperDatePredicate(criteriaBuilder, lastUpdatedExpression, upperBound);
-
-        if (lowerPredicate == null && upperPredicate == null) {
+        List<Predicate> bounds = DateParamBounds.predicates(context.getCriteriaBuilder(), lastUpdatedExpression,
+                lastUpdated);
+        if (bounds.isEmpty()) {
             return Optional.empty();
         }
-
-        if (lowerPredicate == null) {
-            return Optional.of(upperPredicate);
-        }
-
-        if (upperPredicate == null) {
-            return Optional.of(lowerPredicate);
-        }
-
-        return Optional.of(criteriaBuilder.and(lowerPredicate, upperPredicate));
+        return Optional.of(context.getCriteriaBuilder().and(bounds.toArray(new Predicate[0])));
     }
 
-    /**
-     * Creates a lower bound date predicate.
-     */
     protected Predicate createLowerDatePredicate(CriteriaBuilder criteriaBuilder, Expression<Date> expression,
             DateParam parameter) {
 

--- a/src/main/java/org/openelisglobal/common/fhir/dao/DateParamBounds.java
+++ b/src/main/java/org/openelisglobal/common/fhir/dao/DateParamBounds.java
@@ -1,0 +1,121 @@
+package org.openelisglobal.common.fhir.dao;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.rest.param.DateParam;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ParamPrefixEnum;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Turns a FHIR date parameter into Criteria bounds over a timestamp column.
+ *
+ * <p>
+ * OpenELIS stores dates as local timestamps, so a day-precision search value
+ * spans that calendar day in the server's zone rather than in GMT. Prefixes
+ * keep FHIR semantics: {@code gt} starts after the period, {@code lt} ends
+ * before it, and {@code eq}/{@code ge}/{@code le} include it. The same rules
+ * back {@code _lastUpdated} on every resource and the in-memory Location search
+ * through {@link #contains(DateRangeParam, Date)}.
+ */
+public final class DateParamBounds {
+
+    private DateParamBounds() {
+    }
+
+    public static List<Predicate> predicates(CriteriaBuilder criteriaBuilder, Expression<Date> column,
+            DateRangeParam range) {
+
+        List<Predicate> predicates = new ArrayList<>();
+        if (range == null) {
+            return predicates;
+        }
+
+        DateParam lower = range.getLowerBound();
+        if (lower != null && lower.getValue() != null) {
+            Date[] period = period(lower);
+            boolean exclusive = lower.getPrefix() == ParamPrefixEnum.GREATERTHAN;
+            predicates.add(criteriaBuilder.greaterThanOrEqualTo(column, timestamp(exclusive ? period[1] : period[0])));
+        }
+
+        DateParam upper = range.getUpperBound();
+        if (upper != null && upper.getValue() != null) {
+            Date[] period = period(upper);
+            boolean exclusive = upper.getPrefix() == ParamPrefixEnum.LESSTHAN;
+            predicates.add(criteriaBuilder.lessThan(column, timestamp(exclusive ? period[0] : period[1])));
+        }
+        return predicates;
+    }
+
+    /**
+     * Whether {@code value} falls inside the range, with the same period rules as
+     * the predicates.
+     */
+    public static boolean contains(DateRangeParam range, Date value) {
+        if (range == null) {
+            return true;
+        }
+        if (value == null) {
+            return range.getLowerBound() == null && range.getUpperBound() == null;
+        }
+        DateParam lower = range.getLowerBound();
+        if (lower != null && lower.getValue() != null) {
+            Date[] period = period(lower);
+            Date from = lower.getPrefix() == ParamPrefixEnum.GREATERTHAN ? period[1] : period[0];
+            if (value.before(from)) {
+                return false;
+            }
+        }
+        DateParam upper = range.getUpperBound();
+        if (upper != null && upper.getValue() != null) {
+            Date[] period = period(upper);
+            Date to = upper.getPrefix() == ParamPrefixEnum.LESSTHAN ? period[0] : period[1];
+            if (!value.before(to)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static java.sql.Timestamp timestamp(Date date) {
+        return new java.sql.Timestamp(date.getTime());
+    }
+
+    /** [start inclusive, end exclusive] of the period the parameter names. */
+    private static Date[] period(DateParam parameter) {
+
+        Date value = parameter.getValue();
+        TemporalPrecisionEnum precision = parameter.getPrecision();
+        if (precision == null || precision.ordinal() > TemporalPrecisionEnum.DAY.ordinal()) {
+            return new Date[] { value, new Date(value.getTime() + 1) };
+        }
+
+        Calendar start = Calendar.getInstance();
+        start.setTime(value);
+        start.set(Calendar.HOUR_OF_DAY, 0);
+        start.set(Calendar.MINUTE, 0);
+        start.set(Calendar.SECOND, 0);
+        start.set(Calendar.MILLISECOND, 0);
+        if (precision == TemporalPrecisionEnum.MONTH || precision == TemporalPrecisionEnum.YEAR) {
+            start.set(Calendar.DAY_OF_MONTH, 1);
+        }
+        if (precision == TemporalPrecisionEnum.YEAR) {
+            start.set(Calendar.MONTH, Calendar.JANUARY);
+        }
+
+        Calendar end = (Calendar) start.clone();
+        if (precision == TemporalPrecisionEnum.YEAR) {
+            end.add(Calendar.YEAR, 1);
+        } else if (precision == TemporalPrecisionEnum.MONTH) {
+            end.add(Calendar.MONTH, 1);
+        } else {
+            end.add(Calendar.DAY_OF_MONTH, 1);
+        }
+        return new Date[] { start.getTime(), end.getTime() };
+    }
+}

--- a/src/main/java/org/openelisglobal/common/hibernateConverter/StringListConverter.java
+++ b/src/main/java/org/openelisglobal/common/hibernateConverter/StringListConverter.java
@@ -10,11 +10,11 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
 
     @Override
     public String convertToDatabaseColumn(List<String> stringList) {
-        return stringList != null ? String.join(SPLIT_CHAR, stringList) : "";
+        return stringList == null || stringList.isEmpty() ? null : String.join(SPLIT_CHAR, stringList);
     }
 
     @Override
     public List<String> convertToEntityAttribute(String string) {
-        return string != null ? Arrays.asList(string.split(SPLIT_CHAR)) : Collections.emptyList();
+        return string == null || string.isBlank() ? Collections.emptyList() : Arrays.asList(string.split(SPLIT_CHAR));
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/FhirConstants.java
+++ b/src/main/java/org/openelisglobal/fhir/FhirConstants.java
@@ -87,4 +87,37 @@ public final class FhirConstants {
     public static final String ANALYSIS_PATIENT_HANDLER = ANALYSIS + "." + PATIENT;
     public static final String SERVICE_REQUEST_REQUESTER_REV_INCLUDE = "ServiceRequest:" + ServiceRequest.SP_REQUESTER;
 
+    public static final String SERVICE_REQUEST_PATIENT_REV_INCLUDE = "ServiceRequest:" + ServiceRequest.SP_PATIENT;
+    public static final String SERVICE_REQUEST_SUBJECT_REV_INCLUDE = "ServiceRequest:" + ServiceRequest.SP_SUBJECT;
+    public static final String SPECIMEN_PATIENT_REV_INCLUDE = "Specimen:patient";
+    public static final String SPECIMEN_SUBJECT_REV_INCLUDE = "Specimen:subject";
+    public static final String OBSERVATION_PATIENT_REV_INCLUDE = "Observation:patient";
+    public static final String OBSERVATION_SUBJECT_REV_INCLUDE = "Observation:subject";
+    public static final String DIAGNOSTIC_REPORT_PATIENT_REV_INCLUDE = "DiagnosticReport:patient";
+    public static final String DIAGNOSTIC_REPORT_SUBJECT_REV_INCLUDE = "DiagnosticReport:subject";
+    public static final String ORGANIZATION_PARTOF_INCLUDE = "Organization:partof";
+    public static final String SPECIMEN_PATIENT_INCLUDE = "Specimen:patient";
+    public static final String SPECIMEN_SUBJECT_INCLUDE = "Specimen:subject";
+    public static final String SERVICE_REQUEST_SPECIMEN_REV_INCLUDE = "ServiceRequest:specimen";
+    public static final String OBSERVATION_SPECIMEN_REV_INCLUDE = "Observation:specimen";
+    public static final String SERVICE_REQUEST_PATIENT_INCLUDE = "ServiceRequest:patient";
+    public static final String SERVICE_REQUEST_SUBJECT_INCLUDE = "ServiceRequest:subject";
+    public static final String SERVICE_REQUEST_REQUESTER_INCLUDE = "ServiceRequest:requester";
+    public static final String SERVICE_REQUEST_SPECIMEN_INCLUDE = "ServiceRequest:specimen";
+    public static final String OBSERVATION_BASED_ON_REV_INCLUDE = "Observation:based-on";
+    public static final String DIAGNOSTIC_REPORT_BASED_ON_REV_INCLUDE = "DiagnosticReport:based-on";
+    public static final String OBSERVATION_PATIENT_INCLUDE = "Observation:patient";
+    public static final String OBSERVATION_SUBJECT_INCLUDE = "Observation:subject";
+    public static final String OBSERVATION_BASED_ON_INCLUDE = "Observation:based-on";
+    public static final String OBSERVATION_SPECIMEN_INCLUDE = "Observation:specimen";
+    public static final String OBSERVATION_PERFORMER_INCLUDE = "Observation:performer";
+    public static final String DIAGNOSTIC_REPORT_RESULT_REV_INCLUDE = "DiagnosticReport:result";
+    public static final String DIAGNOSTIC_REPORT_PATIENT_INCLUDE = "DiagnosticReport:patient";
+    public static final String DIAGNOSTIC_REPORT_SUBJECT_INCLUDE = "DiagnosticReport:subject";
+    public static final String DIAGNOSTIC_REPORT_BASED_ON_INCLUDE = "DiagnosticReport:based-on";
+    public static final String DIAGNOSTIC_REPORT_RESULT_INCLUDE = "DiagnosticReport:result";
+    public static final String DIAGNOSTIC_REPORT_SPECIMEN_INCLUDE = "DiagnosticReport:specimen";
+    public static final String LOCATION_PARTOF_INCLUDE = "Location:partof";
+    public static final String OBSERVATION_PERFORMER_REV_INCLUDE = "Observation:performer";
+    public static final String DIAGNOSTIC_REPORT_SPECIMEN_REV_INCLUDE = "DiagnosticReport:specimen";
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/DeviceProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/DeviceProvider.java
@@ -1,16 +1,19 @@
 package org.openelisglobal.fhir.providers;
 
-import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
-import ca.uhn.fhir.rest.annotation.IncludeParam;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
@@ -18,22 +21,18 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.analyzer.service.AnalyzerService;
 import org.openelisglobal.analyzer.valueholder.Analyzer;
 import org.openelisglobal.common.log.LogEvent;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.searchparams.DeviceSearchParams;
+import org.openelisglobal.search.service.DeviceSearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -42,8 +41,8 @@ import org.springframework.stereotype.Component;
  *
  * <p>
  * Read and write operations hit the OpenELIS database directly; the result is
- * mirrored to the FHIR store on a best-effort basis. Search still forwards to
- * the FHIR store.
+ * mirrored to the FHIR store on a best-effort basis; search is answered from
+ * the analyzer table.
  *
  * <p>
  * Supported operations:
@@ -59,7 +58,7 @@ import org.springframework.stereotype.Component;
 public class DeviceProvider implements IResourceProvider {
 
     @Autowired
-    private FhirUtil util;
+    private DeviceSearchService deviceSearchService;
 
     @Autowired
     private FhirTransformService fhirTransformService;
@@ -94,6 +93,9 @@ public class DeviceProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Device", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method, e.getMessage());
             throw new InternalErrorException("Unexpected error reading Device", e);
         }
@@ -147,6 +149,9 @@ public class DeviceProvider implements IResourceProvider {
         } catch (UnprocessableEntityException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Device", e);
+            }
             LogEvent.logError(getClass().getSimpleName(), method, e.getMessage());
             throw new InternalErrorException("Unexpected error creating Device", e);
         }
@@ -201,6 +206,9 @@ public class DeviceProvider implements IResourceProvider {
         } catch (UnprocessableEntityException | InvalidRequestException | ResourceNotFoundException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Device", e);
+            }
             LogEvent.logError(getClass().getSimpleName(), method, e.getMessage());
             throw new InternalErrorException("Unexpected error updating Device", e);
         }
@@ -239,37 +247,39 @@ public class DeviceProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Device", e);
+            }
             LogEvent.logError(getClass().getSimpleName(), method, e.getMessage());
             throw new InternalErrorException("Unexpected error deleting Device", e);
         }
     }
 
     @Search
-    public Bundle searchDeviceBundle(@OptionalParam(name = Device.SP_IDENTIFIER) TokenAndListParam identifier,
-            @OptionalParam(name = Device.SP_DEVICE_NAME) TokenAndListParam deviceName,
+    public IBundleProvider searchDevices(@OptionalParam(name = Device.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = Device.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = Device.SP_DEVICE_NAME) StringAndListParam deviceName,
             @OptionalParam(name = Device.SP_TYPE) TokenAndListParam type,
-            @IncludeParam(reverse = true, allow = { "Encounter:" + Encounter.SP_PARTICIPANT,
-                    "ServiceRequest:" + ServiceRequest.SP_REQUESTER }) HashSet<Include> revIncludes,
+            @OptionalParam(name = Device.SP_STATUS) TokenAndListParam status,
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
             HttpServletRequest request) {
 
-        String method = "searchDeviceBundle";
+        String method = "searchDevices";
+        LogEvent.logDebug(getClass().getSimpleName(), method, "Searching for Devices");
 
         try {
-            Bundle bundle = util.forwardSearchToFhirStore(request);
-
-            if (bundle == null) {
-                bundle = new Bundle();
-            }
-            if (bundle.getType() == null) {
-                bundle.setType(Bundle.BundleType.SEARCHSET);
-            }
-            if (bundle.getEntry() == null) {
-                bundle.setEntry(new ArrayList<>());
-            }
-
-            return bundle;
-
+            DeviceSearchParams params = new DeviceSearchParams(id, identifier, deviceName, type, status, lastUpdated,
+                    sort);
+            return deviceSearchService.searchDevices(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(getClass().getSimpleName(), method, "Invalid Device search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Device search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Device", e);
+            }
             LogEvent.logError(getClass().getSimpleName(), method, e.getMessage());
             throw new InternalErrorException("Error searching Device", e);
         }

--- a/src/main/java/org/openelisglobal/fhir/providers/DiagnosticReportProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/DiagnosticReportProvider.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
@@ -18,23 +19,22 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DiagnosticReport;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.Patient;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.IStatusService;
 import org.openelisglobal.common.services.StatusService.AnalysisStatus;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.DiagnosticReportSearchParams;
+import org.openelisglobal.search.service.DiagnosticReportSearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +52,8 @@ import org.springframework.stereotype.Component;
  * Supported operations:
  * <ul>
  * <li>READ: GET /fhir/DiagnosticReport/{uuid}</li>
- * <li>SEARCH: GET /fhir/DiagnosticReport?patient={uuid}&amp;...</li>
+ * <li>SEARCH: GET /fhir/DiagnosticReport?patient={uuid}&amp;... (answered from
+ * the OpenELIS database)</li>
  * <li>DELETE: DELETE /fhir/DiagnosticReport/{uuid} (cancels the Analysis)</li>
  * </ul>
  */
@@ -69,7 +70,7 @@ public class DiagnosticReportProvider implements IResourceProvider {
     private IStatusService statusService;
 
     @Autowired
-    private FhirUtil util;
+    private DiagnosticReportSearchService diagnosticReportSearchService;
 
     @Override
     public Class<? extends IBaseResource> getResourceType() {
@@ -109,6 +110,9 @@ public class DiagnosticReportProvider implements IResourceProvider {
                     "FHIR transformation error while reading DiagnosticReport: " + e.getMessage());
             throw new InternalErrorException("FHIR transformation failed for DiagnosticReport", e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("DiagnosticReport", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while reading DiagnosticReport: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while reading DiagnosticReport", e);
@@ -155,6 +159,9 @@ public class DiagnosticReportProvider implements IResourceProvider {
         } catch (IllegalArgumentException e) {
             throw new InvalidRequestException("DiagnosticReport ID must be a valid UUID");
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("DiagnosticReport", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unhandled exception: " + FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
@@ -163,39 +170,42 @@ public class DiagnosticReportProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle searchDiagnosticReports(
-            @OptionalParam(name = DiagnosticReport.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_GIVEN, Patient.SP_FAMILY,
-                    Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
-            @OptionalParam(name = DiagnosticReport.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_NAME, Patient.SP_GIVEN, Patient.SP_FAMILY }) ReferenceAndListParam subjectReference,
-            @OptionalParam(name = DiagnosticReport.SP_ISSUED) DateRangeParam issueDate,
-            @OptionalParam(name = DiagnosticReport.SP_CODE) TokenAndListParam code,
-            @OptionalParam(name = DiagnosticReport.SP_RESULT) ReferenceAndListParam result,
+    public IBundleProvider searchDiagnosticReports(
             @OptionalParam(name = DiagnosticReport.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = DiagnosticReport.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = DiagnosticReport.SP_PATIENT) ReferenceAndListParam patient,
+            @OptionalParam(name = DiagnosticReport.SP_SUBJECT) ReferenceAndListParam subject,
+            @OptionalParam(name = DiagnosticReport.SP_BASED_ON) ReferenceAndListParam basedOn,
+            @OptionalParam(name = DiagnosticReport.SP_RESULT) ReferenceAndListParam result,
+            @OptionalParam(name = DiagnosticReport.SP_SPECIMEN) ReferenceAndListParam specimen,
+            @OptionalParam(name = DiagnosticReport.SP_CODE) TokenAndListParam code,
+            @OptionalParam(name = DiagnosticReport.SP_STATUS) TokenAndListParam status,
+            @OptionalParam(name = DiagnosticReport.SP_ISSUED) DateRangeParam issued,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
-            @IncludeParam(allow = { "DiagnosticReport:" + DiagnosticReport.SP_ENCOUNTER,
-                    "DiagnosticReport:" + DiagnosticReport.SP_PATIENT,
-                    "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> includes,
+            @IncludeParam(allow = { FhirConstants.DIAGNOSTIC_REPORT_PATIENT_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_SUBJECT_INCLUDE, FhirConstants.DIAGNOSTIC_REPORT_BASED_ON_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_RESULT_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_SPECIMEN_INCLUDE }) HashSet<Include> includes,
             HttpServletRequest request) {
+
         String method = "searchDiagnosticReports";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method, "Searching for DiagnosticReports");
+
         try {
-            Bundle resultBundle = util.forwardSearchToFhirStore(request);
-
-            if (resultBundle == null) {
-                resultBundle = new Bundle();
-            }
-
-            if (resultBundle.getType() == null) {
-                resultBundle.setType(Bundle.BundleType.SEARCHSET);
-            }
-
-            if (resultBundle.getEntry() == null) {
-                resultBundle.setEntry(new ArrayList<>());
-            }
-
-            return resultBundle;
+            DiagnosticReportSearchParams params = new DiagnosticReportSearchParams(id, identifier,
+                    FhirProviderUtils.merge(patient, subject), basedOn, result, specimen, code, status, issued,
+                    lastUpdated, sort, includes);
+            return diagnosticReportSearchService.searchDiagnosticReports(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Invalid DiagnosticReport search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid DiagnosticReport search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("DiagnosticReport", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Error searching DiagnosticReports: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error searching DiagnosticReports", e);

--- a/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
@@ -2,6 +2,7 @@ package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.StringOrListParam;
 import ca.uhn.fhir.rest.param.StringParam;
@@ -9,6 +10,7 @@ import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenOrListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -288,5 +290,78 @@ public final class FhirProviderUtils {
     public static boolean hasValue(TokenAndListParam parameter) {
 
         return !tokenParameterGroups(parameter).isEmpty();
+    }
+
+    /**
+     * Folds two spellings of the same reference search parameter (for example
+     * {@code patient} and {@code subject}) into one AND list.
+     */
+    public static ReferenceAndListParam merge(ReferenceAndListParam first, ReferenceAndListParam second) {
+
+        if (first == null) {
+            return second;
+        }
+        if (second == null) {
+            return first;
+        }
+        ReferenceAndListParam merged = new ReferenceAndListParam();
+        first.getValuesAsQueryTokens().forEach(merged::addAnd);
+        second.getValuesAsQueryTokens().forEach(merged::addAnd);
+        return merged;
+    }
+
+    /**
+     * True when the failure is the caller's data rather than a server fault: a
+     * bean-validation violation, a database constraint or column-length rejection,
+     * or an SQL data/integrity error anywhere in the cause chain.
+     */
+    public static boolean isDataError(Throwable e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof jakarta.validation.ConstraintViolationException
+                    || current instanceof org.hibernate.exception.DataException
+                    || current instanceof org.hibernate.exception.ConstraintViolationException
+                    || current instanceof org.springframework.dao.DataIntegrityViolationException) {
+                return true;
+            }
+            if (current instanceof java.sql.SQLException sqlException) {
+                String state = sqlException.getSQLState();
+                if (state != null && (state.startsWith("22") || state.startsWith("23"))) {
+                    return true;
+                }
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    /**
+     * Maps a data error (see {@link #isDataError(Throwable)}) to a 422 whose
+     * diagnostics name the rejected field or constraint instead of a bare 500.
+     */
+    public static UnprocessableEntityException unprocessableData(String resourceType, Throwable e) {
+        Throwable current = e;
+        String reason = null;
+        while (current != null) {
+            if (current instanceof jakarta.validation.ConstraintViolationException violation) {
+                reason = violation.getConstraintViolations().stream()
+                        .map(v -> v.getPropertyPath() + " " + v.getMessage()).sorted()
+                        .collect(java.util.stream.Collectors.joining("; "));
+                break;
+            }
+            if (current instanceof java.sql.SQLException || current.getCause() == null
+                    || current.getCause() == current) {
+                reason = current.getMessage();
+                break;
+            }
+            current = current.getCause();
+        }
+        if (reason == null || reason.isBlank()) {
+            reason = e.getClass().getSimpleName();
+        }
+        return new UnprocessableEntityException(resourceType + " could not be stored: " + reason.trim());
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/LocationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/LocationProvider.java
@@ -1,18 +1,23 @@
 package org.openelisglobal.fhir.providers;
 
+import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.IncludeParam;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
-import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
@@ -21,12 +26,12 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Location;
@@ -34,7 +39,9 @@ import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.common.valueholder.BaseObject;
-import org.openelisglobal.dataexchange.fhir.FhirUtil;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.LocationSearchParams;
+import org.openelisglobal.search.service.LocationSearchService;
 import org.openelisglobal.storage.fhir.StorageLocationFhirTransform;
 import org.openelisglobal.storage.service.StorageBoxService;
 import org.openelisglobal.storage.service.StorageDeviceService;
@@ -58,9 +65,8 @@ import org.springframework.stereotype.Component;
  * Every level shares one id space, so a Location id is resolved by trying each
  * level in turn. The storage level of an inbound resource is read from the
  * {@code storage-hierarchy} tag, falling back to {@code physicalType.text}.
- * Read and write operations use the OpenELIS database; the result is mirrored
- * to the FHIR store on a best-effort basis. Search still forwards to the FHIR
- * store.
+ * Read, write and search operations use the OpenELIS database; the result of a
+ * write is mirrored to the FHIR store on a best-effort basis.
  *
  * <p>
  * Supported operations:
@@ -104,7 +110,7 @@ public class LocationProvider implements IResourceProvider {
     private StorageLocationService locationService;
 
     @Autowired
-    private FhirUtil util;
+    private LocationSearchService locationSearchService;
 
     private final List<StorageLevel<?>> levels = new ArrayList<>();
 
@@ -181,6 +187,9 @@ public class LocationProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Location", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while reading Location: " + FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException("Unexpected server error while reading Location", e);
@@ -205,6 +214,9 @@ public class LocationProvider implements IResourceProvider {
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Location", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
                     "Unexpected server error while creating Location: " + FhirProviderUtils.safeMessage(e), e);
@@ -233,6 +245,9 @@ public class LocationProvider implements IResourceProvider {
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Location", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
                     "Unexpected server error while updating Location: " + FhirProviderUtils.safeMessage(e), e);
@@ -265,6 +280,9 @@ public class LocationProvider implements IResourceProvider {
                     "Internal error: " + FhirProviderUtils.safeMessage(e));
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Location", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unhandled exception: " + FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
@@ -273,33 +291,35 @@ public class LocationProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle searchLocationBundle(@OptionalParam(name = Location.SP_IDENTIFIER) TokenAndListParam identifier,
+    public IBundleProvider searchLocations(@OptionalParam(name = Location.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = Location.SP_IDENTIFIER) TokenAndListParam identifier,
             @OptionalParam(name = Location.SP_NAME) StringAndListParam name,
-            @OptionalParam(name = Location.SP_STATUS) TokenParam status,
+            @OptionalParam(name = Location.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = Location.SP_PARTOF) ReferenceAndListParam partOf,
-            @OptionalParam(name = Location.SP_ORGANIZATION) ReferenceAndListParam organization,
-            @OptionalParam(name = "physical-type") TokenAndListParam physicalType,
-            @OptionalParam(name = Location.SP_TYPE) TokenAndListParam type,
-            @OptionalParam(name = "_tag") TokenAndListParam tag, HttpServletRequest request) {
+            @OptionalParam(name = "_tag") TokenAndListParam tag,
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @IncludeParam(allow = { FhirConstants.LOCATION_PARTOF_INCLUDE }) HashSet<Include> includes,
+            @IncludeParam(reverse = true, allow = {
+                    FhirConstants.LOCATION_PARTOF_INCLUDE }) HashSet<Include> revIncludes,
+            HttpServletRequest request) {
 
-        final String methodName = "searchLocationBundle";
+        final String methodName = "searchLocations";
+        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Locations");
 
         try {
-            Bundle bundle = util.forwardSearchToFhirStore(request);
-
-            if (bundle == null) {
-                bundle = new Bundle();
-            }
-            if (bundle.getType() == null) {
-                bundle.setType(Bundle.BundleType.SEARCHSET);
-            }
-            if (bundle.getEntry() == null) {
-                bundle.setEntry(new ArrayList<>());
-            }
-
-            return bundle;
-
+            LocationSearchParams params = new LocationSearchParams(id, identifier, name, status, partOf, tag,
+                    lastUpdated, sort, includes, revIncludes);
+            return locationSearchService.searchLocations(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(this.getClass().getSimpleName(), methodName,
+                    "Invalid Location search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Location search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Location", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), methodName,
                     "Error searching Locations: " + FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException("Unexpected server error while searching Locations", e);

--- a/src/main/java/org/openelisglobal/fhir/providers/ObservationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/ObservationProvider.java
@@ -13,15 +13,15 @@ import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.param.QuantityAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
-import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
@@ -29,13 +29,10 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.DiagnosticReport;
-import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.Patient;
+import org.openelisglobal.common.exception.LIMSDuplicateRecordException;
 import org.openelisglobal.common.formfields.FormFields;
 import org.openelisglobal.common.formfields.FormFields.Field;
 import org.openelisglobal.common.log.LogEvent;
@@ -48,6 +45,8 @@ import org.openelisglobal.common.util.ConfigurationProperties.Property;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.dictionary.service.DictionaryService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.ObservationSearchParams;
 import org.openelisglobal.provider.service.ProviderService;
 import org.openelisglobal.provider.valueholder.Provider;
 import org.openelisglobal.result.action.util.ResultSet;
@@ -60,6 +59,7 @@ import org.openelisglobal.sample.valueholder.Sample;
 import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.samplehuman.valueholder.SampleHuman;
 import org.openelisglobal.sampleitem.service.SampleItemService;
+import org.openelisglobal.search.service.ObservationSearchService;
 import org.openelisglobal.test.beanItems.TestResultItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -71,9 +71,8 @@ import org.springframework.validation.ObjectError;
  *
  * <p>
  * Exposes lab results from OpenELIS directly via the native FHIR facade. Read
- * and Write operations query OpenELIS DB directly for consistency with the
- * source of truth. Search forwards to the HAPI FHIR store to support the full
- * FHIR search parameter set.
+ * Write and Search operations query the OpenELIS DB directly for consistency
+ * with the source of truth.
  *
  * <p>
  * Note: {@code @Create} is not yet supported because creating an Observation
@@ -118,6 +117,9 @@ public class ObservationProvider implements IResourceProvider {
     @Autowired
     private FhirUtil util;
 
+    @Autowired
+    private ObservationSearchService observationSearchService;
+
     @Override
     public Class<Observation> getResourceType() {
         return Observation.class;
@@ -147,6 +149,9 @@ public class ObservationProvider implements IResourceProvider {
         } catch (ResourceNotFoundException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Observation", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error reading observation: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error retrieving Observation");
@@ -203,6 +208,9 @@ public class ObservationProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Observation", e);
+            }
 
             LogEvent.logError(e);
 
@@ -302,6 +310,9 @@ public class ObservationProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Observation", e);
+            }
 
             LogEvent.logError(getClass().getSimpleName(), method, "Unexpected error during Observation update");
 
@@ -351,7 +362,14 @@ public class ObservationProvider implements IResourceProvider {
 
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
+        } catch (LIMSDuplicateRecordException e) {
+            LogEvent.logWarn(this.getClass().getSimpleName(), method, "Duplicate rejection note: " + e.getMessage());
+            throw new ResourceVersionConflictException(
+                    "Observation cannot be deleted: its analysis already carries an identical rejection note");
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Observation", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error deleting observation: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error deleting Observation", e);
@@ -359,50 +377,42 @@ public class ObservationProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle search(
-            @OptionalParam(name = Observation.SP_ENCOUNTER, chainWhitelist = { "",
-                    Encounter.SP_TYPE }, targetTypes = Encounter.class) ReferenceAndListParam encounterReference,
-            @OptionalParam(name = Observation.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_GIVEN, Patient.SP_FAMILY,
-                    Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
-            @OptionalParam(name = Observation.SP_HAS_MEMBER, chainWhitelist = { "",
-                    Observation.SP_CODE }, targetTypes = Observation.class) ReferenceAndListParam hasMemberReference,
-            @OptionalParam(name = Observation.SP_VALUE_CONCEPT) TokenAndListParam valueConcept,
-            @OptionalParam(name = Observation.SP_VALUE_DATE) DateRangeParam valueDateParam,
-            @OptionalParam(name = Observation.SP_VALUE_QUANTITY) QuantityAndListParam valueQuantityParam,
-            @OptionalParam(name = Observation.SP_VALUE_STRING) StringAndListParam valueStringParam,
-            @OptionalParam(name = Observation.SP_DATE) DateRangeParam date,
+    public IBundleProvider searchObservations(@OptionalParam(name = Observation.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = Observation.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = Observation.SP_PATIENT) ReferenceAndListParam patient,
+            @OptionalParam(name = Observation.SP_SUBJECT) ReferenceAndListParam subject,
+            @OptionalParam(name = Observation.SP_BASED_ON) ReferenceAndListParam basedOn,
+            @OptionalParam(name = Observation.SP_SPECIMEN) ReferenceAndListParam specimen,
             @OptionalParam(name = Observation.SP_CODE) TokenAndListParam code,
-            @OptionalParam(name = Observation.SP_CATEGORY) TokenAndListParam category,
-            @OptionalParam(name = Observation.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = Observation.SP_STATUS) TokenAndListParam status,
+            @OptionalParam(name = Observation.SP_DATE) DateRangeParam date,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
-            @OptionalParam(name = Observation.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_GIVEN, Patient.SP_FAMILY,
-                    Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam,
-            @IncludeParam(allow = { "Observation:" + Observation.SP_ENCOUNTER, "Observation:" + Observation.SP_PATIENT,
-                    "Observation:" + Observation.SP_HAS_MEMBER }) HashSet<Include> includes,
-            @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_HAS_MEMBER,
-                    "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> revIncludes,
+            @IncludeParam(allow = { FhirConstants.OBSERVATION_PATIENT_INCLUDE,
+                    FhirConstants.OBSERVATION_SUBJECT_INCLUDE, FhirConstants.OBSERVATION_BASED_ON_INCLUDE,
+                    FhirConstants.OBSERVATION_SPECIMEN_INCLUDE,
+                    FhirConstants.OBSERVATION_PERFORMER_INCLUDE }) HashSet<Include> includes,
+            @IncludeParam(reverse = true, allow = {
+                    FhirConstants.DIAGNOSTIC_REPORT_RESULT_REV_INCLUDE }) HashSet<Include> revIncludes,
             HttpServletRequest request) {
-        String method = "search";
+
+        String method = "searchObservations";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method, "Searching for Observations");
+
         try {
-
-            Bundle resultBundle = util.forwardSearchToFhirStore(request);
-
-            if (resultBundle == null) {
-                resultBundle = new Bundle();
-            }
-
-            if (resultBundle.getType() == null) {
-                resultBundle.setType(Bundle.BundleType.SEARCHSET);
-            }
-
-            if (resultBundle.getEntry() == null) {
-                resultBundle.setEntry(new ArrayList<>());
-            }
-
-            return resultBundle;
+            ObservationSearchParams params = new ObservationSearchParams(id, identifier,
+                    FhirProviderUtils.merge(patient, subject), basedOn, specimen, code, status, date, lastUpdated, sort,
+                    includes, revIncludes);
+            return observationSearchService.searchObservations(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Invalid Observation search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Observation search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Observation", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Error searching Observations: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error searching Observations");

--- a/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
@@ -1,36 +1,43 @@
 package org.openelisglobal.fhir.providers;
 
+import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.IncludeParam;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
-import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashSet;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Organization;
-import org.hl7.fhir.r4.model.Practitioner;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.OrganizationSearchParams;
 import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.search.service.OrganizationSearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -48,6 +55,9 @@ public class OrganizationProvider implements IResourceProvider {
 
     @Autowired
     private FhirUtil util;
+
+    @Autowired
+    private OrganizationSearchService organizationSearchService;
 
     @Autowired
     private FhirTransformService fhirTransformService;
@@ -78,6 +88,9 @@ public class OrganizationProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Organization", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while Reading Organization: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while Reading Organization", e);
@@ -105,6 +118,7 @@ public class OrganizationProvider implements IResourceProvider {
 
             org.openelisglobal.organization.valueholder.Organization organization = fhirTransformService
                     .transformToOrganization(fhirOrganization);
+            organization.setOrganization(resolveParent(fhirOrganization));
 
             org.openelisglobal.organization.valueholder.Organization savedOrganization = organizationService
                     .save(organization);
@@ -125,12 +139,40 @@ public class OrganizationProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Organization", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while creating Organization: " + e.getMessage());
 
             throw new InternalErrorException("Unexpected server error while creating Organization", e);
         }
+    }
+
+    /**
+     * Resolves {@code partOf} to the parent OpenELIS organization, or null when the
+     * resource has none. An unknown or malformed parent reference is a 422.
+     */
+    private org.openelisglobal.organization.valueholder.Organization resolveParent(Organization fhirOrganization) {
+        if (!fhirOrganization.hasPartOf() || !fhirOrganization.getPartOf().hasReference()) {
+            return null;
+        }
+        String parentId = fhirOrganization.getPartOf().getReferenceElement().getIdPart();
+        if (parentId == null || parentId.isBlank()) {
+            throw new UnprocessableEntityException("Organization.partOf must reference a parent Organization");
+        }
+        org.openelisglobal.organization.valueholder.Organization parent = null;
+        try {
+            UUID.fromString(parentId);
+            parent = organizationService.getOrganizationByFhirId(parentId);
+        } catch (IllegalArgumentException e) {
+            parent = organizationService.get(parentId);
+        }
+        if (parent == null) {
+            throw new UnprocessableEntityException("Parent Organization not found for partOf reference: " + parentId);
+        }
+        return parent;
     }
 
     @Update
@@ -157,6 +199,7 @@ public class OrganizationProvider implements IResourceProvider {
                     .transformToOrganization(fhirOrganization);
             existingOrg.setOrganizationName(incomingOrg.getOrganizationName());
             existingOrg.setIsActive(incomingOrg.getIsActive());
+            existingOrg.setOrganization(resolveParent(fhirOrganization));
             existingOrg.setSysUserId(FhirProviderUtils.getSysUserId(request));
             org.openelisglobal.organization.valueholder.Organization updatedOrg = organizationService.save(existingOrg);
             if (updatedOrg == null) {
@@ -176,6 +219,9 @@ public class OrganizationProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Organization", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while updating Organization: " + e.getMessage());
@@ -221,6 +267,9 @@ public class OrganizationProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Organization", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Organization: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while deleting Organization", e);
@@ -228,33 +277,40 @@ public class OrganizationProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle searchPractitionerBundle(
+    public IBundleProvider searchOrganizations(@OptionalParam(name = Organization.SP_RES_ID) TokenAndListParam id,
             @OptionalParam(name = Organization.SP_IDENTIFIER) TokenAndListParam identifier,
-            @OptionalParam(name = Organization.SP_NAME) StringParam name,
-            @OptionalParam(name = Organization.SP_ACTIVE) TokenParam active,
+            @OptionalParam(name = Organization.SP_NAME) StringAndListParam name,
+            @OptionalParam(name = Organization.SP_ACTIVE) TokenAndListParam active,
             @OptionalParam(name = Organization.SP_TYPE) TokenAndListParam type,
-            @OptionalParam(name = Organization.SP_ADDRESS) StringParam address,
-            @OptionalParam(name = Organization.SP_ADDRESS_CITY) StringParam addressCity,
-            @OptionalParam(name = Organization.SP_ADDRESS_STATE) StringParam addressState,
-            @OptionalParam(name = Organization.SP_ADDRESS_POSTALCODE) StringParam addressPostalCode,
-            @OptionalParam(name = Organization.SP_ADDRESS_COUNTRY) StringParam addressCountry,
-            @OptionalParam(name = Practitioner.SP_RES_ID) TokenAndListParam id,
-            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, HttpServletRequest request) {
+            @OptionalParam(name = Organization.SP_PARTOF) ReferenceAndListParam partOf,
+            @OptionalParam(name = Organization.SP_ADDRESS_CITY) StringAndListParam addressCity,
+            @OptionalParam(name = Organization.SP_ADDRESS_STATE) StringAndListParam addressState,
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @IncludeParam(allow = { FhirConstants.ORGANIZATION_PARTOF_INCLUDE }) HashSet<Include> includes,
+            @IncludeParam(reverse = true, allow = {
+                    FhirConstants.ORGANIZATION_PARTOF_INCLUDE }) HashSet<Include> revIncludes,
+            HttpServletRequest request) {
 
-        String methodName = "searchPractitionerBundle";
-        LogEvent.logDebug(this.getClass().getSimpleName(), methodName,
-                "Searching for Practitioners (returning Bundle)");
+        String methodName = "searchOrganizations";
+        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Organizations");
 
         try {
-
-            Bundle bundle = util.forwardSearchToFhirStore(request);
-
-            return bundle;
-
-        } catch (Exception e) {
+            OrganizationSearchParams params = new OrganizationSearchParams(id, identifier, name, active, type, partOf,
+                    addressCity, addressState, lastUpdated, sort, includes, revIncludes);
+            return organizationSearchService.searchOrganizations(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
             LogEvent.logError(this.getClass().getSimpleName(), methodName,
-                    "Error searching Practitioners: " + e.getMessage());
-            throw new InternalErrorException("Error searching Practitioners", e);
+                    "Invalid Organization search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Organization search parameter: " + e.getMessage(), e);
+        } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Organization", e);
+            }
+            LogEvent.logError(this.getClass().getSimpleName(), methodName,
+                    "Error searching Organizations: " + e.getMessage());
+            throw new InternalErrorException("Error searching Organizations", e);
         }
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/PatientProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PatientProvider.java
@@ -9,16 +9,21 @@ import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.StringAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceVersionConflictException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.List;
@@ -26,16 +31,15 @@ import java.util.UUID;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.StaleObjectStateException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirPersistanceException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.PatientSearchParams;
 import org.openelisglobal.patient.action.IPatientUpdate.PatientUpdateStatus;
 import org.openelisglobal.patient.action.bean.PatientManagementInfo;
 import org.openelisglobal.patient.service.PatientContactService;
@@ -44,6 +48,7 @@ import org.openelisglobal.patient.util.PatientUtil;
 import org.openelisglobal.patient.validator.ValidatePatientInfo;
 import org.openelisglobal.patient.valueholder.Patient;
 import org.openelisglobal.patient.valueholder.PatientContact;
+import org.openelisglobal.search.service.PatientSearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindException;
@@ -70,6 +75,9 @@ public class PatientProvider implements IResourceProvider {
 
     @Autowired
     private FhirUtil util;
+
+    @Autowired
+    private PatientSearchService patientSearchService;
 
     @Autowired
     private FhirTransformService fhirTransformService;
@@ -104,6 +112,9 @@ public class PatientProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while Reading Patient: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while Reading Patient", e);
@@ -148,8 +159,7 @@ public class PatientProvider implements IResourceProvider {
                     LogEvent.logError(this.getClass().getSimpleName(), method,
                             "Validation error: " + error.getDefaultMessage());
                 }
-                outcome.setOperationOutcome(operationOutcome);
-                return outcome;
+                throw new UnprocessableEntityException("Patient failed validation", operationOutcome);
             }
 
             Patient patient = new Patient();
@@ -198,43 +208,57 @@ public class PatientProvider implements IResourceProvider {
             LogEvent.logInfo(this.getClass().getSimpleName(), method,
                     "Patient creation completed successfully: " + patient.getId());
 
+        } catch (BaseServerResponseException e) {
+            throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Exception during patient creation: " + e.getMessage());
-
-            operationOutcome.addIssue().setSeverity(OperationOutcome.IssueSeverity.ERROR)
-                    .setCode(OperationOutcome.IssueType.EXCEPTION).setDiagnostics(e.getMessage());
-
-            outcome.setOperationOutcome(operationOutcome);
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
+            throw new InternalErrorException("Unexpected server error while creating Patient", e);
         }
 
         return outcome;
     }
 
     @Search
-    public Bundle searchPatientBundle(
+    public IBundleProvider searchPatients(
+            @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_RES_ID) TokenAndListParam id,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_NAME) StringAndListParam name,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_GIVEN) StringAndListParam given,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_FAMILY) StringAndListParam family,
-            @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_NAME) StringAndListParam name,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_BIRTHDATE) DateRangeParam birthdate,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_GENDER) TokenAndListParam gender,
-            @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_RES_ID) TokenAndListParam id,
-            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated,
-            @IncludeParam(reverse = true, allow = { "Encounter:" + Encounter.SP_PATIENT,
-                    "ServiceRequest:" + ServiceRequest.SP_SUBJECT, }) HashSet<Include> revIncludes,
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_PATIENT_REV_INCLUDE,
+                    FhirConstants.SERVICE_REQUEST_SUBJECT_REV_INCLUDE, FhirConstants.SPECIMEN_PATIENT_REV_INCLUDE,
+                    FhirConstants.SPECIMEN_SUBJECT_REV_INCLUDE, FhirConstants.OBSERVATION_PATIENT_REV_INCLUDE,
+                    FhirConstants.OBSERVATION_SUBJECT_REV_INCLUDE, FhirConstants.DIAGNOSTIC_REPORT_PATIENT_REV_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_SUBJECT_REV_INCLUDE }) HashSet<Include> revIncludes,
             HttpServletRequest request) {
 
-        String methodName = "searchPatientBundle";
-        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Patients (returning Bundle)");
+        String methodName = "searchPatients";
+        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Patients");
 
         try {
-
-            Bundle bundle = util.forwardSearchToFhirStore(request);
-
-            return bundle;
-
+            PatientSearchParams params = new PatientSearchParams(id, identifier, name, given, family, birthdate, gender,
+                    lastUpdated, sort, revIncludes);
+            return patientSearchService.searchPatients(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(this.getClass().getSimpleName(), methodName,
+                    "Invalid Patient search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Patient search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), methodName,
                     "Error searching Patients: " + e.getMessage());
             throw new InternalErrorException("Error searching Patients", e);
@@ -344,6 +368,9 @@ public class PatientProvider implements IResourceProvider {
             throw new ResourceVersionConflictException("Patient was modified by another user");
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
             throw new InternalErrorException("Update failed: " + e.getMessage(), e);
         }
     }
@@ -383,6 +410,9 @@ public class PatientProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Patient", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Patient: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while deleting Patient", e);

--- a/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
@@ -28,12 +28,12 @@ import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Practitioner;
-import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.exception.FhirLocalPersistingException;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
 import org.openelisglobal.fhir.search.searchparams.PractitionerSearchParams;
 import org.openelisglobal.person.service.PersonService;
 import org.openelisglobal.person.valueholder.Person;
@@ -85,6 +85,9 @@ public class PractitionerProvider implements IResourceProvider {
         } catch (ResourceNotFoundException | InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Practitioner", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while Reading Practitioner: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while Reading Practitioner", e);
@@ -130,6 +133,9 @@ public class PractitionerProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Practitioner", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while creating Practitioner: " + e.getMessage());
@@ -175,6 +181,9 @@ public class PractitionerProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Practitioner", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while updating Practitioner: " + e.getMessage());
@@ -218,6 +227,9 @@ public class PractitionerProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Practitioner", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Practitioner: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while deleting Practitioner", e);
@@ -255,8 +267,8 @@ public class PractitionerProvider implements IResourceProvider {
 
             @Sort SortSpec sort,
 
-            @IncludeParam(reverse = true, allow = {
-                    "ServiceRequest:" + ServiceRequest.SP_REQUESTER }) HashSet<Include> revIncludes,
+            @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_REQUESTER_REV_INCLUDE,
+                    FhirConstants.OBSERVATION_PERFORMER_REV_INCLUDE }) HashSet<Include> revIncludes,
 
             HttpServletRequest request) {
 

--- a/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
@@ -9,8 +9,11 @@ import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
@@ -27,12 +30,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hibernate.StaleObjectStateException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.ServiceRequest;
-import org.hl7.fhir.r4.model.Specimen;
 import org.openelisglobal.analysis.service.AnalysisService;
 import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.constants.Constants;
@@ -48,6 +48,8 @@ import org.openelisglobal.common.util.DateUtil;
 import org.openelisglobal.common.util.validator.GenericValidator;
 import org.openelisglobal.dataexchange.fhir.FhirUtil;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.ServiceRequestSearchParams;
 import org.openelisglobal.patient.action.IPatientUpdate.PatientUpdateStatus;
 import org.openelisglobal.patient.action.bean.PatientManagementInfo;
 import org.openelisglobal.patient.service.PatientService;
@@ -68,6 +70,7 @@ import org.openelisglobal.samplehuman.service.SampleHumanService;
 import org.openelisglobal.samplehuman.valueholder.SampleHuman;
 import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.search.service.ServiceRequestSearchService;
 import org.openelisglobal.spring.util.SpringContext;
 import org.openelisglobal.systemuser.service.UserService;
 import org.openelisglobal.test.service.TestService;
@@ -104,6 +107,9 @@ public class ServiceRequestProvider implements IResourceProvider {
 
     @Autowired
     private FhirUtil util;
+
+    @Autowired
+    private ServiceRequestSearchService serviceRequestSearchService;
 
     @Autowired
     public SampleEditFormValidator formValidator;
@@ -157,6 +163,9 @@ public class ServiceRequestProvider implements IResourceProvider {
         } catch (IllegalArgumentException e) {
             throw new InvalidRequestException("ServiceRequest ID must be a valid UUID");
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("ServiceRequest", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while Reading ServiceRequest: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error while Reading ServiceRequest", e);
@@ -308,6 +317,9 @@ public class ServiceRequestProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("ServiceRequest", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
                     "Unexpected server error while creating ServiceRequest: " + FhirProviderUtils.safeMessage(e), e);
@@ -466,6 +478,9 @@ public class ServiceRequestProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("ServiceRequest", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method, FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException(
                     "Unexpected server error while updating ServiceRequest: " + FhirProviderUtils.safeMessage(e), e);
@@ -519,6 +534,9 @@ public class ServiceRequestProvider implements IResourceProvider {
                     "Internal error: " + FhirProviderUtils.safeMessage(e));
             throw e;
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("ServiceRequest", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unhandled exception: " + FhirProviderUtils.safeMessage(e));
             throw new InternalErrorException("Unexpected server error while deleting ServiceRequest: " + e.getMessage(),
@@ -527,57 +545,40 @@ public class ServiceRequestProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle searchForServiceRequests(
-            @OptionalParam(name = ServiceRequest.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_GIVEN, Patient.SP_FAMILY,
-                    Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
-
-            @OptionalParam(name = ServiceRequest.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
-                    Patient.SP_GIVEN, Patient.SP_FAMILY,
-                    Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference,
-
+    public IBundleProvider searchServiceRequests(@OptionalParam(name = ServiceRequest.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = ServiceRequest.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = ServiceRequest.SP_PATIENT) ReferenceAndListParam patient,
+            @OptionalParam(name = ServiceRequest.SP_SUBJECT) ReferenceAndListParam subject,
+            @OptionalParam(name = ServiceRequest.SP_REQUESTER) ReferenceAndListParam requester,
+            @OptionalParam(name = ServiceRequest.SP_SPECIMEN) ReferenceAndListParam specimen,
             @OptionalParam(name = ServiceRequest.SP_CODE) TokenAndListParam code,
-
-            @OptionalParam(name = ServiceRequest.SP_REQUESTER, chainWhitelist = { "", Practitioner.SP_IDENTIFIER,
-                    Practitioner.SP_GIVEN, Practitioner.SP_FAMILY,
-                    Practitioner.SP_NAME }, targetTypes = Practitioner.class) ReferenceAndListParam participantReference,
-
-            @OptionalParam(name = ServiceRequest.SP_OCCURRENCE) DateRangeParam occurrence,
-
-            @OptionalParam(name = ServiceRequest.SP_RES_ID) TokenAndListParam uuid,
-
-            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated,
-
-            @OptionalParam(name = ServiceRequest.SP_SPECIMEN, chainWhitelist = { "",
-                    Specimen.SP_IDENTIFIER }, targetTypes = Specimen.class) ReferenceAndListParam specimenReference,
-
-            @IncludeParam(allow = { "ServiceRequest:" + ServiceRequest.SP_PATIENT,
-                    "ServiceRequest:" + ServiceRequest.SP_SUBJECT, "ServiceRequest:" + ServiceRequest.SP_REQUESTER,
-                    "ServiceRequest:" + ServiceRequest.SP_SPECIMEN }) HashSet<Include> includes,
-
-            @IncludeParam(reverse = true, allow = { "Observation:based-on" }) HashSet<Include> revIncludes,
-
+            @OptionalParam(name = ServiceRequest.SP_STATUS) TokenAndListParam status,
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @IncludeParam(allow = { FhirConstants.SERVICE_REQUEST_PATIENT_INCLUDE,
+                    FhirConstants.SERVICE_REQUEST_SUBJECT_INCLUDE, FhirConstants.SERVICE_REQUEST_REQUESTER_INCLUDE,
+                    FhirConstants.SERVICE_REQUEST_SPECIMEN_INCLUDE }) HashSet<Include> includes,
+            @IncludeParam(reverse = true, allow = { FhirConstants.OBSERVATION_BASED_ON_REV_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_BASED_ON_REV_INCLUDE }) HashSet<Include> revIncludes,
             HttpServletRequest request) {
 
-        String method = "search";
+        String method = "searchServiceRequests";
+        LogEvent.logDebug(this.getClass().getSimpleName(), method, "Searching for ServiceRequests");
 
         try {
-            Bundle resultBundle = util.forwardSearchToFhirStore(request);
-
-            if (resultBundle == null) {
-                resultBundle = new Bundle();
-            }
-
-            if (resultBundle.getType() == null) {
-                resultBundle.setType(Bundle.BundleType.SEARCHSET);
-            }
-
-            if (resultBundle.getEntry() == null) {
-                resultBundle.setEntry(new ArrayList<>());
-            }
-
-            return resultBundle;
+            ServiceRequestSearchParams params = new ServiceRequestSearchParams(id, identifier,
+                    FhirProviderUtils.merge(patient, subject), requester, specimen, code, status, lastUpdated, sort,
+                    includes, revIncludes);
+            return serviceRequestSearchService.searchServiceRequests(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
+            LogEvent.logError(this.getClass().getSimpleName(), method,
+                    "Invalid ServiceRequest search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid ServiceRequest search parameter: " + e.getMessage(), e);
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("ServiceRequest", e);
+            }
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Error searching ServiceRequest: " + e.getMessage());
             throw new InternalErrorException("Unexpected server error searching ServiceRequest");

--- a/src/main/java/org/openelisglobal/fhir/providers/SpecimenProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/SpecimenProvider.java
@@ -9,11 +9,13 @@ import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
+import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.param.ReferenceParam;
-import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
@@ -25,9 +27,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.UUID;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.Specimen;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.IStatusService;
@@ -37,8 +37,11 @@ import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.dictionary.service.DictionaryService;
 import org.openelisglobal.dictionary.valueholder.Dictionary;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.SpecimenSearchParams;
 import org.openelisglobal.sampleitem.service.SampleItemService;
 import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.search.service.SpecimenSearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +50,9 @@ public class SpecimenProvider implements IResourceProvider {
 
     @Autowired
     private FhirUtil util;
+
+    @Autowired
+    private SpecimenSearchService specimenSearchService;
 
     @Autowired
     private FhirTransformService fhirTransformService;
@@ -116,6 +122,9 @@ public class SpecimenProvider implements IResourceProvider {
             throw new InternalErrorException("A required value was unexpectedly null while processing the request", e);
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Specimen", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while reading Specimen: " + e.getMessage());
@@ -177,6 +186,9 @@ public class SpecimenProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Specimen", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while creating Specimen: " + e.getMessage());
@@ -271,6 +283,9 @@ public class SpecimenProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Specimen", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while updating Specimen: " + e.getMessage());
@@ -319,6 +334,9 @@ public class SpecimenProvider implements IResourceProvider {
             throw e;
 
         } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Specimen", e);
+            }
 
             LogEvent.logError(this.getClass().getSimpleName(), method,
                     "Unexpected error while deleting Specimen: " + e.getMessage());
@@ -328,37 +346,43 @@ public class SpecimenProvider implements IResourceProvider {
     }
 
     @Search
-    public Bundle searchSpecimenBundle(@OptionalParam(name = Specimen.SP_IDENTIFIER) TokenAndListParam identifier,
-            @OptionalParam(name = Specimen.SP_SUBJECT) ReferenceParam subject,
+    public IBundleProvider searchSpecimens(@OptionalParam(name = Specimen.SP_RES_ID) TokenAndListParam id,
+            @OptionalParam(name = Specimen.SP_IDENTIFIER) TokenAndListParam identifier,
+            @OptionalParam(name = Specimen.SP_ACCESSION) TokenAndListParam accession,
+            @OptionalParam(name = Specimen.SP_PATIENT) ReferenceAndListParam patient,
+            @OptionalParam(name = Specimen.SP_SUBJECT) ReferenceAndListParam subject,
             @OptionalParam(name = Specimen.SP_TYPE) TokenAndListParam type,
             @OptionalParam(name = Specimen.SP_STATUS) TokenAndListParam status,
-            @OptionalParam(name = Specimen.SP_ACCESSION) TokenAndListParam accession,
             @OptionalParam(name = Specimen.SP_COLLECTED) DateRangeParam collected,
-            @OptionalParam(name = Specimen.SP_CONTAINER) TokenAndListParam container,
-            @OptionalParam(name = "_id") StringParam id,
-            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated,
-
-            @IncludeParam(allow = { "ServiceRequest:" + ServiceRequest.SP_PATIENT,
-                    "ServiceRequest:" + ServiceRequest.SP_SUBJECT,
-                    "ServiceRequest:" + ServiceRequest.SP_REQUESTER }) HashSet<Include> includes,
-
-            @IncludeParam(reverse = true, allow = { "Observation:based-on" }) HashSet<Include> revIncludes,
-
+            @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @IncludeParam(allow = { FhirConstants.SPECIMEN_PATIENT_INCLUDE,
+                    FhirConstants.SPECIMEN_SUBJECT_INCLUDE }) HashSet<Include> includes,
+            @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_SPECIMEN_REV_INCLUDE,
+                    FhirConstants.OBSERVATION_SPECIMEN_REV_INCLUDE,
+                    FhirConstants.DIAGNOSTIC_REPORT_SPECIMEN_REV_INCLUDE }) HashSet<Include> revIncludes,
             HttpServletRequest request) {
 
-        String methodName = "searchSpecimenBundle";
-        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Specimens (returning Bundle)");
+        String methodName = "searchSpecimens";
+        LogEvent.logDebug(this.getClass().getSimpleName(), methodName, "Searching for Specimens");
 
         try {
-
-            Bundle bundle = util.forwardSearchToFhirStore(request);
-
-            return bundle;
-
-        } catch (Exception e) {
+            SpecimenSearchParams params = new SpecimenSearchParams(id, identifier, accession,
+                    FhirProviderUtils.merge(patient, subject), type, status, collected, lastUpdated, sort, includes,
+                    revIncludes);
+            return specimenSearchService.searchSpecimens(params);
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (IllegalArgumentException e) {
             LogEvent.logError(this.getClass().getSimpleName(), methodName,
-                    "Error searching Practitioners: " + e.getMessage());
-            throw new InternalErrorException("Error searching Practitioners", e);
+                    "Invalid Specimen search parameter: " + e.getMessage());
+            throw new InvalidRequestException("Invalid Specimen search parameter: " + e.getMessage(), e);
+        } catch (Exception e) {
+            if (FhirProviderUtils.isDataError(e)) {
+                throw FhirProviderUtils.unprocessableData("Specimen", e);
+            }
+            LogEvent.logError(this.getClass().getSimpleName(), methodName,
+                    "Error searching Specimens: " + e.getMessage());
+            throw new InternalErrorException("Error searching Specimens", e);
         }
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DeviceBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DeviceBundleProvider.java
@@ -1,0 +1,52 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.List;
+import java.util.Objects;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Device;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.searchparams.DeviceSearchParams;
+import org.openelisglobal.search.dao.DeviceSearchDao;
+
+/** Pages OpenELIS analyzers as FHIR Device resources. */
+public class DeviceBundleProvider extends BaseFhirBundleProvider<Analyzer, Device> {
+
+    private final DeviceSearchParams searchParams;
+    private final DeviceSearchDao deviceSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public DeviceBundleProvider(DeviceSearchParams searchParams, DeviceSearchDao deviceSearchDao,
+            FhirTransformService fhirTransformService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "DeviceSearchParams must not be null");
+        this.deviceSearchDao = Objects.requireNonNull(deviceSearchDao, "DeviceSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+    }
+
+    @Override
+    protected List<Analyzer> loadEntities(int offset, int pageSize) {
+        return deviceSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return deviceSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected Device transformEntity(Analyzer analyzer) {
+        Device device = fhirTransformService.transformAnalyzerToDevice(analyzer);
+        if (device != null) {
+            ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(device, BundleEntrySearchModeEnum.MATCH);
+        }
+        return device;
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+        return super.getResources(fromIndex, toIndex);
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DiagnosticReportBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DiagnosticReportBundleProvider.java
@@ -1,0 +1,136 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.DiagnosticReportSearchParams;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.dao.DiagnosticReportSearchDao;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.service.SampleHumanSearchDao;
+
+/**
+ * Pages OpenELIS analyses as FHIR DiagnosticReport resources, adding the
+ * patient, order, results and specimen for {@code _include}.
+ */
+public class DiagnosticReportBundleProvider extends BaseFhirBundleProvider<Analysis, DiagnosticReport> {
+
+    private final DiagnosticReportSearchParams searchParams;
+    private final DiagnosticReportSearchDao diagnosticReportSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public DiagnosticReportBundleProvider(DiagnosticReportSearchParams searchParams,
+            DiagnosticReportSearchDao diagnosticReportSearchDao, SampleHumanSearchDao sampleHumanSearchDao,
+            ObservationSearchDao observationSearchDao, FhirTransformService fhirTransformService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "DiagnosticReportSearchParams must not be null");
+        this.diagnosticReportSearchDao = Objects.requireNonNull(diagnosticReportSearchDao,
+                "DiagnosticReportSearchDao must not be null");
+        this.sampleHumanSearchDao = Objects.requireNonNull(sampleHumanSearchDao,
+                "SampleHumanSearchDao must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+    }
+
+    @Override
+    protected List<Analysis> loadEntities(int offset, int pageSize) {
+        return diagnosticReportSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return diagnosticReportSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected DiagnosticReport transformEntity(Analysis analysis) {
+        try {
+            return fhirTransformService.transformResultToDiagnosticReport(analysis);
+        } catch (FhirTransformationException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "transformEntity",
+                    "skipping DiagnosticReport for analysis " + analysis.getId() + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<Analysis> analyses = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        for (Analysis analysis : analyses) {
+            DiagnosticReport report = transformEntity(analysis);
+            if (report != null) {
+                ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(report, BundleEntrySearchModeEnum.MATCH);
+                resources.add(report);
+            }
+        }
+        if (analyses.isEmpty()) {
+            return resources;
+        }
+        int matchCount = resources.size();
+
+        if (searchParams.hasInclude(FhirConstants.DIAGNOSTIC_REPORT_PATIENT_INCLUDE,
+                FhirConstants.DIAGNOSTIC_REPORT_SUBJECT_INCLUDE)) {
+            List<String> sampleIds = analyses.stream().map(Analysis::getSampleItem).filter(Objects::nonNull)
+                    .map(item -> item.getSample().getId()).distinct().toList();
+            Set<String> patientIds = new LinkedHashSet<>();
+            for (SampleHuman sampleHuman : sampleHumanSearchDao.findBySampleIds(sampleIds)) {
+                if (sampleHuman.getPatientId() != null) {
+                    patientIds.add(sampleHuman.getPatientId());
+                }
+            }
+            for (String patientId : patientIds) {
+                try {
+                    resources.add(fhirTransformService.transformToFhirPatient(patientId));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping Patient " + patientId + ": " + e.getMessage());
+                }
+            }
+        }
+        if (searchParams.hasInclude(FhirConstants.DIAGNOSTIC_REPORT_BASED_ON_INCLUDE)) {
+            analyses.stream().map(analysis -> fhirTransformService.transformToServiceRequest(analysis.getId()))
+                    .filter(Objects::nonNull).forEach(resources::add);
+        }
+        if (searchParams.hasInclude(FhirConstants.DIAGNOSTIC_REPORT_RESULT_INCLUDE)) {
+            List<String> analysisIds = analyses.stream().map(Analysis::getId).toList();
+            for (Result result : observationSearchDao.findByAnalysisIds(analysisIds)) {
+                try {
+                    resources.add(fhirTransformService.transformResultToObservation(result));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+                }
+            }
+        }
+        if (searchParams.hasInclude(FhirConstants.DIAGNOSTIC_REPORT_SPECIMEN_INCLUDE)) {
+            analyses.stream().map(Analysis::getSampleItem).filter(Objects::nonNull).distinct()
+                    .map(fhirTransformService::transformToSpecimen).forEach(resources::add);
+        }
+
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
+        return resources;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ObservationBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ObservationBundleProvider.java
@@ -1,0 +1,168 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Observation;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.ObservationSearchParams;
+import org.openelisglobal.provider.valueholder.Provider;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PractitionerSearchDao;
+import org.openelisglobal.search.service.SampleHumanSearchDao;
+
+/**
+ * Pages OpenELIS results as FHIR Observation resources, adding the patient,
+ * order, specimen and performer for {@code _include} and the finalized report
+ * for {@code _revinclude=DiagnosticReport:result}.
+ */
+public class ObservationBundleProvider extends BaseFhirBundleProvider<Result, Observation> {
+
+    private final ObservationSearchParams searchParams;
+    private final ObservationSearchDao observationSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final PractitionerSearchDao practitionerSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
+
+    public ObservationBundleProvider(ObservationSearchParams searchParams, ObservationSearchDao observationSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, PractitionerSearchDao practitionerSearchDao,
+            FhirTransformService fhirTransformService, IStatusService statusService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "ObservationSearchParams must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
+        this.sampleHumanSearchDao = Objects.requireNonNull(sampleHumanSearchDao,
+                "SampleHumanSearchDao must not be null");
+        this.practitionerSearchDao = Objects.requireNonNull(practitionerSearchDao,
+                "PractitionerSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+        this.statusService = Objects.requireNonNull(statusService, "IStatusService must not be null");
+    }
+
+    @Override
+    protected List<Result> loadEntities(int offset, int pageSize) {
+        return observationSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return observationSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected Observation transformEntity(Result result) {
+        try {
+            return fhirTransformService.transformResultToObservation(result);
+        } catch (FhirTransformationException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "transformEntity",
+                    "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<Result> results = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        for (Result result : results) {
+            Observation observation = transformEntity(result);
+            if (observation != null) {
+                ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(observation, BundleEntrySearchModeEnum.MATCH);
+                resources.add(observation);
+            }
+        }
+        if (results.isEmpty()) {
+            return resources;
+        }
+        int matchCount = resources.size();
+
+        Map<String, Analysis> analyses = new LinkedHashMap<>();
+        for (Result result : results) {
+            Analysis analysis = result.getAnalysis();
+            if (analysis != null) {
+                analyses.putIfAbsent(analysis.getId(), analysis);
+            }
+        }
+
+        boolean wantsPatient = searchParams.hasInclude(FhirConstants.OBSERVATION_PATIENT_INCLUDE,
+                FhirConstants.OBSERVATION_SUBJECT_INCLUDE);
+        boolean wantsPerformer = searchParams.hasInclude(FhirConstants.OBSERVATION_PERFORMER_INCLUDE);
+        if (wantsPatient || wantsPerformer) {
+            List<String> sampleIds = analyses.values().stream().map(Analysis::getSampleItem).filter(Objects::nonNull)
+                    .map(item -> item.getSample().getId()).distinct().toList();
+            Set<String> patientIds = new LinkedHashSet<>();
+            Set<String> providerIds = new LinkedHashSet<>();
+            for (SampleHuman sampleHuman : sampleHumanSearchDao.findBySampleIds(sampleIds)) {
+                if (sampleHuman.getPatientId() != null) {
+                    patientIds.add(sampleHuman.getPatientId());
+                }
+                if (sampleHuman.getProviderId() != null) {
+                    providerIds.add(sampleHuman.getProviderId());
+                }
+            }
+            if (wantsPatient) {
+                for (String patientId : patientIds) {
+                    try {
+                        resources.add(fhirTransformService.transformToFhirPatient(patientId));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping Patient " + patientId + ": " + e.getMessage());
+                    }
+                }
+            }
+            if (wantsPerformer) {
+                for (Provider provider : practitionerSearchDao.findByIds(new ArrayList<>(providerIds))) {
+                    resources.add(fhirTransformService.transformProviderToPractitioner(provider));
+                }
+            }
+        }
+
+        if (searchParams.hasInclude(FhirConstants.OBSERVATION_BASED_ON_INCLUDE)) {
+            analyses.values().stream().map(analysis -> fhirTransformService.transformToServiceRequest(analysis.getId()))
+                    .filter(Objects::nonNull).forEach(resources::add);
+        }
+        if (searchParams.hasInclude(FhirConstants.OBSERVATION_SPECIMEN_INCLUDE)) {
+            analyses.values().stream().map(Analysis::getSampleItem).filter(Objects::nonNull).distinct()
+                    .map(fhirTransformService::transformToSpecimen).forEach(resources::add);
+        }
+        if (searchParams.hasRevInclude(FhirConstants.DIAGNOSTIC_REPORT_RESULT_REV_INCLUDE)) {
+            for (Analysis analysis : analyses.values()) {
+                if (!statusService.matches(analysis.getStatusId(), AnalysisStatus.Finalized)) {
+                    continue;
+                }
+                try {
+                    resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping DiagnosticReport for analysis " + analysis.getId() + ": " + e.getMessage());
+                }
+            }
+        }
+
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
+        return resources;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/OrganizationBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/OrganizationBundleProvider.java
@@ -1,0 +1,108 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.OrganizationSearchParams;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.search.dao.OrganizationSearchDao;
+
+/**
+ * Pages OpenELIS organizations as FHIR Organization resources, adding parents
+ * for {@code _include=Organization:partof} and children for
+ * {@code _revinclude=Organization:partof}.
+ */
+public class OrganizationBundleProvider
+        extends BaseFhirBundleProvider<Organization, org.hl7.fhir.r4.model.Organization> {
+
+    private final OrganizationSearchParams searchParams;
+    private final OrganizationSearchDao organizationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public OrganizationBundleProvider(OrganizationSearchParams searchParams,
+            OrganizationSearchDao organizationSearchDao, FhirTransformService fhirTransformService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "OrganizationSearchParams must not be null");
+        this.organizationSearchDao = Objects.requireNonNull(organizationSearchDao,
+                "OrganizationSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+    }
+
+    @Override
+    protected List<Organization> loadEntities(int offset, int pageSize) {
+        return organizationSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return organizationSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected org.hl7.fhir.r4.model.Organization transformEntity(Organization organization) {
+        try {
+            return fhirTransformService.transformToFhirOrganization(organization);
+        } catch (FhirTransformationException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "transformEntity",
+                    "skipping Organization " + organization.getId() + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<Organization> matches = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        for (Organization organization : matches) {
+            org.hl7.fhir.r4.model.Organization resource = transformEntity(organization);
+            if (resource != null) {
+                ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.MATCH);
+                resources.add(resource);
+            }
+        }
+        if (matches.isEmpty()) {
+            return resources;
+        }
+
+        Map<String, Organization> included = new LinkedHashMap<>();
+        if (searchParams.hasInclude(FhirConstants.ORGANIZATION_PARTOF_INCLUDE)) {
+            for (Organization organization : matches) {
+                Organization parent = organization.getOrganization();
+                if (parent != null && parent.getId() != null) {
+                    included.putIfAbsent(parent.getId(), parent);
+                }
+            }
+        }
+        if (searchParams.hasRevInclude(FhirConstants.ORGANIZATION_PARTOF_INCLUDE)) {
+            List<String> matchIds = matches.stream().map(Organization::getId).toList();
+            for (Organization child : organizationSearchDao.findByParentIds(matchIds)) {
+                included.putIfAbsent(child.getId(), child);
+            }
+        }
+        matches.forEach(organization -> included.remove(organization.getId()));
+
+        for (Organization organization : included.values()) {
+            org.hl7.fhir.r4.model.Organization resource = transformEntity(organization);
+            if (resource != null) {
+                ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE);
+                resources.add(resource);
+            }
+        }
+        return resources;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PatientBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PatientBundleProvider.java
@@ -1,0 +1,151 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.PatientSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PatientSearchDao;
+import org.openelisglobal.search.dao.ServiceRequestSearchDao;
+import org.openelisglobal.search.dao.SpecimenSearchDao;
+import org.openelisglobal.search.service.SampleHumanSearchDao;
+
+/**
+ * Pages OpenELIS patients as FHIR Patient resources and, on request, the
+ * orders, specimens, results and reports linked to them through sample_human.
+ */
+public class PatientBundleProvider extends BaseFhirBundleProvider<Patient, org.hl7.fhir.r4.model.Patient> {
+
+    private final PatientSearchParams searchParams;
+    private final PatientSearchDao patientSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final SpecimenSearchDao specimenSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public PatientBundleProvider(PatientSearchParams searchParams, PatientSearchDao patientSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, ServiceRequestSearchDao serviceRequestSearchDao,
+            SpecimenSearchDao specimenSearchDao, ObservationSearchDao observationSearchDao,
+            FhirTransformService fhirTransformService) {
+
+        this.searchParams = Objects.requireNonNull(searchParams, "PatientSearchParams must not be null");
+        this.patientSearchDao = Objects.requireNonNull(patientSearchDao, "PatientSearchDao must not be null");
+        this.sampleHumanSearchDao = Objects.requireNonNull(sampleHumanSearchDao,
+                "SampleHumanSearchDao must not be null");
+        this.serviceRequestSearchDao = Objects.requireNonNull(serviceRequestSearchDao,
+                "ServiceRequestSearchDao must not be null");
+        this.specimenSearchDao = Objects.requireNonNull(specimenSearchDao, "SpecimenSearchDao must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+    }
+
+    @Override
+    protected List<Patient> loadEntities(int offset, int pageSize) {
+        return patientSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return patientSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected org.hl7.fhir.r4.model.Patient transformEntity(Patient patient) {
+        try {
+            return fhirTransformService.transformToFhirPatient(patient.getId());
+        } catch (FhirTransformationException e) {
+            LogEvent.logWarn(getClass().getSimpleName(), "transformEntity",
+                    "skipping Patient " + patient.getId() + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<Patient> patients = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        patients.stream().map(this::transformEntity).filter(Objects::nonNull).forEach(resources::add);
+        resources.forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.MATCH));
+
+        if (patients.isEmpty() || searchParams.getRevIncludes().isEmpty()) {
+            return resources;
+        }
+        int matchCount = resources.size();
+
+        List<SampleHuman> sampleHumans = sampleHumanSearchDao.findByPatients(patients);
+        if (sampleHumans.isEmpty()) {
+            return resources;
+        }
+        List<String> sampleIds = sampleHumans.stream().map(SampleHuman::getSampleId).filter(Objects::nonNull).distinct()
+                .toList();
+
+        boolean wantsServiceRequests = searchParams.hasRevInclude(FhirConstants.SERVICE_REQUEST_PATIENT_REV_INCLUDE,
+                FhirConstants.SERVICE_REQUEST_SUBJECT_REV_INCLUDE);
+        boolean wantsObservations = searchParams.hasRevInclude(FhirConstants.OBSERVATION_PATIENT_REV_INCLUDE,
+                FhirConstants.OBSERVATION_SUBJECT_REV_INCLUDE);
+        boolean wantsReports = searchParams.hasRevInclude(FhirConstants.DIAGNOSTIC_REPORT_PATIENT_REV_INCLUDE,
+                FhirConstants.DIAGNOSTIC_REPORT_SUBJECT_REV_INCLUDE);
+
+        if (searchParams.hasRevInclude(FhirConstants.SPECIMEN_PATIENT_REV_INCLUDE,
+                FhirConstants.SPECIMEN_SUBJECT_REV_INCLUDE)) {
+            for (SampleItem sampleItem : specimenSearchDao.findBySampleIds(sampleIds)) {
+                resources.add(fhirTransformService.transformToSpecimen(sampleItem));
+            }
+        }
+
+        if (wantsServiceRequests || wantsObservations || wantsReports) {
+            List<Analysis> analyses = serviceRequestSearchDao.findBySampleHumans(sampleHumans);
+            if (wantsServiceRequests) {
+                analyses.stream().map(analysis -> fhirTransformService.transformToServiceRequest(analysis.getId()))
+                        .filter(Objects::nonNull).forEach(resources::add);
+            }
+            if (wantsReports) {
+                for (Analysis analysis : analyses) {
+                    try {
+                        resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping DiagnosticReport for analysis " + analysis.getId() + ": " + e.getMessage());
+                    }
+                }
+            }
+            if (wantsObservations) {
+                List<String> analysisIds = analyses.stream().map(Analysis::getId).toList();
+                for (Result result : observationSearchDao.findByAnalysisIds(analysisIds)) {
+                    try {
+                        resources.add(fhirTransformService.transformResultToObservation(result));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+                    }
+                }
+            }
+        }
+
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
+        return resources;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PractitionerBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PractitionerBundleProvider.java
@@ -1,17 +1,22 @@
 package org.openelisglobal.fhir.search.bundleProviders;
 
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Practitioner;
-import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.fhir.FhirConstants;
 import org.openelisglobal.fhir.search.searchparams.PractitionerSearchParams;
 import org.openelisglobal.provider.valueholder.Provider;
+import org.openelisglobal.result.valueholder.Result;
 import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.dao.ObservationSearchDao;
 import org.openelisglobal.search.dao.PractitionerSearchDao;
 import org.openelisglobal.search.dao.ServiceRequestSearchDao;
 import org.openelisglobal.search.service.SampleHumanSearchDao;
@@ -26,11 +31,14 @@ public class PractitionerBundleProvider extends BaseFhirBundleProvider<Provider,
 
     private final ServiceRequestSearchDao serviceRequestSearchDao;
 
+    private final ObservationSearchDao observationSearchDao;
+
     private final FhirTransformService fhirTransformService;
 
     public PractitionerBundleProvider(PractitionerSearchParams searchParams,
             PractitionerSearchDao practitionerSearchDao, SampleHumanSearchDao sampleHumanSearchDao,
-            ServiceRequestSearchDao serviceRequestSearchDao, FhirTransformService fhirTransformService) {
+            ServiceRequestSearchDao serviceRequestSearchDao, ObservationSearchDao observationSearchDao,
+            FhirTransformService fhirTransformService) {
 
         this.searchParams = searchParams;
 
@@ -42,6 +50,8 @@ public class PractitionerBundleProvider extends BaseFhirBundleProvider<Provider,
 
         this.serviceRequestSearchDao = Objects.requireNonNull(serviceRequestSearchDao,
                 "ServiceRequestSearchDao must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
 
         this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
                 "FhirTransformService must not be null");
@@ -88,53 +98,43 @@ public class PractitionerBundleProvider extends BaseFhirBundleProvider<Provider,
         List<Provider> providers = practitionerSearchDao.search(searchParams, fromIndex, pageSize);
 
         List<IBaseResource> resources = new ArrayList<>();
+        providers.stream().map(this::transformEntity).filter(Objects::nonNull).forEach(resources::add);
+        resources.forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.MATCH));
 
-        /*
-         * Step 2: Transform the Providers into matching Practitioners.
-         */
-        providers.stream().map(this::transformEntity).forEach(resources::add);
-
-        /*
-         * Step 3: Return only Practitioners when _revinclude was not requested.
-         */
-        if (!hasServiceRequestRequesterRevInclude()) {
+        boolean wantsServiceRequests = searchParams != null
+                && searchParams.hasRevInclude(FhirConstants.SERVICE_REQUEST_REQUESTER_REV_INCLUDE);
+        boolean wantsObservations = searchParams != null
+                && searchParams.hasRevInclude(FhirConstants.OBSERVATION_PERFORMER_REV_INCLUDE);
+        if (providers.isEmpty() || !(wantsServiceRequests || wantsObservations)) {
             return resources;
         }
+        int matchCount = resources.size();
 
-        /*
-         * Step 4: Find SampleHuman rows connected to these Providers.
-         *
-         * The DAO internally extracts Provider.id.
-         */
         List<SampleHuman> sampleHumans = sampleHumanSearchDao.findByProviders(providers);
-
         if (sampleHumans.isEmpty()) {
             return resources;
         }
-
-        /*
-         * Step 5: Find Analysis records connected to the SampleHuman samples.
-         *
-         * The DAO internally extracts SampleHuman.sampleId.
-         */
         List<Analysis> analyses = serviceRequestSearchDao.findBySampleHumans(sampleHumans);
 
-        /*
-         * Step 6: Transform Analysis records into ServiceRequests.
-         */
-        analyses.forEach(analysis -> {
-            ServiceRequest serviceRequest = fhirTransformService.transformToServiceRequest(analysis.getId());
-
-            if (serviceRequest != null) {
-                resources.add(serviceRequest);
+        if (wantsServiceRequests) {
+            analyses.stream().map(analysis -> fhirTransformService.transformToServiceRequest(analysis.getId()))
+                    .filter(Objects::nonNull).forEach(resources::add);
+        }
+        if (wantsObservations) {
+            List<String> analysisIds = analyses.stream().map(Analysis::getId).toList();
+            for (Result result : observationSearchDao.findByAnalysisIds(analysisIds)) {
+                try {
+                    resources.add(fhirTransformService.transformResultToObservation(result));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+                }
             }
-        });
+        }
 
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
         return resources;
-    }
-
-    private boolean hasServiceRequestRequesterRevInclude() {
-
-        return searchParams != null && searchParams.hasRevInclude(FhirConstants.SERVICE_REQUEST_REQUESTER_REV_INCLUDE);
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ServiceRequestBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ServiceRequestBundleProvider.java
@@ -1,16 +1,63 @@
 package org.openelisglobal.fhir.search.bundleProviders;
 
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
 import org.openelisglobal.fhir.search.searchparams.ServiceRequestSearchParams;
+import org.openelisglobal.provider.valueholder.Provider;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PractitionerSearchDao;
 import org.openelisglobal.search.dao.ServiceRequestSearchDao;
+import org.openelisglobal.search.service.SampleHumanSearchDao;
 
+/**
+ * Pages OpenELIS analyses as FHIR ServiceRequest resources, adding the patient,
+ * requester and specimen for {@code _include} and the results and reports for
+ * {@code _revinclude=Observation:based-on} and
+ * {@code _revinclude=DiagnosticReport:based-on}.
+ */
 public class ServiceRequestBundleProvider extends BaseFhirBundleProvider<Analysis, ServiceRequest> {
-    private ServiceRequestSearchDao serviceRequestSearchDao;
-    private ServiceRequestSearchParams searchParams;
-    private FhirTransformService fhirTransformService;
+
+    private final ServiceRequestSearchParams searchParams;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final PractitionerSearchDao practitionerSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
+
+    public ServiceRequestBundleProvider(ServiceRequestSearchParams searchParams,
+            ServiceRequestSearchDao serviceRequestSearchDao, SampleHumanSearchDao sampleHumanSearchDao,
+            PractitionerSearchDao practitionerSearchDao, ObservationSearchDao observationSearchDao,
+            FhirTransformService fhirTransformService, IStatusService statusService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "ServiceRequestSearchParams must not be null");
+        this.serviceRequestSearchDao = Objects.requireNonNull(serviceRequestSearchDao,
+                "ServiceRequestSearchDao must not be null");
+        this.sampleHumanSearchDao = Objects.requireNonNull(sampleHumanSearchDao,
+                "SampleHumanSearchDao must not be null");
+        this.practitionerSearchDao = Objects.requireNonNull(practitionerSearchDao,
+                "PractitionerSearchDao must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+        this.statusService = Objects.requireNonNull(statusService, "IStatusService must not be null");
+    }
 
     @Override
     protected List<Analysis> loadEntities(int offset, int pageSize) {
@@ -23,8 +70,99 @@ public class ServiceRequestBundleProvider extends BaseFhirBundleProvider<Analysi
     }
 
     @Override
-    protected ServiceRequest transformEntity(Analysis entity) {
-        return fhirTransformService.transformToServiceRequest(entity.getId());
+    protected ServiceRequest transformEntity(Analysis analysis) {
+        return fhirTransformService.transformToServiceRequest(analysis.getId());
     }
 
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<Analysis> analyses = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        for (Analysis analysis : analyses) {
+            ServiceRequest serviceRequest = transformEntity(analysis);
+            if (serviceRequest != null) {
+                ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(serviceRequest, BundleEntrySearchModeEnum.MATCH);
+                resources.add(serviceRequest);
+            }
+        }
+        if (analyses.isEmpty()) {
+            return resources;
+        }
+        int matchCount = resources.size();
+
+        boolean wantsPatient = searchParams.hasInclude(FhirConstants.SERVICE_REQUEST_PATIENT_INCLUDE,
+                FhirConstants.SERVICE_REQUEST_SUBJECT_INCLUDE);
+        boolean wantsRequester = searchParams.hasInclude(FhirConstants.SERVICE_REQUEST_REQUESTER_INCLUDE);
+        if (wantsPatient || wantsRequester) {
+            List<String> sampleIds = analyses.stream().map(Analysis::getSampleItem).filter(Objects::nonNull)
+                    .map(item -> item.getSample().getId()).distinct().toList();
+            Set<String> patientIds = new LinkedHashSet<>();
+            Set<String> providerIds = new LinkedHashSet<>();
+            for (SampleHuman sampleHuman : sampleHumanSearchDao.findBySampleIds(sampleIds)) {
+                if (sampleHuman.getPatientId() != null) {
+                    patientIds.add(sampleHuman.getPatientId());
+                }
+                if (sampleHuman.getProviderId() != null) {
+                    providerIds.add(sampleHuman.getProviderId());
+                }
+            }
+            if (wantsPatient) {
+                for (String patientId : patientIds) {
+                    try {
+                        resources.add(fhirTransformService.transformToFhirPatient(patientId));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping Patient " + patientId + ": " + e.getMessage());
+                    }
+                }
+            }
+            if (wantsRequester) {
+                for (Provider provider : practitionerSearchDao.findByIds(new ArrayList<>(providerIds))) {
+                    resources.add(fhirTransformService.transformProviderToPractitioner(provider));
+                }
+            }
+        }
+
+        if (searchParams.hasInclude(FhirConstants.SERVICE_REQUEST_SPECIMEN_INCLUDE)) {
+            analyses.stream().map(Analysis::getSampleItem).filter(Objects::nonNull)
+                    .map(fhirTransformService::transformToSpecimen).forEach(resources::add);
+        }
+
+        boolean wantsObservations = searchParams.hasRevInclude(FhirConstants.OBSERVATION_BASED_ON_REV_INCLUDE);
+        boolean wantsReports = searchParams.hasRevInclude(FhirConstants.DIAGNOSTIC_REPORT_BASED_ON_REV_INCLUDE);
+        if (wantsObservations) {
+            List<String> analysisIds = analyses.stream().map(Analysis::getId).toList();
+            for (Result result : observationSearchDao.findByAnalysisIds(analysisIds)) {
+                try {
+                    resources.add(fhirTransformService.transformResultToObservation(result));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+                }
+            }
+        }
+        if (wantsReports) {
+            for (Analysis analysis : analyses) {
+                if (!statusService.matches(analysis.getStatusId(), AnalysisStatus.Finalized)) {
+                    continue;
+                }
+                try {
+                    resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping DiagnosticReport for analysis " + analysis.getId() + ": " + e.getMessage());
+                }
+            }
+        }
+
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
+        return resources;
+    }
 }

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/SpecimenBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/SpecimenBundleProvider.java
@@ -1,0 +1,146 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Specimen;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.log.LogEvent;
+import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.SpecimenSearchParams;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.ServiceRequestSearchDao;
+import org.openelisglobal.search.dao.SpecimenSearchDao;
+import org.openelisglobal.search.service.SampleHumanSearchDao;
+
+/**
+ * Pages OpenELIS sample items as FHIR Specimen resources, adding the patient
+ * for {@code _include=Specimen:patient|subject} and the orders and results that
+ * used the specimen for {@code _revinclude=ServiceRequest:specimen} and
+ * {@code _revinclude=Observation:specimen}.
+ */
+public class SpecimenBundleProvider extends BaseFhirBundleProvider<SampleItem, Specimen> {
+
+    private final SpecimenSearchParams searchParams;
+    private final SpecimenSearchDao specimenSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public SpecimenBundleProvider(SpecimenSearchParams searchParams, SpecimenSearchDao specimenSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, ServiceRequestSearchDao serviceRequestSearchDao,
+            ObservationSearchDao observationSearchDao, FhirTransformService fhirTransformService) {
+        this.searchParams = Objects.requireNonNull(searchParams, "SpecimenSearchParams must not be null");
+        this.specimenSearchDao = Objects.requireNonNull(specimenSearchDao, "SpecimenSearchDao must not be null");
+        this.sampleHumanSearchDao = Objects.requireNonNull(sampleHumanSearchDao,
+                "SampleHumanSearchDao must not be null");
+        this.serviceRequestSearchDao = Objects.requireNonNull(serviceRequestSearchDao,
+                "ServiceRequestSearchDao must not be null");
+        this.observationSearchDao = Objects.requireNonNull(observationSearchDao,
+                "ObservationSearchDao must not be null");
+        this.fhirTransformService = Objects.requireNonNull(fhirTransformService,
+                "FhirTransformService must not be null");
+    }
+
+    @Override
+    protected List<SampleItem> loadEntities(int offset, int pageSize) {
+        return specimenSearchDao.search(searchParams, offset, pageSize);
+    }
+
+    @Override
+    protected long countEntities() {
+        return specimenSearchDao.count(searchParams);
+    }
+
+    @Override
+    protected Specimen transformEntity(SampleItem sampleItem) {
+        return fhirTransformService.transformToSpecimen(sampleItem);
+    }
+
+    @Override
+    public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+
+        int pageSize = toIndex - fromIndex;
+        if (pageSize <= 0) {
+            return List.of();
+        }
+
+        List<SampleItem> sampleItems = loadEntities(fromIndex, pageSize);
+        List<IBaseResource> resources = new ArrayList<>();
+        for (SampleItem sampleItem : sampleItems) {
+            Specimen specimen = transformEntity(sampleItem);
+            ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(specimen, BundleEntrySearchModeEnum.MATCH);
+            resources.add(specimen);
+        }
+        if (sampleItems.isEmpty()) {
+            return resources;
+        }
+        int matchCount = resources.size();
+
+        if (searchParams.hasInclude(FhirConstants.SPECIMEN_PATIENT_INCLUDE, FhirConstants.SPECIMEN_SUBJECT_INCLUDE)) {
+            List<String> sampleIds = sampleItems.stream().map(item -> item.getSample().getId()).distinct().toList();
+            Set<String> patientIds = new LinkedHashSet<>();
+            for (SampleHuman sampleHuman : sampleHumanSearchDao.findBySampleIds(sampleIds)) {
+                if (sampleHuman.getPatientId() != null) {
+                    patientIds.add(sampleHuman.getPatientId());
+                }
+            }
+            for (String patientId : patientIds) {
+                try {
+                    resources.add(fhirTransformService.transformToFhirPatient(patientId));
+                } catch (FhirTransformationException e) {
+                    LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                            "skipping Patient " + patientId + ": " + e.getMessage());
+                }
+            }
+        }
+
+        boolean wantsServiceRequests = searchParams.hasRevInclude(FhirConstants.SERVICE_REQUEST_SPECIMEN_REV_INCLUDE);
+        boolean wantsObservations = searchParams.hasRevInclude(FhirConstants.OBSERVATION_SPECIMEN_REV_INCLUDE);
+        boolean wantsReports = searchParams.hasRevInclude(FhirConstants.DIAGNOSTIC_REPORT_SPECIMEN_REV_INCLUDE);
+        if (wantsServiceRequests || wantsObservations || wantsReports) {
+            List<String> sampleItemIds = sampleItems.stream().map(SampleItem::getId).toList();
+            List<Analysis> analyses = serviceRequestSearchDao.findBySampleItemIds(sampleItemIds);
+            if (wantsServiceRequests) {
+                analyses.stream().map(analysis -> fhirTransformService.transformToServiceRequest(analysis.getId()))
+                        .filter(Objects::nonNull).forEach(resources::add);
+            }
+            if (wantsReports) {
+                for (Analysis analysis : analyses) {
+                    try {
+                        resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping DiagnosticReport for analysis " + analysis.getId() + ": " + e.getMessage());
+                    }
+                }
+            }
+            if (wantsObservations) {
+                List<String> analysisIds = analyses.stream().map(Analysis::getId).toList();
+                for (Result result : observationSearchDao.findByAnalysisIds(analysisIds)) {
+                    try {
+                        resources.add(fhirTransformService.transformResultToObservation(result));
+                    } catch (FhirTransformationException e) {
+                        LogEvent.logWarn(getClass().getSimpleName(), "getResources",
+                                "skipping Observation for result " + result.getId() + ": " + e.getMessage());
+                    }
+                }
+            }
+        }
+
+        resources.subList(matchCount, resources.size()).forEach(
+                resource -> ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(resource, BundleEntrySearchModeEnum.INCLUDE));
+        return resources;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/DeviceSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/DeviceSearchParams.java
@@ -1,0 +1,64 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import org.hl7.fhir.r4.model.Device;
+
+/**
+ * Search parameters the Device facade answers from the OpenELIS analyzer table:
+ * logical id, identifiers (uuid, machine id, discovered source id), device
+ * name, type, status and last-updated timestamp.
+ */
+public class DeviceSearchParams extends BaseSearchParam {
+
+    private StringAndListParam deviceName;
+
+    private TokenAndListParam type;
+
+    private TokenAndListParam status;
+
+    public DeviceSearchParams(TokenAndListParam id, TokenAndListParam identifier, StringAndListParam deviceName,
+            TokenAndListParam type, TokenAndListParam status, DateRangeParam lastUpdated, SortSpec sort) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.deviceName = deviceName;
+        this.type = type;
+        this.status = status;
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (deviceName != null) {
+            map.addParameter(Device.SP_DEVICE_NAME, deviceName);
+        }
+        if (type != null) {
+            map.addParameter(Device.SP_TYPE, type);
+        }
+        if (status != null) {
+            map.addParameter(Device.SP_STATUS, status);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public StringAndListParam getDeviceName() {
+        return deviceName;
+    }
+
+    public TokenAndListParam getType() {
+        return type;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/DiagnosticReportSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/DiagnosticReportSearchParams.java
@@ -1,0 +1,141 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+
+/**
+ * Search parameters the DiagnosticReport facade answers from the OpenELIS
+ * database: logical id, patient, order ({@code based-on}), result, specimen,
+ * test code, status, issued date and last-updated timestamp.
+ *
+ * <p>
+ * {@code patient} and {@code subject} arrive merged. The OpenELIS analysis
+ * status ids behind each FHIR status code are supplied by the search service.
+ */
+public class DiagnosticReportSearchParams extends BaseSearchParam {
+
+    private ReferenceAndListParam patient;
+
+    private ReferenceAndListParam basedOn;
+
+    private ReferenceAndListParam result;
+
+    private ReferenceAndListParam specimen;
+
+    private TokenAndListParam code;
+
+    private TokenAndListParam status;
+
+    private DateRangeParam issued;
+
+    private Map<String, List<String>> statusIdsByCode = Collections.emptyMap();
+
+    private final Set<Include> includes;
+
+    public DiagnosticReportSearchParams(TokenAndListParam id, TokenAndListParam identifier,
+            ReferenceAndListParam patient, ReferenceAndListParam basedOn, ReferenceAndListParam result,
+            ReferenceAndListParam specimen, TokenAndListParam code, TokenAndListParam status, DateRangeParam issued,
+            DateRangeParam lastUpdated, SortSpec sort, Set<Include> includes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.patient = patient;
+        this.basedOn = basedOn;
+        this.result = result;
+        this.specimen = specimen;
+        this.code = code;
+        this.status = status;
+        this.issued = issued;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (patient != null) {
+            map.addParameter(DiagnosticReport.SP_PATIENT, patient);
+        }
+        if (basedOn != null) {
+            map.addParameter(DiagnosticReport.SP_BASED_ON, basedOn);
+        }
+        if (result != null) {
+            map.addParameter(DiagnosticReport.SP_RESULT, result);
+        }
+        if (specimen != null) {
+            map.addParameter(DiagnosticReport.SP_SPECIMEN, specimen);
+        }
+        if (code != null) {
+            map.addParameter(DiagnosticReport.SP_CODE, code);
+        }
+        if (status != null) {
+            map.addParameter(DiagnosticReport.SP_STATUS, status);
+        }
+        if (issued != null) {
+            map.addParameter(DiagnosticReport.SP_ISSUED, issued);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public ReferenceAndListParam getPatient() {
+        return patient;
+    }
+
+    public ReferenceAndListParam getBasedOn() {
+        return basedOn;
+    }
+
+    public ReferenceAndListParam getResult() {
+        return result;
+    }
+
+    public ReferenceAndListParam getSpecimen() {
+        return specimen;
+    }
+
+    public TokenAndListParam getCode() {
+        return code;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+
+    public DateRangeParam getIssued() {
+        return issued;
+    }
+
+    public Map<String, List<String>> getStatusIdsByCode() {
+        return statusIdsByCode;
+    }
+
+    public void setStatusIdsByCode(Map<String, List<String>> statusIdsByCode) {
+        this.statusIdsByCode = statusIdsByCode == null ? Collections.emptyMap() : statusIdsByCode;
+    }
+
+    public boolean hasInclude(String... includeValues) {
+        for (Include include : includes) {
+            for (String value : includeValues) {
+                if (value != null && value.equals(include.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/LocationSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/LocationSearchParams.java
@@ -1,0 +1,96 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.hl7.fhir.r4.model.Location;
+
+/**
+ * Search parameters the Location facade answers over the storage hierarchy:
+ * logical id, identifier (storage code), name, status, parent and the
+ * storage-hierarchy tag (room, device, shelf, rack, box).
+ */
+public class LocationSearchParams extends BaseSearchParam {
+
+    private StringAndListParam name;
+
+    private TokenAndListParam status;
+
+    private ReferenceAndListParam partOf;
+
+    private TokenAndListParam tag;
+
+    private final Set<Include> includes;
+
+    private final Set<Include> revIncludes;
+
+    public LocationSearchParams(TokenAndListParam id, TokenAndListParam identifier, StringAndListParam name,
+            TokenAndListParam status, ReferenceAndListParam partOf, TokenAndListParam tag, DateRangeParam lastUpdated,
+            SortSpec sort, Set<Include> includes, Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.name = name;
+        this.status = status;
+        this.partOf = partOf;
+        this.tag = tag;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (name != null) {
+            map.addParameter(Location.SP_NAME, name);
+        }
+        if (status != null) {
+            map.addParameter(Location.SP_STATUS, status);
+        }
+        if (partOf != null) {
+            map.addParameter(Location.SP_PARTOF, partOf);
+        }
+        if (tag != null) {
+            map.addParameter("_tag", tag);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public StringAndListParam getName() {
+        return name;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+
+    public ReferenceAndListParam getPartOf() {
+        return partOf;
+    }
+
+    public TokenAndListParam getTag() {
+        return tag;
+    }
+
+    public boolean hasInclude(String includeValue) {
+        return includes.stream().map(Include::getValue).anyMatch(includeValue::equals);
+    }
+
+    public boolean hasRevInclude(String includeValue) {
+        return revIncludes.stream().map(Include::getValue).anyMatch(includeValue::equals);
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/ObservationSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/ObservationSearchParams.java
@@ -1,0 +1,143 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hl7.fhir.r4.model.Observation;
+
+/**
+ * Search parameters the Observation facade answers from the OpenELIS database:
+ * logical id, patient, order ({@code based-on}), specimen, test code, status,
+ * effective date and last-updated timestamp.
+ *
+ * <p>
+ * {@code patient} and {@code subject} arrive merged. The OpenELIS analysis
+ * status ids behind each FHIR status code are supplied by the search service.
+ */
+public class ObservationSearchParams extends BaseSearchParam {
+
+    private ReferenceAndListParam patient;
+
+    private ReferenceAndListParam basedOn;
+
+    private ReferenceAndListParam specimen;
+
+    private TokenAndListParam code;
+
+    private TokenAndListParam status;
+
+    private DateRangeParam date;
+
+    private Map<String, List<String>> statusIdsByCode = Collections.emptyMap();
+
+    private final Set<Include> includes;
+
+    private final Set<Include> revIncludes;
+
+    public ObservationSearchParams(TokenAndListParam id, TokenAndListParam identifier, ReferenceAndListParam patient,
+            ReferenceAndListParam basedOn, ReferenceAndListParam specimen, TokenAndListParam code,
+            TokenAndListParam status, DateRangeParam date, DateRangeParam lastUpdated, SortSpec sort,
+            Set<Include> includes, Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.patient = patient;
+        this.basedOn = basedOn;
+        this.specimen = specimen;
+        this.code = code;
+        this.status = status;
+        this.date = date;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (patient != null) {
+            map.addParameter(Observation.SP_PATIENT, patient);
+        }
+        if (basedOn != null) {
+            map.addParameter(Observation.SP_BASED_ON, basedOn);
+        }
+        if (specimen != null) {
+            map.addParameter(Observation.SP_SPECIMEN, specimen);
+        }
+        if (code != null) {
+            map.addParameter(Observation.SP_CODE, code);
+        }
+        if (status != null) {
+            map.addParameter(Observation.SP_STATUS, status);
+        }
+        if (date != null) {
+            map.addParameter(Observation.SP_DATE, date);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public ReferenceAndListParam getPatient() {
+        return patient;
+    }
+
+    public ReferenceAndListParam getBasedOn() {
+        return basedOn;
+    }
+
+    public ReferenceAndListParam getSpecimen() {
+        return specimen;
+    }
+
+    public TokenAndListParam getCode() {
+        return code;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+
+    public DateRangeParam getDate() {
+        return date;
+    }
+
+    public Map<String, List<String>> getStatusIdsByCode() {
+        return statusIdsByCode;
+    }
+
+    public void setStatusIdsByCode(Map<String, List<String>> statusIdsByCode) {
+        this.statusIdsByCode = statusIdsByCode == null ? Collections.emptyMap() : statusIdsByCode;
+    }
+
+    public boolean hasInclude(String... includeValues) {
+        return matchesAny(includes, includeValues);
+    }
+
+    public boolean hasRevInclude(String... includeValues) {
+        return matchesAny(revIncludes, includeValues);
+    }
+
+    private static boolean matchesAny(Set<Include> candidates, String... includeValues) {
+        for (Include include : candidates) {
+            for (String value : includeValues) {
+                if (value != null && value.equals(include.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/OrganizationSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/OrganizationSearchParams.java
@@ -1,0 +1,117 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.hl7.fhir.r4.model.Organization;
+
+/**
+ * Search parameters the Organization facade answers from the OpenELIS database:
+ * logical id, business identifiers (code, short name, CLIA number, uuid), name,
+ * active flag, organization type, parent organization and address parts.
+ */
+public class OrganizationSearchParams extends BaseSearchParam {
+
+    private StringAndListParam name;
+
+    private TokenAndListParam active;
+
+    private TokenAndListParam type;
+
+    private ReferenceAndListParam partOf;
+
+    private StringAndListParam city;
+
+    private StringAndListParam state;
+
+    private final Set<Include> includes;
+
+    private final Set<Include> revIncludes;
+
+    public OrganizationSearchParams(TokenAndListParam id, TokenAndListParam identifier, StringAndListParam name,
+            TokenAndListParam active, TokenAndListParam type, ReferenceAndListParam partOf, StringAndListParam city,
+            StringAndListParam state, DateRangeParam lastUpdated, SortSpec sort, Set<Include> includes,
+            Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.name = name;
+        this.active = active;
+        this.type = type;
+        this.partOf = partOf;
+        this.city = city;
+        this.state = state;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (name != null) {
+            map.addParameter(Organization.SP_NAME, name);
+        }
+        if (active != null) {
+            map.addParameter(Organization.SP_ACTIVE, active);
+        }
+        if (type != null) {
+            map.addParameter(Organization.SP_TYPE, type);
+        }
+        if (partOf != null) {
+            map.addParameter(Organization.SP_PARTOF, partOf);
+        }
+        if (city != null) {
+            map.addParameter(Organization.SP_ADDRESS_CITY, city);
+        }
+        if (state != null) {
+            map.addParameter(Organization.SP_ADDRESS_STATE, state);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public StringAndListParam getName() {
+        return name;
+    }
+
+    public TokenAndListParam getActive() {
+        return active;
+    }
+
+    public TokenAndListParam getType() {
+        return type;
+    }
+
+    public ReferenceAndListParam getPartOf() {
+        return partOf;
+    }
+
+    public StringAndListParam getCity() {
+        return city;
+    }
+
+    public StringAndListParam getState() {
+        return state;
+    }
+
+    public boolean hasInclude(String includeValue) {
+        return includes.stream().map(Include::getValue).anyMatch(includeValue::equals);
+    }
+
+    public boolean hasRevInclude(String includeValue) {
+        return revIncludes.stream().map(Include::getValue).anyMatch(includeValue::equals);
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/PatientSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/PatientSearchParams.java
@@ -1,0 +1,118 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.hl7.fhir.r4.model.Patient;
+
+/**
+ * Search parameters the Patient facade answers from the OpenELIS database.
+ *
+ * <p>
+ * Only parameters with an OpenELIS counterpart are accepted: the logical id and
+ * business identifiers (subject number, national id, ST number, GUID), names,
+ * birth date, gender and the last-updated timestamp.
+ */
+public class PatientSearchParams extends BaseSearchParam {
+
+    private StringAndListParam name;
+
+    private StringAndListParam given;
+
+    private StringAndListParam family;
+
+    private DateRangeParam birthDate;
+
+    private TokenAndListParam gender;
+
+    private final Set<Include> revIncludes;
+
+    public PatientSearchParams(TokenAndListParam id, TokenAndListParam identifier, StringAndListParam name,
+            StringAndListParam given, StringAndListParam family, DateRangeParam birthDate, TokenAndListParam gender,
+            DateRangeParam lastUpdated, SortSpec sort, Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.name = name;
+        this.given = given;
+        this.family = family;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+
+        addBaseSearchParameters(map);
+
+        if (name != null) {
+            map.addParameter(Patient.SP_NAME, name);
+        }
+        if (given != null) {
+            map.addParameter(Patient.SP_GIVEN, given);
+        }
+        if (family != null) {
+            map.addParameter(Patient.SP_FAMILY, family);
+        }
+        if (birthDate != null) {
+            map.addParameter(Patient.SP_BIRTHDATE, birthDate);
+        }
+        if (gender != null) {
+            map.addParameter(Patient.SP_GENDER, gender);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+
+        return map;
+    }
+
+    public StringAndListParam getName() {
+        return name;
+    }
+
+    public StringAndListParam getGiven() {
+        return given;
+    }
+
+    public StringAndListParam getFamily() {
+        return family;
+    }
+
+    public DateRangeParam getBirthDate() {
+        return birthDate;
+    }
+
+    public TokenAndListParam getGender() {
+        return gender;
+    }
+
+    public Set<Include> getRevIncludes() {
+        return revIncludes;
+    }
+
+    /**
+     * True when any of the given {@code Resource:param} values was requested via
+     * {@code _revinclude}.
+     */
+    public boolean hasRevInclude(String... includeValues) {
+
+        for (Include include : revIncludes) {
+            for (String candidate : includeValues) {
+                if (candidate != null && candidate.equals(include.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/ServiceRequestSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/ServiceRequestSearchParams.java
@@ -1,21 +1,136 @@
 package org.openelisglobal.fhir.search.searchparams;
 
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hl7.fhir.r4.model.ServiceRequest;
 
+/**
+ * Search parameters the ServiceRequest facade answers from the OpenELIS
+ * database: logical id, identifiers (analysis uuid, lab number), patient,
+ * requester, specimen, test code, status and last-updated timestamp.
+ *
+ * <p>
+ * {@code patient} and {@code subject} arrive merged. The OpenELIS analysis
+ * status ids behind each FHIR status code are supplied by the search service.
+ */
 public class ServiceRequestSearchParams extends BaseSearchParam {
 
-    protected ServiceRequestSearchParams(TokenAndListParam id, TokenAndListParam identifier,
-            DateRangeParam lastUpdated) {
-        super(id, identifier, lastUpdated);
+    private ReferenceAndListParam patient;
 
+    private ReferenceAndListParam requester;
+
+    private ReferenceAndListParam specimen;
+
+    private TokenAndListParam code;
+
+    private TokenAndListParam status;
+
+    private Map<String, List<String>> statusIdsByCode = Collections.emptyMap();
+
+    private final Set<Include> includes;
+
+    private final Set<Include> revIncludes;
+
+    public ServiceRequestSearchParams(TokenAndListParam id, TokenAndListParam identifier, ReferenceAndListParam patient,
+            ReferenceAndListParam requester, ReferenceAndListParam specimen, TokenAndListParam code,
+            TokenAndListParam status, DateRangeParam lastUpdated, SortSpec sort, Set<Include> includes,
+            Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.patient = patient;
+        this.requester = requester;
+        this.specimen = specimen;
+        this.code = code;
+        this.status = status;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
     }
 
     @Override
     public SearchParameterMap toSearchParameterMap() {
+
         SearchParameterMap map = new SearchParameterMap();
         addBaseSearchParameters(map);
+
+        if (patient != null) {
+            map.addParameter(ServiceRequest.SP_PATIENT, patient);
+        }
+        if (requester != null) {
+            map.addParameter(ServiceRequest.SP_REQUESTER, requester);
+        }
+        if (specimen != null) {
+            map.addParameter(ServiceRequest.SP_SPECIMEN, specimen);
+        }
+        if (code != null) {
+            map.addParameter(ServiceRequest.SP_CODE, code);
+        }
+        if (status != null) {
+            map.addParameter(ServiceRequest.SP_STATUS, status);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
         return map;
     }
 
+    public ReferenceAndListParam getPatient() {
+        return patient;
+    }
+
+    public ReferenceAndListParam getRequester() {
+        return requester;
+    }
+
+    public ReferenceAndListParam getSpecimen() {
+        return specimen;
+    }
+
+    public TokenAndListParam getCode() {
+        return code;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+
+    /**
+     * FHIR status code (lower case) to the OpenELIS analysis status ids it covers.
+     */
+    public Map<String, List<String>> getStatusIdsByCode() {
+        return statusIdsByCode;
+    }
+
+    public void setStatusIdsByCode(Map<String, List<String>> statusIdsByCode) {
+        this.statusIdsByCode = statusIdsByCode == null ? Collections.emptyMap() : statusIdsByCode;
+    }
+
+    public boolean hasInclude(String... includeValues) {
+        return matchesAny(includes, includeValues);
+    }
+
+    public boolean hasRevInclude(String... includeValues) {
+        return matchesAny(revIncludes, includeValues);
+    }
+
+    private static boolean matchesAny(Set<Include> candidates, String... includeValues) {
+        for (Include include : candidates) {
+            for (String value : includeValues) {
+                if (value != null && value.equals(include.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/openelisglobal/fhir/search/searchparams/SpecimenSearchParams.java
+++ b/src/main/java/org/openelisglobal/fhir/search/searchparams/SpecimenSearchParams.java
@@ -1,0 +1,141 @@
+package org.openelisglobal.fhir.search.searchparams;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.hl7.fhir.r4.model.Specimen;
+
+/**
+ * Search parameters the Specimen facade answers from the OpenELIS database:
+ * logical id, identifiers (sample item uuid, lab number), accession, patient,
+ * sample type, status, collection date and last-updated timestamp.
+ *
+ * <p>
+ * {@code patient} and {@code subject} are the same lookup and arrive merged.
+ * The OpenELIS status ids behind the FHIR status codes are resolved by the
+ * search service before the DAO runs.
+ */
+public class SpecimenSearchParams extends BaseSearchParam {
+
+    private TokenAndListParam accession;
+
+    private ReferenceAndListParam patient;
+
+    private TokenAndListParam type;
+
+    private TokenAndListParam status;
+
+    private DateRangeParam collected;
+
+    private String canceledStatusId;
+
+    private String disposedStatusId;
+
+    private final Set<Include> includes;
+
+    private final Set<Include> revIncludes;
+
+    public SpecimenSearchParams(TokenAndListParam id, TokenAndListParam identifier, TokenAndListParam accession,
+            ReferenceAndListParam patient, TokenAndListParam type, TokenAndListParam status, DateRangeParam collected,
+            DateRangeParam lastUpdated, SortSpec sort, Set<Include> includes, Set<Include> revIncludes) {
+
+        super(id, identifier, lastUpdated, sort);
+
+        this.accession = accession;
+        this.patient = patient;
+        this.type = type;
+        this.status = status;
+        this.collected = collected;
+        this.includes = includes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(includes));
+        this.revIncludes = revIncludes == null ? Collections.emptySet()
+                : Collections.unmodifiableSet(new HashSet<>(revIncludes));
+    }
+
+    @Override
+    public SearchParameterMap toSearchParameterMap() {
+
+        SearchParameterMap map = new SearchParameterMap();
+        addBaseSearchParameters(map);
+
+        if (accession != null) {
+            map.addParameter(Specimen.SP_ACCESSION, accession);
+        }
+        if (patient != null) {
+            map.addParameter(Specimen.SP_PATIENT, patient);
+        }
+        if (type != null) {
+            map.addParameter(Specimen.SP_TYPE, type);
+        }
+        if (status != null) {
+            map.addParameter(Specimen.SP_STATUS, status);
+        }
+        if (collected != null) {
+            map.addParameter(Specimen.SP_COLLECTED, collected);
+        }
+        if (getSort() != null) {
+            map.setSortSpec(getSort());
+        }
+        return map;
+    }
+
+    public TokenAndListParam getAccession() {
+        return accession;
+    }
+
+    public ReferenceAndListParam getPatient() {
+        return patient;
+    }
+
+    public TokenAndListParam getType() {
+        return type;
+    }
+
+    public TokenAndListParam getStatus() {
+        return status;
+    }
+
+    public DateRangeParam getCollected() {
+        return collected;
+    }
+
+    public String getCanceledStatusId() {
+        return canceledStatusId;
+    }
+
+    public void setCanceledStatusId(String canceledStatusId) {
+        this.canceledStatusId = canceledStatusId;
+    }
+
+    public String getDisposedStatusId() {
+        return disposedStatusId;
+    }
+
+    public void setDisposedStatusId(String disposedStatusId) {
+        this.disposedStatusId = disposedStatusId;
+    }
+
+    public boolean hasInclude(String... includeValues) {
+        return matchesAny(includes, includeValues);
+    }
+
+    public boolean hasRevInclude(String... includeValues) {
+        return matchesAny(revIncludes, includeValues);
+    }
+
+    private static boolean matchesAny(Set<Include> candidates, String... includeValues) {
+        for (Include include : candidates) {
+            for (String value : includeValues) {
+                if (value != null && value.equals(include.getValue())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/openelisglobal/fhir/service/DeviceTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/DeviceTransformServiceImpl.java
@@ -304,6 +304,7 @@ public class DeviceTransformServiceImpl implements DeviceTransformService {
 
         String fhirUuid = analyzer.ensureFhirUuid();
         device.setId(fhirUuid);
+        device.getMeta().setLastUpdated(analyzer.getLastupdated());
         if (analyzer.getStatus() != null) {
 
             switch (analyzer.getStatus()) {

--- a/src/main/java/org/openelisglobal/fhir/service/DiagnosticReportTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/DiagnosticReportTransformServiceImpl.java
@@ -95,6 +95,7 @@ public class DiagnosticReportTransformServiceImpl implements DiagnosticReportTra
 
         DiagnosticReport diagnosticReport = new DiagnosticReport();
         diagnosticReport.setId(analysis.getFhirUuidAsString());
+        diagnosticReport.getMeta().setLastUpdated(analysis.getLastupdated());
         diagnosticReport.addIdentifier(common.createIdentifier(fhirConfig.getOeFhirSystem() + "/analysisResult_uuid",
                 analysis.getFhirUuidAsString()));
         Identifier facilityId = common.createFacilityIdentifier();

--- a/src/main/java/org/openelisglobal/fhir/service/ObservationTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/ObservationTransformServiceImpl.java
@@ -256,6 +256,7 @@ public class ObservationTransformServiceImpl implements ObservationTransformServ
         Observation observation = new Observation();
 
         observation.setId(result.getFhirUuidAsString());
+        observation.getMeta().setLastUpdated(result.getLastupdated());
         observation.addIdentifier(
                 common.createIdentifier(fhirConfig.getOeFhirSystem() + "/result_uuid", result.getFhirUuidAsString()));
         Identifier facilityId = common.createFacilityIdentifier();

--- a/src/main/java/org/openelisglobal/fhir/service/OrganizationTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/OrganizationTransformServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.ResourceType;
 import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.validator.GenericValidator;
@@ -38,11 +39,16 @@ public class OrganizationTransformServiceImpl implements OrganizationTransformSe
         org.hl7.fhir.r4.model.Organization fhirOrganization = new org.hl7.fhir.r4.model.Organization();
         fhirOrganization
                 .setId(organization.getFhirUuid() == null ? organization.getId() : organization.getFhirUuidAsString());
+        fhirOrganization.getMeta().setLastUpdated(organization.getLastupdated());
         fhirOrganization.setName(organization.getOrganizationName());
-        fhirOrganization.setActive(organization.getIsActive().equals(IActionConstants.YES) ? true : false);
+        fhirOrganization.setActive(!IActionConstants.NO.equals(organization.getIsActive()));
         this.setFhirOrganizationIdentifiers(fhirOrganization, organization);
         this.setFhirAddressInfo(fhirOrganization, organization);
         this.setFhirOrganizationTypes(fhirOrganization, organization);
+        if (organization.getOrganization() != null && organization.getOrganization().getFhirUuid() != null) {
+            fhirOrganization.setPartOf(common.createReferenceFor(ResourceType.Organization,
+                    organization.getOrganization().getFhirUuidAsString()));
+        }
         return fhirOrganization;
     }
 

--- a/src/main/java/org/openelisglobal/fhir/service/PatientTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/PatientTransformServiceImpl.java
@@ -127,6 +127,7 @@ public class PatientTransformServiceImpl implements PatientTransformService {
                 "transforming patient with id: " + patient.getId() + " fhirUuid: " + uuid);
 
         fhirPatient.setId(uuid);
+        fhirPatient.getMeta().setLastUpdated(patient.getLastupdated());
         fhirPatient.setIdentifier(createPatientIdentifiers(subjectNumber, nationalId, stNumber, guid, uuid));
         Identifier facilityId = common.createFacilityIdentifier();
         if (facilityId != null) {

--- a/src/main/java/org/openelisglobal/fhir/service/PractitionerTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/PractitionerTransformServiceImpl.java
@@ -34,6 +34,7 @@ public class PractitionerTransformServiceImpl implements PractitionerTransformSe
 
         Practitioner practitioner = new Practitioner();
         practitioner.setId(provider.getFhirUuidAsString());
+        practitioner.getMeta().setLastUpdated(provider.getLastupdated());
         practitioner.addIdentifier(common.createIdentifier(fhirConfig.getOeFhirSystem() + "/provider_uuid",
                 provider.getFhirUuidAsString()));
         Identifier facilityId = common.createFacilityIdentifier();

--- a/src/main/java/org/openelisglobal/fhir/service/ServiceRequestTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/ServiceRequestTransformServiceImpl.java
@@ -185,6 +185,7 @@ public class ServiceRequestTransformServiceImpl implements ServiceRequestTransfo
         Test test = analysis.getTest();
         ServiceRequest serviceRequest = new ServiceRequest();
         serviceRequest.setId(analysis.getFhirUuidAsString());
+        serviceRequest.getMeta().setLastUpdated(analysis.getLastupdated());
         serviceRequest.addIdentifier(common.createIdentifier(fhirConfig.getOeFhirSystem() + "/analysis_uuid",
                 analysis.getFhirUuidAsString()));
         Identifier facilityId = common.createFacilityIdentifier();

--- a/src/main/java/org/openelisglobal/fhir/service/SpecimenTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/SpecimenTransformServiceImpl.java
@@ -242,6 +242,7 @@ public class SpecimenTransformServiceImpl implements SpecimenTransformService {
         Specimen specimen = new Specimen();
 
         specimen.setId(sampleItem.getFhirUuidAsString());
+        specimen.getMeta().setLastUpdated(sampleItem.getLastupdated());
 
         specimen.addIdentifier(common.createIdentifier(fhirConfig.getOeFhirSystem() + "/sampleItem_uuid",
                 sampleItem.getFhirUuidAsString()));

--- a/src/main/java/org/openelisglobal/fhir/service/TerminologyTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/TerminologyTransformServiceImpl.java
@@ -106,6 +106,9 @@ public class TerminologyTransformServiceImpl implements TerminologyTransformServ
         }
 
         addPrioritizedCodings(codeableConcept, bySystem);
+        if (display != null && !display.isBlank()) {
+            codeableConcept.setText(display);
+        }
         return codeableConcept;
     }
 

--- a/src/main/java/org/openelisglobal/search/dao/DeviceSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/DeviceSearchDao.java
@@ -1,0 +1,180 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.openelisglobal.analyzer.valueholder.Analyzer;
+import org.openelisglobal.analyzer.valueholder.Analyzer.AnalyzerStatus;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.DeviceSearchParams;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS Analyzer records with FHIR Device search parameters.
+ * Identifier systems mirror the transform: {@code analyzer_uuid},
+ * {@code analyzer_machineId} and {@code analyzer_sourceId}; status codes are
+ * the inverse of the outbound analyzer-status mapping.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class DeviceSearchDao extends BaseFhirDao {
+
+    private static final String NAME_PROPERTY = "name";
+    private static final String TYPE_PROPERTY = "type";
+    private static final String STATUS_PROPERTY = "status";
+    private static final String MACHINE_ID_PROPERTY = "machineId";
+    private static final String SOURCE_ID_PROPERTY = "discoveredSourceId";
+
+    public DeviceSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<Analyzer> search(DeviceSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+        FhirCriteriaContext<Analyzer, Analyzer> context = createCriteriaContext(Analyzer.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(DeviceSearchParams params) {
+
+        return count(Analyzer.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<Analyzer, R> context, DeviceSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createDeviceIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createStringPredicate(context, NAME_PROPERTY, params.getDeviceName()));
+        addPredicate(context, createTypePredicate(context, params.getType()));
+        addPredicate(context, createStatusPredicate(context, params.getStatus()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    private <R> Optional<Predicate> createTypePredicate(FhirCriteriaContext<Analyzer, R> context,
+            TokenAndListParam type) {
+
+        if (type == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, TYPE_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, type, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional
+                    .of(criteriaBuilder.equal(criteriaBuilder.lower(expression), value.toLowerCase(Locale.ROOT)));
+        });
+    }
+
+    /**
+     * FHIR device status back to analyzer statuses: active covers setup,
+     * validation, active and offline analyzers; inactive covers inactive and
+     * deleted; entered-in-error is error-pending; unknown is pending registration.
+     */
+    private <R> Optional<Predicate> createStatusPredicate(FhirCriteriaContext<Analyzer, R> context,
+            TokenAndListParam status) {
+
+        if (status == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<AnalyzerStatus> expression = resolveExpression(context, STATUS_PROPERTY, AnalyzerStatus.class);
+
+        return handleTokenAndListParam(criteriaBuilder, status, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            return switch (code) {
+            case "active" ->
+                Optional.of(criteriaBuilder.or(criteriaBuilder.isNull(expression), expression.in(AnalyzerStatus.SETUP,
+                        AnalyzerStatus.VALIDATION, AnalyzerStatus.ACTIVE, AnalyzerStatus.OFFLINE)));
+            case "inactive" -> Optional.of(expression.in(AnalyzerStatus.INACTIVE, AnalyzerStatus.DELETED));
+            case "entered-in-error" -> Optional.of(criteriaBuilder.equal(expression, AnalyzerStatus.ERROR_PENDING));
+            case "unknown" -> Optional.of(criteriaBuilder.equal(expression, AnalyzerStatus.PENDING_REGISTRATION));
+            default -> Optional.of(criteriaBuilder.disjunction());
+            };
+        });
+    }
+
+    private <R> Optional<Predicate> createDeviceIdentifierPredicate(FhirCriteriaContext<Analyzer, R> context,
+            TokenAndListParam identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        return handleTokenAndListParam(criteriaBuilder, identifier, token -> identifierPredicate(context, token));
+    }
+
+    private <R> Optional<Predicate> identifierPredicate(FhirCriteriaContext<Analyzer, R> context, TokenParam token) {
+
+        String value = token.getValue() == null ? "" : token.getValue().trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Root<Analyzer> root = context.getRoot();
+        String system = normalizeSystem(token.getSystem());
+        String systemKey = system.contains("/") ? system.substring(system.lastIndexOf('/') + 1) : system;
+
+        List<Predicate> alternatives = new ArrayList<>();
+        switch (systemKey) {
+        case "":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            alternatives.add(criteriaBuilder.equal(root.get(MACHINE_ID_PROPERTY), value));
+            alternatives.add(criteriaBuilder.equal(root.get(SOURCE_ID_PROPERTY), value));
+            break;
+        case "analyzer_uuid":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            break;
+        case "analyzer_machineId":
+            alternatives.add(criteriaBuilder.equal(root.get(MACHINE_ID_PROPERTY), value));
+            break;
+        case "analyzer_sourceId":
+            alternatives.add(criteriaBuilder.equal(root.get(SOURCE_ID_PROPERTY), value));
+            break;
+        default:
+            break;
+        }
+        if (alternatives.isEmpty()) {
+            return Optional.of(criteriaBuilder.disjunction());
+        }
+        return combineWithOr(criteriaBuilder, alternatives);
+    }
+
+    private Optional<Predicate> uuidPredicate(CriteriaBuilder criteriaBuilder, Root<Analyzer> root, String value) {
+        try {
+            return Optional
+                    .of(criteriaBuilder.equal(root.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(value)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/search/dao/DiagnosticReportSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/DiagnosticReportSearchDao.java
@@ -1,0 +1,248 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import org.openelisglobal.analysis.valueholder.Analysis;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.dao.DateParamBounds;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.DiagnosticReportSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS Analysis records with FHIR DiagnosticReport search
+ * parameters. A report shares its logical id with the ServiceRequest for the
+ * same analysis, so {@code based-on} and {@code _id} resolve the same rows;
+ * {@code result} resolves through the analysis' results; {@code issued} is the
+ * analysis release date.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class DiagnosticReportSearchDao extends BaseFhirDao {
+
+    private static final String STATUS_PROPERTY = "statusId";
+    private static final String RELEASED_DATE_PROPERTY = "releasedDate";
+    private static final String SAMPLE_ID_PROPERTY = FhirConstants.ANALYSIS_SAMPLE_ID_HANDLER;
+    private static final String SAMPLE_ITEM_UUID_PROPERTY = FhirConstants.SAMPLE_ITEM_FHIR_UUID_HANDLER;
+    private static final String SAMPLE_ITEM_ID_PROPERTY = FhirConstants.SAMPLE_ITEM_ID_HANDLER;
+    private static final String TEST_LOINC_PROPERTY = "test.loinc";
+    private static final String TEST_NAME_PROPERTY = "test.description";
+
+    public DiagnosticReportSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<Analysis> search(DiagnosticReportSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+        FhirCriteriaContext<Analysis, Analysis> context = createCriteriaContext(Analysis.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(DiagnosticReportSearchParams params) {
+
+        return count(Analysis.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<Analysis, R> context,
+            DiagnosticReportSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createPatientPredicate(context, params.getPatient()));
+        addPredicate(context,
+                createUuidReferencePredicate(context, params.getBasedOn(), FhirConstants.ID_PROPERTY, "id"));
+        addPredicate(context, createResultPredicate(context, params.getResult()));
+        addPredicate(context, createUuidReferencePredicate(context, params.getSpecimen(), SAMPLE_ITEM_UUID_PROPERTY,
+                SAMPLE_ITEM_ID_PROPERTY));
+        addPredicate(context, createCodePredicate(context, params.getCode()));
+        addPredicate(context, createStatusPredicate(context, params));
+        addPredicate(context, createIssuedPredicate(context, params.getIssued()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    private <R> Optional<Predicate> createPatientPredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam patient) {
+
+        if (patient == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> sampleId = resolveStringExpression(context, SAMPLE_ID_PROPERTY);
+
+        return handleAndListParam(criteriaBuilder, patient, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(sampleId.in(sampleIdsForPatient(context, idPart.trim())));
+        });
+    }
+
+    private <R> Subquery<String> sampleIdsForPatient(FhirCriteriaContext<Analysis, R> context, String patientRef) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        FhirCriteriaContext<SampleHuman, String> sub = createSubQuery(context, SampleHuman.class, String.class);
+        Subquery<String> subquery = sub.getSubquery();
+        Root<SampleHuman> sampleHuman = sub.getRoot();
+        Root<Patient> patient = subquery.from(Patient.class);
+        subquery.select(sampleHuman.get(FhirConstants.SAMPLE_ID));
+
+        List<Predicate> where = new ArrayList<>();
+        where.add(criteriaBuilder.equal(sampleHuman.get(FhirConstants.PATIENT_ID), patient.get("id")));
+        try {
+            where.add(criteriaBuilder.equal(patient.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(patientRef)));
+        } catch (IllegalArgumentException e) {
+            where.add(criteriaBuilder.equal(patient.get("id"), patientRef));
+        }
+        subquery.where(where.toArray(Predicate[]::new));
+        return subquery;
+    }
+
+    /** {@code result=Observation/<uuid>}: analyses owning a result with that id. */
+    private <R> Optional<Predicate> createResultPredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam result) {
+
+        if (result == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+
+        return handleAndListParam(criteriaBuilder, result, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            FhirCriteriaContext<Result, String> sub = createSubQuery(context, Result.class, String.class);
+            Subquery<String> subquery = sub.getSubquery();
+            Root<Result> resultRoot = sub.getRoot();
+            subquery.select(resultRoot.get("analysis").get("id"));
+            try {
+                subquery.where(criteriaBuilder.equal(resultRoot.<UUID>get(FhirConstants.ID_PROPERTY),
+                        UUID.fromString(idPart.trim())));
+            } catch (IllegalArgumentException e) {
+                subquery.where(criteriaBuilder.equal(resultRoot.get("id"), idPart.trim()));
+            }
+            return Optional.of(context.getRoot().get("id").in(subquery));
+        });
+    }
+
+    private <R> Optional<Predicate> createUuidReferencePredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam reference, String uuidProperty, String idProperty) {
+
+        if (reference == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<UUID> uuidExpression = resolveUuidExpression(context, uuidProperty);
+        Expression<String> idExpression = resolveStringExpression(context, idProperty);
+
+        return handleAndListParam(criteriaBuilder, reference, (ReferenceParam value) -> {
+            String idPart = value.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(criteriaBuilder.equal(uuidExpression, UUID.fromString(idPart.trim())));
+            } catch (IllegalArgumentException e) {
+                return Optional.of(criteriaBuilder.equal(idExpression, idPart.trim()));
+            }
+        });
+    }
+
+    private <R> Optional<Predicate> createCodePredicate(FhirCriteriaContext<Analysis, R> context,
+            TokenAndListParam code) {
+
+        if (code == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> loinc = resolveStringExpression(context, TEST_LOINC_PROPERTY);
+        Expression<String> name = resolveStringExpression(context, TEST_NAME_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, code, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            String system = normalizeSystem(token.getSystem());
+            if (system.isEmpty()) {
+                return Optional.of(criteriaBuilder.or(criteriaBuilder.equal(loinc, value),
+                        criteriaBuilder.equal(criteriaBuilder.lower(name), value.toLowerCase(Locale.ROOT))));
+            }
+            if ("http://loinc.org".equalsIgnoreCase(system)) {
+                return Optional.of(criteriaBuilder.equal(loinc, value));
+            }
+            return Optional.of(criteriaBuilder.disjunction());
+        });
+    }
+
+    private <R> Optional<Predicate> createStatusPredicate(FhirCriteriaContext<Analysis, R> context,
+            DiagnosticReportSearchParams params) {
+
+        TokenAndListParam status = params.getStatus();
+        if (status == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, STATUS_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, status, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            List<String> ids = params.getStatusIdsByCode().getOrDefault(code, List.of());
+            if ("unknown".equals(code)) {
+                List<String> mapped = new ArrayList<>();
+                params.getStatusIdsByCode().values().forEach(mapped::addAll);
+                return Optional.of(
+                        mapped.isEmpty() ? criteriaBuilder.conjunction() : criteriaBuilder.not(expression.in(mapped)));
+            }
+            if (ids.isEmpty()) {
+                return Optional.of(criteriaBuilder.disjunction());
+            }
+            return Optional.of(expression.in(ids));
+        });
+    }
+
+    private <R> Optional<Predicate> createIssuedPredicate(FhirCriteriaContext<Analysis, R> context,
+            DateRangeParam issued) {
+
+        if (issued == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<Date> expression = resolveExpression(context, RELEASED_DATE_PROPERTY, Date.class);
+        return combineWithAnd(criteriaBuilder, DateParamBounds.predicates(criteriaBuilder, expression, issued));
+    }
+}

--- a/src/main/java/org/openelisglobal/search/dao/ObservationSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/ObservationSearchDao.java
@@ -1,0 +1,241 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.dao.DateParamBounds;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.ObservationSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.result.valueholder.Result;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS Result records with FHIR Observation search parameters. The
+ * order is the analysis ({@code based-on}), the specimen is the analysis'
+ * sample item, and the effective date is the analysis release date.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class ObservationSearchDao extends BaseFhirDao {
+
+    private static final String ANALYSIS_ID_PROPERTY = "analysis.id";
+    private static final String ANALYSIS_UUID_PROPERTY = "analysis." + FhirConstants.ID_PROPERTY;
+    private static final String ANALYSIS_STATUS_PROPERTY = "analysis.statusId";
+    private static final String RELEASED_DATE_PROPERTY = "analysis.releasedDate";
+    private static final String SAMPLE_ID_PROPERTY = "analysis." + FhirConstants.ANALYSIS_SAMPLE_ID_HANDLER;
+    private static final String SAMPLE_ITEM_UUID_PROPERTY = "analysis." + FhirConstants.SAMPLE_ITEM_FHIR_UUID_HANDLER;
+    private static final String SAMPLE_ITEM_ID_PROPERTY = "analysis." + FhirConstants.SAMPLE_ITEM_ID_HANDLER;
+    private static final String TEST_LOINC_PROPERTY = "analysis.test.loinc";
+    private static final String TEST_NAME_PROPERTY = "analysis.test.description";
+
+    public ObservationSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<Result> search(ObservationSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+        FhirCriteriaContext<Result, Result> context = createCriteriaContext(Result.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(ObservationSearchParams params) {
+
+        return count(Result.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    /** Every result recorded against one of the given Analysis primary keys. */
+    public List<Result> findByAnalysisIds(List<String> analysisIds) {
+
+        List<String> ids = analysisIds == null ? List.of()
+                : analysisIds.stream().filter(Objects::nonNull).map(String::trim).filter(id -> !id.isEmpty()).distinct()
+                        .toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        FhirCriteriaContext<Result, Result> context = createCriteriaContext(Result.class);
+        Expression<String> analysisId = resolveExpression(context, ANALYSIS_ID_PROPERTY, String.class);
+        context.addPredicate(analysisId.in(ids));
+        context.distinct(true);
+        return list(context);
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<Result, R> context, ObservationSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createPatientPredicate(context, params.getPatient()));
+        addPredicate(context, createUuidReferencePredicate(context, params.getBasedOn(), ANALYSIS_UUID_PROPERTY,
+                ANALYSIS_ID_PROPERTY));
+        addPredicate(context, createUuidReferencePredicate(context, params.getSpecimen(), SAMPLE_ITEM_UUID_PROPERTY,
+                SAMPLE_ITEM_ID_PROPERTY));
+        addPredicate(context, createCodePredicate(context, params.getCode()));
+        addPredicate(context, createStatusPredicate(context, params));
+        addPredicate(context, createDatePredicate(context, params.getDate()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    private <R> Optional<Predicate> createPatientPredicate(FhirCriteriaContext<Result, R> context,
+            ReferenceAndListParam patient) {
+
+        if (patient == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> sampleId = resolveStringExpression(context, SAMPLE_ID_PROPERTY);
+
+        return handleAndListParam(criteriaBuilder, patient, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(sampleId.in(sampleIdsForPatient(context, idPart.trim())));
+        });
+    }
+
+    private <R> Subquery<String> sampleIdsForPatient(FhirCriteriaContext<Result, R> context, String patientRef) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        FhirCriteriaContext<SampleHuman, String> sub = createSubQuery(context, SampleHuman.class, String.class);
+        Subquery<String> subquery = sub.getSubquery();
+        Root<SampleHuman> sampleHuman = sub.getRoot();
+        Root<Patient> patient = subquery.from(Patient.class);
+        subquery.select(sampleHuman.get(FhirConstants.SAMPLE_ID));
+
+        List<Predicate> where = new ArrayList<>();
+        where.add(criteriaBuilder.equal(sampleHuman.get(FhirConstants.PATIENT_ID), patient.get("id")));
+        try {
+            where.add(criteriaBuilder.equal(patient.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(patientRef)));
+        } catch (IllegalArgumentException e) {
+            where.add(criteriaBuilder.equal(patient.get("id"), patientRef));
+        }
+        subquery.where(where.toArray(Predicate[]::new));
+        return subquery;
+    }
+
+    /**
+     * A reference whose id is the linked row's FHIR uuid, or its OpenELIS id as a
+     * fallback.
+     */
+    private <R> Optional<Predicate> createUuidReferencePredicate(FhirCriteriaContext<Result, R> context,
+            ReferenceAndListParam reference, String uuidProperty, String idProperty) {
+
+        if (reference == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<UUID> uuidExpression = resolveUuidExpression(context, uuidProperty);
+        Expression<String> idExpression = resolveStringExpression(context, idProperty);
+
+        return handleAndListParam(criteriaBuilder, reference, (ReferenceParam value) -> {
+            String idPart = value.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(criteriaBuilder.equal(uuidExpression, UUID.fromString(idPart.trim())));
+            } catch (IllegalArgumentException e) {
+                return Optional.of(criteriaBuilder.equal(idExpression, idPart.trim()));
+            }
+        });
+    }
+
+    private <R> Optional<Predicate> createCodePredicate(FhirCriteriaContext<Result, R> context,
+            TokenAndListParam code) {
+
+        if (code == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> loinc = resolveStringExpression(context, TEST_LOINC_PROPERTY);
+        Expression<String> name = resolveStringExpression(context, TEST_NAME_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, code, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            String system = normalizeSystem(token.getSystem());
+            if (system.isEmpty()) {
+                return Optional.of(criteriaBuilder.or(criteriaBuilder.equal(loinc, value),
+                        criteriaBuilder.equal(criteriaBuilder.lower(name), value.toLowerCase(Locale.ROOT))));
+            }
+            if ("http://loinc.org".equalsIgnoreCase(system)) {
+                return Optional.of(criteriaBuilder.equal(loinc, value));
+            }
+            return Optional.of(criteriaBuilder.disjunction());
+        });
+    }
+
+    private <R> Optional<Predicate> createStatusPredicate(FhirCriteriaContext<Result, R> context,
+            ObservationSearchParams params) {
+
+        TokenAndListParam status = params.getStatus();
+        if (status == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, ANALYSIS_STATUS_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, status, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            List<String> ids = params.getStatusIdsByCode().getOrDefault(code, List.of());
+            if ("preliminary".equals(code)) {
+                List<String> others = new ArrayList<>();
+                params.getStatusIdsByCode().forEach((key, value) -> {
+                    if (!"preliminary".equals(key)) {
+                        others.addAll(value);
+                    }
+                });
+                return Optional.of(
+                        others.isEmpty() ? criteriaBuilder.conjunction() : criteriaBuilder.not(expression.in(others)));
+            }
+            if (ids.isEmpty()) {
+                return Optional.of(criteriaBuilder.disjunction());
+            }
+            return Optional.of(expression.in(ids));
+        });
+    }
+
+    private <R> Optional<Predicate> createDatePredicate(FhirCriteriaContext<Result, R> context, DateRangeParam date) {
+
+        if (date == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<Date> expression = resolveExpression(context, RELEASED_DATE_PROPERTY, Date.class);
+        return combineWithAnd(criteriaBuilder, DateParamBounds.predicates(criteriaBuilder, expression, date));
+    }
+}

--- a/src/main/java/org/openelisglobal/search/dao/OrganizationSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/OrganizationSearchDao.java
@@ -1,0 +1,237 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.OrganizationSearchParams;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS Organization records with FHIR Organization search
+ * parameters. Identifier systems mirror the transform: {@code org_uuid},
+ * {@code org_code}, {@code org_shortName} and {@code org_cliaNum}; a bare value
+ * is matched against all of them.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class OrganizationSearchDao extends BaseFhirDao {
+
+    private static final String NAME_PROPERTY = "organizationName";
+    private static final String ACTIVE_PROPERTY = "isActive";
+    private static final String CODE_PROPERTY = "code";
+    private static final String SHORT_NAME_PROPERTY = "shortName";
+    private static final String CLIA_PROPERTY = "cliaNum";
+    private static final String CITY_PROPERTY = "city";
+    private static final String STATE_PROPERTY = "state";
+    private static final String TYPE_NAME_PROPERTY = "organizationTypes.name";
+    private static final String PARENT_ID_PROPERTY = "organization.id";
+    private static final String PARENT_UUID_PROPERTY = "organization.fhirUuid";
+
+    public OrganizationSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<Organization> search(OrganizationSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+
+        FhirCriteriaContext<Organization, Organization> context = createCriteriaContext(Organization.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(OrganizationSearchParams params) {
+
+        return count(Organization.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    /**
+     * Child organizations of the given parents (for
+     * {@code _revinclude=Organization:partof}).
+     */
+    public List<Organization> findByParentIds(List<String> parentIds) {
+
+        List<String> ids = parentIds == null ? List.of()
+                : parentIds.stream().filter(Objects::nonNull).distinct().toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        FhirCriteriaContext<Organization, Organization> context = createCriteriaContext(Organization.class);
+        Expression<String> parentId = resolveExpression(context, PARENT_ID_PROPERTY, String.class);
+        context.addPredicate(parentId.in(ids));
+        context.distinct(true);
+        return list(context);
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<Organization, R> context,
+            OrganizationSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createOrganizationIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createStringPredicate(context, NAME_PROPERTY, params.getName()));
+        addPredicate(context, createActivePredicate(context, params.getActive()));
+        addPredicate(context, createTypePredicate(context, params.getType()));
+        addPredicate(context, createPartOfPredicate(context, params.getPartOf()));
+        addPredicate(context, createStringPredicate(context, CITY_PROPERTY, params.getCity()));
+        addPredicate(context, createStringPredicate(context, STATE_PROPERTY, params.getState()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    private <R> Optional<Predicate> createActivePredicate(FhirCriteriaContext<Organization, R> context,
+            TokenAndListParam active) {
+
+        if (active == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, ACTIVE_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, active, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            return switch (value) {
+            case "true" -> Optional.of(criteriaBuilder.equal(criteriaBuilder.upper(expression), "Y"));
+            case "false" -> Optional.of(criteriaBuilder.or(criteriaBuilder.isNull(expression),
+                    criteriaBuilder.notEqual(criteriaBuilder.upper(expression), "Y")));
+            default -> Optional.of(criteriaBuilder.disjunction());
+            };
+        });
+    }
+
+    /**
+     * {@code type=<code>} matches the organization type name, case-insensitively.
+     */
+    private <R> Optional<Predicate> createTypePredicate(FhirCriteriaContext<Organization, R> context,
+            TokenAndListParam type) {
+
+        if (type == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, TYPE_NAME_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, type, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional
+                    .of(criteriaBuilder.equal(criteriaBuilder.lower(expression), value.toLowerCase(Locale.ROOT)));
+        });
+    }
+
+    /**
+     * {@code partof=Organization/<id>} accepts the parent's FHIR uuid or OpenELIS
+     * id.
+     */
+    private <R> Optional<Predicate> createPartOfPredicate(FhirCriteriaContext<Organization, R> context,
+            ReferenceAndListParam partOf) {
+
+        if (partOf == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<UUID> parentUuid = resolveUuidExpression(context, PARENT_UUID_PROPERTY);
+        Expression<String> parentId = resolveStringExpression(context, PARENT_ID_PROPERTY);
+
+        return handleAndListParam(criteriaBuilder, partOf, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(criteriaBuilder.equal(parentUuid, UUID.fromString(idPart.trim())));
+            } catch (IllegalArgumentException e) {
+                return Optional.of(criteriaBuilder.equal(parentId, idPart.trim()));
+            }
+        });
+    }
+
+    private <R> Optional<Predicate> createOrganizationIdentifierPredicate(FhirCriteriaContext<Organization, R> context,
+            TokenAndListParam identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        return handleTokenAndListParam(criteriaBuilder, identifier, token -> identifierPredicate(context, token));
+    }
+
+    private <R> Optional<Predicate> identifierPredicate(FhirCriteriaContext<Organization, R> context,
+            TokenParam token) {
+
+        String value = token.getValue() == null ? "" : token.getValue().trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Root<Organization> root = context.getRoot();
+        String system = normalizeSystem(token.getSystem());
+        String systemKey = system.contains("/") ? system.substring(system.lastIndexOf('/') + 1) : system;
+
+        List<Predicate> alternatives = new ArrayList<>();
+        switch (systemKey) {
+        case "":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            alternatives.add(criteriaBuilder.equal(root.get(CODE_PROPERTY), value));
+            alternatives.add(criteriaBuilder.equal(root.get(SHORT_NAME_PROPERTY), value));
+            alternatives.add(criteriaBuilder.equal(root.get(CLIA_PROPERTY), value));
+            break;
+        case "org_uuid":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            break;
+        case "org_code":
+            alternatives.add(criteriaBuilder.equal(root.get(CODE_PROPERTY), value));
+            break;
+        case "org_shortName":
+            alternatives.add(criteriaBuilder.equal(root.get(SHORT_NAME_PROPERTY), value));
+            break;
+        case "org_cliaNum":
+            alternatives.add(criteriaBuilder.equal(root.get(CLIA_PROPERTY), value));
+            break;
+        default:
+            break;
+        }
+        if (alternatives.isEmpty()) {
+            return Optional.of(criteriaBuilder.disjunction());
+        }
+        return combineWithOr(criteriaBuilder, alternatives);
+    }
+
+    private Optional<Predicate> uuidPredicate(CriteriaBuilder criteriaBuilder, Root<Organization> root, String value) {
+        try {
+            return Optional
+                    .of(criteriaBuilder.equal(root.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(value)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/openelisglobal/search/dao/PatientSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/PatientSearchDao.java
@@ -1,0 +1,245 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.dao.DateParamBounds;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.PatientSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.patientidentity.valueholder.PatientIdentity;
+import org.openelisglobal.patientidentitytype.valueholder.PatientIdentityType;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS Patient records with FHIR Patient search parameters.
+ *
+ * <p>
+ * Identifiers map onto the same systems the Patient transform emits:
+ * {@code pat_uuid} (fhirUuid), {@code pat_nationalId} (nationalId column or the
+ * NATIONAL identity), {@code pat_subjectNumber}, {@code pat_stNumber} and
+ * {@code pat_guid} (patient_identity rows). A bare value is matched against all
+ * of them.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class PatientSearchDao extends BaseFhirDao {
+
+    private static final String BIRTH_DATE_PROPERTY = "birthDate";
+    private static final String GENDER_PROPERTY = "gender";
+    private static final String NATIONAL_ID_PROPERTY = "nationalId";
+    private static final String EXTERNAL_ID_PROPERTY = "externalId";
+    private static final String SUBJECT_IDENTITY = "SUBJECT";
+    private static final String NATIONAL_IDENTITY = "NATIONAL";
+    private static final String ST_IDENTITY = "ST";
+    private static final String GUID_IDENTITY = "GUID";
+
+    public PatientSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<Patient> search(PatientSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+
+        FhirCriteriaContext<Patient, Patient> context = createCriteriaContext(Patient.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(PatientSearchParams params) {
+
+        return count(Patient.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<Patient, R> context, PatientSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createPatientIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createNamePredicate(context, params.getName()));
+        addPredicate(context,
+                createStringPredicate(context, FhirConstants.FIRST_NAME_SEARCH_HANDLER, params.getGiven()));
+        addPredicate(context,
+                createStringPredicate(context, FhirConstants.LAST_NAME_SEARCH_HANDLER, params.getFamily()));
+        addPredicate(context, createBirthDatePredicate(context, params.getBirthDate()));
+        addPredicate(context, createGenderPredicate(context, params.getGender()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    /** {@code Patient?name=x} matches either the given or the family name. */
+    private <R> Optional<Predicate> createNamePredicate(FhirCriteriaContext<Patient, R> context,
+            StringAndListParam name) {
+
+        if (name == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> given = resolveStringExpression(context, FhirConstants.FIRST_NAME_SEARCH_HANDLER);
+        Expression<String> family = resolveStringExpression(context, FhirConstants.LAST_NAME_SEARCH_HANDLER);
+
+        return handleStringAndListParam(criteriaBuilder, name,
+                parameter -> combineWithOr(criteriaBuilder,
+                        Stream.of(createSingleStringPredicate(criteriaBuilder, given, parameter),
+                                createSingleStringPredicate(criteriaBuilder, family, parameter))
+                                .flatMap(Optional::stream).toList()));
+    }
+
+    /**
+     * Day-precision values span the calendar day in the server zone, and the
+     * {@code gt}/{@code lt} prefixes stay exclusive.
+     */
+    private <R> Optional<Predicate> createBirthDatePredicate(FhirCriteriaContext<Patient, R> context,
+            DateRangeParam birthDate) {
+
+        if (birthDate == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<Date> expression = resolveExpression(context, BIRTH_DATE_PROPERTY, Date.class);
+        return combineWithAnd(criteriaBuilder, DateParamBounds.predicates(criteriaBuilder, expression, birthDate));
+    }
+
+    /**
+     * FHIR administrative gender codes against the single-letter OpenELIS column:
+     * male/female map to M/F, unknown to a missing value, other to anything else.
+     */
+    private <R> Optional<Predicate> createGenderPredicate(FhirCriteriaContext<Patient, R> context,
+            TokenAndListParam gender) {
+
+        if (gender == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, GENDER_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, gender, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            return switch (code) {
+            case "male" -> Optional.of(criteriaBuilder.equal(criteriaBuilder.upper(expression), "M"));
+            case "female" -> Optional.of(criteriaBuilder.equal(criteriaBuilder.upper(expression), "F"));
+            case "unknown" -> Optional.of(criteriaBuilder.or(criteriaBuilder.isNull(expression),
+                    criteriaBuilder.equal(criteriaBuilder.trim(expression), "")));
+            case "other" -> Optional.of(criteriaBuilder.and(criteriaBuilder.isNotNull(expression),
+                    criteriaBuilder.not(criteriaBuilder.upper(expression).in("M", "F"))));
+            default -> Optional.of(criteriaBuilder.disjunction());
+            };
+        });
+    }
+
+    private <R> Optional<Predicate> createPatientIdentifierPredicate(FhirCriteriaContext<Patient, R> context,
+            TokenAndListParam identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        return handleTokenAndListParam(criteriaBuilder, identifier, token -> identifierPredicate(context, token));
+    }
+
+    private <R> Optional<Predicate> identifierPredicate(FhirCriteriaContext<Patient, R> context, TokenParam token) {
+
+        String value = token.getValue() == null ? "" : token.getValue().trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Root<Patient> root = context.getRoot();
+        String system = normalizeSystem(token.getSystem());
+        String systemKey = system.contains("/") ? system.substring(system.lastIndexOf('/') + 1) : system;
+
+        List<Predicate> alternatives = new ArrayList<>();
+        switch (systemKey) {
+        case "":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            alternatives.add(criteriaBuilder.equal(root.get(NATIONAL_ID_PROPERTY), value));
+            alternatives.add(criteriaBuilder.equal(root.get(EXTERNAL_ID_PROPERTY), value));
+            alternatives.add(identityPredicate(context, value, null));
+            break;
+        case "pat_uuid":
+            uuidPredicate(criteriaBuilder, root, value).ifPresent(alternatives::add);
+            break;
+        case "pat_nationalId":
+            alternatives.add(criteriaBuilder.equal(root.get(NATIONAL_ID_PROPERTY), value));
+            alternatives.add(identityPredicate(context, value, NATIONAL_IDENTITY));
+            break;
+        case "pat_subjectNumber":
+            alternatives.add(identityPredicate(context, value, SUBJECT_IDENTITY));
+            break;
+        case "pat_stNumber":
+            alternatives.add(identityPredicate(context, value, ST_IDENTITY));
+            break;
+        case "pat_guid":
+            alternatives.add(identityPredicate(context, value, GUID_IDENTITY));
+            break;
+        default:
+            break;
+        }
+        if (alternatives.isEmpty()) {
+            return Optional.of(criteriaBuilder.disjunction());
+        }
+        return combineWithOr(criteriaBuilder, alternatives);
+    }
+
+    private Optional<Predicate> uuidPredicate(CriteriaBuilder criteriaBuilder, Root<Patient> root, String value) {
+        try {
+            UUID uuid = UUID.fromString(value);
+            return Optional.of(criteriaBuilder.equal(root.<UUID>get(FhirConstants.ID_PROPERTY), uuid));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * {@code patient.id IN (select pi.patientId from PatientIdentity pi [join type]
+     * where pi.identityData = value)}.
+     */
+    private <R> Predicate identityPredicate(FhirCriteriaContext<Patient, R> context, String value,
+            String identityType) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        FhirCriteriaContext<PatientIdentity, String> sub = createSubQuery(context, PatientIdentity.class, String.class);
+        Subquery<String> subquery = sub.getSubquery();
+        Root<PatientIdentity> identity = sub.getRoot();
+        subquery.select(identity.get("patientId"));
+
+        List<Predicate> where = new ArrayList<>();
+        where.add(criteriaBuilder.equal(identity.get("identityData"), value));
+        if (identityType != null) {
+            Root<PatientIdentityType> type = subquery.from(PatientIdentityType.class);
+            where.add(criteriaBuilder.equal(identity.get("identityTypeId"), type.get("id")));
+            where.add(criteriaBuilder.equal(criteriaBuilder.upper(type.get("identityType")), identityType));
+        }
+        subquery.where(where.toArray(Predicate[]::new));
+
+        return context.getRoot().get("id").in(subquery);
+    }
+}

--- a/src/main/java/org/openelisglobal/search/dao/PractitionerSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/PractitionerSearchDao.java
@@ -361,4 +361,22 @@ public class PractitionerSearchDao extends BaseFhirDao {
         return normalized.isEmpty() ? null : normalized;
     }
 
+    /** Providers by primary key, for the ServiceRequest requester include. */
+    public List<Provider> findByIds(List<String> providerIds) {
+
+        List<String> ids = providerIds == null ? List.of()
+                : providerIds.stream().filter(java.util.Objects::nonNull).map(String::trim).filter(id -> !id.isEmpty())
+                        .distinct().toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        FhirCriteriaContext<Provider, Provider> context = createCriteriaContext(Provider.class);
+
+        context.addPredicate(context.getRoot().get("id").in(ids));
+
+        context.distinct(true);
+
+        return list(context);
+    }
 }

--- a/src/main/java/org/openelisglobal/search/dao/ServiceRequestSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/ServiceRequestSearchDao.java
@@ -1,64 +1,76 @@
 package org.openelisglobal.search.dao;
 
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.fhir.dao.BaseFhirDao;
 import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
 import org.openelisglobal.fhir.FhirConstants;
 import org.openelisglobal.fhir.search.searchparams.ServiceRequestSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.provider.valueholder.Provider;
 import org.openelisglobal.samplehuman.valueholder.SampleHuman;
 import org.openelisglobal.search.FhirPropertyResolver;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Searches OpenELIS Analysis records with FHIR ServiceRequest search
+ * parameters. Identifier systems mirror the transform: {@code analysis_uuid}
+ * (the logical id) and {@code samp_labNo} (the requisition, i.e. the sample
+ * accession number).
+ */
 @Repository
 @Transactional(readOnly = true)
 public class ServiceRequestSearchDao extends BaseFhirDao {
 
-    public ServiceRequestSearchDao(FhirPropertyResolver propertyResolver) {
+    private static final String SAMPLE_ID_PROPERTY = FhirConstants.ANALYSIS_SAMPLE_ID_HANDLER;
+    private static final String ACCESSION_PROPERTY = FhirConstants.SAMPLE_ITEM + "." + FhirConstants.SAMPLE
+            + ".accessionNumber";
+    private static final String SAMPLE_ITEM_UUID_PROPERTY = FhirConstants.SAMPLE_ITEM_FHIR_UUID_HANDLER;
+    private static final String TEST_LOINC_PROPERTY = "test.loinc";
+    private static final String TEST_NAME_PROPERTY = "test.description";
+    private static final String TEST_SHORT_NAME_PROPERTY = "test.name";
+    private static final String STATUS_PROPERTY = "statusId";
 
+    public ServiceRequestSearchDao(FhirPropertyResolver propertyResolver) {
         super(propertyResolver);
     }
 
-    /**
-     * Searches ServiceRequests represented by Analysis entities.
-     */
     public List<Analysis> search(ServiceRequestSearchParams params) {
 
         FhirCriteriaContext<Analysis, Analysis> context = createCriteriaContext(Analysis.class);
-
         if (params != null) {
             addSearchPredicates(context, params);
         }
-
         context.distinct(true);
-
         return list(context);
     }
 
-    /**
-     * Searches ServiceRequests using zero-based pagination.
-     */
     public List<Analysis> search(ServiceRequestSearchParams params, int offset, int pageSize) {
 
         validatePagination(offset, pageSize);
-
         FhirCriteriaContext<Analysis, Analysis> context = createCriteriaContext(Analysis.class);
-
         if (params != null) {
             addSearchPredicates(context, params);
         }
-
         context.distinct(true);
-
         return list(context, offset, pageSize);
     }
 
-    /**
-     * Counts ServiceRequests matching the supplied search parameters.
-     */
     public long count(ServiceRequestSearchParams params) {
 
         return count(Analysis.class, context -> {
@@ -69,60 +81,242 @@ public class ServiceRequestSearchDao extends BaseFhirDao {
     }
 
     /**
-     * Finds Analysis records related to the supplied SampleHuman records.
-     *
-     * This supports the Practitioner reverse-include flow:
-     *
-     * matched Provider objects -> SampleHumanSearchDao.findByProviders(...) ->
-     * List<SampleHuman> -> ServiceRequestSearchDao.findBySampleHumans(...) ->
-     * List<Analysis>
-     *
-     * SampleHuman.sampleId is an OpenELIS Sample primary key. It is matched against
-     * Analysis.sampleItem.sample.id.
+     * Analyses whose sample belongs to one of the given sample_human rows (the
+     * Practitioner and Patient reverse-include path).
      */
     public List<Analysis> findBySampleHumans(List<SampleHuman> sampleHumans) {
 
-        List<String> sampleIds = extractSampleIds(sampleHumans);
-
+        List<String> sampleIds = sampleHumans == null ? List.of()
+                : sampleHumans.stream().filter(Objects::nonNull).map(SampleHuman::getSampleId).filter(Objects::nonNull)
+                        .map(String::trim).filter(id -> !id.isEmpty()).distinct().toList();
         if (sampleIds.isEmpty()) {
             return List.of();
         }
-
         FhirCriteriaContext<Analysis, Analysis> context = createCriteriaContext(Analysis.class);
-
-        Expression<String> analysisSampleId = resolveExpression(context, FhirConstants.ANALYSIS_SAMPLE_ID_HANDLER,
-                String.class);
-
+        Expression<String> analysisSampleId = resolveExpression(context, SAMPLE_ID_PROPERTY, String.class);
         context.addPredicate(analysisSampleId.in(sampleIds));
-
         context.distinct(true);
-
         return list(context);
     }
 
-    /**
-     * Adds the standard ServiceRequest search predicates.
-     */
+    /** Analyses recorded against the given SampleItem primary keys. */
+    public List<Analysis> findBySampleItemIds(List<String> sampleItemIds) {
+
+        List<String> ids = sampleItemIds == null ? List.of()
+                : sampleItemIds.stream().filter(Objects::nonNull).map(String::trim).filter(id -> !id.isEmpty())
+                        .distinct().toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        FhirCriteriaContext<Analysis, Analysis> context = createCriteriaContext(Analysis.class);
+        Expression<String> sampleItemId = resolveExpression(context, FhirConstants.SAMPLE_ITEM_ID_HANDLER,
+                String.class);
+        context.addPredicate(sampleItemId.in(ids));
+        context.distinct(true);
+        return list(context);
+    }
+
     private <R> void addSearchPredicates(FhirCriteriaContext<Analysis, R> context, ServiceRequestSearchParams params) {
 
         addPredicate(context, createIdPredicate(context, params.getId()));
-
-        addPredicate(context, createIdentifierPredicate(context, params.getIdentifier()));
-
+        addPredicate(context, createServiceRequestIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createPatientPredicate(context, params.getPatient()));
+        addPredicate(context, createRequesterPredicate(context, params.getRequester()));
+        addPredicate(context, createSpecimenPredicate(context, params.getSpecimen()));
+        addPredicate(context, createCodePredicate(context, params.getCode()));
+        addPredicate(context, createStatusPredicate(context, params));
         addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
     }
 
-    /**
-     * Extracts distinct OpenELIS Sample primary keys from SampleHuman records.
-     */
-    private List<String> extractSampleIds(List<SampleHuman> sampleHumans) {
+    private <R> Optional<Predicate> createPatientPredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam patient) {
 
-        if (sampleHumans == null || sampleHumans.isEmpty()) {
-            return List.of();
+        if (patient == null) {
+            return Optional.empty();
         }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> sampleId = resolveStringExpression(context, SAMPLE_ID_PROPERTY);
 
-        return sampleHumans.stream().filter(Objects::nonNull).map(SampleHuman::getSampleId).filter(Objects::nonNull)
-                .map(String::trim).filter(sampleId -> !sampleId.isEmpty()).distinct().toList();
+        return handleAndListParam(criteriaBuilder, patient, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional
+                    .of(sampleId.in(sampleIdsFor(context, Patient.class, FhirConstants.PATIENT_ID, idPart.trim())));
+        });
+    }
+
+    private <R> Optional<Predicate> createRequesterPredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam requester) {
+
+        if (requester == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> sampleId = resolveStringExpression(context, SAMPLE_ID_PROPERTY);
+
+        return handleAndListParam(criteriaBuilder, requester, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional
+                    .of(sampleId.in(sampleIdsFor(context, Provider.class, FhirConstants.PROVIDER_ID, idPart.trim())));
+        });
+    }
+
+    /**
+     * {@code select sh.sampleId from SampleHuman sh, <Patient|Provider> x where
+     * sh.<column> = x.id and (x.fhirUuid = :uuid or x.id = :id)}.
+     */
+    private <R, X> Subquery<String> sampleIdsFor(FhirCriteriaContext<Analysis, R> context, Class<X> linkedType,
+            String sampleHumanColumn, String reference) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        FhirCriteriaContext<SampleHuman, String> sub = createSubQuery(context, SampleHuman.class, String.class);
+        Subquery<String> subquery = sub.getSubquery();
+        Root<SampleHuman> sampleHuman = sub.getRoot();
+        Root<X> linked = subquery.from(linkedType);
+        subquery.select(sampleHuman.get(FhirConstants.SAMPLE_ID));
+
+        List<Predicate> where = new ArrayList<>();
+        where.add(criteriaBuilder.equal(sampleHuman.get(sampleHumanColumn), linked.get("id")));
+        try {
+            where.add(criteriaBuilder.equal(linked.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(reference)));
+        } catch (IllegalArgumentException e) {
+            where.add(criteriaBuilder.equal(linked.get("id"), reference));
+        }
+        subquery.where(where.toArray(Predicate[]::new));
+        return subquery;
+    }
+
+    private <R> Optional<Predicate> createSpecimenPredicate(FhirCriteriaContext<Analysis, R> context,
+            ReferenceAndListParam specimen) {
+
+        if (specimen == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<UUID> sampleItemUuid = resolveUuidExpression(context, SAMPLE_ITEM_UUID_PROPERTY);
+        Expression<String> sampleItemId = resolveStringExpression(context, FhirConstants.SAMPLE_ITEM_ID_HANDLER);
+
+        return handleAndListParam(criteriaBuilder, specimen, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            try {
+                return Optional.of(criteriaBuilder.equal(sampleItemUuid, UUID.fromString(idPart.trim())));
+            } catch (IllegalArgumentException e) {
+                return Optional.of(criteriaBuilder.equal(sampleItemId, idPart.trim()));
+            }
+        });
+    }
+
+    /**
+     * {@code code=http://loinc.org|<code>} matches the test's LOINC; a bare value
+     * matches the LOINC or the test name.
+     */
+    private <R> Optional<Predicate> createCodePredicate(FhirCriteriaContext<Analysis, R> context,
+            TokenAndListParam code) {
+
+        if (code == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> loinc = resolveStringExpression(context, TEST_LOINC_PROPERTY);
+        Expression<String> name = resolveStringExpression(context, TEST_NAME_PROPERTY);
+        Expression<String> shortName = resolveStringExpression(context, TEST_SHORT_NAME_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, code, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            String system = normalizeSystem(token.getSystem());
+            if (system.isEmpty()) {
+                String lowered = value.toLowerCase(Locale.ROOT);
+                return Optional.of(criteriaBuilder.or(criteriaBuilder.equal(loinc, value),
+                        criteriaBuilder.equal(criteriaBuilder.lower(name), lowered),
+                        criteriaBuilder.equal(criteriaBuilder.lower(shortName), lowered)));
+            }
+            if ("http://loinc.org".equalsIgnoreCase(system)) {
+                return Optional.of(criteriaBuilder.equal(loinc, value));
+            }
+            return Optional.of(criteriaBuilder.disjunction());
+        });
+    }
+
+    private <R> Optional<Predicate> createStatusPredicate(FhirCriteriaContext<Analysis, R> context,
+            ServiceRequestSearchParams params) {
+
+        TokenAndListParam status = params.getStatus();
+        if (status == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, STATUS_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, status, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            List<String> ids = params.getStatusIdsByCode().getOrDefault(code, List.of());
+            if (ids.isEmpty()) {
+                return Optional.of(criteriaBuilder.disjunction());
+            }
+            return Optional.of(expression.in(ids));
+        });
+    }
+
+    private <R> Optional<Predicate> createServiceRequestIdentifierPredicate(FhirCriteriaContext<Analysis, R> context,
+            TokenAndListParam identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        return handleTokenAndListParam(criteriaBuilder, identifier, token -> identifierPredicate(context, token));
+    }
+
+    private <R> Optional<Predicate> identifierPredicate(FhirCriteriaContext<Analysis, R> context, TokenParam token) {
+
+        String value = token.getValue() == null ? "" : token.getValue().trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> accession = resolveStringExpression(context, ACCESSION_PROPERTY);
+        String system = normalizeSystem(token.getSystem());
+        String systemKey = system.contains("/") ? system.substring(system.lastIndexOf('/') + 1) : system;
+
+        List<Predicate> alternatives = new ArrayList<>();
+        switch (systemKey) {
+        case "":
+            uuidPredicate(context, value).ifPresent(alternatives::add);
+            alternatives.add(criteriaBuilder.equal(accession, value));
+            break;
+        case "analysis_uuid":
+            uuidPredicate(context, value).ifPresent(alternatives::add);
+            break;
+        case "samp_labNo":
+            alternatives.add(criteriaBuilder.equal(accession, value));
+            break;
+        default:
+            break;
+        }
+        if (alternatives.isEmpty()) {
+            return Optional.of(criteriaBuilder.disjunction());
+        }
+        return combineWithOr(criteriaBuilder, alternatives);
+    }
+
+    private <R> Optional<Predicate> uuidPredicate(FhirCriteriaContext<Analysis, R> context, String value) {
+        try {
+            return Optional.of(requireCriteriaBuilder(context)
+                    .equal(context.getRoot().<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(value)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 
     private void validatePagination(int offset, int pageSize) {
@@ -130,7 +324,6 @@ public class ServiceRequestSearchDao extends BaseFhirDao {
         if (offset < 0) {
             throw new IllegalArgumentException("Offset must be zero or greater");
         }
-
         if (pageSize <= 0) {
             throw new IllegalArgumentException("Page size must be greater than zero");
         }

--- a/src/main/java/org/openelisglobal/search/dao/SpecimenSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/SpecimenSearchDao.java
@@ -1,0 +1,308 @@
+package org.openelisglobal.search.dao;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.openelisglobal.common.fhir.dao.BaseFhirDao;
+import org.openelisglobal.common.fhir.dao.DateParamBounds;
+import org.openelisglobal.common.fhir.internals.FhirCriteriaContext;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.SpecimenSearchParams;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.samplehuman.valueholder.SampleHuman;
+import org.openelisglobal.sampleitem.valueholder.SampleItem;
+import org.openelisglobal.search.FhirPropertyResolver;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Searches OpenELIS SampleItem records with FHIR Specimen search parameters.
+ *
+ * <p>
+ * Identifier systems mirror the transform: {@code sampleItem_uuid} and
+ * {@code sampleItem_labNo} (accession number, optionally suffixed with the item
+ * sort order). Status codes are the inverse of the outbound mapping: available
+ * excludes cancelled and disposed items, unsatisfactory is cancelled,
+ * unavailable is disposed.
+ */
+@Repository
+@Transactional(readOnly = true)
+public class SpecimenSearchDao extends BaseFhirDao {
+
+    private static final String SAMPLE_ID_PROPERTY = "sample.id";
+    private static final String ACCESSION_PROPERTY = "sample.accessionNumber";
+    private static final String SORT_ORDER_PROPERTY = "sortOrder";
+    private static final String EXTERNAL_ID_PROPERTY = "externalId";
+    private static final String STATUS_PROPERTY = "statusId";
+    private static final String COLLECTION_DATE_PROPERTY = "collectionDate";
+    private static final String TYPE_ABBREVIATION_PROPERTY = "typeOfSample.localAbbreviation";
+    private static final String TYPE_DESCRIPTION_PROPERTY = "typeOfSample.description";
+
+    public SpecimenSearchDao(FhirPropertyResolver propertyResolver) {
+        super(propertyResolver);
+    }
+
+    public List<SampleItem> search(SpecimenSearchParams params, int offset, int pageSize) {
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be zero or greater");
+        }
+        if (pageSize <= 0) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+        FhirCriteriaContext<SampleItem, SampleItem> context = createCriteriaContext(SampleItem.class);
+        if (params != null) {
+            addSearchPredicates(context, params);
+        }
+        context.distinct(true);
+        return list(context, offset, pageSize);
+    }
+
+    public long count(SpecimenSearchParams params) {
+
+        return count(SampleItem.class, context -> {
+            if (params != null) {
+                addSearchPredicates(context, params);
+            }
+        });
+    }
+
+    /** Every sample item belonging to one of the given Sample primary keys. */
+    public List<SampleItem> findBySampleIds(List<String> sampleIds) {
+
+        List<String> ids = distinctIds(sampleIds);
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+        FhirCriteriaContext<SampleItem, SampleItem> context = createCriteriaContext(SampleItem.class);
+        Expression<String> sampleId = resolveExpression(context, SAMPLE_ID_PROPERTY, String.class);
+        context.addPredicate(sampleId.in(ids));
+        context.distinct(true);
+        return list(context);
+    }
+
+    private <R> void addSearchPredicates(FhirCriteriaContext<SampleItem, R> context, SpecimenSearchParams params) {
+
+        addPredicate(context, createIdPredicate(context, params.getId()));
+        addPredicate(context, createSpecimenIdentifierPredicate(context, params.getIdentifier()));
+        addPredicate(context, createAccessionPredicate(context, params.getAccession()));
+        addPredicate(context, createPatientPredicate(context, params.getPatient()));
+        addPredicate(context, createTypePredicate(context, params.getType()));
+        addPredicate(context, createStatusPredicate(context, params));
+        addPredicate(context, createCollectedPredicate(context, params.getCollected()));
+        addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
+    }
+
+    private <R> Optional<Predicate> createAccessionPredicate(FhirCriteriaContext<SampleItem, R> context,
+            TokenAndListParam accession) {
+
+        if (accession == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, ACCESSION_PROPERTY);
+        return handleTokenAndListParam(criteriaBuilder, accession,
+                token -> createTokenValuePredicate(criteriaBuilder, expression, token));
+    }
+
+    /**
+     * {@code patient=Patient/<uuid>} resolves through sample_human; a non-uuid
+     * value is taken as the OpenELIS patient id.
+     */
+    private <R> Optional<Predicate> createPatientPredicate(FhirCriteriaContext<SampleItem, R> context,
+            ReferenceAndListParam patient) {
+
+        if (patient == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> sampleId = resolveStringExpression(context, SAMPLE_ID_PROPERTY);
+
+        return handleAndListParam(criteriaBuilder, patient, (ReferenceParam reference) -> {
+            String idPart = reference.getIdPart();
+            if (idPart == null || idPart.isBlank()) {
+                return Optional.empty();
+            }
+            return Optional.of(sampleId.in(sampleIdsForPatient(context, idPart.trim())));
+        });
+    }
+
+    private <R> Subquery<String> sampleIdsForPatient(FhirCriteriaContext<SampleItem, R> context, String patientRef) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        FhirCriteriaContext<SampleHuman, String> sub = createSubQuery(context, SampleHuman.class, String.class);
+        Subquery<String> subquery = sub.getSubquery();
+        Root<SampleHuman> sampleHuman = sub.getRoot();
+        Root<Patient> patient = subquery.from(Patient.class);
+        subquery.select(sampleHuman.get(FhirConstants.SAMPLE_ID));
+
+        List<Predicate> where = new ArrayList<>();
+        where.add(criteriaBuilder.equal(sampleHuman.get(FhirConstants.PATIENT_ID), patient.get("id")));
+        try {
+            where.add(criteriaBuilder.equal(patient.<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(patientRef)));
+        } catch (IllegalArgumentException e) {
+            where.add(criteriaBuilder.equal(patient.get("id"), patientRef));
+        }
+        subquery.where(where.toArray(Predicate[]::new));
+        return subquery;
+    }
+
+    /** {@code type=<code>} matches the sample type abbreviation or description. */
+    private <R> Optional<Predicate> createTypePredicate(FhirCriteriaContext<SampleItem, R> context,
+            TokenAndListParam type) {
+
+        if (type == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> abbreviation = resolveStringExpression(context, TYPE_ABBREVIATION_PROPERTY);
+        Expression<String> description = resolveStringExpression(context, TYPE_DESCRIPTION_PROPERTY);
+
+        return handleTokenAndListParam(criteriaBuilder, type, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(criteriaBuilder.or(criteriaBuilder.equal(criteriaBuilder.lower(abbreviation), value),
+                    criteriaBuilder.equal(criteriaBuilder.lower(description), value)));
+        });
+    }
+
+    private <R> Optional<Predicate> createStatusPredicate(FhirCriteriaContext<SampleItem, R> context,
+            SpecimenSearchParams params) {
+
+        TokenAndListParam status = params.getStatus();
+        if (status == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> expression = resolveStringExpression(context, STATUS_PROPERTY);
+        List<String> terminal = new ArrayList<>();
+        if (params.getCanceledStatusId() != null) {
+            terminal.add(params.getCanceledStatusId());
+        }
+        if (params.getDisposedStatusId() != null) {
+            terminal.add(params.getDisposedStatusId());
+        }
+
+        return handleTokenAndListParam(criteriaBuilder, status, token -> {
+            String code = token.getValue() == null ? "" : token.getValue().trim().toLowerCase(Locale.ROOT);
+            return switch (code) {
+            case "available" -> Optional.of(terminal.isEmpty() ? criteriaBuilder.conjunction()
+                    : criteriaBuilder.or(criteriaBuilder.isNull(expression),
+                            criteriaBuilder.not(expression.in(terminal))));
+            case "unsatisfactory" -> Optional.of(params.getCanceledStatusId() == null ? criteriaBuilder.disjunction()
+                    : criteriaBuilder.equal(expression, params.getCanceledStatusId()));
+            case "unavailable" -> Optional.of(params.getDisposedStatusId() == null ? criteriaBuilder.disjunction()
+                    : criteriaBuilder.equal(expression, params.getDisposedStatusId()));
+            default -> Optional.of(criteriaBuilder.disjunction());
+            };
+        });
+    }
+
+    private <R> Optional<Predicate> createCollectedPredicate(FhirCriteriaContext<SampleItem, R> context,
+            DateRangeParam collected) {
+
+        if (collected == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<Date> expression = resolveExpression(context, COLLECTION_DATE_PROPERTY, Date.class);
+        return combineWithAnd(criteriaBuilder, DateParamBounds.predicates(criteriaBuilder, expression, collected));
+    }
+
+    private <R> Optional<Predicate> createSpecimenIdentifierPredicate(FhirCriteriaContext<SampleItem, R> context,
+            TokenAndListParam identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        return handleTokenAndListParam(criteriaBuilder, identifier, token -> identifierPredicate(context, token));
+    }
+
+    private <R> Optional<Predicate> identifierPredicate(FhirCriteriaContext<SampleItem, R> context, TokenParam token) {
+
+        String value = token.getValue() == null ? "" : token.getValue().trim();
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        String system = normalizeSystem(token.getSystem());
+        String systemKey = system.contains("/") ? system.substring(system.lastIndexOf('/') + 1) : system;
+
+        List<Predicate> alternatives = new ArrayList<>();
+        switch (systemKey) {
+        case "":
+            Optional<Predicate> uuid = uuidPredicate(context, value);
+            if (uuid.isPresent()) {
+                alternatives.add(uuid.get());
+            } else {
+                alternatives.add(labNumberPredicate(context, value));
+                alternatives.add(criteriaBuilder.equal(context.getRoot().get(EXTERNAL_ID_PROPERTY), value));
+            }
+            break;
+        case "sampleItem_uuid":
+            uuidPredicate(context, value).ifPresent(alternatives::add);
+            break;
+        case "sampleItem_labNo":
+            alternatives.add(labNumberPredicate(context, value));
+            break;
+        default:
+            break;
+        }
+        if (alternatives.isEmpty()) {
+            return Optional.of(criteriaBuilder.disjunction());
+        }
+        return combineWithOr(criteriaBuilder, alternatives);
+    }
+
+    /**
+     * The lab number identifier is {@code accession[-sortOrder]}; the plain
+     * accession matches every item of the sample.
+     */
+    private <R> Predicate labNumberPredicate(FhirCriteriaContext<SampleItem, R> context, String value) {
+
+        CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
+        Expression<String> accession = resolveStringExpression(context, ACCESSION_PROPERTY);
+        Expression<String> sortOrder = resolveStringExpression(context, SORT_ORDER_PROPERTY);
+
+        int dash = value.lastIndexOf('-');
+        Predicate whole = criteriaBuilder.equal(accession, value);
+        if (dash <= 0 || dash == value.length() - 1
+                || !value.substring(dash + 1).chars().allMatch(Character::isDigit)) {
+            return whole;
+        }
+        return criteriaBuilder.or(whole, criteriaBuilder.and(criteriaBuilder.equal(accession, value.substring(0, dash)),
+                criteriaBuilder.equal(sortOrder, value.substring(dash + 1))));
+    }
+
+    private <R> Optional<Predicate> uuidPredicate(FhirCriteriaContext<SampleItem, R> context, String value) {
+        try {
+            return Optional.of(requireCriteriaBuilder(context)
+                    .equal(context.getRoot().<UUID>get(FhirConstants.ID_PROPERTY), UUID.fromString(value)));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static List<String> distinctIds(List<String> ids) {
+        return ids == null ? List.of()
+                : ids.stream().filter(Objects::nonNull).map(String::trim).filter(id -> !id.isEmpty()).distinct()
+                        .toList();
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/DeviceSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/DeviceSearchService.java
@@ -1,0 +1,26 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.DeviceBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.DeviceSearchParams;
+import org.openelisglobal.search.dao.DeviceSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DeviceSearchService {
+
+    private final DeviceSearchDao deviceSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public DeviceSearchService(DeviceSearchDao deviceSearchDao, FhirTransformService fhirTransformService) {
+        this.deviceSearchDao = deviceSearchDao;
+        this.fhirTransformService = fhirTransformService;
+    }
+
+    public IBundleProvider searchDevices(DeviceSearchParams params) {
+        return new DeviceBundleProvider(params, deviceSearchDao, fhirTransformService);
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/DiagnosticReportSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/DiagnosticReportSearchService.java
@@ -1,0 +1,64 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.DiagnosticReportBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.DiagnosticReportSearchParams;
+import org.openelisglobal.search.dao.DiagnosticReportSearchDao;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Local DiagnosticReport search. Status codes follow the outbound transform:
+ * final, preliminary, partial and registered map to finalized, technically
+ * accepted, technically rejected and not-started analyses.
+ */
+@Service
+@Transactional(readOnly = true)
+public class DiagnosticReportSearchService {
+
+    private final DiagnosticReportSearchDao diagnosticReportSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
+
+    public DiagnosticReportSearchService(DiagnosticReportSearchDao diagnosticReportSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, ObservationSearchDao observationSearchDao,
+            FhirTransformService fhirTransformService, IStatusService statusService) {
+        this.diagnosticReportSearchDao = diagnosticReportSearchDao;
+        this.sampleHumanSearchDao = sampleHumanSearchDao;
+        this.observationSearchDao = observationSearchDao;
+        this.fhirTransformService = fhirTransformService;
+        this.statusService = statusService;
+    }
+
+    public IBundleProvider searchDiagnosticReports(DiagnosticReportSearchParams params) {
+        Map<String, List<String>> byCode = new LinkedHashMap<>();
+        byCode.put("final", ids(AnalysisStatus.Finalized));
+        byCode.put("preliminary", ids(AnalysisStatus.TechnicalAcceptance));
+        byCode.put("partial", ids(AnalysisStatus.TechnicalRejected));
+        byCode.put("registered", ids(AnalysisStatus.NotStarted));
+        params.setStatusIdsByCode(byCode);
+        return new DiagnosticReportBundleProvider(params, diagnosticReportSearchDao, sampleHumanSearchDao,
+                observationSearchDao, fhirTransformService);
+    }
+
+    private List<String> ids(AnalysisStatus... statuses) {
+        List<String> ids = new ArrayList<>();
+        for (AnalysisStatus status : statuses) {
+            String id = statusService.getStatusID(status);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/LocationSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/LocationSearchService.java
@@ -1,0 +1,262 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
+import ca.uhn.fhir.model.primitive.InstantDt;
+import ca.uhn.fhir.model.valueset.BundleEntrySearchModeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.ReferenceOrListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.StringOrListParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Location;
+import org.openelisglobal.common.fhir.dao.DateParamBounds;
+import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.searchparams.LocationSearchParams;
+import org.openelisglobal.storage.fhir.StorageLocationFhirTransform;
+import org.openelisglobal.storage.service.StorageBoxService;
+import org.openelisglobal.storage.service.StorageDeviceService;
+import org.openelisglobal.storage.service.StorageRackService;
+import org.openelisglobal.storage.service.StorageRoomService;
+import org.openelisglobal.storage.service.StorageShelfService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Local Location search over the storage hierarchy.
+ *
+ * <p>
+ * The five storage levels live in separate tables and the whole hierarchy is
+ * small, so the search renders every level to a Location once and filters the
+ * FHIR view in memory. That keeps the filter identical to what a client sees
+ * (identifier codes, names, status, partOf, hierarchy tag) at the cost of
+ * reading the tables on each request.
+ */
+@Service
+@Transactional(readOnly = true)
+public class LocationSearchService {
+
+    private final StorageLocationFhirTransform transform;
+    private final StorageRoomService roomService;
+    private final StorageDeviceService deviceService;
+    private final StorageShelfService shelfService;
+    private final StorageRackService rackService;
+    private final StorageBoxService boxService;
+
+    public LocationSearchService(StorageLocationFhirTransform transform, StorageRoomService roomService,
+            StorageDeviceService deviceService, StorageShelfService shelfService, StorageRackService rackService,
+            StorageBoxService boxService) {
+        this.transform = transform;
+        this.roomService = roomService;
+        this.deviceService = deviceService;
+        this.shelfService = shelfService;
+        this.rackService = rackService;
+        this.boxService = boxService;
+    }
+
+    public IBundleProvider searchLocations(LocationSearchParams params) {
+
+        Map<String, Location> all = renderHierarchy();
+        List<Location> matches = all.values().stream().filter(matcher(params)).toList();
+
+        List<IBaseResource> resources = new ArrayList<>();
+        for (Location match : matches) {
+            ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(match, BundleEntrySearchModeEnum.MATCH);
+            resources.add(match);
+        }
+
+        Map<String, Location> included = new LinkedHashMap<>();
+        if (params.hasInclude(FhirConstants.LOCATION_PARTOF_INCLUDE)) {
+            for (Location match : matches) {
+                String parentId = referencedId(match);
+                if (parentId != null && all.containsKey(parentId)) {
+                    included.putIfAbsent(parentId, all.get(parentId));
+                }
+            }
+        }
+        if (params.hasRevInclude(FhirConstants.LOCATION_PARTOF_INCLUDE)) {
+            for (Location candidate : all.values()) {
+                String parentId = referencedId(candidate);
+                if (parentId != null
+                        && matches.stream().anyMatch(match -> parentId.equals(match.getIdElement().getIdPart()))) {
+                    included.putIfAbsent(candidate.getIdElement().getIdPart(), candidate);
+                }
+            }
+        }
+        matches.forEach(match -> included.remove(match.getIdElement().getIdPart()));
+        List<IBaseResource> extras = new ArrayList<>();
+        for (Location extra : included.values()) {
+            ResourceMetadataKeyEnum.ENTRY_SEARCH_MODE.put(extra, BundleEntrySearchModeEnum.INCLUDE);
+            extras.add(extra);
+        }
+
+        return new HierarchyBundleProvider(resources, extras);
+    }
+
+    /**
+     * In-memory bundle provider whose size is the match count while every page
+     * carries the included parents and children, mirroring how the database-backed
+     * bundle providers append their includes.
+     */
+    static final class HierarchyBundleProvider implements IBundleProvider {
+
+        private final List<IBaseResource> matches;
+        private final List<IBaseResource> includes;
+        private final InstantDt published = InstantDt.withCurrentTime();
+
+        HierarchyBundleProvider(List<IBaseResource> matches, List<IBaseResource> includes) {
+            this.matches = matches;
+            this.includes = includes;
+        }
+
+        @Override
+        public List<IBaseResource> getResources(int fromIndex, int toIndex) {
+            int from = Math.max(0, Math.min(fromIndex, matches.size()));
+            int to = Math.max(from, Math.min(toIndex, matches.size()));
+            List<IBaseResource> page = new ArrayList<>(matches.subList(from, to));
+            page.addAll(includes);
+            return page;
+        }
+
+        @Override
+        public Integer size() {
+            return matches.size();
+        }
+
+        @Override
+        public IPrimitiveType<Date> getPublished() {
+            return published;
+        }
+
+        @Override
+        public String getUuid() {
+            return null;
+        }
+
+        @Override
+        public Integer preferredPageSize() {
+            return null;
+        }
+    }
+
+    private Map<String, Location> renderHierarchy() {
+        Map<String, Location> all = new LinkedHashMap<>();
+        roomService.getAll().forEach(room -> put(all, transform.transformToFhirLocation(room)));
+        deviceService.getAll().forEach(device -> put(all, transform.transformToFhirLocation(device)));
+        shelfService.getAll().forEach(shelf -> put(all, transform.transformToFhirLocation(shelf)));
+        rackService.getAll().forEach(rack -> put(all, transform.transformToFhirLocation(rack)));
+        boxService.getAll().forEach(box -> put(all, transform.transformToFhirLocation(box)));
+        return all;
+    }
+
+    private static void put(Map<String, Location> all, Location location) {
+        if (location != null && location.hasId()) {
+            all.putIfAbsent(location.getIdElement().getIdPart(), location);
+        }
+    }
+
+    private static String referencedId(Location location) {
+        if (!location.hasPartOf() || !location.getPartOf().hasReference()) {
+            return null;
+        }
+        return location.getPartOf().getReferenceElement().getIdPart();
+    }
+
+    private static Predicate<Location> matcher(LocationSearchParams params) {
+
+        Predicate<Location> predicate = location -> true;
+
+        if (params.getId() != null) {
+            predicate = predicate.and(location -> tokenAndList(params.getId().getValuesAsQueryTokens(),
+                    token -> equalsIgnoreCase(token.getValue(), location.getIdElement().getIdPart())));
+        }
+        if (params.getIdentifier() != null) {
+            predicate = predicate
+                    .and(location -> tokenAndList(params.getIdentifier().getValuesAsQueryTokens(), token -> location
+                            .getIdentifier().stream().anyMatch(identifier -> identifierMatches(identifier, token))));
+        }
+        if (params.getName() != null) {
+            predicate = predicate.and(location -> stringAndList(params.getName().getValuesAsQueryTokens(),
+                    value -> stringMatches(location.getName(), value)));
+        }
+        if (params.getStatus() != null) {
+            predicate = predicate.and(
+                    location -> tokenAndList(params.getStatus().getValuesAsQueryTokens(), token -> location.hasStatus()
+                            && equalsIgnoreCase(token.getValue(), location.getStatus().toCode())));
+        }
+        if (params.getPartOf() != null) {
+            predicate = predicate.and(location -> referenceAndList(params.getPartOf().getValuesAsQueryTokens(),
+                    reference -> equalsIgnoreCase(reference.getIdPart(), referencedId(location))));
+        }
+        if (params.getLastUpdated() != null) {
+            predicate = predicate.and(location -> location.getMeta().hasLastUpdated()
+                    && DateParamBounds.contains(params.getLastUpdated(), location.getMeta().getLastUpdated()));
+        }
+        if (params.getTag() != null) {
+            predicate = predicate.and(location -> tokenAndList(params.getTag().getValuesAsQueryTokens(),
+                    token -> location.getMeta().getTag().stream().anyMatch(tag -> tagMatches(tag, token))));
+        }
+        return predicate;
+    }
+
+    private static boolean identifierMatches(Identifier identifier, TokenParam token) {
+        if (!equalsIgnoreCase(token.getValue(), identifier.getValue())) {
+            return false;
+        }
+        String system = token.getSystem();
+        return system == null || system.isBlank() || system.equals(identifier.getSystem());
+    }
+
+    private static boolean tagMatches(Coding tag, TokenParam token) {
+        if (!equalsIgnoreCase(token.getValue(), tag.getCode())) {
+            return false;
+        }
+        String system = token.getSystem();
+        return system == null || system.isBlank() || system.equals(tag.getSystem());
+    }
+
+    private static boolean stringMatches(String actual, StringParam value) {
+        if (actual == null || value.getValue() == null) {
+            return false;
+        }
+        if (value.isExact()) {
+            return actual.equals(value.getValue());
+        }
+        String haystack = actual.toLowerCase(Locale.ROOT);
+        String needle = value.getValue().toLowerCase(Locale.ROOT);
+        return value.isContains() ? haystack.contains(needle) : haystack.startsWith(needle);
+    }
+
+    private static boolean equalsIgnoreCase(String expected, String actual) {
+        return expected != null && actual != null && expected.trim().equalsIgnoreCase(actual.trim());
+    }
+
+    private static boolean tokenAndList(List<TokenOrListParam> andList, Predicate<TokenParam> tokenMatches) {
+        return andList.stream().allMatch(
+                orList -> orList.getValuesAsQueryTokens().stream().filter(Objects::nonNull).anyMatch(tokenMatches));
+    }
+
+    private static boolean stringAndList(List<StringOrListParam> andList, Predicate<StringParam> valueMatches) {
+        return andList.stream().allMatch(
+                orList -> orList.getValuesAsQueryTokens().stream().filter(Objects::nonNull).anyMatch(valueMatches));
+    }
+
+    private static boolean referenceAndList(List<ReferenceOrListParam> andList,
+            Predicate<ReferenceParam> referenceMatches) {
+        return andList.stream().allMatch(
+                orList -> orList.getValuesAsQueryTokens().stream().filter(Objects::nonNull).anyMatch(referenceMatches));
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/ObservationSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/ObservationSearchService.java
@@ -1,0 +1,62 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.ObservationBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.ObservationSearchParams;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PractitionerSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Local Observation search. Status codes follow the outbound transform: final
+ * is a finalized analysis, unknown a not-started one, and preliminary
+ * everything else.
+ */
+@Service
+@Transactional(readOnly = true)
+public class ObservationSearchService {
+
+    private final ObservationSearchDao observationSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final PractitionerSearchDao practitionerSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
+
+    public ObservationSearchService(ObservationSearchDao observationSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, PractitionerSearchDao practitionerSearchDao,
+            FhirTransformService fhirTransformService, IStatusService statusService) {
+        this.observationSearchDao = observationSearchDao;
+        this.sampleHumanSearchDao = sampleHumanSearchDao;
+        this.practitionerSearchDao = practitionerSearchDao;
+        this.fhirTransformService = fhirTransformService;
+        this.statusService = statusService;
+    }
+
+    public IBundleProvider searchObservations(ObservationSearchParams params) {
+        Map<String, List<String>> byCode = new LinkedHashMap<>();
+        byCode.put("final", ids(AnalysisStatus.Finalized));
+        byCode.put("unknown", ids(AnalysisStatus.NotStarted));
+        params.setStatusIdsByCode(byCode);
+        return new ObservationBundleProvider(params, observationSearchDao, sampleHumanSearchDao, practitionerSearchDao,
+                fhirTransformService, statusService);
+    }
+
+    private List<String> ids(AnalysisStatus... statuses) {
+        List<String> ids = new ArrayList<>();
+        for (AnalysisStatus status : statuses) {
+            String id = statusService.getStatusID(status);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/OrganizationSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/OrganizationSearchService.java
@@ -1,0 +1,27 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.OrganizationBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.OrganizationSearchParams;
+import org.openelisglobal.search.dao.OrganizationSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class OrganizationSearchService {
+
+    private final OrganizationSearchDao organizationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public OrganizationSearchService(OrganizationSearchDao organizationSearchDao,
+            FhirTransformService fhirTransformService) {
+        this.organizationSearchDao = organizationSearchDao;
+        this.fhirTransformService = fhirTransformService;
+    }
+
+    public IBundleProvider searchOrganizations(OrganizationSearchParams params) {
+        return new OrganizationBundleProvider(params, organizationSearchDao, fhirTransformService);
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/PatientSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/PatientSearchService.java
@@ -1,0 +1,40 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.PatientBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.PatientSearchParams;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PatientSearchDao;
+import org.openelisglobal.search.dao.ServiceRequestSearchDao;
+import org.openelisglobal.search.dao.SpecimenSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PatientSearchService {
+
+    private final PatientSearchDao patientSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final SpecimenSearchDao specimenSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+
+    public PatientSearchService(PatientSearchDao patientSearchDao, SampleHumanSearchDao sampleHumanSearchDao,
+            ServiceRequestSearchDao serviceRequestSearchDao, SpecimenSearchDao specimenSearchDao,
+            ObservationSearchDao observationSearchDao, FhirTransformService fhirTransformService) {
+        this.patientSearchDao = patientSearchDao;
+        this.sampleHumanSearchDao = sampleHumanSearchDao;
+        this.serviceRequestSearchDao = serviceRequestSearchDao;
+        this.specimenSearchDao = specimenSearchDao;
+        this.observationSearchDao = observationSearchDao;
+        this.fhirTransformService = fhirTransformService;
+    }
+
+    public IBundleProvider searchPatients(PatientSearchParams params) {
+        return new PatientBundleProvider(params, patientSearchDao, sampleHumanSearchDao, serviceRequestSearchDao,
+                specimenSearchDao, observationSearchDao, fhirTransformService);
+    }
+}

--- a/src/main/java/org/openelisglobal/search/service/PractitionerSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/PractitionerSearchService.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.fhir.search.bundleProviders.PractitionerBundleProvider;
 import org.openelisglobal.fhir.search.searchparams.PractitionerSearchParams;
+import org.openelisglobal.search.dao.ObservationSearchDao;
 import org.openelisglobal.search.dao.PractitionerSearchDao;
 import org.openelisglobal.search.dao.ServiceRequestSearchDao;
 import org.springframework.stereotype.Service;
@@ -19,21 +20,24 @@ public class PractitionerSearchService {
 
     private final ServiceRequestSearchDao serviceRequestSearchDao;
 
+    private final ObservationSearchDao observationSearchDao;
+
     private final FhirTransformService fhirTransformService;
 
     public PractitionerSearchService(PractitionerSearchDao practitionerSearchDao,
             SampleHumanSearchDao sampleHumanSearchDao, ServiceRequestSearchDao serviceRequestSearchDao,
-            FhirTransformService fhirTransformService) {
+            ObservationSearchDao observationSearchDao, FhirTransformService fhirTransformService) {
 
         this.practitionerSearchDao = practitionerSearchDao;
         this.sampleHumanSearchDao = sampleHumanSearchDao;
         this.serviceRequestSearchDao = serviceRequestSearchDao;
+        this.observationSearchDao = observationSearchDao;
         this.fhirTransformService = fhirTransformService;
     }
 
     public IBundleProvider searchPractitioners(PractitionerSearchParams params) {
 
         return new PractitionerBundleProvider(params, practitionerSearchDao, sampleHumanSearchDao,
-                serviceRequestSearchDao, fhirTransformService);
+                serviceRequestSearchDao, observationSearchDao, fhirTransformService);
     }
 }

--- a/src/main/java/org/openelisglobal/search/service/SampleHumanSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/service/SampleHumanSearchDao.java
@@ -41,4 +41,47 @@ public class SampleHumanSearchDao extends BaseFhirDao {
 
         return list(context);
     }
+
+    /** sample_human rows for the given patients, keyed off Patient.id. */
+    public List<SampleHuman> findByPatients(List<org.openelisglobal.patient.valueholder.Patient> patients) {
+
+        if (patients == null || patients.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> patientIds = patients.stream().filter(Objects::nonNull)
+                .map(org.openelisglobal.patient.valueholder.Patient::getId).filter(Objects::nonNull).map(String::trim)
+                .filter(id -> !id.isEmpty()).distinct().toList();
+
+        if (patientIds.isEmpty()) {
+            return List.of();
+        }
+
+        FhirCriteriaContext<SampleHuman, SampleHuman> context = createCriteriaContext(SampleHuman.class);
+
+        context.addPredicate(context.getRoot().get(FhirConstants.PATIENT_ID).in(patientIds));
+
+        context.distinct(true);
+
+        return list(context);
+    }
+
+    /** sample_human rows for the given Sample primary keys. */
+    public List<SampleHuman> findBySampleIds(List<String> sampleIds) {
+
+        List<String> ids = sampleIds == null ? List.of()
+                : sampleIds.stream().filter(Objects::nonNull).map(String::trim).filter(id -> !id.isEmpty()).distinct()
+                        .toList();
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        FhirCriteriaContext<SampleHuman, SampleHuman> context = createCriteriaContext(SampleHuman.class);
+
+        context.addPredicate(context.getRoot().get(FhirConstants.SAMPLE_ID).in(ids));
+
+        context.distinct(true);
+
+        return list(context);
+    }
 }

--- a/src/main/java/org/openelisglobal/search/service/ServiceRequestSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/ServiceRequestSearchService.java
@@ -1,18 +1,72 @@
 package org.openelisglobal.search.service;
 
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.ServiceRequestBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.ServiceRequestSearchParams;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.PractitionerSearchDao;
 import org.openelisglobal.search.dao.ServiceRequestSearchDao;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Local ServiceRequest search. The FHIR status codes are widened to the
+ * OpenELIS analysis statuses the outbound transform folds into them.
+ */
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class ServiceRequestSearchService {
 
-    @Autowired
-    private FhirTransformService fhirTransformService;
-    @Autowired
-    private ServiceRequestSearchDao serviceRequestSearchDao;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final PractitionerSearchDao practitionerSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
 
+    public ServiceRequestSearchService(ServiceRequestSearchDao serviceRequestSearchDao,
+            SampleHumanSearchDao sampleHumanSearchDao, PractitionerSearchDao practitionerSearchDao,
+            ObservationSearchDao observationSearchDao, FhirTransformService fhirTransformService,
+            IStatusService statusService) {
+        this.serviceRequestSearchDao = serviceRequestSearchDao;
+        this.sampleHumanSearchDao = sampleHumanSearchDao;
+        this.practitionerSearchDao = practitionerSearchDao;
+        this.observationSearchDao = observationSearchDao;
+        this.fhirTransformService = fhirTransformService;
+        this.statusService = statusService;
+    }
+
+    public IBundleProvider searchServiceRequests(ServiceRequestSearchParams params) {
+        params.setStatusIdsByCode(statusIdsByFhirCode());
+        return new ServiceRequestBundleProvider(params, serviceRequestSearchDao, sampleHumanSearchDao,
+                practitionerSearchDao, observationSearchDao, fhirTransformService, statusService);
+    }
+
+    private Map<String, List<String>> statusIdsByFhirCode() {
+        Map<String, List<String>> byCode = new LinkedHashMap<>();
+        byCode.put("active",
+                ids(AnalysisStatus.NotStarted, AnalysisStatus.TechnicalAcceptance, AnalysisStatus.BiologistRejected));
+        byCode.put("completed", ids(AnalysisStatus.Finalized));
+        byCode.put("revoked", ids(AnalysisStatus.TechnicalRejected, AnalysisStatus.Canceled));
+        byCode.put("entered-in-error", ids(AnalysisStatus.SampleRejected));
+        return byCode;
+    }
+
+    private List<String> ids(AnalysisStatus... statuses) {
+        List<String> ids = new ArrayList<>();
+        for (AnalysisStatus status : statuses) {
+            String id = statusService.getStatusID(status);
+            if (id != null) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
 }

--- a/src/main/java/org/openelisglobal/search/service/SpecimenSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/SpecimenSearchService.java
@@ -1,0 +1,43 @@
+package org.openelisglobal.search.service;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import org.openelisglobal.common.services.IStatusService;
+import org.openelisglobal.common.services.StatusService.SampleStatus;
+import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
+import org.openelisglobal.fhir.search.bundleProviders.SpecimenBundleProvider;
+import org.openelisglobal.fhir.search.searchparams.SpecimenSearchParams;
+import org.openelisglobal.search.dao.ObservationSearchDao;
+import org.openelisglobal.search.dao.ServiceRequestSearchDao;
+import org.openelisglobal.search.dao.SpecimenSearchDao;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SpecimenSearchService {
+
+    private final SpecimenSearchDao specimenSearchDao;
+    private final SampleHumanSearchDao sampleHumanSearchDao;
+    private final ServiceRequestSearchDao serviceRequestSearchDao;
+    private final ObservationSearchDao observationSearchDao;
+    private final FhirTransformService fhirTransformService;
+    private final IStatusService statusService;
+
+    public SpecimenSearchService(SpecimenSearchDao specimenSearchDao, SampleHumanSearchDao sampleHumanSearchDao,
+            ServiceRequestSearchDao serviceRequestSearchDao, ObservationSearchDao observationSearchDao,
+            FhirTransformService fhirTransformService, IStatusService statusService) {
+        this.specimenSearchDao = specimenSearchDao;
+        this.sampleHumanSearchDao = sampleHumanSearchDao;
+        this.serviceRequestSearchDao = serviceRequestSearchDao;
+        this.observationSearchDao = observationSearchDao;
+        this.fhirTransformService = fhirTransformService;
+        this.statusService = statusService;
+    }
+
+    public IBundleProvider searchSpecimens(SpecimenSearchParams params) {
+        params.setCanceledStatusId(statusService.getStatusID(SampleStatus.Canceled));
+        params.setDisposedStatusId(statusService.getStatusID(SampleStatus.Disposed));
+        return new SpecimenBundleProvider(params, specimenSearchDao, sampleHumanSearchDao, serviceRequestSearchDao,
+                observationSearchDao, fhirTransformService);
+    }
+}

--- a/src/main/java/org/openelisglobal/storage/fhir/StorageLocationFhirTransform.java
+++ b/src/main/java/org/openelisglobal/storage/fhir/StorageLocationFhirTransform.java
@@ -110,6 +110,7 @@ public class StorageLocationFhirTransform {
         Location location = new Location();
 
         location.setId(room.getFhirUuidAsString());
+        location.getMeta().setLastUpdated(room.getLastupdated());
         location.setStatus(
                 room.getActive() != null && room.getActive() ? LocationStatus.ACTIVE : LocationStatus.INACTIVE);
         location.setName(room.getName());
@@ -224,6 +225,7 @@ public class StorageLocationFhirTransform {
         Location location = new Location();
 
         location.setId(device.getFhirUuidAsString());
+        location.getMeta().setLastUpdated(device.getLastupdated());
         location.setStatus(
                 device.getActive() != null && device.getActive() ? LocationStatus.ACTIVE : LocationStatus.INACTIVE);
         location.setName(device.getName());
@@ -340,6 +342,7 @@ public class StorageLocationFhirTransform {
         Location location = new Location();
 
         location.setId(shelf.getFhirUuidAsString());
+        location.getMeta().setLastUpdated(shelf.getLastupdated());
         location.setStatus(
                 shelf.getActive() != null && shelf.getActive() ? LocationStatus.ACTIVE : LocationStatus.INACTIVE);
         location.setName(shelf.getLabel());
@@ -423,6 +426,7 @@ public class StorageLocationFhirTransform {
         Location location = new Location();
 
         location.setId(rack.getFhirUuidAsString());
+        location.getMeta().setLastUpdated(rack.getLastupdated());
         location.setStatus(
                 rack.getActive() != null && rack.getActive() ? LocationStatus.ACTIVE : LocationStatus.INACTIVE);
         location.setName(rack.getLabel());
@@ -552,6 +556,7 @@ public class StorageLocationFhirTransform {
         Location location = new Location();
 
         location.setId(box.getFhirUuidAsString());
+        location.getMeta().setLastUpdated(box.getLastupdated());
         location.setStatus(
                 box.getActive() != null && box.getActive() ? LocationStatus.ACTIVE : LocationStatus.INACTIVE);
         location.setMode(LocationMode.INSTANCE);

--- a/src/main/resources/hibernate/hbm/Patient.hbm.xml
+++ b/src/main/resources/hibernate/hbm/Patient.hbm.xml
@@ -71,7 +71,8 @@
         <property name="chartNumber" type="java.lang.String">
             <column name="CHART_NUMBER" length="20" />
         </property>
-        <property name="birthDateForDisplay" type="java.lang.String">
+        <property name="birthDateForDisplay" access="field"
+            type="java.lang.String">
             <column name="entered_birth_date" length="10" />
         </property>
         <property name="fhirUuid" column="fhir_uuid"

--- a/src/main/resources/hibernate/hbm/Provider.hbm.xml
+++ b/src/main/resources/hibernate/hbm/Provider.hbm.xml
@@ -34,7 +34,7 @@
         </property>
         <property name="fhirUuid" column="fhir_uuid"
             type="java.util.UUID" />
-        <property name="active" column="active"
+        <property name="active" access="field" column="active"
             type="java.lang.Boolean" />
         <property name="desynchronized" column="desynchronized"
             type="java.lang.Boolean" />

--- a/src/test/java/org/openelisglobal/fhir/DeviceSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/DeviceSearchFacadeTest.java
@@ -1,0 +1,127 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.DeviceProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Device search answered from the analyzer table (facade-device.xml: Cobas
+ * 6800, ABL800 FLEX, Sysmex XN-1000).
+ */
+public class DeviceSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String COBAS_UUID = "2d335c87-1def-42e9-a610-2748b9872a1c";
+    private static final String ABL800_UUID = "2d335c87-1def-42e9-a610-2748b9872a2c";
+    private static final String SYSMEX_UUID = "2d335c87-1def-42e9-a610-2748b9872a3c";
+
+    @Autowired
+    private DeviceProvider deviceProvider;
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-device.xml");
+        resyncSequence("clinlims.analyzer_seq", "clinlims.analyzer");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(deviceProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_byIdAndIdentifiers() throws Exception {
+        assertEquals(3, search().get("total").asInt());
+        assertEquals(List.of(ABL800_UUID), idsOf(search("_id", ABL800_UUID)));
+        assertEquals(List.of(COBAS_UUID), idsOf(search("identifier", "COBAS6800-001")));
+        assertEquals(List.of(SYSMEX_UUID),
+                idsOf(search("identifier", "http://openelis-global.org/analyzer_machineId|SYSMEX-XN1000-45")));
+        assertEquals(List.of(ABL800_UUID),
+                idsOf(search("identifier", "http://openelis-global.org/analyzer_uuid|" + ABL800_UUID)));
+        assertEquals(0, search("identifier", "http://example.org/other|COBAS6800-001").get("total").asInt());
+    }
+
+    @Test
+    public void search_byNameTypeAndStatus() throws Exception {
+        assertEquals(List.of(COBAS_UUID), idsOf(search("device-name", "cobas")));
+        assertEquals(List.of(ABL800_UUID), idsOf(search("type", "CHEMISTRY")));
+        assertEquals(0, search("type", "SEROLOGY").get("total").asInt());
+
+        new JdbcTemplate(dataSource).update("UPDATE clinlims.analyzer SET status = 'INACTIVE' WHERE id = 3");
+        assertEquals(List.of(SYSMEX_UUID), idsOf(search("status", "inactive")));
+        assertEquals(2, search("status", "active").get("total").asInt());
+        assertEquals(0, search("status", "entered-in-error").get("total").asInt());
+    }
+
+    @Test
+    public void search_returnsTransformedDevices() throws Exception {
+        JsonNode resource = search("_id", COBAS_UUID).get("entry").get(0).get("resource");
+        assertEquals("Device", resource.get("resourceType").asText());
+        assertEquals("COBAS6800-001", resource.get("serialNumber").asText());
+        assertTrue(resource.get("deviceName").size() >= 1);
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Device"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Device");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            ids.add(entry.get("resource").get("id").asText());
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(List.of(SYSMEX_UUID), idsOf(search("_lastUpdated", "ge2023-01-01T13:00:00")));
+        assertEquals(List.of(COBAS_UUID), idsOf(search("_lastUpdated", "lt2023-01-01T12:30:00")));
+        assertEquals(3, search("_lastUpdated", "2023-01-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2023-01-01").get("total").asInt());
+        JsonNode resource = search("_id", ABL800_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2023-01-01"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/DiagnosticReportSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/DiagnosticReportSearchFacadeTest.java
@@ -1,0 +1,158 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.DiagnosticReportProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * DiagnosticReport search answered from the OpenELIS database
+ * (result-facade.xml: analysis 1, technically accepted, patient 1 / sample item
+ * 601 / result 3; analysis 2, finalized, patient 2 / sample item 602 / result
+ * 4; both released on 2025-07-07).
+ */
+public class DiagnosticReportSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String ANALYSIS_2_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02";
+    private static final String PATIENT_1_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    private static final String PATIENT_2_UUID = "550e8400-e29b-41d4-a716-446655440004";
+    private static final String SAMPLE_ITEM_601_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+    private static final String RESULT_4_UUID = "550e8400-e29b-41d4-a716-446655440004";
+
+    @Autowired
+    private DiagnosticReportProvider diagnosticReportProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        resyncSequence("clinlims.result_seq", "clinlims.result");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(diagnosticReportProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_byIdPatientOrderResultAndSpecimen() throws Exception {
+        assertEquals(2, search().get("total").asInt());
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(search("_id", ANALYSIS_2_UUID), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_1_UUID),
+                idsOf(search("patient", "Patient/" + PATIENT_1_UUID), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(search("subject", PATIENT_2_UUID), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_1_UUID),
+                idsOf(search("based-on", "ServiceRequest/" + ANALYSIS_1_UUID), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_2_UUID),
+                idsOf(search("result", "Observation/" + RESULT_4_UUID), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_1_UUID),
+                idsOf(search("specimen", "Specimen/" + SAMPLE_ITEM_601_UUID), "DiagnosticReport"));
+        assertEquals(0, search("result", "00000000-0000-0000-0000-000000000000").get("total").asInt());
+    }
+
+    @Test
+    public void search_byCodeStatusAndIssued() throws Exception {
+        assertEquals(2, search("code", "http://loinc.org|123456").get("total").asInt());
+        assertEquals(0, search("code", "http://loinc.org|000000").get("total").asInt());
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(search("status", "final"), "DiagnosticReport"));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(search("status", "preliminary"), "DiagnosticReport"));
+        assertEquals(0, search("status", "partial").get("total").asInt());
+        assertEquals(2, search("issued", "2025-07-07").get("total").asInt());
+        assertEquals(0, search("issued", "lt2025-07-07").get("total").asInt());
+    }
+
+    @Test
+    public void search_includes_addLinkedResources() throws Exception {
+        JsonNode bundle = searchWithInclude(ANALYSIS_1_UUID, "DiagnosticReport:patient");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(PATIENT_1_UUID), idsOf(bundle, "Patient"));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+
+        bundle = searchWithInclude(ANALYSIS_1_UUID, "DiagnosticReport:based-on");
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+
+        bundle = searchWithInclude(ANALYSIS_1_UUID, "DiagnosticReport:result");
+        assertEquals(List.of(RESULT_3_UUID), idsOf(bundle, "Observation"));
+
+        bundle = searchWithInclude(ANALYSIS_1_UUID, "DiagnosticReport:specimen");
+        assertEquals(List.of(SAMPLE_ITEM_601_UUID), idsOf(bundle, "Specimen"));
+    }
+
+    @Test
+    public void search_returnsTransformedReports() throws Exception {
+        JsonNode resource = search("_id", ANALYSIS_2_UUID).get("entry").get(0).get("resource");
+        assertEquals("DiagnosticReport", resource.get("resourceType").asText());
+        assertEquals("final", resource.get("status").asText());
+        assertEquals(1, resource.get("result").size());
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/DiagnosticReport"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/DiagnosticReport");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode searchWithInclude(String id, String include) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/DiagnosticReport");
+        request.setQueryString("_id=" + id + "&_include=" + include);
+        request.addParameter("_id", id);
+        request.addParameter("_include", include);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(2, search("_lastUpdated", "ge2025-07-07").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2025-07-07").get("total").asInt());
+        JsonNode resource = search("_id", ANALYSIS_2_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2025-07-07"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/FacadeReadsPreserveLastUpdatedTest.java
+++ b/src/test/java/org/openelisglobal/fhir/FacadeReadsPreserveLastUpdatedTest.java
@@ -1,0 +1,142 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.DeviceProvider;
+import org.openelisglobal.fhir.providers.DiagnosticReportProvider;
+import org.openelisglobal.fhir.providers.LocationProvider;
+import org.openelisglobal.fhir.providers.ObservationProvider;
+import org.openelisglobal.fhir.providers.OrganizationProvider;
+import org.openelisglobal.fhir.providers.PatientProvider;
+import org.openelisglobal.fhir.providers.PractitionerProvider;
+import org.openelisglobal.fhir.providers.ServiceRequestProvider;
+import org.openelisglobal.fhir.providers.SpecimenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+
+/**
+ * {@code _lastUpdated} and {@code meta.lastUpdated} describe when a record was
+ * last modified, so reading or searching through the facade must leave every
+ * row's lastupdated untouched. Guards the write-on-read causes fixed with the
+ * facade search work: the Patient entered-birth-date setter re-deriving
+ * {@code birth_date} during hydration, the Provider active getter normalising
+ * null to false, and the list converter turning an empty list into a non-null
+ * column value.
+ */
+public class FacadeReadsPreserveLastUpdatedTest extends BaseWebContextSensitiveTest {
+
+    private static final String PATIENT_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    private static final String PROVIDER_UUID = "550e8400-e29b-41d4-a716-446655441004";
+    private static final String ANALYSIS_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String SAMPLE_ITEM_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+    private static final String RESULT_UUID = "550e8400-e29b-41d4-a716-446655440003";
+    private static final String ANALYZER_UUID = "2d335c87-1def-42e9-a610-2748b9872a1c";
+    private static final String ROOM_UUID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d3";
+
+    @Autowired
+    private PatientProvider patientProvider;
+    @Autowired
+    private PractitionerProvider practitionerProvider;
+    @Autowired
+    private OrganizationProvider organizationProvider;
+    @Autowired
+    private SpecimenProvider specimenProvider;
+    @Autowired
+    private ServiceRequestProvider serviceRequestProvider;
+    @Autowired
+    private ObservationProvider observationProvider;
+    @Autowired
+    private DiagnosticReportProvider diagnosticReportProvider;
+    @Autowired
+    private DeviceProvider deviceProvider;
+    @Autowired
+    private LocationProvider locationProvider;
+
+    private RestfulServer fhirServlet;
+    private EntityManager entityManager;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-device.xml");
+        executeDataSetWithStateManagement("testdata/facade-location.xml");
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(patientProvider, practitionerProvider, organizationProvider,
+                specimenProvider, serviceRequestProvider, observationProvider, diagnosticReportProvider, deviceProvider,
+                locationProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        entityManager = SharedEntityManagerCreator
+                .createSharedEntityManager(applicationContext.getBean(EntityManagerFactory.class));
+    }
+
+    @Test
+    public void searchesAndReads_doNotTouchLastUpdated() throws Exception {
+        Map<String, Object> before = snapshot();
+
+        for (String path : new String[] { "/Patient",
+                "/Patient?_id=" + PATIENT_UUID + "&_revinclude=Observation:patient", "/Patient/" + PATIENT_UUID,
+                "/Practitioner?_revinclude=Observation:performer", "/Practitioner/" + PROVIDER_UUID, "/Organization",
+                "/Specimen?_include=Specimen:patient", "/Specimen/" + SAMPLE_ITEM_UUID,
+                "/ServiceRequest?_include=ServiceRequest:patient&_include=ServiceRequest:requester",
+                "/ServiceRequest/" + ANALYSIS_UUID, "/Observation?_include=Observation:performer",
+                "/Observation/" + RESULT_UUID, "/DiagnosticReport?_include=DiagnosticReport:result",
+                "/DiagnosticReport/" + ANALYSIS_UUID, "/Device", "/Device/" + ANALYZER_UUID,
+                "/Location?_revinclude=Location:partof", "/Location/" + ROOM_UUID }) {
+            get(path);
+        }
+
+        Map<String, Object> after = snapshot();
+        before.forEach((row, lastUpdated) -> assertEquals(row + " was rewritten by a read", String.valueOf(lastUpdated),
+                String.valueOf(after.get(row))));
+    }
+
+    private Map<String, Object> snapshot() {
+        Map<String, Object> rows = new LinkedHashMap<>();
+        rows.put("patient 1", single("select p.lastupdated from Patient p where p.id = '1'"));
+        rows.put("provider 1", single("select p.lastupdated from Provider p where p.id = '1'"));
+        rows.put("organization 3", single("select o.lastupdated from Organization o where o.id = '3'"));
+        rows.put("sample item 601", single("select s.lastupdated from SampleItem s where s.id = '601'"));
+        rows.put("analysis 1", single("select a.lastupdated from Analysis a where a.id = '1'"));
+        rows.put("result 3", single("select r.lastupdated from Result r where r.id = '3'"));
+        rows.put("analyzer 1", single("select a.lastupdated from Analyzer a where a.id = '1'"));
+        rows.put("storage room 1", single("select r.lastupdated from StorageRoom r where r.id = 1"));
+        return rows;
+    }
+
+    private Object single(String jpql) {
+        return entityManager.createQuery(jpql).getSingleResult();
+    }
+
+    private void get(String path) throws Exception {
+        String query = path.contains("?") ? path.substring(path.indexOf('?') + 1) : null;
+        String pathInfo = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+        MockHttpServletRequest request = buildFhirRequest("GET", pathInfo);
+        if (query != null) {
+            request.setQueryString(query);
+            for (String pair : query.split("&")) {
+                String[] kv = pair.split("=", 2);
+                request.addParameter(kv[0], kv.length > 1 ? kv[1] : "");
+            }
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(path + " -> " + response.getContentAsString(), 200, response.getStatus());
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/LocationSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/LocationSearchFacadeTest.java
@@ -1,0 +1,142 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.LocationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Location search over the storage hierarchy (facade-location.xml: two rooms,
+ * two freezers in room 1, two shelves, two racks, two boxes).
+ */
+public class LocationSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String ROOM_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d3";
+    private static final String ROOM_2_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d4";
+    private static final String DEVICE_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d6";
+    private static final String DEVICE_2_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d7";
+    private static final String SHELF_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6a3";
+    private static final String BOX_FHIRID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b1a3";
+
+    @Autowired
+    private LocationProvider locationProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-location.xml");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(locationProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_withoutParameters_returnsEveryLevel() throws Exception {
+        JsonNode bundle = search();
+        assertEquals(10, bundle.get("total").asInt());
+        assertTrue(idsOf(bundle).containsAll(List.of(ROOM_FHIRID, DEVICE_FHIRID, SHELF_FHIRID, BOX_FHIRID)));
+    }
+
+    @Test
+    public void search_byIdIdentifierAndName() throws Exception {
+        assertEquals(List.of(SHELF_FHIRID), idsOf(search("_id", SHELF_FHIRID)));
+        assertEquals(List.of(ROOM_FHIRID), idsOf(search("identifier", "MAIN")));
+        assertEquals(List.of(DEVICE_FHIRID), idsOf(search("identifier", "MAIN-FRZ01")));
+        assertEquals(List.of(ROOM_2_FHIRID), idsOf(search("name", "secondary")));
+        assertEquals(2, search("name:contains", "Unit").get("total").asInt());
+        assertEquals(0, search("name", "Nowhere").get("total").asInt());
+    }
+
+    @Test
+    public void search_byTagStatusAndPartOf() throws Exception {
+        assertEquals(2, search("_tag", "room").get("total").asInt());
+        assertEquals(2, search("_tag", "http://openelis.org/fhir/tag/storage-hierarchy|box").get("total").asInt());
+        assertEquals(0, search("_tag", "http://example.org/other|box").get("total").asInt());
+        assertEquals(10, search("status", "active").get("total").asInt());
+        assertEquals(0, search("status", "inactive").get("total").asInt());
+        assertTrue(idsOf(search("partof", "Location/" + ROOM_FHIRID))
+                .containsAll(List.of(DEVICE_FHIRID, DEVICE_2_FHIRID)));
+        assertEquals(2, search("partof", ROOM_FHIRID).get("total").asInt());
+    }
+
+    @Test
+    public void search_includes_walkTheHierarchy() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Location");
+        request.setQueryString("_id=" + SHELF_FHIRID + "&_include=Location:partof");
+        request.addParameter("_id", SHELF_FHIRID);
+        request.addParameter("_include", "Location:partof");
+        JsonNode bundle = serve(request);
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(SHELF_FHIRID, DEVICE_FHIRID), idsOf(bundle));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+
+        request = buildFhirRequest("GET", "/Location");
+        request.setQueryString("_id=" + ROOM_FHIRID + "&_revinclude=Location:partof");
+        request.addParameter("_id", ROOM_FHIRID);
+        request.addParameter("_revinclude", "Location:partof");
+        bundle = serve(request);
+        assertEquals(1, bundle.get("total").asInt());
+        assertTrue(idsOf(bundle).containsAll(List.of(ROOM_FHIRID, DEVICE_FHIRID, DEVICE_2_FHIRID)));
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Location"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Location");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            ids.add(entry.get("resource").get("id").asText());
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(10, search("_lastUpdated", "ge2025-01-01").get("total").asInt());
+        assertEquals(10, search("_lastUpdated", "2025-01-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2025-01-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "gt2025-01-02").get("total").asInt());
+        JsonNode resource = search("_id", SHELF_FHIRID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2025-01-01"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/ObservationFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/ObservationFacadeTest.java
@@ -407,9 +407,10 @@ public class ObservationFacadeTest extends BaseWebContextSensitiveTest {
     }
 
     /**
-     * Result entry validation requires the analysis to belong to a panel; the
-     * fixture's analyses have none, so tests that write through the result workflow
-     * attach one first.
+     * The result workflow merges the analysis together with its panel, and
+     * Hibernate treats a panel without a version (lastupdated) as transient. The
+     * fixture's analyses have no panel, so tests that write through the result
+     * workflow attach a freshly saved, versioned one first.
      */
     private void attachPanelToAnalysis(String analysisId) {
         Analysis analysis = analysisService.getAnalysisById(analysisId);

--- a/src/test/java/org/openelisglobal/fhir/ObservationSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/ObservationSearchFacadeTest.java
@@ -1,0 +1,162 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.ObservationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Observation search answered from the OpenELIS database (result-facade.xml:
+ * result 3 on analysis 1, technically accepted, patient 1 / provider 1 / sample
+ * item 601; result 4 on analysis 2, finalized, patient 2 / sample item 602;
+ * both analyses released on 2025-07-07).
+ */
+public class ObservationSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+    private static final String RESULT_4_UUID = "550e8400-e29b-41d4-a716-446655440004";
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String ANALYSIS_2_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02";
+    private static final String PATIENT_1_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    private static final String PROVIDER_1_UUID = "550e8400-e29b-41d4-a716-446655441004";
+    private static final String SAMPLE_ITEM_601_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+
+    @Autowired
+    private ObservationProvider observationProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        resyncSequence("clinlims.result_seq", "clinlims.result");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(observationProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_byIdPatientOrderAndSpecimen() throws Exception {
+        assertEquals(2, search().get("total").asInt());
+        assertEquals(List.of(RESULT_4_UUID), idsOf(search("_id", RESULT_4_UUID), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID), idsOf(search("patient", "Patient/" + PATIENT_1_UUID), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID), idsOf(search("subject", PATIENT_1_UUID), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID),
+                idsOf(search("based-on", "ServiceRequest/" + ANALYSIS_1_UUID), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID),
+                idsOf(search("specimen", "Specimen/" + SAMPLE_ITEM_601_UUID), "Observation"));
+        assertEquals(0, search("based-on", "00000000-0000-0000-0000-000000000000").get("total").asInt());
+    }
+
+    @Test
+    public void search_byCodeStatusAndDate() throws Exception {
+        assertEquals(2, search("code", "http://loinc.org|123456").get("total").asInt());
+        assertEquals(0, search("code", "http://loinc.org|000000").get("total").asInt());
+        assertEquals(List.of(RESULT_4_UUID), idsOf(search("status", "final"), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID), idsOf(search("status", "preliminary"), "Observation"));
+        assertEquals(0, search("status", "cancelled").get("total").asInt());
+        assertEquals(2, search("date", "2025-07-07").get("total").asInt());
+        assertEquals(2, search("date", "ge2025-07-01").get("total").asInt());
+        assertEquals(0, search("date", "lt2025-07-07").get("total").asInt());
+        assertEquals(0, search("date", "gt2025-07-07").get("total").asInt());
+    }
+
+    @Test
+    public void search_includes_addLinkedResources() throws Exception {
+        JsonNode bundle = search(RESULT_3_UUID, "_include", "Observation:patient");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(PATIENT_1_UUID), idsOf(bundle, "Patient"));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+
+        bundle = search(RESULT_3_UUID, "_include", "Observation:based-on");
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+
+        bundle = search(RESULT_3_UUID, "_include", "Observation:specimen");
+        assertEquals(List.of(SAMPLE_ITEM_601_UUID), idsOf(bundle, "Specimen"));
+
+        bundle = search(RESULT_3_UUID, "_include", "Observation:performer");
+        assertEquals(List.of(PROVIDER_1_UUID), idsOf(bundle, "Practitioner"));
+
+        bundle = search(RESULT_4_UUID, "_revinclude", "DiagnosticReport:result");
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(bundle, "DiagnosticReport"));
+    }
+
+    @Test
+    public void search_returnsTransformedObservations() throws Exception {
+        JsonNode resource = search("_id", RESULT_4_UUID).get("entry").get(0).get("resource");
+        assertEquals("Observation", resource.get("resourceType").asText());
+        assertEquals("final", resource.get("status").asText());
+        assertTrue(resource.has("valueQuantity"));
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Observation"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Observation");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode search(String id, String includeParam, String includeValue) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Observation");
+        request.setQueryString("_id=" + id + "&" + includeParam + "=" + includeValue);
+        request.addParameter("_id", id);
+        request.addParameter(includeParam, includeValue);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(List.of(RESULT_4_UUID), idsOf(search("_lastUpdated", "ge2025-05-01"), "Observation"));
+        assertEquals(List.of(RESULT_3_UUID), idsOf(search("_lastUpdated", "lt2025-05-01"), "Observation"));
+        assertEquals(2, search("_lastUpdated", "ge2025-01-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2025-01-01").get("total").asInt());
+        JsonNode resource = search("_id", RESULT_3_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2025-04-04"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/OrganizationFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/OrganizationFacadeTest.java
@@ -3,6 +3,7 @@ package org.openelisglobal.fhir;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.server.RestfulServer;
@@ -238,5 +239,58 @@ public class OrganizationFacadeTest extends BaseWebContextSensitiveTest {
         assertNotNull(deletedOrg);
         assertEquals("N", deletedOrg.getIsActive());
         assertFalse(deletedOrg.getIsActive().equals("Y"));
+    }
+
+    @Test
+    public void createOrganization_withPartOf_linksParentAndAnswersPartofSearch() throws Exception {
+        cleanupDatabase();
+
+        JsonNode parent = post("/Organization", """
+                {"resourceType": "Organization", "active": true, "name": "Parent Laboratory"}
+                """, 201);
+        String parentId = parent.get("id").asText();
+
+        JsonNode child = post("/Organization", """
+                {"resourceType": "Organization", "active": true, "name": "Child Ward",
+                 "partOf": {"reference": "Organization/%s"}}
+                """.formatted(parentId), 201);
+        assertEquals("Organization/" + parentId, child.get("partOf").get("reference").asText());
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Organization");
+        request.setQueryString("partof=Organization/" + parentId);
+        request.addParameter("partof", "Organization/" + parentId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(200, response.getStatus());
+        JsonNode bundle = objectMapper.readTree(response.getContentAsString());
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(child.get("id").asText(), bundle.get("entry").get(0).get("resource").get("id").asText());
+    }
+
+    @Test
+    public void createOrganization_withUnknownPartOf_returns422() throws Exception {
+        JsonNode outcome = post("/Organization", """
+                {"resourceType": "Organization", "active": true, "name": "Orphan Ward",
+                 "partOf": {"reference": "Organization/00000000-0000-0000-0000-000000000000"}}
+                """, 422);
+        assertEquals("OperationOutcome", outcome.get("resourceType").asText());
+    }
+
+    @Test
+    public void createOrganization_withOverlongState_returns422NotServerError() throws Exception {
+        JsonNode outcome = post("/Organization", """
+                {"resourceType": "Organization", "active": true, "name": "Wide State Clinic",
+                 "address": [{"city": "Kampala", "state": "Central Region"}]}
+                """, 422);
+        assertTrue(outcome.get("issue").get(0).get("diagnostics").asText().contains("could not be stored"));
+    }
+
+    private JsonNode post(String path, String json, int expectedStatus) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", path);
+        request.setContent(json.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), expectedStatus, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
     }
 }

--- a/src/test/java/org/openelisglobal/fhir/OrganizationSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/OrganizationSearchFacadeTest.java
@@ -1,0 +1,187 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.OrganizationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Organization search answered from the OpenELIS database
+ * (facade-organization.xml: Global Health Org, Health Services Inc, Community
+ * Health Center).
+ */
+public class OrganizationSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String GLOBAL_HEALTH_UUID = "f2cdeff8-8d5b-4023-bd7c-932b4b98b6d3";
+    private static final String HEALTH_SERVICES_UUID = "a3bdeff8-8d5b-4023-bd7c-932b4b98b6d4";
+    private static final String COMMUNITY_HEALTH_UUID = "c4dfeff8-8d5b-4023-bd7c-932b4b98b6d5";
+
+    @Autowired
+    private OrganizationProvider organizationProvider;
+
+    @Autowired
+    private javax.sql.DataSource dataSource;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-organization.xml");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(organizationProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_withoutParameters_returnsEveryOrganization() throws Exception {
+        JsonNode bundle = search();
+
+        assertEquals(3, bundle.get("total").asInt());
+        assertTrue(idsOf(bundle).containsAll(List.of(GLOBAL_HEALTH_UUID, HEALTH_SERVICES_UUID, COMMUNITY_HEALTH_UUID)));
+    }
+
+    @Test
+    public void search_byId_returnsOnlyThatOrganization() throws Exception {
+        assertEquals(List.of(HEALTH_SERVICES_UUID), idsOf(search("_id", HEALTH_SERVICES_UUID)));
+        assertEquals(0, search("_id", "00000000-0000-0000-0000-000000000000").get("total").asInt());
+    }
+
+    @Test
+    public void search_byIdentifier_matchesCodeShortNameCliaAndUuid() throws Exception {
+        assertEquals(List.of(GLOBAL_HEALTH_UUID), idsOf(search("identifier", "GHG001")));
+        assertEquals(List.of(GLOBAL_HEALTH_UUID), idsOf(search("identifier", "GHG")));
+        assertEquals(List.of(HEALTH_SERVICES_UUID), idsOf(search("identifier", "CLIA67890")));
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID),
+                idsOf(search("identifier", "http://openelis-global.org/org_code|CHC003")));
+        assertEquals(0, search("identifier", "http://openelis-global.org/org_code|GHG").get("total").asInt());
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID),
+                idsOf(search("identifier", "http://openelis-global.org/org_uuid|" + COMMUNITY_HEALTH_UUID)));
+    }
+
+    @Test
+    public void search_byName_isPrefixAndCaseInsensitive() throws Exception {
+        assertEquals(List.of(HEALTH_SERVICES_UUID), idsOf(search("name", "health services")));
+        assertEquals(0, search("name", "Services").get("total").asInt());
+        assertEquals(List.of(HEALTH_SERVICES_UUID), idsOf(search("name:contains", "Services")));
+    }
+
+    @Test
+    public void search_byActive_mapsBooleanToYesNoColumn() throws Exception {
+        assertEquals(2, search("active", "true").get("total").asInt());
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID), idsOf(search("active", "false")));
+    }
+
+    @Test
+    public void search_byType_matchesOrganizationTypeName() throws Exception {
+        assertEquals(2, search("type", "Healthcare").get("total").asInt());
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID), idsOf(search("type", "referingClinic")));
+        assertEquals(0, search("type", "Pharmacy").get("total").asInt());
+    }
+
+    @Test
+    public void search_byAddressCity_andActive_areAndCombined() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Organization");
+        request.setQueryString("address-city=Chicago&active=true");
+        request.addParameter("address-city", "Chicago");
+        request.addParameter("active", "true");
+
+        assertEquals(0, serve(request).get("total").asInt());
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID), idsOf(search("address-city", "Chicago")));
+    }
+
+    @Test
+    public void search_byPartOf_andIncludes_followTheHierarchy() throws Exception {
+        new JdbcTemplate(dataSource).update("UPDATE clinlims.organization SET org_id = 3 WHERE id IN (4, 5)");
+
+        assertEquals(2, search("partof", "Organization/" + GLOBAL_HEALTH_UUID).get("total").asInt());
+        assertEquals(2, search("partof", "3").get("total").asInt());
+
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Organization");
+        request.setQueryString("_id=" + HEALTH_SERVICES_UUID + "&_include=Organization:partof");
+        request.addParameter("_id", HEALTH_SERVICES_UUID);
+        request.addParameter("_include", "Organization:partof");
+        JsonNode bundle = serve(request);
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(HEALTH_SERVICES_UUID, GLOBAL_HEALTH_UUID), idsOf(bundle));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+
+        request = buildFhirRequest("GET", "/Organization");
+        request.setQueryString("_id=" + GLOBAL_HEALTH_UUID + "&_revinclude=Organization:partof");
+        request.addParameter("_id", GLOBAL_HEALTH_UUID);
+        request.addParameter("_revinclude", "Organization:partof");
+        bundle = serve(request);
+        assertEquals(1, bundle.get("total").asInt());
+        assertTrue(idsOf(bundle).containsAll(List.of(GLOBAL_HEALTH_UUID, HEALTH_SERVICES_UUID, COMMUNITY_HEALTH_UUID)));
+    }
+
+    @Test
+    public void search_returnsTransformedOrganizations() throws Exception {
+        JsonNode resource = search("_id", GLOBAL_HEALTH_UUID).get("entry").get(0).get("resource");
+
+        assertEquals("Organization", resource.get("resourceType").asText());
+        assertEquals("Global Health Org", resource.get("name").asText());
+        assertTrue(resource.get("active").asBoolean());
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Organization"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Organization");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            ids.add(entry.get("resource").get("id").asText());
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(List.of(COMMUNITY_HEALTH_UUID), idsOf(search("_lastUpdated", "ge2024-06-05")));
+        assertEquals(List.of(GLOBAL_HEALTH_UUID), idsOf(search("_lastUpdated", "le2024-06-03")));
+        assertEquals(3, search("_lastUpdated", "ge2024-06-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2024-01-01").get("total").asInt());
+        JsonNode resource = search("_id", HEALTH_SERVICES_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2024-06-04"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientFacadeTest.java
@@ -264,4 +264,18 @@ public class PatientFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals(404, response.getStatus());
     }
 
+    @Test
+    public void createPatient_withInvalidName_returns422() throws Exception {
+        MockHttpServletRequest request = buildRequest("POST", "/Patient");
+        request.setContent("""
+                {"resourceType": "Patient", "name": [{"family": "Probe123", "given": ["Live"]}],
+                 "gender": "female", "birthDate": "1990-05-05"}
+                """.getBytes());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(422, response.getStatus());
+        JsonNode outcome = objectMapper.readTree(response.getContentAsString());
+        assertEquals("OperationOutcome", outcome.get("resourceType").asText());
+    }
 }

--- a/src/test/java/org/openelisglobal/fhir/PatientSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientSearchFacadeTest.java
@@ -1,0 +1,207 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.PatientProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Patient search answered from the OpenELIS database (facade-patient.xml).
+ */
+public class PatientSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String JOHN_DOE_UUID = "b479ab79-5f53-4d1f-bc9b-10f19ce04635";
+    private static final String JAMES_MULIZI_UUID = "b479ab79-5f53-4d1f-bc9b-10f19ce04636";
+    private static final String FAITH_KUKKI_UUID = "b479ab79-5f53-4d1f-bc9b-10f19ce04637";
+
+    @Autowired
+    private PatientProvider patientProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-patient.xml");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(patientProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_withoutParameters_returnsEveryPatient() throws Exception {
+        JsonNode bundle = search();
+
+        assertEquals("searchset", bundle.get("type").asText());
+        assertEquals(3, bundle.get("total").asInt());
+        assertTrue(patientIds(bundle).containsAll(List.of(JOHN_DOE_UUID, JAMES_MULIZI_UUID, FAITH_KUKKI_UUID)));
+    }
+
+    @Test
+    public void search_byId_returnsOnlyThatPatient() throws Exception {
+        JsonNode bundle = search("_id", JAMES_MULIZI_UUID);
+
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(JAMES_MULIZI_UUID), patientIds(bundle));
+    }
+
+    @Test
+    public void search_byUnknownId_returnsEmptySearchset() throws Exception {
+        JsonNode bundle = search("_id", "00000000-0000-0000-0000-000000000000");
+
+        assertEquals(0, bundle.get("total").asInt());
+    }
+
+    @Test
+    public void search_byNonUuidId_returnsEmptyRatherThanError() throws Exception {
+        JsonNode bundle = search("_id", "not-a-uuid");
+
+        assertEquals(0, bundle.get("total").asInt());
+    }
+
+    @Test
+    public void search_byBareIdentifier_matchesNationalId() throws Exception {
+        JsonNode bundle = search("identifier", "1234");
+
+        assertEquals("patients 1 and 3 share national id 1234", 2, bundle.get("total").asInt());
+        assertTrue(patientIds(bundle).containsAll(List.of(JOHN_DOE_UUID, FAITH_KUKKI_UUID)));
+    }
+
+    @Test
+    public void search_byBareIdentifier_matchesPatientIdentityRow() throws Exception {
+        JsonNode bundle = search("identifier", "334-422-A");
+
+        assertEquals(List.of(JOHN_DOE_UUID), patientIds(bundle));
+    }
+
+    @Test
+    public void search_byNationalIdSystem_matchesOnlyNationalId() throws Exception {
+        JsonNode bundle = search("identifier", "http://openelis-global.org/pat_nationalId|56789");
+
+        assertEquals(List.of(JAMES_MULIZI_UUID), patientIds(bundle));
+    }
+
+    @Test
+    public void search_byUuidSystem_matchesFhirUuid() throws Exception {
+        JsonNode bundle = search("identifier", "http://openelis-global.org/pat_uuid|" + FAITH_KUKKI_UUID);
+
+        assertEquals(List.of(FAITH_KUKKI_UUID), patientIds(bundle));
+    }
+
+    @Test
+    public void search_byUnknownIdentifierSystem_returnsNothing() throws Exception {
+        JsonNode bundle = search("identifier", "http://example.org/other|1234");
+
+        assertEquals(0, bundle.get("total").asInt());
+    }
+
+    @Test
+    public void search_byName_matchesGivenOrFamily() throws Exception {
+        assertEquals(List.of(JOHN_DOE_UUID), patientIds(search("name", "Doe")));
+        assertEquals(List.of(JAMES_MULIZI_UUID), patientIds(search("name", "james")));
+    }
+
+    @Test
+    public void search_byGivenAndFamily_areAndCombined() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient");
+        request.setQueryString("given=Faith&family=Kukki");
+        request.addParameter("given", "Faith");
+        request.addParameter("family", "Kukki");
+
+        assertEquals(List.of(FAITH_KUKKI_UUID), patientIds(serve(request)));
+
+        request = buildFhirRequest("GET", "/Patient");
+        request.setQueryString("given=Faith&family=Doe");
+        request.addParameter("given", "Faith");
+        request.addParameter("family", "Doe");
+
+        assertEquals(0, serve(request).get("total").asInt());
+    }
+
+    @Test
+    public void search_byGender_mapsFhirCodesToOpenElisColumn() throws Exception {
+        assertEquals(List.of(JAMES_MULIZI_UUID), patientIds(search("gender", "female")));
+        assertEquals(2, search("gender", "male").get("total").asInt());
+        assertEquals(0, search("gender", "unknown").get("total").asInt());
+    }
+
+    @Test
+    public void search_byBirthDateRange_usesPrefixes() throws Exception {
+        assertEquals(List.of(JAMES_MULIZI_UUID), patientIds(search("birthdate", "ge1995-01-01")));
+        assertEquals(2, search("birthdate", "lt1995-01-01").get("total").asInt());
+        assertEquals(2, search("birthdate", "1992-12-12").get("total").asInt());
+    }
+
+    @Test
+    public void search_returnsFullyTransformedPatients() throws Exception {
+        JsonNode bundle = search("_id", JOHN_DOE_UUID);
+        JsonNode patient = bundle.get("entry").get(0).get("resource");
+
+        assertEquals("Patient", patient.get("resourceType").asText());
+        assertEquals("Doe", patient.get("name").get(0).get("family").asText());
+        assertEquals("male", patient.get("gender").asText());
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Patient"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> patientIds(JsonNode bundle) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if ("Patient".equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(3, search("_lastUpdated", "ge2023-11-01").get("total").asInt());
+        assertEquals(3, search("_lastUpdated", "le2023-11-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2023-11-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "gt2023-11-02").get("total").asInt());
+        JsonNode resource = search("_id", JOHN_DOE_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2023-11-01"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/PatientSearchRevIncludeFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PatientSearchRevIncludeFacadeTest.java
@@ -1,0 +1,161 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.PatientProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * {@code Patient?_revinclude=...} pulls the orders, specimens, results and
+ * reports linked to a patient through sample_human (result-facade.xml).
+ */
+public class PatientSearchRevIncludeFacadeTest extends BaseWebContextSensitiveTest {
+
+    /** patient 1: sample 1, sample item 601, analysis 1, result 3. */
+    private static final String PATIENT_1_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    /** patient 2: sample 2, sample item 602, analysis 2 (final), result 4. */
+    private static final String PATIENT_2_UUID = "550e8400-e29b-41d4-a716-446655440004";
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String ANALYSIS_2_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02";
+    private static final String SAMPLE_ITEM_601_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+
+    @Autowired
+    private PatientProvider patientProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        resyncSequence("clinlims.result_seq", "clinlims.result");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(patientProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_withoutRevInclude_returnsPatientsOnly() throws Exception {
+        JsonNode bundle = search(PATIENT_1_UUID, null);
+
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of("Patient"), resourceTypes(bundle));
+    }
+
+    @Test
+    public void revIncludeServiceRequestPatient_addsTheOrders() throws Exception {
+        JsonNode bundle = search(PATIENT_1_UUID, "ServiceRequest:patient");
+
+        assertEquals("total counts matches only, not included resources", 1, bundle.get("total").asInt());
+        assertTrue(idsOf(bundle, "Patient").contains(PATIENT_1_UUID));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+        assertEquals("include", searchModeOf(bundle, "ServiceRequest"));
+    }
+
+    @Test
+    public void revIncludeServiceRequestSubject_isAcceptedAsAlias() throws Exception {
+        JsonNode bundle = search(PATIENT_1_UUID, "ServiceRequest:subject");
+
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+    }
+
+    @Test
+    public void revIncludeSpecimenPatient_addsTheSampleItems() throws Exception {
+        JsonNode bundle = search(PATIENT_1_UUID, "Specimen:patient");
+
+        assertEquals(List.of(SAMPLE_ITEM_601_UUID), idsOf(bundle, "Specimen"));
+    }
+
+    @Test
+    public void revIncludeObservationPatient_addsTheResults() throws Exception {
+        JsonNode bundle = search(PATIENT_1_UUID, "Observation:patient");
+
+        assertEquals(List.of(RESULT_3_UUID), idsOf(bundle, "Observation"));
+    }
+
+    @Test
+    public void revIncludeDiagnosticReportPatient_addsReports() throws Exception {
+        JsonNode bundle = search(PATIENT_2_UUID, "DiagnosticReport:patient");
+
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(bundle, "DiagnosticReport"));
+        assertEquals("final", bundle.get("entry").get(1).get("resource").get("status").asText());
+    }
+
+    @Test
+    public void unsupportedRevInclude_isRejected() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient");
+        request.setQueryString("_id=" + PATIENT_1_UUID + "&_revinclude=Encounter:patient");
+        request.addParameter("_id", PATIENT_1_UUID);
+        request.addParameter("_revinclude", "Encounter:patient");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    private JsonNode search(String patientUuid, String revInclude) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Patient");
+        String query = "_id=" + patientUuid;
+        request.addParameter("_id", patientUuid);
+        if (revInclude != null) {
+            query += "&_revinclude=" + revInclude;
+            request.addParameter("_revinclude", revInclude);
+        }
+        request.setQueryString(query);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> resourceTypes(JsonNode bundle) {
+        List<String> types = new ArrayList<>();
+        for (JsonNode entry : bundle.get("entry")) {
+            types.add(entry.get("resource").get("resourceType").asText());
+        }
+        return types;
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        for (JsonNode entry : bundle.get("entry")) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    private static String searchModeOf(JsonNode bundle, String resourceType) {
+        for (JsonNode entry : bundle.get("entry")) {
+            if (resourceType.equals(entry.get("resource").get("resourceType").asText())) {
+                return entry.get("search").get("mode").asText();
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/PractitionerRevIncludeFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/PractitionerRevIncludeFacadeTest.java
@@ -1,0 +1,114 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.PractitionerProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Practitioner reverse includes over result-facade.xml: provider 1 requested
+ * analysis 1 (result 3); analysis 2's sample has no provider.
+ */
+public class PractitionerRevIncludeFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String PROVIDER_1_UUID = "550e8400-e29b-41d4-a716-446655441004";
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+
+    @Autowired
+    private PractitionerProvider practitionerProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(practitionerProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void revIncludeObservationPerformer_addsTheProvidersResults() throws Exception {
+        JsonNode bundle = search(PROVIDER_1_UUID, "Observation:performer");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(PROVIDER_1_UUID), idsOf(bundle, "Practitioner"));
+        assertEquals(List.of(RESULT_3_UUID), idsOf(bundle, "Observation"));
+        assertEquals("match", bundle.get("entry").get(0).get("search").get("mode").asText());
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+        assertEquals("Practitioner/" + PROVIDER_1_UUID,
+                bundle.get("entry").get(1).get("resource").get("performer").get(0).get("reference").asText());
+    }
+
+    @Test
+    public void revIncludeServiceRequestRequester_addsTheProvidersOrders() throws Exception {
+        JsonNode bundle = search(PROVIDER_1_UUID, "ServiceRequest:requester");
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+    }
+
+    @Test
+    public void lastUpdated_isSearchableAndExposed() throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner");
+        request.setQueryString("_lastUpdated=ge2023-11-01");
+        request.addParameter("_lastUpdated", "ge2023-11-01");
+        JsonNode bundle = serve(request);
+        assertTrue(idsOf(bundle, "Practitioner").contains(PROVIDER_1_UUID));
+        assertTrue(bundle.get("entry").get(0).get("resource").get("meta").get("lastUpdated").asText()
+                .startsWith("2023-11-01"));
+
+        request = buildFhirRequest("GET", "/Practitioner");
+        request.setQueryString("_lastUpdated=lt2023-11-01");
+        request.addParameter("_lastUpdated", "lt2023-11-01");
+        assertEquals(0, serve(request).get("total").asInt());
+    }
+
+    private JsonNode search(String id, String revInclude) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Practitioner");
+        request.setQueryString("_id=" + id + "&_revinclude=" + revInclude);
+        request.addParameter("_id", id);
+        request.addParameter("_revinclude", revInclude);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/ServiceRequestSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/ServiceRequestSearchFacadeTest.java
@@ -1,0 +1,169 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.ServiceRequestProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * ServiceRequest search answered from the OpenELIS database (result-facade.xml:
+ * analysis 1, technically accepted, for patient 1 / provider 1 / sample item
+ * 601 with result 3; analysis 2, finalized, for patient 2 / sample item 602).
+ */
+public class ServiceRequestSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String ANALYSIS_2_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b02";
+    private static final String PATIENT_1_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    private static final String PROVIDER_1_UUID = "550e8400-e29b-41d4-a716-446655441004";
+    private static final String SAMPLE_ITEM_601_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+
+    @Autowired
+    private ServiceRequestProvider serviceRequestProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        resyncSequence("clinlims.result_seq", "clinlims.result");
+
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(serviceRequestProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_byIdAndIdentifiers() throws Exception {
+        assertEquals(2, search().get("total").asInt());
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(search("_id", ANALYSIS_2_UUID), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(
+                search("identifier", "http://openelis-global.org/analysis_uuid|" + ANALYSIS_1_UUID), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(search("identifier", "DEV01260000000000001"), "ServiceRequest"));
+        assertEquals(0, search("identifier", "http://example.org/other|DEV01260000000000001").get("total").asInt());
+    }
+
+    @Test
+    public void search_byPatientRequesterAndSpecimen() throws Exception {
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(search("patient", "Patient/" + PATIENT_1_UUID), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(search("subject", PATIENT_1_UUID), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID),
+                idsOf(search("requester", "Practitioner/" + PROVIDER_1_UUID), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID),
+                idsOf(search("specimen", "Specimen/" + SAMPLE_ITEM_601_UUID), "ServiceRequest"));
+        assertEquals(0, search("patient", "00000000-0000-0000-0000-000000000000").get("total").asInt());
+    }
+
+    @Test
+    public void search_byCodeAndStatus() throws Exception {
+        assertEquals(2, search("code", "http://loinc.org|123456").get("total").asInt());
+        assertEquals(2, search("code", "123456").get("total").asInt());
+        assertEquals(2, search("code", "complete blood count").get("total").asInt());
+        assertEquals(2, search("code", "blood test").get("total").asInt());
+        assertEquals(0, search("code", "http://loinc.org|999999").get("total").asInt());
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(search("status", "completed"), "ServiceRequest"));
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(search("status", "active"), "ServiceRequest"));
+        assertEquals(2, search("status", "active,completed").get("total").asInt());
+        assertEquals(0, search("status", "revoked").get("total").asInt());
+        assertEquals(0, search("status", "draft").get("total").asInt());
+    }
+
+    @Test
+    public void search_includes_addLinkedResources() throws Exception {
+        JsonNode bundle = search(ANALYSIS_1_UUID, "_include", "ServiceRequest:patient");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(PATIENT_1_UUID), idsOf(bundle, "Patient"));
+
+        bundle = search(ANALYSIS_1_UUID, "_include", "ServiceRequest:requester");
+        assertEquals(List.of(PROVIDER_1_UUID), idsOf(bundle, "Practitioner"));
+
+        bundle = search(ANALYSIS_1_UUID, "_include", "ServiceRequest:specimen");
+        assertEquals(List.of(SAMPLE_ITEM_601_UUID), idsOf(bundle, "Specimen"));
+
+        bundle = search(ANALYSIS_1_UUID, "_revinclude", "Observation:based-on");
+        assertEquals(List.of(RESULT_3_UUID), idsOf(bundle, "Observation"));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+
+        bundle = search(ANALYSIS_2_UUID, "_revinclude", "DiagnosticReport:based-on");
+        assertEquals(List.of(ANALYSIS_2_UUID), idsOf(bundle, "DiagnosticReport"));
+    }
+
+    @Test
+    public void search_returnsTransformedServiceRequests() throws Exception {
+        JsonNode resource = search("_id", ANALYSIS_2_UUID).get("entry").get(0).get("resource");
+        assertEquals("ServiceRequest", resource.get("resourceType").asText());
+        assertEquals("completed", resource.get("status").asText());
+        assertTrue(resource.get("code").get("coding").size() >= 1);
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/ServiceRequest"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/ServiceRequest");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode search(String id, String includeParam, String includeValue) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/ServiceRequest");
+        request.setQueryString("_id=" + id + "&" + includeParam + "=" + includeValue);
+        request.addParameter("_id", id);
+        request.addParameter(includeParam, includeValue);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andExposesMetaLastUpdated() throws Exception {
+        assertEquals(2, search("_lastUpdated", "ge2025-07-07").get("total").asInt());
+        assertEquals(2, search("_lastUpdated", "2025-07-07").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2025-07-07").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "gt2025-07-08").get("total").asInt());
+        JsonNode resource = search("_id", ANALYSIS_1_UUID).get("entry").get(0).get("resource");
+        assertTrue(resource.get("meta").get("lastUpdated").asText().startsWith("2025-07-07"));
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/SpecimenSearchFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/SpecimenSearchFacadeTest.java
@@ -1,0 +1,164 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.SpecimenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Specimen search answered from the OpenELIS database. facade-specimen.xml
+ * seeds two sample items without a patient; result-facade.xml adds the patient,
+ * order and result links used for includes.
+ */
+public class SpecimenSearchFacadeTest extends BaseWebContextSensitiveTest {
+
+    private static final String SERUM_ITEM_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+    private static final String URINE_ITEM_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93271";
+    private static final String PATIENT_1_UUID = "550e8400-e29b-41d4-a716-446655440001";
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+    private static final String RESULT_3_UUID = "550e8400-e29b-41d4-a716-446655440003";
+
+    @Autowired
+    private SpecimenProvider specimenProvider;
+
+    private RestfulServer fhirServlet;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.asList(specimenProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void search_byIdAndIdentifiers_findTheSampleItem() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-specimen.xml");
+
+        assertEquals(2, search().get("total").asInt());
+        assertEquals(List.of(SERUM_ITEM_UUID), idsOf(search("_id", SERUM_ITEM_UUID), "Specimen"));
+        assertEquals(List.of(URINE_ITEM_UUID), idsOf(search("identifier", URINE_ITEM_UUID), "Specimen"));
+        assertEquals(List.of(SERUM_ITEM_UUID),
+                idsOf(search("identifier", "http://openelis-global.org/sampleItem_labNo|DEV01260000000000001-1"),
+                        "Specimen"));
+        assertEquals(List.of(URINE_ITEM_UUID), idsOf(search("identifier", "DEV01260000000000002"), "Specimen"));
+        assertEquals(List.of(URINE_ITEM_UUID), idsOf(search("accession", "DEV01260000000000002"), "Specimen"));
+        assertEquals(0, search("identifier", "http://example.org/other|DEV01260000000000002").get("total").asInt());
+    }
+
+    @Test
+    public void search_byTypeStatusAndCollectionDate() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-specimen.xml");
+
+        assertEquals(List.of(URINE_ITEM_UUID), idsOf(search("type", "urine sample"), "Specimen"));
+        assertEquals(0, search("type", "Plasma").get("total").asInt());
+        assertEquals(2, search("status", "available").get("total").asInt());
+        assertEquals(0, search("status", "unsatisfactory").get("total").asInt());
+        assertEquals(2, search("collected", "2023-11-15").get("total").asInt());
+        assertEquals(0, search("collected", "lt2023-11-15").get("total").asInt());
+        assertEquals(2, search("collected", "ge2023-11-01").get("total").asInt());
+    }
+
+    @Test
+    public void search_byPatient_andIncludes_followSampleHuman() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        resyncSequence("clinlims.result_seq", "clinlims.result");
+
+        assertEquals(List.of(SERUM_ITEM_UUID), idsOf(search("patient", "Patient/" + PATIENT_1_UUID), "Specimen"));
+        assertEquals(List.of(SERUM_ITEM_UUID), idsOf(search("subject", PATIENT_1_UUID), "Specimen"));
+        assertEquals(0, search("patient", "00000000-0000-0000-0000-000000000000").get("total").asInt());
+
+        JsonNode bundle = search(SERUM_ITEM_UUID, "_include", "Specimen:patient");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(PATIENT_1_UUID), idsOf(bundle, "Patient"));
+
+        bundle = search(SERUM_ITEM_UUID, "_revinclude", "ServiceRequest:specimen");
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "ServiceRequest"));
+
+        bundle = search(SERUM_ITEM_UUID, "_revinclude", "Observation:specimen");
+        assertEquals(List.of(RESULT_3_UUID), idsOf(bundle, "Observation"));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+    }
+
+    @Test
+    public void search_returnsTransformedSpecimens() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-specimen.xml");
+
+        JsonNode resource = search("_id", SERUM_ITEM_UUID).get("entry").get(0).get("resource");
+        assertEquals("Specimen", resource.get("resourceType").asText());
+        assertEquals("DEV01260000000000001-1", resource.get("accessionIdentifier").get("value").asText());
+        assertTrue(resource.get("type").get("coding").size() >= 1);
+    }
+
+    private JsonNode search() throws Exception {
+        return serve(buildFhirRequest("GET", "/Specimen"));
+    }
+
+    private JsonNode search(String param, String value) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Specimen");
+        request.setQueryString(param + "=" + value);
+        request.addParameter(param, value);
+        return serve(request);
+    }
+
+    private JsonNode search(String id, String includeParam, String includeValue) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", "/Specimen");
+        request.setQueryString("_id=" + id + "&" + includeParam + "=" + includeValue);
+        request.addParameter("_id", id);
+        request.addParameter(includeParam, includeValue);
+        return serve(request);
+    }
+
+    private JsonNode serve(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private static List<String> idsOf(JsonNode bundle, String resourceType) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resourceType.equals(resource.get("resourceType").asText())) {
+                ids.add(resource.get("id").asText());
+            }
+        }
+        return ids;
+    }
+
+    @Test
+    public void search_byLastUpdated_andRevIncludeDiagnosticReport() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+        assertEquals(2, search("_lastUpdated", "ge2023-12-01").get("total").asInt());
+        assertEquals(0, search("_lastUpdated", "lt2023-12-01").get("total").asInt());
+        JsonNode bundle = search(SERUM_ITEM_UUID, "_revinclude", "DiagnosticReport:specimen");
+        assertEquals(1, bundle.get("total").asInt());
+        assertEquals(List.of(ANALYSIS_1_UUID), idsOf(bundle, "DiagnosticReport"));
+        assertEquals("include", bundle.get("entry").get(1).get("search").get("mode").asText());
+        assertTrue(bundle.get("entry").get(0).get("resource").get("meta").get("lastUpdated").asText()
+                .startsWith("2023-12-01"));
+    }
+}

--- a/src/test/resources/testdata/facade-patient.xml
+++ b/src/test/resources/testdata/facade-patient.xml
@@ -55,21 +55,21 @@
         national_id="1234" ethnicity="U" external_id="EX456"
         school_attend="Makerere College" birth_place="Mulago"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04635"
-        entered_birth_date="1992-12-12" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="12/12/1992" lastupdated="2023-11-01 12:00:02" />
 
     <patient id="2" person_id="2" race="black" gender="F"
         birth_date="1997-10-09 09:00:00" birth_time="1997-10-09 09:00:00"
         national_id="56789" ethnicity="A" external_id="EX123"
         school_attend="Merryland College" birth_place="Nevada"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04636"
-        entered_birth_date="1997-10-09" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="09/10/1997" lastupdated="2023-11-01 12:00:02" />
 
     <patient id="3" person_id="3" race="black" gender="M"
         birth_date="1992-12-12 02:00:00" birth_time="1992-12-12 02:00:00"
         national_id="1234" ethnicity="U" external_id="EX432"
         school_attend="Makerere College" birth_place="Kawempe"
         fhir_uuid="b479ab79-5f53-4d1f-bc9b-10f19ce04637"
-        entered_birth_date="1992-12-12" lastupdated="2023-11-01 12:00:02" />
+        entered_birth_date="12/12/1992" lastupdated="2023-11-01 12:00:02" />
 
     <patient_identity id="1" identity_type_id="9"
         patient_id="1" identity_data="334-422-A"

--- a/src/test/resources/testdata/result-facade.xml
+++ b/src/test/resources/testdata/result-facade.xml
@@ -6,6 +6,15 @@
     <localization id="2" description="Test Name"
         lastupdated="2025-03-08 12:00:00" />
 
+    <localization id="3" description="Test 1 name"
+        lastupdated="2025-03-08 12:00:00" />
+    <localization_value id="9301" localization_id="3"
+        locale="en" value="Complete Blood Count"
+        last_updated="2025-03-08 12:00:00" />
+    <localization_value id="9302" localization_id="3"
+        locale="fr" value="Complete Blood Count"
+        last_updated="2025-03-08 12:00:00" />
+
     <system_user id="1" external_id="EXT003" login_name="admin"
         last_name="Doe" first_name="John" initials="JD" is_active="Y"
         is_employee="Y" lastupdated="2025-03-08 12:00:00" />
@@ -132,7 +141,7 @@
         lastupdated="2025-03-20 12:00:00" label_id="1" test_trailer_id="1"
         test_section_id="1" scriptlet_id="1" test_format_id="1"
         local_code="CBC" sort_order="2147483646" name="Complete Blood Count"
-        orderable="true" guid="abc-123" name_localization_id="1"
+        orderable="true" guid="abc-123" name_localization_id="3"
         reporting_name_localization_id="2" is_active="Y"
         antimicrobial_resistance="true" />
     <test id="2" method_id="2" uom_id="2" description="Urine Test"


### PR DESCRIPTION
## What
Answers every FHIR facade search from the OpenELIS database instead of forwarding to the external FHIR store: Patient, Organization, Specimen, ServiceRequest, Observation, DiagnosticReport, Device and Location (Practitioner already did). Every resource supports `_id` (FHIR uuid), `_lastUpdated` (the row's `lastupdated`, now also exposed as `meta.lastUpdated`), and the `_include`/`_revinclude` pairs OpenELIS actually stores, plus the resource-specific parameters that map onto OpenELIS data.

## Why
The facade is meant to make OpenELIS independent of the external HAPI server. Reads and writes were already local; search was the last operation that still depended on the FHIR store.

## How tested
- Integration tests per resource cover every search parameter, `_id`, `_lastUpdated`, `meta.lastUpdated`, each `_include`/`_revinclude` and the error paths (new: Patient/Organization/Specimen/ServiceRequest/Observation/DiagnosticReport/Device/Location search suites, Practitioner reverse includes, Organization `partOf`/422 regressions).
- Full backend suite on develop + this change: 5871 tests green.
- Live: WAR deployed to a dev-compose stack seeded from the facade fixtures; a 140-check probe over CRUD, every search parameter, `_lastUpdated` on all nine resources and all includes passes.

## Notes
- Live testing surfaced and this PR fixes: Organization create/update dropped `partOf`; Patient create answered 201 with an empty body when validation failed; every provider turned bean-validation and database constraint failures into 500s (now 422 with the rejected field in the diagnostics); `ServiceRequest?code=` did not match the test's short name; Patient `_revinclude=DiagnosticReport:*` only returned finalized reports while the DiagnosticReport search returns all; Observation delete returned 500 when the analysis already carried the same rejection note (now 409); Organizations without an `is_active` flag NPE'd in the transform.
- Test codings now always carry `code.text` with the test name, so unmapped tests are still identifiable.
- `_lastUpdated` has to mean "last modified", but reads were rewriting rows: `@Transactional(readOnly = true)` does not switch Hibernate to manual flush here (no `HibernateJpaDialect`), so anything dirty straight after load is written back with a version bump. Three such causes are fixed: the Patient `entered_birth_date` setter re-derived `birth_date` during hydration (now field access), the Provider `active` getter normalised null to false (now field access), and `StringListConverter` wrote empty lists as `""` over NULL columns (now symmetric). `FacadeReadsPreserveLastUpdatedTest` guards every facade read path. Adding the dialect globally is left for its own review because it would also drop accidental persistence such as `ensureFhirUuid()` backfills.
- Known hazard (pre-existing): `Test.getName()` returns the localized name, so any flush after loading a test rewrites `test.name` (the fixture gives test 1 a localization so the name-based code search is deterministic).
- Deletes remain soft (inactive/rejected), so deleted resources stay readable; a follow-up can decide on 410 semantics.
