### PR TITLE
fix(results): space status filter chips below the toolbar row

### DIFF
--- a/frontend/src/components/resultPage/unified/unified-results.scss
+++ b/frontend/src/components/resultPage/unified/unified-results.scss
@@ -698,3 +698,17 @@
   padding-block: 0;
   align-items: center;
 }
+
+// Status filter chips sit right beneath the toolbar row; give the row its
+// own breathing room so "All" / "Not Started" don't collide with the
+// Search and Load buttons above.
+.unifiedResultsPage .unifiedResultsChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.unifiedResultsPage .unifiedResultsChip {
+  cursor: pointer;
+}


### PR DESCRIPTION
The "All" / "Not Started" status chips on the Results page sat flush against the Search and Load buttons above them because the .unifiedResultsChips wrapper had no styles defined. Add a small top margin plus a flex gap so the chip row reads as its own control strip, not a continuation of the toolbar.
