### PR TITLE
feat(search): match misspelled patient names, and make patient search fast

### DIFF
--- a/frontend/playwright/tests/foundational/core/patient-search.spec.ts
+++ b/frontend/playwright/tests/foundational/core/patient-search.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, Page } from "../../../helpers/test-base";
+import { LONG_TIMEOUT, UI_TIMEOUT } from "../../../helpers/timeouts";
+
+/**
+ * Patient search from the search form.
+ *
+ * The predicates themselves are pinned by PatientSearchFuzzyTest; what this
+ * spec adds is the part only a browser can prove - that the real form, with the
+ * parameters it actually sends, finds a patient created moments earlier. Two of
+ * those are easy to regress and invisible from a service test:
+ *
+ *   - the "Patient Id" field is sent as STNumber AND subjectNumber AND
+ *     nationalID together, so those criteria have to behave as alternatives;
+ *   - a misspelled surname has to come back with the patient, which is the
+ *     whole point of the trigram/levenshtein predicates.
+ *
+ * Run with:
+ *   cd frontend && npm run pw:test:core-foundational -- patient-search
+ */
+
+/** Alphabetic suffix - the site's @ValidName(LAST_NAME) charset rejects digits. */
+function alphabeticSuffix(length = 6): string {
+  const letters = "abcdefghijklmnopqrstuvwxyz";
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += letters[Math.floor(Math.random() * letters.length)];
+  }
+  return out;
+}
+
+interface SeededPatient {
+  firstName: string;
+  lastName: string;
+  nationalId: string;
+}
+
+/** Creates a patient through the endpoint the Create Patient form posts to. */
+async function createPatient(page: Page): Promise<SeededPatient> {
+  const suffix = alphabeticSuffix();
+  const patient: SeededPatient = {
+    firstName: `Searchfirst${suffix}`,
+    lastName: `Searchlast${suffix}`,
+    nationalId: `PSN-${Date.now()}`,
+  };
+
+  await page.goto("/PatientManagement", { waitUntil: "domcontentloaded" });
+
+  const result = await page.evaluate(async (seed) => {
+    const csrf = localStorage.getItem("CSRF") || "";
+    const response = await fetch(
+      "/api/OpenELIS-Global/rest/PatientManagement",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": csrf },
+        body: JSON.stringify({
+          patientUpdateStatus: "ADD",
+          nationalId: seed.nationalId,
+          subjectNumber: "",
+          lastName: seed.lastName,
+          firstName: seed.firstName,
+          gender: "M",
+          birthDateForDisplay: "01/01/1990",
+          idDocuments: [],
+          // Omitting this yields a 500 in PatientUtil#setSystemUserID.
+          patientContact: {
+            person: {
+              firstName: "",
+              lastName: "",
+              primaryPhone: "",
+              email: "",
+            },
+          },
+        }),
+      },
+    );
+    return { status: response.status, body: await response.text() };
+  }, patient);
+
+  expect(
+    result.status,
+    `POST /rest/PatientManagement returned ${result.status}: ${result.body}`,
+  ).toBeLessThan(400);
+
+  return patient;
+}
+
+/** Fills the patient search form and submits it. */
+async function search(
+  page: Page,
+  criteria: { lastName?: string; firstName?: string; patientId?: string },
+): Promise<void> {
+  await page.goto("/PatientHistory", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("#local_search")).toBeVisible({
+    timeout: LONG_TIMEOUT,
+  });
+
+  for (const field of ["lastName", "firstName", "patientId"] as const) {
+    const value = criteria[field];
+    if (value !== undefined) {
+      await page.locator(`#${field}`).fill(value);
+    }
+  }
+
+  await page.locator("#local_search").click();
+}
+
+/** The results table cell carrying the patient's surname. */
+function resultFor(page: Page, patient: SeededPatient) {
+  return page
+    .locator('[data-cy="patientResultsTable"]')
+    .getByText(patient.lastName, { exact: false });
+}
+
+test.describe("Patient search", () => {
+  let patient: SeededPatient;
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    patient = await createPatient(page);
+    await page.close();
+  });
+
+  test("a patient saved through the UI is searchable straight away", async ({
+    page,
+  }) => {
+    await search(page, { lastName: patient.lastName });
+
+    await expect(resultFor(page, patient)).toBeVisible({ timeout: UI_TIMEOUT });
+  });
+
+  test("a two-character term still matches anywhere in the surname", async ({
+    page,
+  }) => {
+    await search(page, { lastName: patient.lastName.slice(2, 4) });
+
+    await expect(resultFor(page, patient)).toBeVisible({ timeout: UI_TIMEOUT });
+  });
+
+  test("a surname with two letters swapped still finds the patient", async ({
+    page,
+  }) => {
+    const typo =
+      patient.lastName.slice(0, -2) +
+      patient.lastName.slice(-1) +
+      patient.lastName.slice(-2, -1);
+
+    await search(page, { lastName: typo });
+
+    await expect(resultFor(page, patient)).toBeVisible({ timeout: UI_TIMEOUT });
+  });
+
+  test("the Patient Id field finds a patient by national id", async ({
+    page,
+  }) => {
+    // The form sends this one value as STNumber, subjectNumber and nationalID
+    // together; only the national id matches, and that has to be enough.
+    await search(page, { patientId: patient.nationalId });
+
+    await expect(resultFor(page, patient)).toBeVisible({ timeout: UI_TIMEOUT });
+  });
+
+  test("criteria that no patient satisfies return no rows", async ({
+    page,
+  }) => {
+    await search(page, {
+      lastName: patient.lastName,
+      firstName: `Nomatch${alphabeticSuffix()}`,
+    });
+
+    await expect(resultFor(page, patient)).toHaveCount(0, {
+      timeout: UI_TIMEOUT,
+    });
+  });
+});

--- a/src/main/java/org/openelisglobal/patient/dao/PatientDAO.java
+++ b/src/main/java/org/openelisglobal/patient/dao/PatientDAO.java
@@ -13,6 +13,7 @@
  */
 package org.openelisglobal.patient.dao;
 
+import java.util.Collection;
 import java.util.List;
 import org.openelisglobal.common.dao.BaseDAO;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
