### PR TITLE
fix(eqa): review and submit now sends the results it reports (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
+++ b/frontend/src/components/eqa/MyCycles/MyCyclesPage.jsx
@@ -254,13 +254,15 @@ const MyCyclesPage = () => {
     t(`eqa.schemeType.${type}`, type.replace(/_/g, " "));
 
   const handleSubmit = (cycle) => {
-    submitCycle(cycle.id, (updated) => {
-      if (updated) {
-        // transition response is the bare cycle DTO — keep the row's
-        // progress/samples, take the new status
+    submitCycle(cycle.id, (result) => {
+      if (result.ok) {
+        // The response carries the cycle's new state and nothing else, so the
+        // row keeps its own progress and samples.
         setCycles((prev) =>
           prev.map((c) =>
-            c.id === updated.id ? { ...c, status: updated.status } : c,
+            c.id === cycle.id
+              ? { ...c, status: (result.status || "submitted").toLowerCase() }
+              : c,
           ),
         );
         setSubmitNotice({
@@ -271,12 +273,17 @@ const MyCyclesPage = () => {
           ),
         });
       } else {
+        // The server says why the cycle could not go — no automatic channel, or
+        // a provider that could not be reached — and that is more use than a
+        // generic failure, so it is shown as it stands.
         setSubmitNotice({
           kind: "error",
-          text: t(
-            "eqa.cycle.submitted.error",
-            "Submit failed — the cycle was not advanced. Check that all results are validated and try again.",
-          ),
+          text:
+            result.error ||
+            t(
+              "eqa.cycle.submitted.error",
+              "Submit failed — the cycle was not advanced. Check that all results are validated and try again.",
+            ),
         });
       }
     });

--- a/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
+++ b/frontend/src/components/eqa/MyCycles/__tests__/MyCyclesPage.test.jsx
@@ -9,13 +9,11 @@ import MyCyclesPage from "../MyCyclesPage";
 import { MOCK_CYCLES } from "../mockCycles";
 import {
   getFromOpenElisServer,
-  patchToOpenElisServerJsonResponse,
   postToOpenElisServerFullResponse,
 } from "../../../utils/Utils";
 
 vi.mock("../../../utils/Utils", () => ({
   getFromOpenElisServer: vi.fn(),
-  patchToOpenElisServerJsonResponse: vi.fn(),
   postToOpenElisServerFullResponse: vi.fn(),
 }));
 
@@ -368,46 +366,60 @@ describe("MyCyclesPage", () => {
     expect(screen.getByTestId("cycle-row-1")).toBeInTheDocument();
   });
 
-  test("Review & submit PATCHes the transition endpoint and flips the row", () => {
-    patchToOpenElisServerJsonResponse.mockImplementation((url, payload, cb) =>
-      cb({ id: 2, status: "SUBMITTED" }),
+  // The plain cycle transition endpoint records the state change and nothing
+  // else, so releasing a cycle through it reported a submission the provider
+  // never received. The click goes to the endpoint that posts and stamps.
+  test("Review & submit posts the results and flips the row", async () => {
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb({
+        ok: true,
+        json: () =>
+          Promise.resolve({ cycleId: 2, status: "SUBMITTED", channel: "FHIR" }),
+      }),
     );
     renderPage();
     fireEvent.click(screen.getByTestId("cycle-row-2"));
     fireEvent.click(screen.getByText("Review & submit"));
 
-    expect(patchToOpenElisServerJsonResponse).toHaveBeenCalledWith(
-      "/rest/eqa/cycles/2/transition",
-      JSON.stringify({
-        newState: "SUBMITTED",
-        stateMachine: "PARTICIPANT",
-        reason: "Participant review & submit from My Cycles",
-      }),
-      expect.any(Function),
-    );
+    const [url, body] = postToOpenElisServerFullResponse.mock.calls[0];
+    expect(url).toBe("/rest/eqa/cycles/2/review-submit");
+    expect(JSON.parse(body)).toEqual({});
+    expect(
+      await screen.findByText("Cycle submitted to provider — awaiting scores."),
+    ).toBeInTheDocument();
     // leaves the Active bucket, awaiting KPI now counts it
     expect(screen.queryByTestId("cycle-row-2")).not.toBeInTheDocument();
     expect(
       within(screen.getByTestId("kpi-awaiting")).getByText("2"),
     ).toBeTruthy();
-    expect(
-      screen.getByText("Cycle submitted to provider — awaiting scores."),
-    ).toBeInTheDocument();
   });
 
-  test("failed submit (409/422) shows an error and leaves the row in place", () => {
-    patchToOpenElisServerJsonResponse.mockImplementation((url, payload, cb) =>
-      cb(undefined),
+  // A cycle that could not be sent must not read as sent, and the reason the
+  // server gives is more use than a generic failure.
+  test("a cycle that could not be sent keeps its row and shows why", async () => {
+    postToOpenElisServerFullResponse.mockImplementation((url, body, cb) =>
+      cb({
+        ok: false,
+        statusText: "Conflict",
+        json: () =>
+          Promise.resolve({
+            error:
+              "The provider could not be reached, so the cycle was not submitted",
+          }),
+      }),
     );
     renderPage();
     fireEvent.click(screen.getByTestId("cycle-row-2"));
     fireEvent.click(screen.getByText("Review & submit"));
 
-    expect(screen.getByTestId("cycle-row-2")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Submit failed — the cycle was not advanced. Check that all results are validated and try again.",
+      await screen.findByText(
+        "The provider could not be reached, so the cycle was not submitted",
       ),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("cycle-row-2")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("kpi-awaiting")).getByText("1"),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/components/eqa/MyCycles/cyclesApi.js
+++ b/frontend/src/components/eqa/MyCycles/cyclesApi.js
@@ -6,7 +6,6 @@
 // mapping is T-19, the NCE link is T-17) — they default false here.
 import {
   getFromOpenElisServer,
-  patchToOpenElisServerJsonResponse,
   postToOpenElisServerFullResponse,
 } from "../../utils/Utils";
 
@@ -30,19 +29,29 @@ export const fetchMyCycles = (callback) => {
   );
 };
 
-// Single-click Review & Submit (FR-V2.2-07): no re-auth, no extra sign-off.
-// The transition endpoint records every HTTP call as a MANUAL override and
-// requires a reason, so a fixed one is sent. 409 = illegal edge, 422 =
-// missing reason; the helper reports both as an undefined response.
+// Single-click review and submit: no re-auth, no extra sign-off. This posts the
+// results and stamps their submission channel, which the plain cycle transition
+// endpoint does not do — it would leave the screen claiming a send the provider
+// never received. 409 carries the reason the cycle could not go, so the raw
+// response is read rather than treating any JSON as success.
 export const submitCycle = (cycleId, callback) => {
-  patchToOpenElisServerJsonResponse(
-    `/rest/eqa/cycles/${cycleId}/transition`,
-    JSON.stringify({
-      newState: "SUBMITTED",
-      stateMachine: "PARTICIPANT",
-      reason: "Participant review & submit from My Cycles",
-    }),
-    (response) => callback(response ? toViewModel(response) : null),
+  postToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/review-submit`,
+    "{}",
+    (response) => {
+      response
+        .json()
+        .catch(() => ({}))
+        .then((payload) =>
+          callback({
+            ok: response.ok,
+            status: payload?.status,
+            error: response.ok
+              ? null
+              : payload?.error || payload?.message || response.statusText,
+          }),
+        );
+    },
   );
 };
 

--- a/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
+++ b/frontend/src/components/eqa/Provider/__tests__/CycleWizard.test.jsx
@@ -204,7 +204,9 @@ describe("CycleWizard", () => {
     fireEvent.change(screen.getByLabelText("Sample code"), {
       target: { value: "PS-1" },
     });
-    fireEvent.change(screen.getByLabelText("Test"), { target: { value: "55" } });
+    fireEvent.change(screen.getByLabelText("Test"), {
+      target: { value: "55" },
+    });
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Add sample" }));
@@ -234,7 +236,9 @@ describe("CycleWizard", () => {
     fireEvent.change(screen.getByLabelText("Sample code"), {
       target: { value: "PS-1" },
     });
-    fireEvent.change(screen.getByLabelText("Test"), { target: { value: "55" } });
+    fireEvent.change(screen.getByLabelText("Test"), {
+      target: { value: "55" },
+    });
 
     fireEvent.change(screen.getByLabelText("Acceptance low"), {
       target: { value: "46.3" },

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQASubmissionRestController.java
@@ -70,6 +70,29 @@ public class EQASubmissionRestController extends BaseRestController {
         }
     }
 
+    /**
+     * The reviewer's release on a scheme that reviews every cycle before it goes.
+     * The click sends over the automatic channel and stamps each result row, which
+     * a state transition on its own does not do.
+     *
+     * <p>
+     * Provenance is not taken from the request body: the submission is recorded
+     * against the session user.
+     */
+    @PostMapping(value = "/cycles/{cycleId}/review-submit", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PARTICIPANT)
+    public ResponseEntity<?> submitAfterReview(HttpServletRequest request, @PathVariable Long cycleId) {
+        try {
+            EQACycle cycle = cycleSubmissionService.submitAfterReview(cycleId, getSysUserId(request));
+            return ResponseEntity
+                    .ok(Map.of("cycleId", cycle.getId(), "status", cycle.getStatus().name(), "channel", "FHIR"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
     /** FR-V2.2-06 export bundle: what a lab uploads to the provider by hand. */
     @GetMapping(value = "/cycles/{cycleId}/export-bundle", produces = "text/csv")
     public ResponseEntity<String> exportBundle(@PathVariable Long cycleId,

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionService.java
@@ -36,6 +36,25 @@ public interface EQACycleSubmissionService {
     boolean advanceCycle(Long cycleId);
 
     /**
+     * Submits a cycle a reviewer has just released, on a scheme that asks a human
+     * to look at each cycle before it goes. The send runs on the same path the
+     * unattended sweep uses, so the result rows carry the channel and timestamp of
+     * a real submission rather than only the cycle carrying a new state.
+     *
+     * <p>
+     * The sweep never revisits a SUBMITTED cycle, so a release that advanced the
+     * state without sending left nothing behind to recover it: the screen reported
+     * a submission the provider never received.
+     *
+     * @throws IllegalArgumentException when no such cycle exists
+     * @throws IllegalStateException    when the cycle is not ready to submit, the
+     *                                  laboratory has no automatic channel, no
+     *                                  validated result is waiting, or the provider
+     *                                  cannot be reached
+     */
+    EQACycle submitAfterReview(Long cycleId, String sysUserId);
+
+    /**
      * FR-V2.2-06 manual fallback: record that this lab submitted outside OpenELIS.
      * The provider's reference is mandatory — an unreferenced manual submission is
      * indistinguishable from a lab claiming it submitted.

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleSubmissionServiceImpl.java
@@ -485,24 +485,71 @@ public class EQACycleSubmissionServiceImpl implements EQACycleSubmissionService 
             return false;
         }
 
-        boolean allSent = true;
-        for (Long enrollmentId : enrollments) {
-            if (!fhirSubmissionService.submitCycleViaFhir(cycle.getId(), enrollmentId)) {
-                allSent = false;
-            }
-        }
-
-        if (allSent) {
-            for (Long enrollmentId : enrollments) {
-                markSent(cycle.getId(), enrollmentId, EQASubmissionChannel.FHIR, null, SCHEDULER_USER);
-            }
-            clearRetryBudget(cycle, SCHEDULER_USER);
-            advanceTo(cycle, SUBMITTED, EQATriggerType.AUTO, EQATriggerEvent.FHIR_SUBMIT_SUCCESS, null, null,
+        if (postToProvider(cycle.getId(), enrollments)) {
+            stampSubmitted(cycle, enrollments, EQATriggerType.AUTO, EQATriggerEvent.FHIR_SUBMIT_SUCCESS, null, null,
                     SCHEDULER_USER);
             return true;
         }
         recordFailedAttempt(cycle, attempts + 1);
         return true;
+    }
+
+    /**
+     * Posts to every enrolled laboratory before reporting, so one unreachable
+     * enrollment does not hide the state of the rest. A partial post counts as a
+     * failure: the caller stamps nothing and the whole cycle is sent again.
+     */
+    private boolean postToProvider(Long cycleId, List<Long> enrollments) {
+        boolean allSent = true;
+        for (Long enrollmentId : enrollments) {
+            if (!fhirSubmissionService.submitCycleViaFhir(cycleId, enrollmentId)) {
+                allSent = false;
+            }
+        }
+        return allSent;
+    }
+
+    /**
+     * What a successful send leaves behind: the channel and timestamp on each
+     * result row, a cleared retry budget, and the cycle at SUBMITTED. The state
+     * transition alone is not a record of a submission, because nothing reading
+     * {@code eqa_participant_result} would see the results as sent.
+     */
+    private void stampSubmitted(EQACycle cycle, List<Long> enrollments, EQATriggerType triggerType,
+            EQATriggerEvent triggerEvent, Long triggeredBy, String reason, String sysUserId) {
+        for (Long enrollmentId : enrollments) {
+            markSent(cycle.getId(), enrollmentId, EQASubmissionChannel.FHIR, null, sysUserId);
+        }
+        clearRetryBudget(cycle, sysUserId);
+        advanceTo(cycle, SUBMITTED, triggerType, triggerEvent, triggeredBy, reason, sysUserId);
+    }
+
+    @Override
+    public EQACycle submitAfterReview(Long cycleId, String sysUserId) {
+        EQACycle cycle = cycleDAO.get(cycleId)
+                .orElseThrow(() -> new IllegalArgumentException("Cycle not found: " + cycleId));
+        if (cycle.getStatus() != READY_TO_SUBMIT) {
+            throw new IllegalStateException("Only a cycle that is ready to submit can be reviewed and submitted");
+        }
+        // The scheme's review flag is not consulted: the reviewer clicking is what
+        // the flag asks for. Neither the review window nor the retry budget is
+        // consulted either — both exist to pace an unattended sweep, and a person
+        // waiting for an answer is told the outcome instead.
+        if (StringUtils.isBlank(fhirConfig.getLocalFhirStorePath())) {
+            throw new IllegalStateException(
+                    "This laboratory has no automatic submission channel configured; submit by hand instead");
+        }
+        List<Long> enrollments = submittingEnrollments(cycleId);
+        if (enrollments.isEmpty()) {
+            throw new IllegalStateException("No validated result to submit for cycle " + cycleId);
+        }
+        if (!postToProvider(cycleId, enrollments)) {
+            logger.warn("EQA cycle {} review submission could not reach the provider", cycleId);
+            throw new IllegalStateException("The provider could not be reached, so the cycle was not submitted");
+        }
+        stampSubmitted(cycle, enrollments, EQATriggerType.MANUAL, EQATriggerEvent.MANUAL_OVERRIDE,
+                actingUser(sysUserId), "Reviewed and submitted from My Cycles", sysUserId);
+        return cycleDAO.get(cycleId).orElseThrow();
     }
 
     /** 15, 30, 60, 120 minutes by default — doubling from the first failure. */

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -113,6 +113,7 @@ public class EQARestGuardMatrixTest {
         WRITE_GUARDS.put("EQAMyProgramsRestController#deleteMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAPanelReceiptRestController#recordReceipt", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQASubmissionRestController#submitManually", EQAGuards.PARTICIPANT);
+        WRITE_GUARDS.put("EQASubmissionRestController#submitAfterReview", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAParticipantResultRestController#createDraft", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAParticipantResultRestController#transition", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAResultRestController#submitResult", EQAGuards.PARTICIPANT);

--- a/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQAAutoSubmissionIntegrationTest.java
@@ -382,6 +382,111 @@ public class EQAAutoSubmissionIntegrationTest extends EQASpineTestBase {
         verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
     }
 
+    // ---- the reviewer's release on a review-gated scheme ----
+
+    /**
+     * The release used to move the cycle to SUBMITTED through the plain transition
+     * endpoint, which records the state change and nothing else: the result rows
+     * stayed VALIDATED_PARTIAL with no channel and nothing was posted, and the
+     * sweep never revisits a SUBMITTED cycle to recover it. So the screen reported
+     * a submission the provider never received.
+     */
+    @Test
+    public void reviewSubmit_postsTheResultsAndStampsEveryRow() {
+        EQACycle cycle = heldAtTheReviewGate(30);
+
+        EQACycle submitted = cycleSubmissionService.submitAfterReview(cycle.getId(), USER);
+
+        assertEquals(EQACycleStatus.SUBMITTED, submitted.getStatus());
+        verify(fhirStub).submitCycleViaFhir(cycle.getId(), ENROLLMENT);
+
+        Map<String, Object> row = participantResults(cycle.getId()).get(0);
+        assertEquals("SUBMITTED", row.get("submission_status"));
+        assertEquals("FHIR", row.get("submission_channel"));
+        assertTrue("a submitted result is stamped", row.get("submitted_at") != null);
+
+        Map<String, Object> release = lastTransition(cycle.getId());
+        assertEquals("MANUAL", release.get("trigger_type"));
+        assertEquals("MANUAL_OVERRIDE", release.get("trigger_event"));
+        assertEquals(1L, ((Number) release.get("triggered_by")).longValue());
+        assertEquals("Reviewed and submitted from My Cycles", release.get("reason"));
+    }
+
+    @Test
+    public void reviewSubmit_whenTheProviderCannotBeReached_recordsNoSubmission() {
+        EQACycle cycle = heldAtTheReviewGate(31);
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(false);
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> cycleSubmissionService.submitAfterReview(cycle.getId(), USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("could not be reached"));
+
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+        assertUnsent(cycle.getId());
+        assertEquals("a hand-driven send spends none of the sweep's budget", 0, attempts(cycle.getId()));
+    }
+
+    @Test
+    public void reviewSubmit_withNoAutomaticChannel_postsNothingAndRecordsNothing() {
+        EQACycle cycle = heldAtTheReviewGate(32);
+        when(fhirConfig.getLocalFhirStorePath()).thenReturn("");
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> cycleSubmissionService.submitAfterReview(cycle.getId(), USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("submit by hand"));
+
+        verify(fhirStub, never()).submitCycleViaFhir(anyLong(), anyLong());
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+        assertUnsent(cycle.getId());
+    }
+
+    @Test
+    public void reviewSubmit_onACycleAlreadySubmitted_isRefused() {
+        EQACycle cycle = heldAtTheReviewGate(33);
+        cycleSubmissionService.submitAfterReview(cycle.getId(), USER);
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> cycleSubmissionService.submitAfterReview(cycle.getId(), USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("ready to submit"));
+
+        verify(fhirStub).submitCycleViaFhir(cycle.getId(), ENROLLMENT);
+        assertEquals(EQACycleStatus.SUBMITTED, readBack(cycle.getId()).getStatus());
+    }
+
+    /**
+     * A cycle on a review-gated scheme, walked to READY_TO_SUBMIT by the sweep and
+     * left there by the gate — which is the state a reviewer finds it in. Walked
+     * rather than seeded, so no hand-chosen id can leave a sequence behind.
+     */
+    private EQACycle heldAtTheReviewGate(int cycleNumber) {
+        EQAProgram scheme = externalScheme(true);
+        EQACycle cycle = readBack(insertCycle(scheme, cycleNumber));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        eqaOrder(cycle, roundId);
+        finalizedAnalysis(VL_TEST, VL_ANALYTE, "4.75");
+        when(fhirStub.submitCycleViaFhir(anyLong(), anyLong())).thenReturn(true);
+        windowElapsed();
+
+        cycleSubmissionService.advanceCycle(cycle.getId());
+        assertEquals(EQACycleStatus.READY_TO_SUBMIT, readBack(cycle.getId()).getStatus());
+        assertEquals("VALIDATED_PARTIAL", participantResults(cycle.getId()).get(0).get("submission_status"));
+        return readBack(cycle.getId());
+    }
+
+    private void assertUnsent(Long cycleId) {
+        Map<String, Object> row = participantResults(cycleId).get(0);
+        assertEquals("VALIDATED_PARTIAL", row.get("submission_status"));
+        assertNull("an unsent result carries no channel", row.get("submission_channel"));
+        assertNull("an unsent result carries no timestamp", row.get("submitted_at"));
+    }
+
+    private Map<String, Object> lastTransition(Long cycleId) {
+        return jdbc.queryForMap(
+                "SELECT trigger_type, trigger_event, triggered_by, reason"
+                        + " FROM clinlims.eqa_cycle_state_transition WHERE cycle_id = ? ORDER BY id DESC LIMIT 1",
+                cycleId);
+    }
+
     @Test
     public void fiveFailures_stopRetryingAndRaiseExactlyOneAlert() {
         EQAProgram scheme = externalScheme(false);


### PR DESCRIPTION
## The defect

**Review & submit** on My Cycles marked a cycle submitted without sending anything.

The button released the cycle through `PATCH /rest/eqa/cycles/{id}/transition`, a
handler that records the state change and nothing else. So the cycle read
`SUBMITTED` and the screen said *"Cycle submitted to provider — awaiting scores"*,
while:

- its participant result rows stayed at `VALIDATED_PARTIAL`, with no channel, no
  `submitted_at` and no reference;
- no submission was posted, and the provider's store received nothing;
- nothing recovered it afterwards, because `findAdvanceCandidates` never revisits a
  cycle that already reads `SUBMITTED`.

Anything reading `eqa_participant_result.submission_status` still saw the results as
unsent, and the laboratory's own record carried no evidence it ever submitted. On a
scheme configured to review every cycle before it goes, this is the path every cycle
takes, every round.

The two paths that work both stamp the rows through `markSent`: the unattended sweep
with channel FHIR, and **Submit by hand** with channel MANUAL and a reference. Those
two buttons sat next to each other on the same expanded row and behaved differently.

## The fix

The click now submits, over the same code the sweep uses. The body of `submitIfDue`
after its gate check is extracted into `postToProvider` and `stampSubmitted`, and the
new `submitAfterReview` calls both, attributing the transition to the person who
clicked. One code path posts and stamps whether a sweep or a reviewer starts it.

`POST /rest/eqa/cycles/{id}/review-submit` replaces the transition call from the page.

**What this path deliberately does not consult, and why**

| Precondition | Sweep | Review submit |
| --- | --- | --- |
| status is `READY_TO_SUBMIT` | yes | yes, 409 otherwise |
| the scheme's review flag | stands the sweep down | not consulted — the click **is** what the flag asks for |
| an automatic channel is configured | returns quietly | refused, pointing at **Submit by hand** |
| the review window has elapsed | yes | no: the reviewer's own look is that window |
| retry budget and backoff | yes | no: these pace an unattended loop |
| a validated result is waiting | returns quietly | refused with a reason |

A send that fails spends none of the retry budget and stamps nothing. The reviewer is
told why and can click again, which is more use than an alert.

**The alternative considered.** Releasing the cycle and letting the sweep send it was
the first proposal. `PARTICIPANT_EDGES` has no `READY_TO_SUBMIT → READY_TO_SUBMIT`
edge, so a per-cycle release cannot ride on a transition row: it needs two columns on
`eqa_cycle`, a new changeset, and a "released, awaiting send" state on the row,
because otherwise nothing visible changes for up to five minutes after the click.
Submitting on the click needs no schema change and keeps the screen truthful.

**The guard moves lane with the meaning.** The endpoint sits beside `submit-manual`
under the participant grant, whose remit already covers FHIR submission, rather than
under the manage grant a state override needs. `EQARestGuardMatrixTest` pins it.

## Tests

Four cases added to the existing auto-submission suite rather than a new class, since
it already owns this service's fixture and stubs its transport:

1. a released cycle is posted, and **every** result row carries `SUBMITTED`, channel
   FHIR and a `submitted_at`, with the audit row naming the actor and the reason;
2. a provider that cannot be reached leaves the cycle `READY_TO_SUBMIT` and every row
   `VALIDATED_PARTIAL` with no channel — a send that did not happen is not reported as
   one — and spends none of the retry budget;
3. with no automatic channel nothing is posted at all and nothing is recorded;
4. an already-submitted cycle is refused.

The cycle is walked to `READY_TO_SUBMIT` through the real state machine rather than
seeded there, so no hand-chosen id can leave a sequence behind.

**Inversion check.** Removing the stamping loop from `stampSubmitted`, which is
exactly the old behaviour, fails case 1 at
`result submission status expected:<SUBMITTED> but was:<VALIDATED_PARTIAL>` and leaves
cases 2 to 4 green, because those assert the refusal paths.

`EQAAutoSubmissionIntegrationTest` 23/23, and the whole EQA package 596/596.

## Verified on the UAT rig

Driven on the participant instance, cycle **22** created and ordered and resulted and
validated through production paths, held at `READY_TO_SUBMIT` by the gate, then
released with one click as a QA officer:

- one request, `POST /rest/eqa/cycles/22/review-submit` → 200, and **zero**
  `input[type=password]` on the page throughout;
- `cycle=22, enrollment=2, resources=2`, then `submission sent to .../fhir/`;
- the provider's store holds `DiagnosticReport/9586f7d0-…-enrollment-2`, `final`,
  identified `cycle_id 22`, with its `Observation` attached;
- participant result: `SUBMITTED`, channel **FHIR**, stamped;
- audit: `READY_TO_SUBMIT → SUBMITTED [MANUAL/MANUAL_OVERRIDE]`, attributed to the
  clicking user, reason "Reviewed and submitted from My Cycles".

**The control group.** Cycle **21** is the same click on the same scheme on the
previous build, still standing on the rig: cycle `SUBMITTED`, result
`VALIDATED_PARTIAL`, and **zero** resources in the provider's store in the ten-minute
window around it. The store proves the defect, rather than a log's silence implying it.

**The sweep still submits**, which this refactor could have broken and which nothing
on the rig had exercised since. A second cycle (**23**) was driven the same way with
the gate turned off: the sweep took it `READY_TO_SUBMIT → SUBMITTED
[AUTO/FHIR_SUBMIT_SUCCESS]`, channel FHIR, attempts still 0, and the provider received
its report. The gate was then restored to on.

A repeat call on the submitted cycle answered **409** and an unknown cycle **400**,
and neither posted anything.
