### PR TITLE
fix(eqa): stop the V2 rollback tag reporting success on an upgraded database (OGC-935)

### DIFF
--- a/docs/eqa/v1-distribution-absorption.md
+++ b/docs/eqa/v1-distribution-absorption.md
@@ -78,21 +78,38 @@ Both now declare an empty `<rollback />`, which is the truthful inverse as well
 as the convenient one: restoring orphaned panel items would restore broken
 references, and the next start would delete them again.
 
-**Say where to stop, do not count.** `liquibase rollbackToTag eqa-v2-start`
-names the point the set begins, written by `qa/040-eqa-v2-start-tag.xml`, which
-is included ahead of the first V2 changeset rather than in file order.
+**Which route you take depends on how the database got the feature.** There are
+two, and only one of them works on any given database.
 
-The tag carries a precondition, which is the honest part. A tag marks the last
-changeset applied when it runs, so on a database that already carries the V2 set
-this file would execute after it and tag the wrong end: a tag that rolls back
-nothing, which is worse than no tag because an operator would trust it. There it
-is marked ran without tagging, and the route is `rollbackCount`. A database
-provisioned after this change gets the tag where it belongs.
+_A database provisioned after `qa/040-eqa-v2-start-tag.xml` shipped_ carries the
+tag `eqa-v2-start`, written ahead of the first V2 changeset rather than in file
+order. Say where to stop: `liquibase rollbackToTag eqa-v2-start`.
 
-Counting, where you have to: the V2 set is 57 changesets, and the two
-`runAlways` rows above it are part of the count, so `rollbackCount 59` is the
-whole set on a running installation. Verify against `databasechangelog` ordered
-by `orderexecuted` before running it rather than trusting the number.
+_A database that already carried the V2 set when that changeset arrived_ has no
+such tag, and `rollbackToTag eqa-v2-start` fails naming the missing tag. That
+failure is the intended outcome, not a fault to work around. A tag marks the
+last changeset applied when it runs, so on such a database the changeset would
+tag the wrong end, above the whole V2 set instead of below it, and
+`rollbackToTag` would report success and remove nothing. Its precondition skips
+it there, and `qa/041` clears the tag from databases that recorded one before
+the precondition was corrected. Use the counted route.
+
+**Counting, where you have to.** The V2 set is 57 changesets, but the count you
+pass is not 57: everything between the set and the head of the changelog goes
+with it. That is always the two `runAlways` rows, plus `qa/041`, plus whatever
+else has been applied since. Two participant databases measured on the same day
+needed 60 and 61, differing only in whether a `qa-079` row was already on file.
+
+So **read the number off `databasechangelog` rather than trusting one**:
+
+```sql
+SELECT COUNT(*) FROM clinlims.databasechangelog
+ WHERE orderexecuted >= (SELECT orderexecuted FROM clinlims.databasechangelog
+                          WHERE id = 'eqa-cycle-001-create-eqa-cycle');
+```
+
+`eqa-cycle-001-create-eqa-cycle` creates `eqa_cycle` and is the first changeset
+of the set. The count is a property of one database's history, not of V2.
 
 **Widened CHECK constraints delete their own rows.** Four V2 changesets widened
 a CHECK precisely so the feature could write a new value, and their rollbacks
@@ -119,9 +136,23 @@ EQA, so leaving them would block a core constraint from being restored.
 had used the feature: eleven V2 tables gone, the eight V1 EQA tables standing,
 `shipping_box.eqa_cycle_id` removed, the one `EQA_SUBMISSION_FAILED` alert
 deleted with the other six untouched, `chk_alert_type` back to the definition
-`3.5.x.x/070-critical-result-alert-type.xml` owns, and 59 rows gone from
-`databasechangelog`. Liquibase reported "Rollback has been successful" with no
-manual step at any point.
+`3.5.x.x/070-critical-result-alert-type.xml` owns, and 61 rows gone from
+`databasechangelog`: the 57, the two `runAlways` rows, `qa/041`, and the
+`qa-079` row that copy already carried. Liquibase reported "Rollback has been
+successful" with no manual step at any point.
+
+Measured on the same copy, the tag route does what it should on a database that
+has no tag: `rollback eqa-v2-start` stops with _"Could not find tag
+'eqa-v2-start' in the database"_, exits non-zero, changes nothing, and leaves
+all nineteen EQA tables standing. An operator who runs it learns at once that it
+is the wrong route for their database, which is the point of recording no tag
+there.
+
+Measured on a database provisioned from the baseline dump with this changelog,
+the tag route is the whole story: the tag lands at the head of the set,
+immediately below `eqa-cycle-001-create-eqa-cycle`, and `rollback eqa-v2-start`
+takes the changelog from 954 rows to 895 with the eleven V2 tables gone, the
+eight V1 tables standing, and nothing left above the tag point.
 
 ## Why the legacy scores stay where they are
 

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -152,4 +152,9 @@
   <include file="liquibase/qa/038-eqa-panel-receipt-shipping-box.xml" />
   <!-- EQA V2.5 — OGC-613: qualitative participant results on the provider side (qa-078) -->
   <include file="liquibase/qa/039-eqa-result-text.xml" />