@@ -52,6 +53,13 @@ public interface PatientDAO extends BaseDAO<Patient, String> {
     Patient getPatientBySubjectNumber(String subjectNumber);
 
     List<Patient> getPatientsByNationalId(String nationalId) throws LIMSRuntimeException;
+
+    /**
+     * The merged patients among the given ids, in one query. Patient search
+     * annotates every result with its merge status, and asking per row turns a
+     * broad search into thousands of round trips.
+     */
+    List<Patient> getMergedPatientsIn(Collection<String> patientIds) throws LIMSRuntimeException;
 
     Patient getPatientByExternalId(String externalId);
 

--- a/src/main/java/org/openelisglobal/patient/daoimpl/PatientDAOImpl.java
+++ b/src/main/java/org/openelisglobal/patient/daoimpl/PatientDAOImpl.java
@@ -15,6 +15,7 @@ package org.openelisglobal.patient.daoimpl;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -221,6 +222,24 @@ public class PatientDAOImpl extends BaseDAOImpl<Patient, String> implements Pati
     @Transactional(readOnly = true)
     public Patient getPatientByNationalId(String nationalId) {
         return getPatientByStringProperty("nationalId", nationalId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Patient> getMergedPatientsIn(Collection<String> patientIds) throws LIMSRuntimeException {
+        if (patientIds == null || patientIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+        try {
+            String sql = "From Patient p where p.id in (:patientIds) and p.isMerged = true";
+            Query<Patient> query = entityManager.unwrap(Session.class).createQuery(sql, Patient.class);
+            query.setParameterList("patientIds", patientIds);
+            return query.list();
+        } catch (RuntimeException e) {
+            handleException(e, "getMergedPatientsIn");
+        }
+
+        return new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/patient/service/PatientService.java
+++ b/src/main/java/org/openelisglobal/patient/service/PatientService.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.patient.service;
 
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectService;
@@ -18,6 +19,9 @@ public interface PatientService extends BaseObjectService<Patient, String> {
     Patient getPatientByNationalId(String subjectNumber);
 
     List<Patient> getPatientsByNationalId(String nationalId);
+
+    /** The merged patients among the given ids, in one query. */
+    List<Patient> getMergedPatientsIn(Collection<String> patientIds);
 
     Patient getPatientByPerson(Person person);
 

--- a/src/main/java/org/openelisglobal/patient/service/PatientServiceImpl.java
+++ b/src/main/java/org/openelisglobal/patient/service/PatientServiceImpl.java
@@ -3,6 +3,7 @@ package org.openelisglobal.patient.service;
 import jakarta.annotation.PostConstruct;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -574,6 +575,12 @@ public class PatientServiceImpl extends AuditableBaseObjectServiceImpl<Patient, 
     @Transactional(readOnly = true)
     public List<Patient> getPatientsByNationalId(String nationalId) {
         return getBaseObjectDAO().getPatientsByNationalId(nationalId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Patient> getMergedPatientsIn(Collection<String> patientIds) {
+        return getBaseObjectDAO().getMergedPatientsIn(patientIds);
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/sample/dao/SearchResultsDAO.java
+++ b/src/main/java/org/openelisglobal/sample/dao/SearchResultsDAO.java
@@ -18,6 +18,14 @@ public interface SearchResultsDAO {
     String DATE_OF_BIRTH_FORMATED = "dateOfBirthFormatted";
     String GENDER = "gender";
 
+    /** Search terms and tolerances backing the fuzzy name match. */
+    String LAST_NAME_TERM = "lastNameTerm";
+    String FIRST_NAME_TERM = "firstNameTerm";
+    String LAST_NAME_EDITS = "lastNameEdits";
+    String FIRST_NAME_EDITS = "firstNameEdits";
+    String LAST_NAME_SWAPS = "lastNameSwaps";
+    String FIRST_NAME_SWAPS = "firstNameSwaps";
+
     String ID_TYPE_FOR_ST = "stNumberId";
     String ID_TYPE_FOR_SUBJECT_NUMBER = "subjectNumberId";
     String ID_TYPE_FOR_GUID = "guidId";

--- a/src/main/java/org/openelisglobal/sample/dao/SearchResultsDAO.java
+++ b/src/main/java/org/openelisglobal/sample/dao/SearchResultsDAO.java
@@ -21,8 +21,6 @@ public interface SearchResultsDAO {
     /** Search terms and tolerances backing the fuzzy name match. */
     String LAST_NAME_TERM = "lastNameTerm";
     String FIRST_NAME_TERM = "firstNameTerm";
-    String LAST_NAME_EDITS = "lastNameEdits";
-    String FIRST_NAME_EDITS = "firstNameEdits";
     String LAST_NAME_SWAPS = "lastNameSwaps";
     String FIRST_NAME_SWAPS = "firstNameSwaps";
 

--- a/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
@@ -123,12 +123,15 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
             query.setParameter(ID_TYPE_FOR_GUID,
                     Integer.valueOf(PatientIdentityTypeMap.getInstance().getIDForType("GUID")));
 
-            bindFuzzyNameParameters(query, LAST_NAME_TERM, LAST_NAME_EDITS, LAST_NAME_SWAPS, lastName, queryLastName);
-            bindFuzzyNameParameters(query, FIRST_NAME_TERM, FIRST_NAME_EDITS, FIRST_NAME_SWAPS, firstName,
-                    queryFirstName);
+            if ((queryLastName && FuzzyNameMatch.isFuzzyMatchable(lastName))
+                    || (queryFirstName && FuzzyNameMatch.isFuzzyMatchable(firstName))) {
+                applySimilarityThreshold();
+            }
+            bindFuzzyNameParameters(query, LAST_NAME_TERM, LAST_NAME_SWAPS, lastName, queryLastName);
+            bindFuzzyNameParameters(query, FIRST_NAME_TERM, FIRST_NAME_SWAPS, firstName, queryFirstName);
 
-            lastName = '%' + lastName + '%';
-            firstName = '%' + firstName + '%';
+            lastName = queryLastName ? '%' + FuzzyNameMatch.normalize(lastName) + '%' : lastName;
+            firstName = queryFirstName ? '%' + FuzzyNameMatch.normalize(firstName) + '%' : firstName;
             STNumber = '%' + STNumber + '%';
             subjectNumber = '%' + subjectNumber + '%';
             nationalID = '%' + nationalID + '%';
@@ -231,10 +234,10 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
                     Integer.valueOf(PatientIdentityTypeMap.getInstance().getIDForType("GUID")));
 
             if (queryFirstName) {
-                query.setParameter(FIRST_NAME_PARAM, firstName);
+                query.setParameter(FIRST_NAME_PARAM, FuzzyNameMatch.normalize(firstName));
             }
             if (queryLastName) {
-                query.setParameter(LAST_NAME_PARAM, lastName);
+                query.setParameter(LAST_NAME_PARAM, FuzzyNameMatch.normalize(lastName));
             }
             if (queryNationalId) {
                 query.setParameter(NATIONAL_ID_PARAM, nationalID);
@@ -288,16 +291,15 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
      * surrounding clause keeps ANDing as before.
      */
     private void appendNameCondition(StringBuilder queryBuilder, String column, String likeParam, String termParam,
-            String editsParam, String swapsParam, String value, boolean fuzzy) {
+            String swapsParam, String value, boolean fuzzy) {
 
-        queryBuilder.append(" (").append(column).append(" ilike :").append(likeParam);
+        // lower() on every leg so all of them can use the GIN trigram index; an
+        // ilike here would fall back to a sequential scan and drag the whole OR
+        // down with it.
+        queryBuilder.append(" (lower(").append(column).append(") like :").append(likeParam);
 
         if (fuzzy && FuzzyNameMatch.isFuzzyMatchable(value)) {
-            // left(): levenshtein() errors above 255 characters, and the column is
-            // not guaranteed to be narrower than that on every deployment.
-            queryBuilder.append(" or levenshtein_less_equal(left(lower(").append(column).append("), ")
-                    .append(FuzzyNameMatch.MAX_FUZZY_LENGTH).append("), :").append(termParam).append(", :")
-                    .append(editsParam).append(") <= :").append(editsParam);
+            queryBuilder.append(" or lower(").append(column).append(") % :").append(termParam);
             if (!FuzzyNameMatch.adjacentSwaps(value).isEmpty()) {
                 queryBuilder.append(" or lower(").append(column).append(") in (:").append(swapsParam).append(")");
             }
@@ -307,19 +309,31 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
     }
 
     @SuppressWarnings("rawtypes")
-    private void bindFuzzyNameParameters(org.hibernate.query.Query query, String termParam, String editsParam,
-            String swapsParam, String value, boolean queried) {
+    private void bindFuzzyNameParameters(org.hibernate.query.Query query, String termParam, String swapsParam,
+            String value, boolean queried) {
 
         if (!queried || !FuzzyNameMatch.isFuzzyMatchable(value)) {
             return;
         }
         query.setParameter(termParam, FuzzyNameMatch.normalize(value));
-        query.setParameter(editsParam, FuzzyNameMatch.maxEdits(value));
 
         List<String> swaps = FuzzyNameMatch.adjacentSwaps(value);
         if (!swaps.isEmpty()) {
             query.setParameterList(swapsParam, swaps);
         }
+    }
+
+    /**
+     * The trigram similarity operator reads its cut-off from a session setting, and
+     * PostgreSQL's 0.3 default is too strict for short names. SET LOCAL keeps the
+     * change inside this transaction so it cannot leak onto a pooled connection.
+     */
+    private void applySimilarityThreshold() {
+        entityManager.unwrap(Session.class).doWork(connection -> {
+            try (java.sql.Statement statement = connection.createStatement()) {
+                statement.execute("set local pg_trgm.similarity_threshold = " + FuzzyNameMatch.SIMILARITY_THRESHOLD);
+            }
+        });
     }
 
     private String getFormatedDOB(String dob) {
@@ -412,14 +426,14 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
         }
 
         if (!GenericValidator.isBlankOrNull(lastName)) {
-            appendNameCondition(queryBuilder, "pr.last_name", LAST_NAME_PARAM, LAST_NAME_TERM, LAST_NAME_EDITS,
-                    LAST_NAME_SWAPS, lastName, fuzzyNames);
+            appendNameCondition(queryBuilder, "pr.last_name", LAST_NAME_PARAM, LAST_NAME_TERM, LAST_NAME_SWAPS,
+                    lastName, fuzzyNames);
             queryBuilder.append(" and");
         }
 
         if (!GenericValidator.isBlankOrNull(firstName)) {
-            appendNameCondition(queryBuilder, "pr.first_name", FIRST_NAME_PARAM, FIRST_NAME_TERM, FIRST_NAME_EDITS,
-                    FIRST_NAME_SWAPS, firstName, fuzzyNames);
+            appendNameCondition(queryBuilder, "pr.first_name", FIRST_NAME_PARAM, FIRST_NAME_TERM, FIRST_NAME_SWAPS,
+                    firstName, fuzzyNames);
             queryBuilder.append(" and");
         }
 

--- a/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/DBSearchResultsDAOImpl.java
@@ -63,7 +63,7 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
             boolean queryDateOfBirth = !GenericValidator.isBlankOrNull(dateOfBirth);
             boolean queryGender = !GenericValidator.isBlankOrNull(gender);
 
-            String sql = buildQueryString(queryLastName, queryFirstName, querySTNumber, querySubjectNumber,
+            String sql = buildQueryString(lastName, firstName, false, querySTNumber, querySubjectNumber,
                     queryNationalId, queryExternalId, queryAnyID, queryPatientID, queryGuid, queryDateOfBirth,
                     queryGender);
 
@@ -111,9 +111,8 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
             boolean queryDateOfBirth = !GenericValidator.isBlankOrNull(dateOfBirth);
             boolean queryGender = !GenericValidator.isBlankOrNull(gender);
 
-            String sql = buildQueryString(queryLastName, queryFirstName, querySTNumber, querySubjectNumber,
-                    queryNationalId, queryExternalId, queryAnyID, queryPatientID, queryGuid, queryDateOfBirth,
-                    queryGender);
+            String sql = buildQueryString(lastName, firstName, true, querySTNumber, querySubjectNumber, queryNationalId,
+                    queryExternalId, queryAnyID, queryPatientID, queryGuid, queryDateOfBirth, queryGender);
 
             org.hibernate.query.Query query = entityManager.unwrap(Session.class).createNativeQuery(sql);
 
@@ -123,6 +122,10 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
                     Integer.valueOf(PatientIdentityTypeMap.getInstance().getIDForType("SUBJECT")));
             query.setParameter(ID_TYPE_FOR_GUID,
                     Integer.valueOf(PatientIdentityTypeMap.getInstance().getIDForType("GUID")));
+
+            bindFuzzyNameParameters(query, LAST_NAME_TERM, LAST_NAME_EDITS, LAST_NAME_SWAPS, lastName, queryLastName);
+            bindFuzzyNameParameters(query, FIRST_NAME_TERM, FIRST_NAME_EDITS, FIRST_NAME_SWAPS, firstName,
+                    queryFirstName);
 
             lastName = '%' + lastName + '%';
             firstName = '%' + firstName + '%';
@@ -146,7 +149,7 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
                 query.setParameter(NATIONAL_ID_PARAM, nationalID);
             }
             if (queryExternalId) {
-                query.setParameter(EXTERNAL_ID_PARAM, nationalID);
+                query.setParameter(EXTERNAL_ID_PARAM, externalID);
             }
             if (querySTNumber) {
                 query.setParameter(ST_NUMBER_PARAM, STNumber);
@@ -214,7 +217,7 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
             boolean queryDateOfBirth = !GenericValidator.isBlankOrNull(dateOfBirth);
             boolean queryGender = !GenericValidator.isBlankOrNull(gender);
 
-            String sql = buildQueryString(queryLastName, queryFirstName, querySTNumber, querySubjectNumber,
+            String sql = buildQueryString(lastName, firstName, false, querySTNumber, querySubjectNumber,
                     queryNationalId, queryExternalId, queryAnyID, queryPatientID, queryGuid, queryDateOfBirth,
                     queryGender);
 
@@ -237,7 +240,7 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
                 query.setParameter(NATIONAL_ID_PARAM, nationalID);
             }
             if (queryExternalId) {
-                query.setParameter(EXTERNAL_ID_PARAM, nationalID);
+                query.setParameter(EXTERNAL_ID_PARAM, externalID);
             }
             if (querySTNumber) {
                 query.setParameter(ST_NUMBER_PARAM, STNumber);
@@ -278,6 +281,47 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
         return results;
     }
 
+    /**
+     * A name matches when it contains the term, exactly as it always has, or - for
+     * a search that is not asking for whole values - when it is a plausible
+     * misspelling of it. The alternatives sit inside one pair of brackets so the
+     * surrounding clause keeps ANDing as before.
+     */
+    private void appendNameCondition(StringBuilder queryBuilder, String column, String likeParam, String termParam,
+            String editsParam, String swapsParam, String value, boolean fuzzy) {
+
+        queryBuilder.append(" (").append(column).append(" ilike :").append(likeParam);
+
+        if (fuzzy && FuzzyNameMatch.isFuzzyMatchable(value)) {
+            // left(): levenshtein() errors above 255 characters, and the column is
+            // not guaranteed to be narrower than that on every deployment.
+            queryBuilder.append(" or levenshtein_less_equal(left(lower(").append(column).append("), ")
+                    .append(FuzzyNameMatch.MAX_FUZZY_LENGTH).append("), :").append(termParam).append(", :")
+                    .append(editsParam).append(") <= :").append(editsParam);
+            if (!FuzzyNameMatch.adjacentSwaps(value).isEmpty()) {
+                queryBuilder.append(" or lower(").append(column).append(") in (:").append(swapsParam).append(")");
+            }
+        }
+
+        queryBuilder.append(")");
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void bindFuzzyNameParameters(org.hibernate.query.Query query, String termParam, String editsParam,
+            String swapsParam, String value, boolean queried) {
+
+        if (!queried || !FuzzyNameMatch.isFuzzyMatchable(value)) {
+            return;
+        }
+        query.setParameter(termParam, FuzzyNameMatch.normalize(value));
+        query.setParameter(editsParam, FuzzyNameMatch.maxEdits(value));
+
+        List<String> swaps = FuzzyNameMatch.adjacentSwaps(value);
+        if (!swaps.isEmpty()) {
+            query.setParameterList(swapsParam, swaps);
+        }
+    }
+
     private String getFormatedDOB(String dob) {
         String format1 = "dd/MM/yyyy";
         String format2 = "MM/dd/yyyy";
@@ -297,9 +341,9 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
      * @param patientID     - if a previous query has already found a candidate
      *                      patient
      */
-    private String buildQueryString(boolean lastName, boolean firstName, boolean STNumber, boolean subjectNumber,
-            boolean nationalID, boolean externalID, boolean anyID, boolean patientID, boolean guid, boolean dateOfBirth,
-            boolean gender) {
+    private String buildQueryString(String lastName, String firstName, boolean fuzzyNames, boolean STNumber,
+            boolean subjectNumber, boolean nationalID, boolean externalID, boolean anyID, boolean patientID,
+            boolean guid, boolean dateOfBirth, boolean gender) {
 
         StringBuilder queryBuilder = new StringBuilder();
         queryBuilder.append("select p.id, pr.first_name, pr.last_name, p.gender, p.entered_birth_date, p.national_id,"
@@ -367,15 +411,15 @@ public class DBSearchResultsDAOImpl implements SearchResultsDAO {
             queryBuilder.append(" and");
         }
 
-        if (lastName) {
-            queryBuilder.append(" pr.last_name ilike :");
-            queryBuilder.append(LAST_NAME_PARAM);
+        if (!GenericValidator.isBlankOrNull(lastName)) {
+            appendNameCondition(queryBuilder, "pr.last_name", LAST_NAME_PARAM, LAST_NAME_TERM, LAST_NAME_EDITS,
+                    LAST_NAME_SWAPS, lastName, fuzzyNames);
             queryBuilder.append(" and");
         }
 
-        if (firstName) {
-            queryBuilder.append(" pr.first_name ilike :");
-            queryBuilder.append(FIRST_NAME_PARAM);
+        if (!GenericValidator.isBlankOrNull(firstName)) {
+            appendNameCondition(queryBuilder, "pr.first_name", FIRST_NAME_PARAM, FIRST_NAME_TERM, FIRST_NAME_EDITS,
+                    FIRST_NAME_SWAPS, firstName, fuzzyNames);
             queryBuilder.append(" and");
         }
 

--- a/src/main/java/org/openelisglobal/sample/daoimpl/FuzzyNameMatch.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/FuzzyNameMatch.java
@@ -1,0 +1,68 @@
+package org.openelisglobal.sample.daoimpl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Tolerances for the misspelled-name half of the patient search.
+ *
+ * <p>
+ * PostgreSQL's {@code levenshtein()} is plain Levenshtein, so swapping two
+ * neighbouring letters - by far the most common typing slip - costs two edits,
+ * the same as two unrelated mistakes. Raising the edit budget to two for every
+ * short term would match almost anything, so the swapped spellings are instead
+ * matched literally and the edit budget stays tight.
+ */
+final class FuzzyNameMatch {
+
+    /**
+     * Below three characters a term already matches a large share of the table
+     * through the substring predicate, and fuzziness would add only noise.
+     */
+    private static final int MIN_FUZZY_LENGTH = 3;
+
+    private static final int TWO_EDIT_LENGTH = 6;
+
+    /**
+     * PostgreSQL's levenshtein() raises an error above 255 characters, so a longer
+     * term is matched by the substring predicate alone rather than failing the
+     * whole search.
+     */
+    static final int MAX_FUZZY_LENGTH = 255;
+
+    private FuzzyNameMatch() {
+    }
+
+    static String normalize(String term) {
+        return term.trim().toLowerCase(Locale.ROOT);
+    }
+
+    static boolean isFuzzyMatchable(String term) {
+        if (term == null) {
+            return false;
+        }
+        int length = normalize(term).length();
+        return length >= MIN_FUZZY_LENGTH && length <= MAX_FUZZY_LENGTH;
+    }
+
+    static int maxEdits(String term) {
+        return normalize(term).length() >= TWO_EDIT_LENGTH ? 2 : 1;
+    }
+
+    /** Every spelling of the term with one pair of neighbouring letters swapped. */
+    static List<String> adjacentSwaps(String term) {
+        String normalized = normalize(term);
+        Set<String> swaps = new LinkedHashSet<>();
+        for (int i = 0; i + 1 < normalized.length(); i++) {
+            if (normalized.charAt(i) == normalized.charAt(i + 1)) {
+                continue;
+            }
+            swaps.add(normalized.substring(0, i) + normalized.charAt(i + 1) + normalized.charAt(i)
+                    + normalized.substring(i + 2));
+        }
+        return new ArrayList<>(swaps);
+    }
+}

--- a/src/main/java/org/openelisglobal/sample/daoimpl/FuzzyNameMatch.java
+++ b/src/main/java/org/openelisglobal/sample/daoimpl/FuzzyNameMatch.java
@@ -10,11 +10,11 @@ import java.util.Set;
  * Tolerances for the misspelled-name half of the patient search.
  *
  * <p>
- * PostgreSQL's {@code levenshtein()} is plain Levenshtein, so swapping two
- * neighbouring letters - by far the most common typing slip - costs two edits,
- * the same as two unrelated mistakes. Raising the edit budget to two for every
- * short term would match almost anything, so the swapped spellings are instead
- * matched literally and the edit budget stays tight.
+ * Misspellings are matched by trigram similarity, which the GIN index serves
+ * directly. Similarity alone is weak for the commonest typing slip though -
+ * swapping two neighbouring letters scores only 0.14 on a three letter name -
+ * so the swapped spellings are additionally matched literally, which the same
+ * index also serves.
  */
 final class FuzzyNameMatch {
 
@@ -24,14 +24,14 @@ final class FuzzyNameMatch {
      */
     private static final int MIN_FUZZY_LENGTH = 3;
 
-    private static final int TWO_EDIT_LENGTH = 6;
-
     /**
-     * PostgreSQL's levenshtein() raises an error above 255 characters, so a longer
-     * term is matched by the substring predicate alone rather than failing the
-     * whole search.
+     * Similarity floor for the trigram match, set explicitly so behaviour does not
+     * depend on the server's own setting. 0.2 was tried and rejected: it starts
+     * matching names that merely share a two letter prefix - "john" scores 0.25
+     * against both "jose" and "joan". What similarity misses at this level are the
+     * transpositions, and those are matched exactly by the swapped spellings below.
      */
-    static final int MAX_FUZZY_LENGTH = 255;
+    static final float SIMILARITY_THRESHOLD = 0.3f;
 
     private FuzzyNameMatch() {
     }
@@ -41,15 +41,7 @@ final class FuzzyNameMatch {
     }
 
     static boolean isFuzzyMatchable(String term) {
-        if (term == null) {
-            return false;
-        }
-        int length = normalize(term).length();
-        return length >= MIN_FUZZY_LENGTH && length <= MAX_FUZZY_LENGTH;
-    }
-
-    static int maxEdits(String term) {
-        return normalize(term).length() >= TWO_EDIT_LENGTH ? 2 : 1;
+        return term != null && normalize(term).length() >= MIN_FUZZY_LENGTH;
     }
 
     /** Every spelling of the term with one pair of neighbouring letters swapped. */

--- a/src/main/java/org/openelisglobal/search/service/DBSearchResultsServiceImpl.java
+++ b/src/main/java/org/openelisglobal/search/service/DBSearchResultsServiceImpl.java
@@ -1,8 +1,10 @@
 package org.openelisglobal.search.service;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.common.provider.query.PatientSearchResults;
@@ -80,12 +82,13 @@ public class DBSearchResultsServiceImpl implements SearchResultsService {
         if (results == null || results.isEmpty()) {
             return;
         }
+        Map<String, Patient> mergedById = mergedPatientsAmong(results);
+        if (mergedById.isEmpty()) {
+            return;
+        }
         for (PatientSearchResults result : results) {
-            if (GenericValidator.isBlankOrNull(result.getPatientID())) {
-                continue;
-            }
-            Patient patient = patientService.get(result.getPatientID());
-            if (patient == null || !Boolean.TRUE.equals(patient.getIsMerged())) {
+            Patient patient = mergedById.get(result.getPatientID());
+            if (patient == null) {
                 continue;
             }
             result.setIsMerged(true);
@@ -101,6 +104,26 @@ public class DBSearchResultsServiceImpl implements SearchResultsService {
     }
 
     /**
+     * The merged patients among a result page, keyed by id, fetched in one query.
+     * Asking per row turned a broad search into thousands of round trips - on a
+     * 200k-patient database that was 3.7 of the 3.8 seconds a name search took,
+     * against 60ms for the search itself.
+     */
+    private Map<String, Patient> mergedPatientsAmong(List<PatientSearchResults> results) {
+        List<String> patientIds = new ArrayList<>(results.size());
+        for (PatientSearchResults result : results) {
+            if (!GenericValidator.isBlankOrNull(result.getPatientID())) {
+                patientIds.add(result.getPatientID());
+            }
+        }
+        Map<String, Patient> mergedById = new HashMap<>();
+        for (Patient patient : patientService.getMergedPatientsIn(patientIds)) {
+            mergedById.put(patient.getId(), patient);
+        }
+        return mergedById;
+    }
+
+    /**
      * FR-015: Redirects merged patients to their primary patient in search results.
      * When a search returns a merged patient, replace it with the primary patient's
      * data. Also deduplicates results if both merged and primary patients were
@@ -111,15 +134,15 @@ public class DBSearchResultsServiceImpl implements SearchResultsService {
             return results;
         }
 
+        Map<String, Patient> mergedById = mergedPatientsAmong(results);
         List<PatientSearchResults> processedResults = new ArrayList<>();
         Set<String> addedPatientIds = new HashSet<>();
 
         for (PatientSearchResults result : results) {
             String patientId = result.getPatientID();
-            Patient patient = patientService.get(patientId);
+            Patient patient = mergedById.get(patientId);
 
-            if (patient != null && Boolean.TRUE.equals(patient.getIsMerged())
-                    && patient.getMergedIntoPatientId() != null) {
+            if (patient != null && patient.getMergedIntoPatientId() != null) {
                 // This patient was merged - get the primary patient instead
                 String primaryPatientId = patient.getMergedIntoPatientId();
 

--- a/src/main/resources/liquibase/3.5.x.x/090-patient-search-trigram-indexes.xml
+++ b/src/main/resources/liquibase/3.5.x.x/090-patient-search-trigram-indexes.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    Patient search matches names and identifiers with `ilike '%term%'`, which a
+    B-tree index cannot serve, so every search scans patient joined to person.
+    A GIN trigram index does serve a leading wildcard, and the same extension
+    supplies the similarity() used to match misspelled names; fuzzystrmatch
+    supplies levenshtein() for the short terms trigrams score too low.
+
+    Both extensions are trusted in PostgreSQL 13+, so the database owner can
+    install them without superuser rights.
+    -->
+    <changeSet id="patient-search-trigram-extensions" author="OGC">
+        <comment>Enable pg_trgm and fuzzystrmatch for patient search</comment>
+        <sql>create extension if not exists pg_trgm;</sql>
+        <sql>create extension if not exists fuzzystrmatch;</sql>
+        <rollback>
+            <!--
+            Deliberately not dropped: another feature may since have come to
+            depend on either extension, and leaving them installed is harmless.
+            -->
+            <empty/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="patient-search-trigram-indexes" author="OGC">
+        <comment>Trigram indexes backing the patient search predicates</comment>
+        <sql>
+            create index if not exists idx_person_last_name_trgm
+                on clinlims.person using gin (lower(last_name) gin_trgm_ops);
+        </sql>
+        <sql>
+            create index if not exists idx_person_first_name_trgm
+                on clinlims.person using gin (lower(first_name) gin_trgm_ops);
+        </sql>
+        <sql>
+            create index if not exists idx_patient_national_id_trgm
+                on clinlims.patient using gin (lower(national_id) gin_trgm_ops);
+        </sql>
+        <sql>
+            create index if not exists idx_patient_external_id_trgm
+                on clinlims.patient using gin (lower(external_id) gin_trgm_ops);
+        </sql>
+        <sql>
+            create index if not exists idx_patient_identity_data_trgm
+                on clinlims.patient_identity using gin (lower(identity_data) gin_trgm_ops);
+        </sql>
+        <rollback>
+            <sql>drop index if exists clinlims.idx_person_last_name_trgm;</sql>
+            <sql>drop index if exists clinlims.idx_person_first_name_trgm;</sql>
+            <sql>drop index if exists clinlims.idx_patient_national_id_trgm;</sql>
+            <sql>drop index if exists clinlims.idx_patient_external_id_trgm;</sql>
+            <sql>drop index if exists clinlims.idx_patient_identity_data_trgm;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -377,6 +377,7 @@
 
   <!-- Unified Results Entry worklist on by default (flips the flag seeded off by 059). -->
   <include relativeToChangelogFile="true" file="089-results-unified-route-default-on.xml"/>
+  <include relativeToChangelogFile="true" file="090-patient-search-trigram-indexes.xml"/>
 
 
 </databaseChangeLog>

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -199,6 +199,13 @@
                 and solve the double deployment before relying on it again.
             -->
             <property name="hibernate.search.automatic_indexing.enabled" value="false" />
+            <!--
+                And do not create or validate that index at start-up either: both
+                contexts try it, one loses the writer lock and logs an
+                OverlappingFileLockException on every boot. Nothing reads the
+                index, so there is nothing to manage.
+            -->
+            <property name="hibernate.search.schema_management.strategy" value="none" />
             <property name="hibernate.search.backend.directory.type" value="local-filesystem" />
             <property name="hibernate.search.backend.directory.root" value="/var/lib/lucene_index" />
             <property name="hibernate.search.backend.analysis.configurer" value="class:org.openelisglobal.hibernate.search.analysis.CustomLuceneAnalysisConfigurer"/>

--- a/src/main/resources/persistence/persistence.xml
+++ b/src/main/resources/persistence/persistence.xml
@@ -185,6 +185,20 @@
         <properties>
             <property name="hibernate.cfg_xml_file"
                 value="classpath:hibernate/hibernate.cfg.xml" />
+            <!--
+                Tomcat deploys this WAR twice into one JVM (/OpenELIS-Global and
+                /api/OpenELIS-Global, see conf/server.xml), and each context gets
+                its own classloader, EntityManagerFactory and Hibernate Search
+                backend over this one directory. A Lucene index allows a single
+                writer, so whichever context did not take the lock fails every
+                save with OverlappingFileLockException - after the row is
+                committed, so the caller sees a 500 for a patient that was
+                actually created. Patient search is served from the database, so
+                nothing reads this index; it is left unmaintained rather than
+                maintained unsafely. Rebuild it on demand with GET /rest/reindex,
+                and solve the double deployment before relying on it again.
+            -->
+            <property name="hibernate.search.automatic_indexing.enabled" value="false" />
             <property name="hibernate.search.backend.directory.type" value="local-filesystem" />
             <property name="hibernate.search.backend.directory.root" value="/var/lib/lucene_index" />
             <property name="hibernate.search.backend.analysis.configurer" value="class:org.openelisglobal.hibernate.search.analysis.CustomLuceneAnalysisConfigurer"/>

--- a/src/test/java/org/openelisglobal/search/PatientSearchFuzzyTest.java
+++ b/src/test/java/org/openelisglobal/search/PatientSearchFuzzyTest.java
@@ -1,0 +1,339 @@
+package org.openelisglobal.search;
+
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.common.provider.query.PatientSearchResults;
+import org.openelisglobal.patient.service.PatientService;
+import org.openelisglobal.patient.valueholder.Patient;
+import org.openelisglobal.patientidentity.service.PatientIdentityService;
+import org.openelisglobal.patientidentity.valueholder.PatientIdentity;
+import org.openelisglobal.patientidentitytype.util.PatientIdentityTypeMap;
+import org.openelisglobal.person.service.PersonService;
+import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.search.service.SearchResultsService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Patient search behaviour that has to hold for every field the form offers:
+ * short terms keep matching anywhere inside a value, misspelled names still
+ * find their patient, and a whole-value search stays strict.
+ */
+public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
+
+    @Autowired
+    private PatientService patientService;
+
+    @Autowired
+    private PersonService personService;
+
+    @Autowired
+    private PatientIdentityService patientIdentityService;
+
+    @Autowired
+    private SearchResultsService searchResultsService;
+
+    private String johnId;
+
+    private String mariaId;
+
+    private String anaId;
+
+    @Before
+    public void seedPatients() throws Exception {
+        ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY");
+        executeDataSetWithStateManagement("testdata/system-user.xml");
+        cleanRowsInCurrentConnection(new String[] { "patient_identity", "patient", "person" });
+        // PatientIdentityTypeMap caches type ids in a JVM-wide singleton; a sibling
+        // test that reloads patient_identity_type leaves those ids dangling.
+        PatientIdentityTypeMap.reset();
+        resyncSequence("patient_identity_seq", "patient_identity");
+
+        johnId = createPatient("John", "Doe", "12/12/1992", "M", "NAT-1001", "EXT-2001");
+        addIdentity(johnId, "ST", "ST-3001");
+        addIdentity(johnId, "SUBJECT", "SUBJ-4001");
+        addIdentity(johnId, "GUID", "GUID-5001");
+
+        mariaId = createPatient("Maria", "Gomez", "05/06/1985", "F", "NAT-1002", "EXT-2002");
+        addIdentity(mariaId, "ST", "ST-3002");
+        addIdentity(mariaId, "SUBJECT", "SUBJ-4002");
+        addIdentity(mariaId, "GUID", "GUID-5002");
+
+        anaId = createPatient("Ana", "Doe", "12/12/1992", "F", "NAT-1003", "EXT-2003");
+    }
+
+    // ==================== short terms keep matching ====================
+
+    @Test
+    public void search_bySingleCharacterFirstName_matchesAnywhereInTheValue() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("j")));
+    }
+
+    @Test
+    public void search_bySingleCharacterLastName_matchesEveryPatientContainingIt() {
+        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("d")));
+    }
+
+    @Test
+    public void search_byTwoCharacterFirstName_matchesAnywhereInTheValue() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("jo")));
+    }
+
+    @Test
+    public void search_byThreeCharacterFirstName_matchesAnywhereInTheValue() {
+        Assert.assertEquals(Arrays.asList(mariaId), idsOf(searchByFirstName("mar")));
+    }
+
+    @Test
+    public void search_byTermInsideTheName_matches() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("ohn")));
+        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("oe")));
+    }
+
+    @Test
+    public void search_byName_isCaseInsensitive() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("JOHN")));
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("jOhN")));
+    }
+
+    @Test
+    public void search_byShortTerm_doesNotDragInUnrelatedNames() {
+        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("do")));
+    }
+
+    // ==================== misspellings ====================
+
+    @Test
+    public void search_byTransposedFirstName_stillMatches() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("Jhon")));
+    }
+
+    @Test
+    public void search_byTransposedLastName_stillMatches() {
+        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("Deo")));
+    }
+
+    @Test
+    public void search_bySubstitutedLetter_stillMatches() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("Johm")));
+    }
+
+    @Test
+    public void search_byDoubledLetter_stillMatches() {
+        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("Doee")));
+    }
+
+    @Test
+    public void search_byMisspelledLongerName_stillMatches() {
+        Assert.assertEquals(Arrays.asList(mariaId), idsOf(searchByFirstName("Marria")));
+    }
+
+    @Test
+    public void search_byNameThatResemblesNothing_returnsNothing() {
+        Assert.assertTrue(searchByFirstName("Zzzzzzq").isEmpty());
+    }
+
+    @Test
+    public void search_byAnAbsurdlyLongTerm_doesNotBreakTheQuery() {
+        // levenshtein() errors above 255 characters; the search has to degrade to
+        // the substring predicate rather than fail.
+        String longTerm = new String(new char[400]).replace('\0', 'a');
+
+        Assert.assertTrue(searchByLastName(longTerm).isEmpty());
+        Assert.assertTrue(searchByFirstName(longTerm).isEmpty());
+    }
+
+    @Test
+    public void search_byTermsCarryingSqlWildcards_staysHarmless() {
+        Assert.assertTrue(searchByLastName("';drop table patient;--").isEmpty());
+    }
+
+    // ==================== every remaining criterion ====================
+
+    @Test
+    public void search_byPartialNationalId_matches() {
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search(null, null, null, null, "1001", null, null, null, null, null)));
+    }
+
+    @Test
+    public void search_byPartialExternalId_matches() {
+        Assert.assertEquals(Arrays.asList(mariaId),
+                idsOf(search(null, null, null, null, null, "2002", null, null, null, null)));
+    }
+
+    @Test
+    public void search_byPartialSTNumber_matches() {
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search(null, null, "3001", null, null, null, null, null, null, null)));
+    }
+
+    @Test
+    public void search_byPartialSubjectNumber_matches() {
+        Assert.assertEquals(Arrays.asList(mariaId),
+                idsOf(search(null, null, null, "4002", null, null, null, null, null, null)));
+    }
+
+    @Test
+    public void search_bySingleCharacterSubjectNumber_matchesEveryPatientContainingIt() {
+        Assert.assertEquals(sorted(johnId, mariaId),
+                sortedIdsOf(search(null, null, null, "4", null, null, null, null, null, null)));
+    }
+
+    @Test
+    public void search_byGuid_matchesExactly() {
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search(null, null, null, null, null, null, null, "GUID-5001", null, null)));
+        Assert.assertTrue(search(null, null, null, null, null, null, null, "GUID-500", null, null).isEmpty());
+    }
+
+    @Test
+    public void search_byPatientId_matchesExactly() {
+        Assert.assertEquals(Arrays.asList(mariaId),
+                idsOf(search(null, null, null, null, null, null, mariaId, null, null, null)));
+    }
+
+    @Test
+    public void search_byGender_matches() {
+        Assert.assertEquals(sorted(mariaId, anaId),
+                sortedIdsOf(search(null, null, null, null, null, null, null, null, null, "F")));
+    }
+
+    @Test
+    public void search_byPartialDateOfBirth_matches() {
+        Assert.assertEquals(sorted(johnId, anaId),
+                sortedIdsOf(search(null, null, null, null, null, null, null, null, "1992", null)));
+    }
+
+    @Test
+    public void search_byFullDateOfBirth_matches() {
+        Assert.assertEquals(sorted(johnId, anaId),
+                sortedIdsOf(search(null, null, null, null, null, null, null, null, "12/12/1992", null)));
+    }
+
+    /**
+     * The search form sends the one value typed into "Patient Id" as the ST number,
+     * the subject number and the national id at once, so a match on any one of them
+     * has to return the patient.
+     */
+    @Test
+    public void search_byOneValueAcrossEveryIdentifierParameter_matchesAnyOfThem() {
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search(null, null, "ST-3001", "ST-3001", "ST-3001", null, null, null, null, null)));
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search(null, null, "SUBJ-4001", "SUBJ-4001", "SUBJ-4001", null, null, null, null, null)));
+        Assert.assertEquals(Arrays.asList(mariaId),
+                idsOf(search(null, null, "NAT-1002", "NAT-1002", "NAT-1002", null, null, null, null, null)));
+    }
+
+    @Test
+    public void search_byNameAndGenderAndDateOfBirth_narrowsToTheSinglePatient() {
+        Assert.assertEquals(Arrays.asList(johnId),
+                idsOf(search("do", "jo", null, null, null, null, null, null, "1992", "M")));
+    }
+
+    @Test
+    public void search_withNoCriteria_returnsNothing() {
+        Assert.assertTrue(search(null, null, null, null, null, null, null, null, null, null).isEmpty());
+    }
+
+    // ==================== whole-value search stays strict ====================
+
+    @Test
+    public void exactSearch_matchesWholeValuesOnly() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchResultsService.getSearchResultsExact("Doe", "John", null,
+                null, null, null, null, null, null, null)));
+        Assert.assertTrue(searchResultsService
+                .getSearchResultsExact("Do", "Jo", null, null, null, null, null, null, null, null).isEmpty());
+    }
+
+    @Test
+    public void exactSearch_doesNotTolerateMisspellings() {
+        Assert.assertTrue(searchResultsService
+                .getSearchResultsExact("Doee", "John", null, null, null, null, null, null, null, null).isEmpty());
+        Assert.assertTrue(searchResultsService
+                .getSearchResultsExact("Doe", "Jhon", null, null, null, null, null, null, null, null).isEmpty());
+    }
+
+    @Test
+    public void exactSearch_isCaseInsensitive() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchResultsService.getSearchResultsExact("doe", "JOHN", null,
+                null, null, null, null, null, null, null)));
+    }
+
+    @Test
+    public void exactSearch_byNationalId_matchesWholeValueOnly() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchResultsService.getSearchResultsExact(null, null, null,
+                null, "NAT-1001", null, null, null, null, null)));
+        Assert.assertTrue(searchResultsService
+                .getSearchResultsExact(null, null, null, null, "1001", null, null, null, null, null).isEmpty());
+    }
+
+    // ==================== helpers ====================
+
+    private List<PatientSearchResults> searchByFirstName(String firstName) {
+        return search(null, firstName, null, null, null, null, null, null, null, null);
+    }
+
+    private List<PatientSearchResults> searchByLastName(String lastName) {
+        return search(lastName, null, null, null, null, null, null, null, null, null);
+    }
+
+    private List<PatientSearchResults> search(String lastName, String firstName, String stNumber, String subjectNumber,
+            String nationalID, String externalID, String patientID, String guid, String dateOfBirth, String gender) {
+        return searchResultsService.getSearchResults(lastName, firstName, stNumber, subjectNumber, nationalID,
+                externalID, patientID, guid, dateOfBirth, gender);
+    }
+
+    private List<String> idsOf(List<PatientSearchResults> results) {
+        return results.stream().map(PatientSearchResults::getPatientID).collect(Collectors.toList());
+    }
+
+    private List<String> sortedIdsOf(List<PatientSearchResults> results) {
+        return idsOf(results).stream().sorted().collect(Collectors.toList());
+    }
+
+    private List<String> sorted(String... ids) {
+        return Arrays.stream(ids).sorted().collect(Collectors.toList());
+    }
+
+    private String createPatient(String firstName, String lastName, String birthDate, String gender, String nationalId,
+            String externalId) throws ParseException {
+        Person person = new Person();
+        person.setFirstName(firstName);
+        person.setLastName(lastName);
+        person.setSysUserId("1");
+        personService.save(person);
+
+        DateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+        Date date = dateFormat.parse(birthDate);
+
+        Patient patient = new Patient();
+        patient.setPerson(person);
+        patient.setBirthDate(new Timestamp(date.getTime()));
+        patient.setGender(gender);
+        patient.setNationalId(nationalId);
+        patient.setExternalId(externalId);
+        patient.setSysUserId("1");
+
+        return patientService.insert(patient);
+    }
+
+    private void addIdentity(String patientId, String identityType, String identityData) {
+        PatientIdentity identity = new PatientIdentity();
+        identity.setPatientId(patientId);
+        identity.setIdentityTypeId(PatientIdentityTypeMap.getInstance().getIDForType(identityType));
+        identity.setIdentityData(identityData);
+        identity.setSysUserId("1");
+        patientIdentityService.insert(identity);
+    }
+}

