### PR TITLE
fix(eqa): show a blank patient name when no name is recorded (OGC-935)

### DIFF
--- a/src/main/java/org/openelisglobal/person/service/PersonServiceImpl.java
+++ b/src/main/java/org/openelisglobal/person/service/PersonServiceImpl.java
@@ -4,6 +4,8 @@ import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.validator.GenericValidator;
 import org.openelisglobal.address.service.AddressPartService;
 import org.openelisglobal.address.service.PersonAddressService;
@@ -69,15 +71,12 @@ public class PersonServiceImpl extends AuditableBaseObjectServiceImpl<Person, St
     @Override
     @Transactional(readOnly = true)
     public String getLastFirstName(Person person) {
-        String lastName = getLastName(person);
-        String firstName = getFirstName(person);
-        if (!GenericValidator.isBlankOrNull(lastName) && !GenericValidator.isBlankOrNull(firstName)) {
-            lastName += ", ";
-        }
-
-        lastName += firstName;
-
-        return lastName;
+        // Both name columns are nullable, and a record can legitimately have neither
+        // - a blinded external-quality-assessment order creates a patient with no
+        // name at all. Concatenating a null String yields the literal "null", so the
+        // present parts are joined instead, and an absent name reads as blank.
+        return Stream.of(getLastName(person), getFirstName(person))
+                .filter(namePart -> !GenericValidator.isBlankOrNull(namePart)).collect(Collectors.joining(", "));
     }
 
     @Override

--- a/src/test/java/org/openelisglobal/person/PersonServiceTest.java
+++ b/src/test/java/org/openelisglobal/person/PersonServiceTest.java
@@ -124,6 +124,39 @@ public class PersonServiceTest extends BaseWebContextSensitiveTest {
         Assert.assertEquals(PERSON1_LASTNAME + ", " + PERSON1_FIRSTNAME, lastFirstName);
     }
 
+    /**
+     * A blinded external-quality-assessment order creates a patient carrying no
+     * name at all, and both name columns are nullable, so the persisted row has SQL
+     * NULL in each. Every screen that shows a sample's patient reads this one
+     * helper.
+     */
+    @Test
+    public void getLastFirstName_shouldReturnBlankWhenNeitherNameIsRecorded() {
+        Person nameless = insertPerson(null, null);
+
+        Assert.assertNull(personService.get(nameless.getId()).getLastName());
+        Assert.assertNull(personService.get(nameless.getId()).getFirstName());
+        Assert.assertEquals("", personService.getLastFirstName(personService.get(nameless.getId())));
+    }
+
+    @Test
+    public void getLastFirstName_shouldReturnTheOneNameRecordedWithNoSeparator() {
+        Person lastOnly = insertPerson(null, "Okello");
+        Person firstOnly = insertPerson("Grace", null);
+
+        Assert.assertEquals("Okello", personService.getLastFirstName(personService.get(lastOnly.getId())));
+        Assert.assertEquals("Grace", personService.getLastFirstName(personService.get(firstOnly.getId())));
+    }
+
+    private Person insertPerson(String firstName, String lastName) {
+        Person person = new Person();
+        person.setFirstName(firstName);
+        person.setLastName(lastName);
+        person.setSysUserId(TEST_SYS_USER_ID);
+        person.setId(personService.insert(person));
+        return person;
+    }
+
     @Test
     public void getWorkPhone_shouldReturnWorkPhone() throws Exception {
         Person person = personService.get("1");


### PR DESCRIPTION
## The defect

Result entry prints the literal **`nullnull`** as the patient name for a blinded external-quality-assessment order, in `div.sampleInfo`, beside a correctly formatted lab number and the EQA badge. Driven on the rig while verifying #4214.

#4214 fixed the other half of this: the `, null, N` tail is gone, and its null-*patient* guard works. That guard never fires here, because the patient is not null. The blinded order flow creates a patient with **no name at all**, both `person` name columns are nullable, and the row holds SQL NULL in each.

The cause is one line in a shared helper:

```java
String lastName = getLastName(person);   // null, the column is SQL NULL
String firstName = getFirstName(person); // null
if (!isBlankOrNull(lastName) && !isBlankOrNull(firstName)) { lastName += ", "; }  // skipped
lastName += firstName;   // null += null  ->  "nullnull"
```

`String += null` compiles to a concatenation of `String.valueOf(null)`, so two absent names produce eight characters of noise.

**A second case, not in the original report.** One recorded name was broken the same way: with the first name absent the separator was correctly skipped, and then the absent half was appended anyway. `Okello` rendered as `Okellonull`. The same fix covers it, and there is a test for it.

This is not the placeholder-patient case #4214 deliberately left alone. That one is a literal uppercase `NULL` stored as data by Add Order; here the columns are genuinely SQL NULL and the output is lowercase.

## The change

```java
return Stream.of(getLastName(person), getFirstName(person))
        .filter(namePart -> !GenericValidator.isBlankOrNull(namePart)).collect(Collectors.joining(", "));
```

Join the parts that are present. Both absent reads as blank, one absent yields that name with no stray separator, and both present is unchanged.

**Fixed in the helper, not at the call sites.** There are sixteen, and they all route through this one method: result entry and `ResultsLoadUtility`, the logbook results controller, the four workplan paths, sample edit and its REST twin, barcode printing, the patient and patient-program reports, and the requester service. Any record with both name columns absent showed this, not only an EQA one.

## Driven

Two cases added to the existing `PersonServiceTest` integration suite, which runs against a real database, so the columns are genuinely SQL NULL rather than empty strings. The both-absent test asserts each column reads back NULL before asserting the helper's output, so it cannot pass on a row that was quietly stored as `""`.

- `PersonServiceTest` **23/23** green.
- `PatientServiceTest` **50/50** green (it calls the same helper through `PatientServiceImpl`).

**Inversion check driven.** With the fix reverted and the tests unchanged, both fail on the defect strings:

```
expected:<[]> but was:<[nullnull]>
expected:<Okello[]> but was:<Okello[null]>
```

## Not driven

The rig's own result-entry screen for the standing `IH-2-04` fixture. Rendering it needs a WAR built from this branch, and the rig was deliberately left on the merged tip for this change. What is proven is the helper's output for exactly the data that fixture carries, and that `ResultsLoadUtility` is the caller that renders it. The screen check is folded into the next rig rebuild.

No schema change, no new dependency, no i18n key.