+
+  <!-- Clears an eqa-v2-start tag that an earlier version of qa/040 recorded without
+       applying. Last on purpose: it repairs a changelog row, so it has to run after
+       every changeset that could have written one. -->
+  <include file="liquibase/qa/041-clear-stale-eqa-v2-start-tag.xml" />
 </databaseChangeLog>

--- a/src/main/resources/liquibase/qa/040-eqa-v2-start-tag.xml
+++ b/src/main/resources/liquibase/qa/040-eqa-v2-start-tag.xml
@@ -22,12 +22,37 @@
         applied when it runs, so on a database that already carries the V2 set
         this file would execute after it and tag the wrong end: a tag that rolls
         back nothing, which is worse than no tag at all because an operator would
-        trust it. There it is marked ran without tagging, and the rollback route
-        stays the counted one documented in docs/eqa/v1-distribution-absorption.md.
-        A database provisioned after this change gets the tag where it belongs.
+        trust it. A database provisioned after this change gets the tag where it
+        belongs; a database that already carries the set gets no tag, and its
+        rollback route is the counted one documented in
+        docs/eqa/v1-distribution-absorption.md.
+
+        onFail is CONTINUE, not MARK_RAN, and the difference is the whole point.
+        MARK_RAN writes a changelog row, and Liquibase stamps the tag column on
+        that row from the tagDatabase change even though the change never
+        executed. That produces the tag this comment warns about: rollbackToTag
+        then finds the name, rolls back only what happens to sit above the row,
+        reports success, and removes no part of the V2 set. CONTINUE writes no
+        row, so the name does not exist and the command fails saying so.
+
+        CONTINUE costs one thing: the precondition is re-evaluated on every run,
+        so an upgraded database reports this changeset as pending for as long as
+        the V2 tables stand. That is accurate. The tag has not been applied, and
+        the row is the only place Liquibase could claim otherwise. Nor is it a new
+        kind of noise: "liquibase status" already lists three core changesets on
+        every running installation: two that are runAlways, and
+        2.6.x.x/update_roles.xml::202303248, which skips on a CONTINUE
+        precondition exactly as this one now does.
+
+        A tag cannot be repaired after the fact, which is why no changeset tries.
+        Placing one on the row below the V2 block would make rollbackToTag work
+        only where the set happens to be contiguous. It is contiguous on a
+        database that took the whole set in one upgrade, and not on one that
+        collected it across releases with core changesets interleaved, where no
+        single tag can name the set at all.
     -->
     <changeSet author="openelisglobal" id="qa-079-tag-eqa-v2-start">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <not>
                 <tableExists schemaName="clinlims" tableName="eqa_cycle" />
             </not>

--- a/src/main/resources/liquibase/qa/041-clear-stale-eqa-v2-start-tag.xml
+++ b/src/main/resources/liquibase/qa/041-clear-stale-eqa-v2-start-tag.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Clears the eqa-v2-start tag from a database that recorded it without ever
+    applying it.
+
+    qa/040 tags the point the EQA V2 set begins, and skips itself on a database
+    that already carries the set, where a tag would name the wrong end. The first
+    version of that changeset skipped by marking itself ran, and Liquibase stamps
+    the tag column on a MARK_RAN row from the tagDatabase change even though the
+    change never executed. The result was a tag sitting above the whole V2 block:
+    "liquibase rollback eqa-v2-start" found the name, rolled back the two
+    housekeeping changesets that happened to sit above the row, reported
+    "Rollback has been successful", and removed no part of the V2 set.
+
+    qa/040 now skips with CONTINUE and records nothing, so no further database
+    acquires the tag that way. This clears the ones that already did. Editing a
+    precondition cannot reach a row that is already on file.
+
+    The WHERE clause is the guard: only the MARK_RAN row is cleared, so the real
+    tag on a database provisioned after this change stays where it belongs.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-080-clear-stale-eqa-v2-start-tag">
+        <comment>Clear an eqa-v2-start tag that was recorded without being applied</comment>
+        <sql>
+            UPDATE clinlims.databasechangelog
+               SET tag = NULL
+             WHERE id = 'qa-079-tag-eqa-v2-start'
+               AND exectype = 'MARK_RAN'
+               AND tag IS NOT NULL;
+        </sql>
+        <!-- Empty on purpose. Re-stamping a tag that rolls back nothing is not an
+             inverse worth having, and a changeset with no inverse sitting above the
+             V2 block is what stopped every counted rollback of this feature until
+             the two housekeeping changesets were given one. -->
+        <rollback />
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## The defect

`liquibase rollback eqa-v2-start` reports **"Rollback has been successful"** and removes no part of the EQA V2 feature, on every database that already carries it. That is every existing deployment, so it is the case every real operator meets. It is worse than the failure #4220 replaced, where the rollback at least stopped loudly.