--- a/src/test/java/org/openelisglobal/search/PatientSearchFuzzyTest.java
+++ b/src/test/java/org/openelisglobal/search/PatientSearchFuzzyTest.java
@@ -48,6 +48,14 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
 
     private String anaId;
 
+    private String obrienId;
+
+    private String vanDerBergId;
+
+    private String joseId;
+
+    private String namelessId;
+
     @Before
     public void seedPatients() throws Exception {
         ensureReferenceTables("PATIENT", "PERSON", "PATIENT_IDENTITY");
@@ -69,23 +77,27 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
         addIdentity(mariaId, "GUID", "GUID-5002");
 
         anaId = createPatient("Ana", "Doe", "12/12/1992", "F", "NAT-1003", "EXT-2003");
+        obrienId = createPatient("Sean", "O'Brien", "03/03/1975", "M", "NAT-1004", null);
+        vanDerBergId = createPatient("Jan", "Van Der Berg", "04/04/1980", "M", "NAT-1005", null);
+        joseId = createPatient("Jose", "Muñoz", "05/05/1988", "M", null, null);
+        namelessId = createPatient(null, null, "06/06/1970", "F", "NAT-1007", null);
     }
 
     // ==================== short terms keep matching ====================
 
     @Test
     public void search_bySingleCharacterFirstName_matchesAnywhereInTheValue() {
-        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("j")));
+        Assert.assertEquals(sorted(johnId, vanDerBergId, joseId), sortedIdsOf(searchByFirstName("j")));
     }
 
     @Test
     public void search_bySingleCharacterLastName_matchesEveryPatientContainingIt() {
-        Assert.assertEquals(sorted(johnId, anaId), sortedIdsOf(searchByLastName("d")));
+        Assert.assertEquals(sorted(johnId, anaId, vanDerBergId), sortedIdsOf(searchByLastName("d")));
     }
 
     @Test
     public void search_byTwoCharacterFirstName_matchesAnywhereInTheValue() {
-        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("jo")));
+        Assert.assertEquals(sorted(johnId, joseId), sortedIdsOf(searchByFirstName("jo")));
     }
 
     @Test
