### PR TITLE
fix: refresh database and FHIR runtime images off Bullseye

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -11,8 +11,15 @@ COPY ./db/dbInit/siteInfo.sql /docker-entrypoint-initdb.d/siteInfo.sql
 RUN chmod -R 755 /docker-entrypoint-initdb.d \
     && chown -R postgres:postgres /docker-entrypoint-initdb.d
 
+# Existing volumes: rebuild indexes once when the OS collation library changed (see the script).
+COPY ./db/docker-entrypoint-collation.sh /usr/local/bin/docker-entrypoint-collation.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint-collation.sh
+
 # Optional: Set working directory (not strictly needed)
 WORKDIR /docker-entrypoint-initdb.d
 
 # Expose the PostgreSQL port
 EXPOSE 5432
+
+ENTRYPOINT ["docker-entrypoint-collation.sh"]
+CMD ["postgres"]

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,10 +1,7 @@
 # Keep the PostgreSQL major version on a supported operating-system base.
 FROM postgres:14.24-bookworm
 
-# Debian 11 (bullseye) left LTS on 2026-08-31: the security suite's Release file has expired and its
-# pool is being pruned, so packages come from archive.debian.org (main + updates only).
-RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
-    && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y gettext-base && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y gettext-base && rm -rf /var/lib/apt/lists/*
 # Copy initialization scripts and data files into the container
 # PostgreSQL will automatically run any *.sql or *.sh files in this folder
 COPY ./db/dbInit /docker-entrypoint-initdb.d

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official PostgreSQL 14.4 image as base
-FROM postgres:14.4
+# Keep the PostgreSQL major version on a supported operating-system base.
+FROM postgres:14.24-bookworm
 
 # Debian 11 (bullseye) left LTS on 2026-08-31: the security suite's Release file has expired and its
 # pool is being pruned, so packages come from archive.debian.org (main + updates only).

--- a/db/docker-entrypoint-collation.sh
+++ b/db/docker-entrypoint-collation.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
-# Rebuilds indexes once when the operating system's collation library changed under an existing cluster.
+# Rebuilds indexes once, online, when the operating system's collation library changed under an
+# existing cluster.
 #
 # Moving the image to another Debian release changes glibc, and with it the sort order of locale
 # collations such as en_US.utf8. PostgreSQL 14 records the glibc version for the collations in
-# pg_collation but not for a database's default collation, so indexes on text columns keep being
-# used silently after the change. On an existing data directory this wrapper starts the server
-# privately (no TCP listener), looks for collations whose recorded version differs from the one the
-# OS now provides, rebuilds every index of the affected databases, records the new version, stops
-# the private server and hands over to the stock entrypoint. Empty volumes (first initialisation)
-# and already-refreshed volumes pass straight through.
+# pg_collation but not for a database's default collation, so after the change indexes on text
+# columns keep being used silently even though they were built under the old ordering.
 #
-# The check never blocks start-up: any failure (private server not starting, local authentication
-# refusing the postgres role, a rebuild error) is logged with the manual statements to run, and the
-# stock entrypoint starts PostgreSQL normally. Set OE_DB_SKIP_COLLATION_REINDEX=true to skip the check.
+# The rebuild runs in the background, after PostgreSQL is already accepting connections, and uses
+# REINDEX DATABASE ... CONCURRENTLY so no table is locked against reads or writes. This matters
+# because the application container starts at the same time as the database and gives up if the
+# database is unreachable when its schema migration runs: a rebuild that held start-up would take
+# the application down for as long as it lasted, and the larger the database the longer that is.
+# Empty volumes (first initialisation) and already-refreshed volumes do nothing at all.
+#
+# Every failure is logged with the statements to run by hand and is otherwise ignored; the recorded
+# collation versions are only refreshed once a rebuild has actually succeeded, so an interrupted run
+# is retried on the next start. Set OE_DB_SKIP_COLLATION_REINDEX=true to skip the check entirely.
 set -uo pipefail
 
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 export PGPASSWORD="${PGPASSWORD:-${POSTGRES_PASSWORD:-}}"
+READY_TIMEOUT="${OE_DB_COLLATION_READY_TIMEOUT:-600}"
 
 log() { printf '%s [collation-check] %s\n' "$(date -u '+%Y-%m-%d %H:%M:%S UTC')" "$*"; }
 
@@ -24,62 +29,63 @@ as_postgres() {
   if [ "$(id -u)" = '0' ]; then gosu postgres "$@"; else "$@"; fi
 }
 
-private_server_running=false
-stop_private_server() {
-  if [ "$private_server_running" = true ]; then
-    as_postgres pg_ctl -D "$PGDATA" -m fast -w -t 120 stop >/dev/null 2>&1 || true
-    private_server_running=false
-  fi
-}
-
 manual_hint() {
-  log "run the statements by hand as the postgres superuser once the server is up:"
-  log "  REINDEX DATABASE <db>; ALTER COLLATION \"en_US.utf8\" REFRESH VERSION; ALTER COLLATION \"en_US\" REFRESH VERSION;"
+  log "run the rebuild by hand as the postgres superuser instead:"
+  log "  REINDEX DATABASE <db> CONCURRENTLY;"
+  log "  ALTER COLLATION \"en_US.utf8\" REFRESH VERSION; ALTER COLLATION \"en_US\" REFRESH VERSION;"
 }
 
-collation_check() {
-  local mismatch_sql db stale coll started
-  if ! as_postgres pg_ctl -D "$PGDATA" -o "-c listen_addresses=''" -w -t 300 start >/dev/null 2>&1; then
-    log "private server did not start within 300s; skipping the check"; manual_hint; return 0
-  fi
-  private_server_running=true
+stale_collations_of() {
+  as_postgres psql -X -At -v ON_ERROR_STOP=1 -d "$1" -c \
+    "SELECT quote_ident(collname) FROM pg_collation
+      WHERE collprovider = 'c' AND collversion IS NOT NULL
+        AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)" 2>&1
+}
 
-  mismatch_sql="SELECT quote_ident(collname) FROM pg_collation
-                 WHERE collprovider = 'c' AND collversion IS NOT NULL
-                   AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)"
-  local dbs
-  if ! dbs=$(as_postgres psql -X -At -v ON_ERROR_STOP=1 -c "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname" 2>&1); then
-    log "cannot query the cluster as the postgres role ($dbs); skipping the check"; manual_hint; return 0
+rebuild_when_ready() {
+  local waited=0 dbs db qdb stale coll started
+  until as_postgres pg_isready -q; do
+    waited=$((waited + 2))
+    if [ "$waited" -ge "$READY_TIMEOUT" ]; then
+      log "PostgreSQL was not accepting connections after ${READY_TIMEOUT}s; skipping the check"
+      manual_hint; return 0
+    fi
+    sleep 2
+  done
+
+  if ! dbs=$(as_postgres psql -X -At -v ON_ERROR_STOP=1 -c \
+      "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname" 2>&1); then
+    log "cannot query the cluster as the postgres role ($dbs); skipping the check"
+    manual_hint; return 0
   fi
+
   while IFS= read -r db; do
     [ -z "$db" ] && continue
-    if ! stale=$(as_postgres psql -X -At -v ON_ERROR_STOP=1 -d "$db" -c "$mismatch_sql" 2>&1); then
+    if ! stale=$(stale_collations_of "$db"); then
       log "$db: cannot read pg_collation ($stale); skipping this database"; manual_hint; continue
     fi
     if [ -z "$stale" ]; then
       log "$db: collation versions match, nothing to do"; continue
     fi
-    log "$db: collation library changed for $(echo "$stale" | tr '\n' ' '); rebuilding all indexes"
+    log "$db: collation library changed for $(echo "$stale" | tr '\n' ' '); rebuilding all indexes online"
     started=$SECONDS
-    if ! as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "REINDEX DATABASE $(as_postgres psql -X -At -d "$db" -c 'SELECT quote_ident(current_database())')" 2>&1; then
-      log "$db: REINDEX failed; versions left unchanged so the check runs again next start"; manual_hint; continue
+    qdb=$(as_postgres psql -X -At -d "$db" -c 'SELECT quote_ident(current_database())')
+    if ! as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "REINDEX DATABASE CONCURRENTLY $qdb" 2>&1; then
+      log "$db: rebuild failed; collation versions left as they were so the next start retries"
+      manual_hint; continue
     fi
     while IFS= read -r coll; do
       [ -z "$coll" ] && continue
-      as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "ALTER COLLATION $coll REFRESH VERSION" 2>&1 || log "$db: could not refresh $coll"
+      as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "ALTER COLLATION $coll REFRESH VERSION" 2>&1 \
+        || log "$db: could not refresh $coll"
     done <<< "$stale"
     log "$db: indexes rebuilt and collation versions refreshed in $((SECONDS - started))s"
   done <<< "$dbs"
-  return 0
 }
 
 if [ "${1:-}" = 'postgres' ] && [ -s "$PGDATA/PG_VERSION" ] && [ "${OE_DB_SKIP_COLLATION_REINDEX:-false}" != 'true' ]; then
-  log "existing cluster found (PostgreSQL $(cat "$PGDATA/PG_VERSION") data directory), checking collation versions"
-  trap stop_private_server EXIT
-  collation_check || log "check ended with an error; starting PostgreSQL normally"
-  stop_private_server
-  trap - EXIT
-  log "check complete, starting PostgreSQL normally"
+  log "existing cluster found (PostgreSQL $(cat "$PGDATA/PG_VERSION") data directory); the collation check will run once the server is up"
+  rebuild_when_ready &
 fi
 
 exec docker-entrypoint.sh "$@"

--- a/db/docker-entrypoint-collation.sh
+++ b/db/docker-entrypoint-collation.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Rebuilds indexes once when the operating system's collation library changed under an existing cluster.
+#
+# Moving the image to another Debian release changes glibc, and with it the sort order of locale
+# collations such as en_US.utf8. PostgreSQL 14 records the glibc version for the collations in
+# pg_collation but not for a database's default collation, so indexes on text columns keep being
+# used silently after the change. On an existing data directory this wrapper starts the server
+# privately (no TCP listener), looks for collations whose recorded version differs from the one the
+# OS now provides, rebuilds every index of the affected databases, records the new version, stops
+# the private server and hands over to the stock entrypoint. Empty volumes (first initialisation)
+# and already-refreshed volumes pass straight through.
+#
+# The check never blocks start-up: any failure (private server not starting, local authentication
+# refusing the postgres role, a rebuild error) is logged with the manual statements to run, and the
+# stock entrypoint starts PostgreSQL normally. Set OE_DB_SKIP_COLLATION_REINDEX=true to skip the check.
+set -uo pipefail
+
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+export PGPASSWORD="${PGPASSWORD:-${POSTGRES_PASSWORD:-}}"
+
+log() { printf '%s [collation-check] %s\n' "$(date -u '+%Y-%m-%d %H:%M:%S UTC')" "$*"; }
+
+as_postgres() {
+  if [ "$(id -u)" = '0' ]; then gosu postgres "$@"; else "$@"; fi
+}
+
+private_server_running=false
+stop_private_server() {
+  if [ "$private_server_running" = true ]; then
+    as_postgres pg_ctl -D "$PGDATA" -m fast -w -t 120 stop >/dev/null 2>&1 || true
+    private_server_running=false
+  fi
+}
+
+manual_hint() {
+  log "run the statements by hand as the postgres superuser once the server is up:"
+  log "  REINDEX DATABASE <db>; ALTER COLLATION \"en_US.utf8\" REFRESH VERSION; ALTER COLLATION \"en_US\" REFRESH VERSION;"
+}
+
+collation_check() {
+  local mismatch_sql db stale coll started
+  if ! as_postgres pg_ctl -D "$PGDATA" -o "-c listen_addresses=''" -w -t 300 start >/dev/null 2>&1; then
+    log "private server did not start within 300s; skipping the check"; manual_hint; return 0
+  fi
+  private_server_running=true
+
+  mismatch_sql="SELECT quote_ident(collname) FROM pg_collation
+                 WHERE collprovider = 'c' AND collversion IS NOT NULL
+                   AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)"
+  local dbs
+  if ! dbs=$(as_postgres psql -X -At -v ON_ERROR_STOP=1 -c "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname" 2>&1); then
+    log "cannot query the cluster as the postgres role ($dbs); skipping the check"; manual_hint; return 0
+  fi
+  while IFS= read -r db; do
+    [ -z "$db" ] && continue
+    if ! stale=$(as_postgres psql -X -At -v ON_ERROR_STOP=1 -d "$db" -c "$mismatch_sql" 2>&1); then
+      log "$db: cannot read pg_collation ($stale); skipping this database"; manual_hint; continue
+    fi
+    if [ -z "$stale" ]; then
+      log "$db: collation versions match, nothing to do"; continue
+    fi
+    log "$db: collation library changed for $(echo "$stale" | tr '\n' ' '); rebuilding all indexes"
+    started=$SECONDS
+    if ! as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "REINDEX DATABASE $(as_postgres psql -X -At -d "$db" -c 'SELECT quote_ident(current_database())')" 2>&1; then
+      log "$db: REINDEX failed; versions left unchanged so the check runs again next start"; manual_hint; continue
+    fi
+    while IFS= read -r coll; do
+      [ -z "$coll" ] && continue
+      as_postgres psql -X -q -v ON_ERROR_STOP=1 -d "$db" -c "ALTER COLLATION $coll REFRESH VERSION" 2>&1 || log "$db: could not refresh $coll"
+    done <<< "$stale"
+    log "$db: indexes rebuilt and collation versions refreshed in $((SECONDS - started))s"
+  done <<< "$dbs"
+  return 0
+}
+
+if [ "${1:-}" = 'postgres' ] && [ -s "$PGDATA/PG_VERSION" ] && [ "${OE_DB_SKIP_COLLATION_REINDEX:-false}" != 'true' ]; then
+  log "existing cluster found (PostgreSQL $(cat "$PGDATA/PG_VERSION") data directory), checking collation versions"
+  trap stop_private_server EXIT
+  collation_check || log "check ended with an error; starting PostgreSQL normally"
+  stop_private_server
+  trap - EXIT
+  log "check complete, starting PostgreSQL normally"
+fi
+
+exec docker-entrypoint.sh "$@"

--- a/docs/service-image-maintenance.md
+++ b/docs/service-image-maintenance.md
@@ -60,18 +60,28 @@ does not track the database's default collation (`en_US.utf8` in every OpenELIS
 install), so indexes on text columns keep working silently on the new image and
 can still hide ordering inconsistencies.
 
-The database image handles this itself. Its entrypoint
-(`db/docker-entrypoint-collation.sh`) runs before PostgreSQL accepts
-connections: on an existing data directory it starts the server privately,
-compares the recorded collation versions with the ones the operating system
-provides, and only when they differ rebuilds every index of the affected
-databases (`REINDEX DATABASE`) and records the new versions
-(`ALTER COLLATION ... REFRESH VERSION`). Empty volumes and already-refreshed
-volumes pass straight through, so the check costs nothing on later starts. The
-check never blocks start-up: if the private server does not come up or the
-`postgres` role cannot connect over the local socket (the check uses
-`POSTGRES_PASSWORD` when local authentication requires one), the wrapper logs
-the statements to run and PostgreSQL starts normally. Set
+The database image handles this itself, without holding up start-up. Its
+entrypoint (`db/docker-entrypoint-collation.sh`) hands over to the stock
+entrypoint immediately and, on an existing data directory, runs the check in the
+background once the server is accepting connections: it compares the recorded
+collation versions with the ones the operating system provides and, only when
+they differ, rebuilds the affected databases' indexes with
+`REINDEX DATABASE ... CONCURRENTLY` before recording the new versions
+(`ALTER COLLATION ... REFRESH VERSION`). Nothing is locked against reads or
+writes, and the database is reachable throughout.
+
+Running online rather than before start-up is deliberate. The application
+container starts at the same time as the database and aborts its deployment if
+the database is unreachable when its schema migration runs, so a rebuild that
+held start-up would take the application down for as long as the rebuild lasted,
+and that time grows with the size of the database.
+
+Empty volumes and already-refreshed volumes do nothing at all, so the check
+costs nothing on later starts. Failures are logged with the statements to run by
+hand and never affect the database: the recorded versions are refreshed only
+after a rebuild has actually succeeded, so an interrupted run is retried on the
+next start. The check connects over the local socket as `postgres`, using
+`POSTGRES_PASSWORD` where local authentication requires a password. Set
 `OE_DB_SKIP_COLLATION_REINDEX=true` on the database service to skip it and run
 the same statements by hand in a maintenance window:
 
@@ -79,15 +89,21 @@ the same statements by hand in a maintenance window:
 -- as the postgres superuser, connected to clinlims
 SELECT collname, collversion, pg_collation_actual_version(oid)
   FROM pg_collation WHERE collname IN ('en_US.utf8', 'en_US');
-REINDEX DATABASE clinlims;
+REINDEX DATABASE clinlims CONCURRENTLY;
 ALTER COLLATION "en_US.utf8" REFRESH VERSION;
 ALTER COLLATION "en_US" REFRESH VERSION;
 ```
 
-Measured on a development database with 913 indexes (11 MB), the rebuild took
-between one and seven seconds depending on host load; the time grows with index
-size, and the first start on the new image is delayed by that much. Take a
-backup before the upgrade regardless, and rehearse on a copy of the production
-volume first. Rolling back to the previous image on the same volume works (same
-PostgreSQL major); the old image then sees recorded version 2.36 against its own
-2.31 and the check would rebuild again on the next start of the new image.
+A concurrent rebuild builds each replacement index alongside the original, so
+the volume needs room for the largest index twice over while it runs; it also
+skips the system catalogues, which is harmless because their text columns use
+the `C` collation and are unaffected by the library change. Stopping the
+container mid-rebuild is safe, and the next start rebuilds again, but PostgreSQL
+may leave invalid indexes named `..._ccnew` behind; they are ignored by queries
+and can be dropped with `DROP INDEX CONCURRENTLY`. Measured on a development
+database with 913 indexes (11 MB) the rebuild took a few seconds, and the time
+grows with index size. Take a backup before the upgrade regardless, and rehearse
+on a copy of the production volume first. Rolling back to the previous image on
+the same volume works (same PostgreSQL major); the old image then sees recorded
+version 2.36 against its own 2.31 and the check would rebuild again on the next
+start of the new image.

--- a/docs/service-image-maintenance.md
+++ b/docs/service-image-maintenance.md
@@ -45,3 +45,27 @@ The fresh-database smoke test does not establish that an existing site's indexes
 are safe after that library change. Site-specific backup, index maintenance,
 restore, and rollback validation are deployment responsibilities. Do not disable
 package signature or expiration checks to retain an obsolete base image.
+
+### What the library change looks like on an OpenELIS database
+
+The move from Debian 11 to Debian 12 takes glibc from 2.31 to 2.36. PostgreSQL 14
+records the glibc version only for named collations in `pg_collation`; it does
+not track the database's default collation (`en_US.utf8` in every OpenELIS
+install), so indexes on text columns keep working silently on the new image
+and can still hide ordering inconsistencies. Run the remediation once, in the
+maintenance window, right after the first start on the new image and before
+the site is opened to users:
+
+```sql
+-- as the postgres superuser, connected to clinlims
+SELECT collname, collversion, pg_collation_actual_version(oid)
+  FROM pg_collation WHERE collname IN ('en_US.utf8', 'en_US');
+REINDEX DATABASE clinlims;
+ALTER COLLATION "en_US.utf8" REFRESH VERSION;
+ALTER COLLATION "en_US" REFRESH VERSION;
+```
+
+Measured on a development database with 914 indexes (11 MB), `REINDEX
+DATABASE` took about one second; the time grows with index size. Take a backup
+before the upgrade regardless, and rehearse the sequence on a copy of the
+production volume first.

--- a/docs/service-image-maintenance.md
+++ b/docs/service-image-maintenance.md
@@ -5,7 +5,13 @@ the unchanged HAPI 6.6.0 WAR on Tomcat 9 with Java 17 on Ubuntu Noble. The old
 HAPI image supplies only the WAR during the build, not the final operating
 system, Tomcat installation, or entrypoint. Configuration stays at
 `/opt/openelis/config/hapi_application.yaml`; TLS settings and runtime user 8443
-are preserved. The Tomcat installation is now `/usr/local/tomcat`.
+are preserved. The Tomcat installation is now `/usr/local/tomcat`. Deployments
+that override the server configuration by mounting a file at the old Bitnami
+path (`/opt/bitnami/tomcat/conf/server.xml`, as `dev.docker-compose.yml` and the
+installer template do) keep working: the image entrypoint
+(`fhir/docker-entrypoint.sh`) applies such a file to the Tomcat configuration
+directory before start-up. Deployments that pass `-Dhapi.ssl.*` through
+`CATALINA_OPTS` use the baked `server.xml` as before.
 
 This addresses the expired Bullseye package metadata that prevented clean image
 builds. It does not constitute a HAPI application upgrade or a PostgreSQL
@@ -48,13 +54,26 @@ package signature or expiration checks to retain an obsolete base image.
 
 ### What the library change looks like on an OpenELIS database
 
-The move from Debian 11 to Debian 12 takes glibc from 2.31 to 2.36. PostgreSQL 14
-records the glibc version only for named collations in `pg_collation`; it does
-not track the database's default collation (`en_US.utf8` in every OpenELIS
-install), so indexes on text columns keep working silently on the new image
-and can still hide ordering inconsistencies. Run the remediation once, in the
-maintenance window, right after the first start on the new image and before
-the site is opened to users:
+The move from Debian 11 to Debian 12 takes glibc from 2.31 to 2.36. PostgreSQL
+14 records the glibc version only for named collations in `pg_collation`; it
+does not track the database's default collation (`en_US.utf8` in every OpenELIS
+install), so indexes on text columns keep working silently on the new image and
+can still hide ordering inconsistencies.
+
+The database image handles this itself. Its entrypoint
+(`db/docker-entrypoint-collation.sh`) runs before PostgreSQL accepts
+connections: on an existing data directory it starts the server privately,
+compares the recorded collation versions with the ones the operating system
+provides, and only when they differ rebuilds every index of the affected
+databases (`REINDEX DATABASE`) and records the new versions
+(`ALTER COLLATION ... REFRESH VERSION`). Empty volumes and already-refreshed
+volumes pass straight through, so the check costs nothing on later starts. The
+check never blocks start-up: if the private server does not come up or the
+`postgres` role cannot connect over the local socket (the check uses
+`POSTGRES_PASSWORD` when local authentication requires one), the wrapper logs
+the statements to run and PostgreSQL starts normally. Set
+`OE_DB_SKIP_COLLATION_REINDEX=true` on the database service to skip it and run
+the same statements by hand in a maintenance window:
 
 ```sql
 -- as the postgres superuser, connected to clinlims
@@ -65,7 +84,10 @@ ALTER COLLATION "en_US.utf8" REFRESH VERSION;
 ALTER COLLATION "en_US" REFRESH VERSION;
 ```
 
-Measured on a development database with 914 indexes (11 MB), `REINDEX
-DATABASE` took about one second; the time grows with index size. Take a backup
-before the upgrade regardless, and rehearse the sequence on a copy of the
-production volume first.
+Measured on a development database with 913 indexes (11 MB), the rebuild took
+between one and seven seconds depending on host load; the time grows with index
+size, and the first start on the new image is delayed by that much. Take a
+backup before the upgrade regardless, and rehearse on a copy of the production
+volume first. Rolling back to the previous image on the same volume works (same
+PostgreSQL major); the old image then sees recorded version 2.36 against its own
+2.31 and the check would rebuild again on the next start of the new image.

--- a/docs/service-image-maintenance.md
+++ b/docs/service-image-maintenance.md
@@ -1,0 +1,47 @@
+# Database and FHIR Image Maintenance
+
+The database image uses PostgreSQL 14.24 on Debian Bookworm. The FHIR image runs
+the unchanged HAPI 6.6.0 WAR on Tomcat 9 with Java 17 on Ubuntu Noble. The old
+HAPI image supplies only the WAR during the build, not the final operating
+system, Tomcat installation, or entrypoint. Configuration stays at
+`/opt/openelis/config/hapi_application.yaml`; TLS settings and runtime user 8443
+are preserved. The Tomcat installation is now `/usr/local/tomcat`.
+
+This addresses the expired Bullseye package metadata that prevented clean image
+builds. It does not constitute a HAPI application upgrade or a PostgreSQL
+major-version upgrade. Both still need their own planned upgrades; pinning
+versions does not replace regular dependency maintenance.
+
+## Validate Images
+
+Run from the repository root with Docker and jq available:
+
+```bash
+docker build --platform linux/amd64 -f db/Dockerfile -t openelis-base-refresh-db:local .
+docker build --platform linux/amd64 -f fhir/Dockerfile -t openelis-base-refresh-fhir:local .
+bash scripts/smoke-test-service-images.sh
+```
+
+The smoke test creates only uniquely named containers, a network, and a
+certificate volume. It exposes no host ports, removes its resources on exit, and
+prints the directory containing its logs and response evidence. It checks fresh
+OpenELIS database initialization, non-root FHIR startup, mutual TLS, FHIR R4
+metadata, and saving/reading a synthetic patient across both services' restart.
+It is an infrastructure test, not browser acceptance or a new CI pipeline. The
+existing end-to-end workflow remains the application gate.
+
+## Existing Deployments
+
+Back up and rehearse the update on a copy before replacing an existing database
+container. Keep the database volume; do not reset production data. An
+operating-system change also changes locale libraries. Existing indexes that
+depend on locale-sensitive text ordering may need rebuilding before normal
+traffic resumes. Review both the database's default locale and any explicit
+column/index collations. Refreshing a recorded collation version alone does not
+rebuild affected indexes. Follow the PostgreSQL
+[collation maintenance guidance](https://www.postgresql.org/docs/14/sql-altercollation.html).
+
+The fresh-database smoke test does not establish that an existing site's indexes
+are safe after that library change. Site-specific backup, index maintenance,
+restore, and rollback validation are deployment responsibilities. Do not disable
+package signature or expiration checks to retain an obsolete base image.

--- a/fhir/Dockerfile
+++ b/fhir/Dockerfile
@@ -17,14 +17,17 @@ RUN groupadd tomcat \
 COPY --from=hapi --chown=tomcat_admin:tomcat /opt/bitnami/tomcat/webapps/ROOT.war /usr/local/tomcat/webapps/ROOT.war
 COPY --chown=tomcat_admin:tomcat ./tomcat/hapi_server.xml /usr/local/tomcat/conf/server.xml
 COPY --chown=tomcat_admin:tomcat ./fhir/hapi_application.yaml /opt/openelis/config/hapi_application.yaml
+COPY ./fhir/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 RUN chown -R tomcat_admin:tomcat "$CATALINA_HOME" \
     && chmod g-w,o-rwx "$CATALINA_HOME" "$CATALINA_HOME/conf" "$CATALINA_HOME/bin" "$CATALINA_HOME/webapps" \
     && chmod o-rwx "$CATALINA_HOME/logs" "$CATALINA_HOME/temp" "$CATALINA_HOME/work" "$CATALINA_HOME/target" \
     && chmod g-w,o-rwx "$CATALINA_HOME"/conf/* \
     && chmod 640 "$CATALINA_HOME/conf/server.xml" \
-    && chmod 600 /opt/openelis/config/hapi_application.yaml
+    && chmod 600 /opt/openelis/config/hapi_application.yaml \
+    && chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 ENV SPRING_CONFIG_LOCATION=file:///opt/openelis/config/hapi_application.yaml
 EXPOSE 8443
 USER tomcat_admin
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/fhir/Dockerfile
+++ b/fhir/Dockerfile
@@ -1,48 +1,30 @@
-FROM hapiproject/hapi:v6.6.0-tomcat
+# Retain the HAPI application without inheriting its retired Bullseye runtime.
+FROM hapiproject/hapi:v6.6.0-tomcat AS hapi
+
+FROM tomcat:9.0.121-jre17-temurin-noble
 
 USER root
-# Debian 11 (bullseye) left LTS on 2026-08-31: the security suite's Release file has expired and its
-# pool is being pruned, so packages come from archive.debian.org (main + updates only).
-RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
-    && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y curl
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY ./tomcat/hapi_server.xml /opt/bitnami/tomcat/conf/server.xml
+RUN groupadd tomcat \
+    && groupadd -g 8443 tomcat-ssl-cert \
+    && useradd -M -s /bin/bash -u 8443 -g tomcat -G tomcat-ssl-cert tomcat_admin \
+    && mkdir -p "$CATALINA_HOME/target" /opt/openelis/config \
+    && printf '\norg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.Digester$EnvironmentPropertySource\n' >> "$CATALINA_HOME/conf/catalina.properties"
 
-RUN chown tomcat:tomcat /opt/bitnami/tomcat/conf/server.xml \
-    && chmod 640 /opt/bitnami/tomcat/conf/server.xml
+COPY --from=hapi --chown=tomcat_admin:tomcat /opt/bitnami/tomcat/webapps/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+COPY --chown=tomcat_admin:tomcat ./tomcat/hapi_server.xml /usr/local/tomcat/conf/server.xml
+COPY --chown=tomcat_admin:tomcat ./fhir/hapi_application.yaml /opt/openelis/config/hapi_application.yaml
 
-# Create groups and custom user, set ownership and folder permissions
-RUN groupadd tomcat; \
-    groupadd tomcat-ssl-cert -g 8443; \
-    useradd -M -s /bin/bash -u 8443 tomcat_admin; \
-    usermod -a -G tomcat,tomcat-ssl-cert tomcat_admin; \
-    chown -R tomcat_admin:tomcat /opt/bitnami/tomcat; \
-    chown -R tomcat_admin:tomcat /target; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf; \
-    chmod o-rwx /opt/bitnami/tomcat/logs; \
-    chmod o-rwx /opt/bitnami/tomcat/temp; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/bin; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/webapps; \
-    chmod 770 /opt/bitnami/tomcat/conf/catalina.policy; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/catalina.properties; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/context.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/logging.properties; \
-    chmod 640 /opt/bitnami/tomcat/conf/server.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/tomcat-users.xml; \
-    chmod g-w,o-rwx /opt/bitnami/tomcat/conf/web.xml;\
-    chown -R tomcat_admin:tomcat /bitnami/tomcat/
-
-# Ensure the target directory exists
-RUN mkdir -p /opt/openelis/config
-
-# Copy your HAPI application YAML into the image
-COPY ./fhir/hapi_application.yaml /opt/openelis/config/hapi_application.yaml
-
-# Ensure proper permissions so tomcat can read it
-RUN chown tomcat_admin:tomcat /opt/openelis/config/hapi_application.yaml \
+RUN chown -R tomcat_admin:tomcat "$CATALINA_HOME" \
+    && chmod g-w,o-rwx "$CATALINA_HOME" "$CATALINA_HOME/conf" "$CATALINA_HOME/bin" "$CATALINA_HOME/webapps" \
+    && chmod o-rwx "$CATALINA_HOME/logs" "$CATALINA_HOME/temp" "$CATALINA_HOME/work" "$CATALINA_HOME/target" \
+    && chmod g-w,o-rwx "$CATALINA_HOME"/conf/* \
+    && chmod 640 "$CATALINA_HOME/conf/server.xml" \
     && chmod 600 /opt/openelis/config/hapi_application.yaml
 
-# Optionally, set SPRING_CONFIG_LOCATION so the container automatically picks it up
 ENV SPRING_CONFIG_LOCATION=file:///opt/openelis/config/hapi_application.yaml
+EXPOSE 8443
 USER tomcat_admin

--- a/fhir/docker-entrypoint.sh
+++ b/fhir/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# The previous FHIR image was Bitnami Tomcat, and existing deployments (the installer template,
+# older compose files) mount their server.xml at /opt/bitnami/tomcat/conf/server.xml. This image
+# runs the official Tomcat, whose configuration lives in /usr/local/tomcat/conf, so a file mounted
+# at the old path is applied there before Tomcat starts. Deployments that pass the hapi.ssl.*
+# properties instead (CI, openelis-docker) use the baked server.xml unchanged.
+set -euo pipefail
+
+LEGACY_SERVER_XML=/opt/bitnami/tomcat/conf/server.xml
+if [ -f "$LEGACY_SERVER_XML" ]; then
+  echo "[fhir-entrypoint] applying server.xml mounted at the legacy Bitnami path"
+  cp "$LEGACY_SERVER_XML" "$CATALINA_HOME/conf/server.xml"
+fi
+
+exec catalina.sh run "$@"

--- a/scripts/smoke-test-service-images.sh
+++ b/scripts/smoke-test-service-images.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Run after building db/Dockerfile and fhir/Dockerfile with the tags below.
+set -euo pipefail
+
+DOCKER=${DOCKER:-docker}
+DB_IMAGE=${DB_IMAGE:-openelis-base-refresh-db:local}
+FHIR_IMAGE=${FHIR_IMAGE:-openelis-base-refresh-fhir:local}
+export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
+evidence=$(mktemp -d "${TMPDIR:-/tmp}/oe-service-images.XXXXXXXX")
+name=$(basename "$evidence" | tr . -)
+
+cleanup() {
+  result=$?
+  trap - EXIT
+  "$DOCKER" logs "$name-db" > "$evidence/database.log" 2>&1 || true
+  "$DOCKER" logs "$name-fhir" > "$evidence/fhir.log" 2>&1 || true
+  "$DOCKER" rm -f -v "$name-fhir" "$name-db" >/dev/null 2>&1 || true
+  "$DOCKER" volume rm "$name-certs" >/dev/null 2>&1 || true
+  "$DOCKER" network rm "$name" >/dev/null 2>&1 || true
+  printf 'Smoke-test logs: %s\n' "$evidence"
+  exit "$result"
+}
+trap cleanup EXIT
+
+"$DOCKER" network create "$name" >/dev/null
+"$DOCKER" volume create "$name-certs" >/dev/null
+"$DOCKER" run --rm --user root -v "$name-certs:/certs" "$FHIR_IMAGE" sh -ec '
+  keytool -genkeypair -alias smoke -keyalg RSA -validity 2 -dname CN=localhost \
+    -ext SAN=dns:localhost -ext EKU=serverAuth,clientAuth -storetype PKCS12 \
+    -keystore /certs/smoke.p12 -storepass smoke-password -noprompt
+  keytool -exportcert -rfc -alias smoke -keystore /certs/smoke.p12 \
+    -storepass smoke-password -file /certs/smoke.crt
+  keytool -importcert -alias smoke -file /certs/smoke.crt -storetype PKCS12 \
+    -keystore /certs/trust.p12 -storepass smoke-password -noprompt
+  chgrp 8443 /certs/*
+  chmod 640 /certs/*
+'
+
+"$DOCKER" run -d --name "$name-db" --network "$name" --network-alias db \
+  --memory 512m --cpus 1 \
+  -e POSTGRES_PASSWORD=smoke-password -e POSTGRES_DB=clinlims \
+  -e POSTGRES_INITDB_ARGS=--auth-host=md5 -e DB_PASSWORD=smoke-password \
+  -e DB_SUPERUSER_PASSWORD=smoke-password "$DB_IMAGE" >/dev/null
+
+db_ready() {
+  "$DOCKER" exec -e PGPASSWORD=smoke-password "$name-db" psql \
+    -h 127.0.0.1 -U clinlims -d clinlims -Atc \
+    "SELECT count(*) FROM clinlims.site_information" >/dev/null 2>&1
+}
+wait_for() {
+  deadline=$((SECONDS + 300))
+  until "$@"; do
+    if (( SECONDS >= deadline )); then
+      printf 'Timed out waiting for %s\n' "$*" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+wait_for db_ready
+"$DOCKER" exec "$name-db" postgres --version
+
+"$DOCKER" run -d --name "$name-fhir" --network "$name" --memory 2g --cpus 2 \
+  -v "$name-certs:/certs:ro" \
+  -e JAVA_OPTS='-Xms256m -Xmx1024m' \
+  -e CATALINA_OPTS='-Dhapi.ssl.keystorepath=/certs/smoke.p12 -Dhapi.ssl.keystorepassword=smoke-password -Dhapi.ssl.truststorepath=/certs/trust.p12 -Dhapi.ssl.truststorepassword=smoke-password' \
+  -e 'FHIR_DATASOURCE_URL=jdbc:postgresql://db:5432/clinlims?currentSchema=clinlims' \
+  -e FHIR_DATASOURCE_USERNAME=clinlims -e FHIR_DATASOURCE_PASSWORD=smoke-password \
+  -e FHIR_SERVER_ADRESS=https://localhost:8443/fhir/ "$FHIR_IMAGE" >/dev/null
+
+fhir() {
+  "$DOCKER" exec "$name-fhir" curl --fail --silent --show-error --max-time 15 \
+    --cacert /certs/smoke.crt --cert-type P12 \
+    --cert /certs/smoke.p12:smoke-password "$@"
+}
+fhir_ready() {
+  fhir 'https://localhost:8443/fhir/metadata?_format=json' \
+    > "$evidence/metadata.json" 2> "$evidence/readiness.log"
+}
+wait_for fhir_ready
+jq -e '.resourceType == "CapabilityStatement" and .fhirVersion == "4.0.1"' \
+  "$evidence/metadata.json" >/dev/null
+test "$("$DOCKER" exec "$name-fhir" id -u)" = 8443
+if "$DOCKER" exec "$name-fhir" curl --fail --silent --show-error --max-time 15 \
+  --cacert /certs/smoke.crt https://localhost:8443/fhir/metadata \
+  > "$evidence/no-client-cert.log" 2>&1; then
+  printf 'FHIR unexpectedly accepted a request without a client certificate.\n' >&2
+  exit 1
+fi
+
+fhir -X PUT -H 'Content-Type: application/fhir+json' \
+  --data '{"resourceType":"Patient","id":"service-image-smoke","active":true}' \
+  https://localhost:8443/fhir/Patient/service-image-smoke \
+  > "$evidence/created.json"
+jq -e '.resourceType == "Patient" and .id == "service-image-smoke"' \
+  "$evidence/created.json" >/dev/null
+
+"$DOCKER" stop "$name-fhir" "$name-db" >/dev/null
+"$DOCKER" start "$name-db" >/dev/null
+wait_for db_ready
+"$DOCKER" start "$name-fhir" >/dev/null
+wait_for fhir_ready
+fhir https://localhost:8443/fhir/Patient/service-image-smoke \
+  > "$evidence/persisted.json"
+jq -e '.resourceType == "Patient" and .id == "service-image-smoke" and .active == true' \
+  "$evidence/persisted.json" >/dev/null
+printf 'PASS: database initialization, non-root FHIR, mutual TLS, R4 metadata, write/read across restart.\n'


### PR DESCRIPTION
Continues #4221 by @pmanko (closed as superseded by #4209; GitHub would not reopen it after the rebase). His commit is kept as authored; on top of it: the automatic collation rebuild in the db image, a compatibility entrypoint in the fhir image, and the docs for both.

## Why

The normal end-to-end image build fails before tests start because both the PostgreSQL and HAPI images use Bullseye security metadata that expired on September 7. Evidence: [failed Shared Build](https://github.com/DIGI-UW/OpenELIS-Global-2/actions/runs/34163136921/job/101870584318). This shared infrastructure failure blocked every PR until #4209 landed a stopgap (bullseye packages from archive.debian.org with the expiry check relaxed); this PR is the durable fix and removes that stopgap.

## Changes

- PostgreSQL 14.4 -> 14.24 on Debian Bookworm; retain the PostgreSQL major version and existing initialization scripts.
- Run the unchanged HAPI 6.6.0 WAR on Tomcat 9.0.121 / Java 17 / Ubuntu Noble. The old HAPI image supplies the WAR only, not the final runtime OS.
- Preserve the checked-in FHIR configuration, mutual TLS settings, UID 8443, and certificate group 8443.
- Add a focused, isolated container smoke test and document existing-database deployment precautions.
- Rebuild indexes automatically and online, once, when the db image starts on an existing volume whose collation library version changed; start-up is never held and nothing is locked.
- Keep a `server.xml` mounted at the old Bitnami path working in the fhir image (dev compose, installer template), alongside the `-Dhapi.ssl.*` wiring CI and openelis-docker use.

No CI workflow changes, manually posted statuses, alternate end-to-end path, analyzer changes, or disabled package authenticity/expiration checks. This is a standalone PR targeting develop, not a new analyzer milestone.

## Validation

Passed locally using linux/amd64 images in OrbStack:

- Clean PostgreSQL image build, including apt update/install.
- Clean HAPI runtime image build, including apt update/install.
- `bash scripts/smoke-test-service-images.sh`: fresh OpenELIS database initialization; FHIR R4 metadata over mutual TLS; runtime UID 8443; rejection without a client certificate; synthetic Patient write/read surviving both services restarting.
- Original and replacement HAPI WAR SHA-256 match: `6b4d61ef8394a8abe47607f99812aba80a67da2d109ed6fc081c95d3a71e200f`.
- Full `mvn spotless:apply` and uncached `mvn clean spotless:check`, shell syntax check, and `git diff --check`.
- Inspected database/FHIR logs and response evidence. The run contains Hibernate schema-initialization constraint-drop messages and connection warnings during the deliberate simultaneous service shutdown; startup and post-restart persistence assertions passed.
- Smoke-test containers, network, and certificate volume were cleaned up; existing local stacks were untouched.

The existing normal GitHub end-to-end workflow remains the application gate.

## Deployment Risks

This is not a full HAPI application upgrade or PostgreSQL major-version upgrade. Existing database volumes need backup and rehearsal: changing operating-system locale libraries can require rebuilding text-ordering indexes. See `docs/service-image-maintenance.md`. Fresh-database smoke evidence does not establish existing-site collation safety.

No deployment or merge is performed by this PR.

## Why this is still needed after #4209

#4209 kept the CI build alive by pointing the two Debian 11 (bullseye) images at `archive.debian.org` and telling apt to accept the archive's expired Release files. That was the right move for the night the pipeline broke, and it is the wrong place to stay:

- **End of life means no more fixes, not just a broken mirror.** Debian 11's LTS ended on 2026-08-31. From that date no security update is published for anything in the image: glibc, OpenSSL, libpq, curl, the JVM's native dependencies. The expired Release file that broke CI on 2026-09-07 was the first visible symptom; every CVE from now on is the invisible one. Keeping `postgres:14.4` and `hapiproject/hapi:v6.6.0-tomcat` means shipping a database and a FHIR server on an operating system nobody patches.
- **The archive is a museum, not a mirror.** `archive.debian.org` serves frozen snapshots on a best-effort basis: the `bullseye-security` suite is not there yet (404), package pools get pruned (the current `security.debian.org` pool already 404s on `libcurl4 deb11u16`), and `Acquire::Check-Valid-Until=false` only papers over the fact that the metadata is no longer maintained. It can break again on any day, with the same symptom.
- **`postgres:14.4` is 20 minor releases behind.** 14.24 carries two years of data-corruption and security fixes for the same major version; nothing in OpenELIS depends on 14.4 specifically.

This PR moves both images onto supported bases and stops depending on the archive: PostgreSQL 14.24 on Debian 12 (bookworm), and the unchanged HAPI 6.6.0 WAR on Tomcat 9 / Java 17 / Ubuntu 24.04. The CI build compose needs no change: it never mounted `server.xml` (the image bakes `tomcat/hapi_server.xml`) and already passes the `-Dhapi.ssl.*` properties that file expects.

## Existing databases: measured, and handled by the image

Data compatibility is intact: 14.4 to 14.24 is a minor upgrade of the same major, in place, no dump or `pg_upgrade`, and the previous image starts again on the upgraded volume (rollback path). What changes is the operating system's collation library (glibc 2.31 to 2.36), and PostgreSQL 14 does not warn about the database's default collation. Measured on a byte-for-byte copy of a real OpenELIS volume created by 14.4:

- Every one of the 413 `clinlims` tables has the same row count and content hash under 14.4 and 14.24; the HAPI tables in the same database included.
- `amcheck` (`bt_index_parent_check`, heap-all-indexed) over all 913 B-tree indexes: 0 bad under the new image, before and after the rebuild.
- `pg_collation` records `en_US.utf8` at 2.31; the new OS reports 2.36.

The remediation is part of this PR, not a runbook, and it is deliberately online. `db/docker-entrypoint-collation.sh` hands over to the stock entrypoint immediately and runs in the background once the server is accepting connections: where the recorded collation versions differ from the operating system's, it rebuilds the affected databases' indexes with `REINDEX DATABASE ... CONCURRENTLY` and only then refreshes the versions. Nothing is locked against reads or writes and the database is reachable throughout.

Blocking start-up was the first shape of this, and testing ruled it out. The webapp container starts alongside the database and reaches its Liquibase migration about twenty seconds later, with no wait and no retry: holding the database back for three minutes fails the `liquibase` bean, fails the Tomcat context permanently (`Context [/api/OpenELIS-Global] startup failed`) and never recovers without a manual restart. Since a blocking rebuild lasts as long as the database is large, the first start after the upgrade could have taken the application down on a big volume. Online avoids that entirely.

Fresh volumes and already-refreshed volumes do nothing at all; a second start is a no-op; an interrupted rebuild is retried next start because the versions are refreshed last; `OE_DB_SKIP_COLLATION_REINDEX=true` disables it for sites that prefer a manual window; every failure is logged with the statements to run by hand and never affects the database. `docs/service-image-maintenance.md` carries the details, the disk-space and catalogue caveats of a concurrent rebuild, and the manual SQL.

## HAPI FHIR: same application, patched runtime

The HAPI 6.6.0 WAR is byte-identical (SHA-256 `f906145e…`, verified in both images); its database schema (`hfj_*`, same `clinlims` database) is untouched. What changes underneath is patch-level: Java 17.0.7 to 17.0.20 and Tomcat 9.0.75 to 9.0.121, on Ubuntu 24.04 instead of Bitnami/Debian 11, still as uid 8443 with the checked-in `server.xml` and mutual TLS.

Both ways of wiring the image keep working. CI's build compose and `openelis-docker` (the testing VM) pass `-Dhapi.ssl.*` through `CATALINA_OPTS` and use the baked `server.xml`, unchanged. `dev.docker-compose.yml` and the installer template instead mount their own `server.xml` at the old Bitnami path; the official Tomcat would ignore that path, so `fhir/docker-entrypoint.sh` applies a file mounted there to the Tomcat configuration directory before start-up.

## Verified

- Both images build from this branch (no archive, no relaxed apt checks); `scripts/smoke-test-service-images.sh` passes (fresh init, non-root FHIR, mutual TLS, R4 metadata, write/read across restart).
- Sort order: for the first text column of all 353 populated `clinlims` tables, `en_US.utf8` ordering is byte-identical under glibc 2.31 and 2.36 on this data; the automatic rebuild stays as the safety net for data where it would differ.
- Automatic remediation on a copy of an existing 14.4 volume: the server answers over TCP one second after start, the rebuild follows and completes, versions refreshed to 2.36; 413 tables hashed identical to the 14.4 baseline; `amcheck` (`bt_index_parent_check`, heap-all-indexed) over all 913 B-tree indexes raised no error; no invalid or leftover `_ccnew` indexes; second start a no-op; skip flag honoured; fresh initialisation with the project's `database.env` unaffected (no check at all, recorded = actual) and its first restart a no-op; rollback to the 14.4 image on the upgraded volume starts with identical data.
- Failure paths on the same copy: with local authentication switched to `md5` and no password available the check gives up, logs the manual statements and the database keeps serving; forcing the recorded version stale again makes the next start rebuild, so an interrupted run is retried.
- Availability under a slow database, which is why the rebuild is online: with the database deliberately held back for three minutes, the webapp's Liquibase bean fails, `Context [/api/OpenELIS-Global] startup failed`, and it never becomes healthy again in ten minutes of polling. The online rebuild never creates that condition.
- Full OpenELIS stack on the final images through `dev.docker-compose.yml` as checked in (its own `server.xml` mount, applied by the fhir entrypoint; fhir runs as uid 8443 on Java 17.0.20), fresh volumes: Liquibase clean, admin programme save and Add Order questionnaire 9/9, Results page patient search 15/15, HAPI written to over mutual TLS (Organization, Patient, Practitioner, Questionnaire, QuestionnaireResponse, ServiceRequest, Specimen, Task), pre-existing Questionnaire read and searched through HAPI, no FHIR errors beyond one start-up transient while HAPI was still booting.
- Same stack on a copy of the existing volume, with the online rebuild running while the webapp migrated: rebuild completed in 4 s, no Liquibase lock waits or errors, no invalid or leftover indexes, existing data intact (samples, patients, programmes, 1089 changesets), same 9/9 and 15/15, HAPI read of pre-existing resources and search OK, 0 fallback warnings, 0 FHIR errors, `amcheck` 913 ok / 0 bad afterwards.
- FHIR runtime on a copy of the existing certificate volume and existing HAPI data, queried from a separate container with the existing client keystore, under both wirings (`CATALINA_OPTS` `-Dhapi.ssl.*`, and `server.xml` mounted at the Bitnami path): metadata HTTP 200 (R4 4.0.1), request without a client certificate rejected at the TLS handshake, pre-existing Questionnaire read 200, search total 4, runs as uid 8443, 0 errors.
- Same harness, same copied data, identical requests against the previous image and the new one: create 201, read 200, update 200, server-assigned create 201, delete 200 on both; the HAPI resource counts on the volume are unchanged afterwards.