The tag changeset guards itself so that on a database already carrying V2 it does not tag the wrong end. Its own comment states the risk: a tag that rolls back nothing is *"worse than no tag at all because an operator would trust it."* But it skipped by **marking itself ran**, and Liquibase stamps the `tag` column on a MARK_RAN row from the `tagDatabase` change even though the change never executes. The tag therefore landed above the whole V2 block, and the rollback removed only the two housekeeping changesets that happened to sit above the row.

Found while verifying #4220 on the two-instance rig. It survived that PR's review because `rollbackCount` was driven end to end and `rollbackToTag`, the command the changeset recommends, was not.

## The change

| File | What |
| --- | --- |
| `qa/040-eqa-v2-start-tag.xml` | `onFail="MARK_RAN"` → `onFail="CONTINUE"`. CONTINUE records no changelog row, so the tag name does not exist on an upgraded database and `rollbackToTag` fails naming it. |
| `qa/041-clear-stale-eqa-v2-start-tag.xml` (new) | One `UPDATE` clearing the tag already stamped on databases that ran #4220, guarded on `exectype = 'MARK_RAN'` so a real tag is untouched. Empty `<rollback />`. |
| `base-changelog.xml` | `qa/041` included last: it repairs a changelog row, so it must run after anything that could write one. |
| `docs/eqa/v1-distribution-absorption.md` | Rollback section: which route belongs to which database, and a query for the count instead of a number. |

Editing the precondition alone is not enough. It cannot reach a row already on file, and every database that ran #4220 carries one.

`qa/041` declares an empty rollback deliberately. Re-stamping a tag that rolls back nothing is not an inverse worth having, and an inverse-less changeset above the V2 block is exactly what stopped every counted rollback of this feature until #4220 gave the two housekeeping changesets one.

## Why not repair the tag instead

The tag could be made to work everywhere by stamping it onto the changelog row directly below the V2 block. That works only where the V2 set is contiguous: true of a database that took the whole set in one upgrade, false of one that collected it across releases with core changesets interleaved, where no single tag can name the set at all. It would have passed on this rig and misled elsewhere, which is the same failure mode as the defect it would replace.

Withholding the tag makes the wrong route fail immediately and pushes the operator to the counted one, which works.

## Driven, on three database shapes

Liquibase 4.8, the jar the webapp ships, run from the webapp container against `pg_dump` copies in the rig's own Postgres. The live databases were never a target. **Every number is a measurement of the database, not a reading of Liquibase's output** — reading that output is what hid the defect.

**A copy of the participant database, before the fix.** Reproduces exactly: changelog **953 → 950**, **all 19 EQA tables standing**, 19 cycles untouched, `shipping_box.eqa_cycle_id` still present, and "Rollback has been successful".

**The same copy, after the fix.** `update` applied the new changeset and cleared the stale tag, with no checksum failure on the edited changeset. Then:

```
rollback eqa-v2-start
  Unexpected error running Liquibase: Could not find tag 'eqa-v2-start' in the database
```

Exit code **255**. Measured afterwards: 954 rows, **11 V2 tables and 8 V1 tables still standing**, nothing removed. The counted route on the same copy took it **954 → 893**, exactly 61 rows, **all 11 V2 tables gone**, the **8 V1 tables standing**, `shipping_box.eqa_cycle_id` removed, **no hand-written SQL**, and no stop on the new changeset's empty rollback.

**A control group: a database provisioned from the baseline dump with this changelog.** Needed, or "it failed loudly" would prove only that the command is broken.

- The tag row reads **`EXECUTED`, `tag = eqa-v2-start`, `orderexecuted` 896**, immediately below `eqa-cycle-001-create-eqa-cycle` at 897. At the head of the set, not above it.
- `qa/041` ran on this database and **did not clear the real tag**.
- `rollback eqa-v2-start` took the changelog **954 → 895**, 11 V2 tables gone, 8 V1 standing, **nothing left above the tag point**. Re-applied and taken the other way, `rollbackCount 59` reached the same end state.

**An upgraded database that never ran #4220**, where CONTINUE does the work rather than the new changeset: `update` writes **no changelog row and no tag**, `rollback eqa-v2-start` fails naming the missing tag, and the counted route needed **60** where the first copy needed **61**.

## Why the doc no longer names a count

Two copies measured on the same day needed 60 and 61, differing only in whether a tag row was already on file. The count is a property of one database's history, not of the V2 set, so the doc carries the query instead, anchored on `eqa-cycle-001-create-eqa-cycle`. Both measured numbers came out of it.

## One accepted cost

CONTINUE re-evaluates the precondition on every run, so an upgraded database reports the tag changeset as pending for as long as the V2 tables stand. That is accurate: the tag has not been applied. It is also not a new kind of noise — `liquibase status` already lists three core changesets on every running installation, one of which (`2.6.x.x/update_roles.xml::202303248`) skips on a CONTINUE precondition exactly as this one now does.

No schema change, no new dependency, no Java touched.