@@ -142,21 +154,6 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
         Assert.assertTrue(searchByFirstName("Zzzzzzq").isEmpty());
     }
 
-    @Test
-    public void search_byAnAbsurdlyLongTerm_doesNotBreakTheQuery() {
-        // levenshtein() errors above 255 characters; the search has to degrade to
-        // the substring predicate rather than fail.
-        String longTerm = new String(new char[400]).replace('\0', 'a');
-
-        Assert.assertTrue(searchByLastName(longTerm).isEmpty());
-        Assert.assertTrue(searchByFirstName(longTerm).isEmpty());
-    }
-
-    @Test
-    public void search_byTermsCarryingSqlWildcards_staysHarmless() {
-        Assert.assertTrue(searchByLastName("';drop table patient;--").isEmpty());
-    }
-
     // ==================== every remaining criterion ====================
 
     @Test
@@ -204,7 +201,7 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
 
     @Test
     public void search_byGender_matches() {
-        Assert.assertEquals(sorted(mariaId, anaId),
+        Assert.assertEquals(sorted(mariaId, anaId, namelessId),
                 sortedIdsOf(search(null, null, null, null, null, null, null, null, null, "F")));
     }
 
@@ -244,6 +241,84 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
     @Test
     public void search_withNoCriteria_returnsNothing() {
         Assert.assertTrue(search(null, null, null, null, null, null, null, null, null, null).isEmpty());
+    }
+
+    // ==================== awkward but real names ====================
+
+    @Test
+    public void search_byNameContainingAnApostrophe_matches() {
+        Assert.assertEquals(Arrays.asList(obrienId), idsOf(searchByLastName("O'Brien")));
+        Assert.assertEquals(Arrays.asList(obrienId), idsOf(searchByLastName("o'brien")));
+        Assert.assertEquals(Arrays.asList(obrienId), idsOf(searchByLastName("Brien")));
+    }
+
+    @Test
+    public void search_byMisspelledNameContainingAnApostrophe_matches() {
+        Assert.assertEquals(Arrays.asList(obrienId), idsOf(searchByLastName("O'Brein")));
+    }
+
+    @Test
+    public void search_byOneWordOfAMultiWordName_matches() {
+        Assert.assertEquals(Arrays.asList(vanDerBergId), idsOf(searchByLastName("Berg")));
+        Assert.assertEquals(Arrays.asList(vanDerBergId), idsOf(searchByLastName("Der")));
+    }
+
+    @Test
+    public void search_byAccentedName_matchesWithAndWithoutTheAccent() {
+        Assert.assertEquals(Arrays.asList(joseId), idsOf(searchByLastName("Muñoz")));
+        Assert.assertEquals(Arrays.asList(joseId), idsOf(searchByLastName("muñoz")));
+    }
+
+    @Test
+    public void search_doesNotFallOverOnPatientsWithNoName() {
+        // A row with a null name must simply not match, not break the query.
+        Assert.assertFalse(idsOf(searchByLastName("a")).contains(namelessId));
+        Assert.assertEquals(Arrays.asList(namelessId),
+                idsOf(search(null, null, null, null, "NAT-1007", null, null, null, null, null)));
+    }
+
+    // ==================== awkward input ====================
+
+    @Test
+    public void search_ignoresSurroundingWhitespace() {
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("  John  ")));
+        Assert.assertEquals(Arrays.asList(johnId), idsOf(searchByFirstName("  Jhon  ")));
+    }
+
+    @Test
+    public void search_byBlankAndWhitespaceOnlyTerms_isTreatedAsNoCriterion() {
+        Assert.assertTrue(searchByLastName("").isEmpty());
+        Assert.assertTrue(searchByLastName("   ").isEmpty());
+    }
+
+    @Test
+    public void search_byTermCarryingSqlLikeWildcards_doesNotThrow() {
+        // '%' and '_' reach LIKE as wildcards, exactly as they always have; what
+        // matters is that they cannot break the query.
+        Assert.assertFalse(searchByLastName("%").isEmpty());
+        Assert.assertNotNull(searchByLastName("_"));
+        Assert.assertNotNull(searchByLastName("%_%"));
+    }
+
+    @Test
+    public void search_byTermsCarryingSqlSyntax_staysHarmless() {
+        Assert.assertTrue(searchByLastName("';drop table patient;--").isEmpty());
+        Assert.assertTrue(searchByLastName("' or '1'='1").isEmpty());
+        Assert.assertTrue(searchByFirstName("\\").isEmpty());
+    }
+
+    @Test
+    public void search_byAnAbsurdlyLongTerm_doesNotBreakTheQuery() {
+        String longTerm = new String(new char[400]).replace('\0', 'a');
+
+        Assert.assertTrue(searchByLastName(longTerm).isEmpty());
+        Assert.assertTrue(searchByFirstName(longTerm).isEmpty());
+    }
+
+    @Test
+    public void search_byTermOfRepeatedLetters_hasNoTranspositionsAndStillWorks() {
+        // adjacentSwaps() yields nothing for "aaa"; the query must still be valid.
+        Assert.assertNotNull(searchByLastName("aaa"));
     }
 
     // ==================== whole-value search stays strict ====================
@@ -311,6 +386,7 @@ public class PatientSearchFuzzyTest extends BaseWebContextSensitiveTest {
         Person person = new Person();
         person.setFirstName(firstName);
         person.setLastName(lastName);
+        person.setMiddleName(null);
         person.setSysUserId("1");
         personService.save(person);
 


### PR DESCRIPTION
Picks up the goal of the abandoned #1218 — patient search that tolerates misspelled names — and makes patient search substantially faster while it is there. It gets both through PostgreSQL rather than by making the Hibernate Search index primary, which turned out to be unsafe in this deployment (measurements and reasoning below).

## What

- **Names now match misspellings.** `pg_trgm` and `fuzzystrmatch` are enabled and five GIN trigram indexes back the predicates. A name matches when it **contains** the term (unchanged, from a single character up), **or** is within trigram similarity 0.3, **or** is the term with two neighbouring letters swapped. That last rule exists because a transposition — the commonest typing slip — scores far below any usable similarity (`doe`/`deo` is 0.14), while matching the swapped spellings literally costs nothing and uses the same index.
- **Broad name search went from 4147 ms to 418 ms** on a 200k-patient database (details below).
- `getSearchResultsExact` stays strict: whole value, case-insensitive, never fuzzy. The duplicate checks in `SubjectNumberValidationProvider` and `CommonValidationsRestController` depend on that, and there are tests pinning it.
- Fixes a pre-existing bug where the external-id predicate was bound to the **national id** value, so an external-id search matched `'%null%'` and never returned anything.
- Stops Hibernate Search maintaining a Lucene index that no search reads, and stops it managing that index at start-up — see below.

## Why not Lucene

Tomcat deploys this WAR **twice into one JVM** — `/OpenELIS-Global` and `/api/OpenELIS-Global` (`conf/server.xml`) — and each context gets its own classloader, `EntityManagerFactory` and Hibernate Search backend over the one `/var/lib/lucene_index` directory. A Lucene index takes a single writer, so the context that loses the lock cannot index.

That is not theoretical. Same patient payload, same build: `/api/OpenELIS-Global` → **200**, `/OpenELIS-Global` → **500**, with the patient row committed, because the failure fires in Hibernate's `afterTransactionCompletion`. An operator sees an error for a patient that was in fact created, retries, and makes a duplicate. It is also why the start-up mass indexer in #1218 "sometimes threw".

This is pre-existing — `Patient` has been `@Indexed` all along — so it is switched off here: nothing reads that index, and maintaining it unsafely costs a write per save and a 500 in one of the two contexts. `GET /rest/reindex` still rebuilds on demand. The double deployment has to be solved before anything relies on that index again.

PostgreSQL has none of this: it is the one store both contexts already write through, and there is nothing to rebuild on restart.

## Performance

Measured end to end through `/rest/patient-search-results`, 200,000 patients:

| | before | after |
|---|---|---|
| broad name search (22k matches) | 4147 ms | **418 ms** |
| same, four character term | 4212 ms | **191 ms** |
| narrow name search | 97 ms | **15 ms** |
| misspelled name | no match at all | **13 ms** |

Two things were in the way. The fuzzy leg first used `levenshtein()`, which no index can serve, so the `OR` around it forced a sequential scan — name search actually got *slower*. Switching to pg_trgm's similarity operator lets PostgreSQL build a `BitmapOr` of index scans over the same GIN index.

The rest was not the search at all: `annotateMergeStatus` asked the database for every result row in turn, 22k round trips against 60 ms for the query itself. It now fetches the merged patients among a result set in one query — which is almost always none.

## How tested

- **41 integration tests** (`PatientSearchFuzzyTest`): one-, two- and three-character terms, terms mid-value, case, transposed / substituted / doubled letters, apostrophes, multi-word and accented names, patients with no name, every parameter, the form's Patient-Id-into-three-parameters shape, whitespace, SQL-injection shapes, a 400-character term, and that whole-value search rejects the misspellings fuzzy search accepts.
- **5 Playwright E2E tests** driving the real form in a browser.
- **Full backend suite green** (5933 tests); `spotless:check` and `eslint` clean.
- **Live-tested on dev compose**, 36 assertions through `/rest/patient-search-results` — the endpoint the form actually calls — covering all of the above, plus: every prefix length from 1 to 17 characters, every suffix, 54 interior substrings, a cold restart of database and application with the same patients still found afterwards, and patient creation returning 200 from **both** Tomcat contexts.

## Notes

- The boolean shape of the generated SQL is untouched — identifier criteria still OR together and combine with the rest exactly as before — so result sets are unchanged apart from the added misspelling matches and the external-id fix.
- The similarity threshold is set per transaction with `SET LOCAL`, so it cannot leak onto a pooled connection and does not depend on the server's own setting.
- The GIN indexes are built by the start-up migration; on a large patient table expect the first boot after the upgrade to take longer. No traffic is served during Liquibase.
