### PR TITLE
fix(fhir): make every declared search parameter work, and page correctly

### DIFF
--- a/src/main/java/org/openelisglobal/common/fhir/dao/BaseFhirDao.java
+++ b/src/main/java/org/openelisglobal/common/fhir/dao/BaseFhirDao.java
@@ -914,6 +914,8 @@ public abstract class BaseFhirDao {
      */
     private <R> List<R> executeQuery(FhirCriteriaContext<?, R> context, int firstResult, int maxResults) {
         try {
+            applyDefaultOrdering(context);
+
             List<R> results = context.createQuery().setFirstResult(firstResult).setMaxResults(maxResults)
                     .getResultList();
 
@@ -922,6 +924,36 @@ public abstract class BaseFhirDao {
         } catch (Exception exception) {
             LOGGER.error("Error executing query: {}", exception.getMessage(), exception);
             throw new RuntimeException("Failed to execute FHIR query", exception);
+        }
+    }
+
+    /**
+     * Orders an otherwise unordered search by the root identifier.
+     *
+     * <p>
+     * Paging is expressed as an offset into a result set, which only means
+     * something if the result set has a stable order. PostgreSQL is free to return
+     * rows in any order for a query with no {@code ORDER BY}, so without this a
+     * client walking the pages of a search could see the same resource twice and
+     * never see another one at all.
+     */
+    private void applyDefaultOrdering(FhirCriteriaContext<?, ?> context) {
+        if (!(context.getCriteriaQuery() instanceof CriteriaQuery<?> criteriaQuery)) {
+            return;
+        }
+        if (!criteriaQuery.getOrderList().isEmpty()) {
+            return;
+        }
+        Root<?> root = context.getRoot();
+        if (root == null || root.getModel() == null) {
+            return;
+        }
+        try {
+            String idAttribute = root.getModel().getId(Object.class).getName();
+            criteriaQuery.orderBy(context.getCriteriaBuilder().asc(root.get(idAttribute)));
+        } catch (IllegalArgumentException exception) {
+            LOGGER.debug("No single-attribute identifier on {}, leaving the search unordered",
+                    root.getModel().getName());
         }
     }
 

--- a/src/main/java/org/openelisglobal/fhir/providers/DeviceProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/DeviceProvider.java
@@ -1,8 +1,10 @@
 package org.openelisglobal.fhir.providers;
 
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -262,7 +264,7 @@ public class DeviceProvider implements IResourceProvider {
             @OptionalParam(name = Device.SP_TYPE) TokenAndListParam type,
             @OptionalParam(name = Device.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
-            HttpServletRequest request) {
+            @Offset Integer offset, @Count Integer count, HttpServletRequest request) {
 
         String method = "searchDevices";
         LogEvent.logDebug(getClass().getSimpleName(), method, "Searching for Devices");
@@ -270,7 +272,7 @@ public class DeviceProvider implements IResourceProvider {
         try {
             DeviceSearchParams params = new DeviceSearchParams(id, identifier, deviceName, type, status, lastUpdated,
                     sort);
-            return deviceSearchService.searchDevices(params);
+            return FhirProviderUtils.withPaging(deviceSearchService.searchDevices(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/DiagnosticReportProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/DiagnosticReportProvider.java
@@ -1,9 +1,11 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.Search;
@@ -182,6 +184,7 @@ public class DiagnosticReportProvider implements IResourceProvider {
             @OptionalParam(name = DiagnosticReport.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = DiagnosticReport.SP_ISSUED) DateRangeParam issued,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.DIAGNOSTIC_REPORT_PATIENT_INCLUDE,
                     FhirConstants.DIAGNOSTIC_REPORT_SUBJECT_INCLUDE, FhirConstants.DIAGNOSTIC_REPORT_BASED_ON_INCLUDE,
                     FhirConstants.DIAGNOSTIC_REPORT_RESULT_INCLUDE,
@@ -195,7 +198,8 @@ public class DiagnosticReportProvider implements IResourceProvider {
             DiagnosticReportSearchParams params = new DiagnosticReportSearchParams(id, identifier,
                     FhirProviderUtils.merge(patient, subject), basedOn, result, specimen, code, status, issued,
                     lastUpdated, sort, includes);
-            return diagnosticReportSearchService.searchDiagnosticReports(params);
+            return FhirProviderUtils.withPaging(diagnosticReportSearchService.searchDiagnosticReports(params), offset,
+                    count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/FhirProviderUtils.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.StringAndListParam;
@@ -24,6 +25,7 @@ import org.hl7.fhir.r4.model.Resource;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.util.ControllerUtills;
 import org.openelisglobal.dataexchange.fhir.service.FhirPersistanceService;
+import org.openelisglobal.fhir.search.bundleProviders.PagedBundleProvider;
 
 public final class FhirProviderUtils {
 
@@ -90,6 +92,25 @@ public final class FhirProviderUtils {
 
     public static String safeMessage(Exception e) {
         return (e == null || e.getMessage() == null) ? "No error message available" : e.getMessage();
+    }
+
+    /**
+     * Tells a search result which page it is serving.
+     *
+     * <p>
+     * Applied to every search so that the {@code next} link HAPI advertises
+     * actually returns the next page. Results that do not page are left alone.
+     *
+     * @param result the bundle provider about to be returned to HAPI
+     * @param offset zero-based {@code _offset}, null when the client sent none
+     * @param count  {@code _count}, null when the client sent none
+     * @return the same result, for use as a return expression
+     */
+    public static IBundleProvider withPaging(IBundleProvider result, Integer offset, Integer count) {
+        if (result instanceof PagedBundleProvider provider) {
+            provider.setCurrentPage(offset, count);
+        }
+        return result;
     }
 
     public static void validateIdParam(IdType theId, String resourceType, String callerClassName, String method) {
@@ -352,8 +373,11 @@ public final class FhirProviderUtils {
                         .collect(java.util.stream.Collectors.joining("; "));
                 break;
             }
-            if (current instanceof java.sql.SQLException || current.getCause() == null
-                    || current.getCause() == current) {
+            if (current instanceof java.sql.SQLException sqlException) {
+                reason = describeSqlError(sqlException);
+                break;
+            }
+            if (current.getCause() == null || current.getCause() == current) {
                 reason = current.getMessage();
                 break;
             }
@@ -363,5 +387,41 @@ public final class FhirProviderUtils {
             reason = e.getClass().getSimpleName();
         }
         return new UnprocessableEntityException(resourceType + " could not be stored: " + reason.trim());
+    }
+
+    /**
+     * Reduces a JDBC failure to the database's own complaint.
+     *
+     * <p>
+     * A batched insert reports itself as {@code BatchUpdateException}, whose
+     * message is the entire generated statement with every bound value inlined and
+     * the real cause appended at the end. Returning that verbatim gave callers a
+     * diagnostics string thousands of characters long that buried the one sentence
+     * explaining what was wrong, so the driver's chained exception is preferred and
+     * the statement text dropped.
+     */
+    private static String describeSqlError(java.sql.SQLException e) {
+        java.sql.SQLException deepest = e;
+        java.sql.SQLException next = e.getNextException();
+        while (next != null && next != deepest) {
+            deepest = next;
+            next = next.getNextException();
+        }
+        String message = deepest.getMessage();
+        if (message == null || message.isBlank()) {
+            message = e.getMessage();
+        }
+        if (message == null) {
+            return null;
+        }
+        int aborted = message.lastIndexOf("was aborted: ");
+        if (aborted >= 0) {
+            message = message.substring(aborted + "was aborted: ".length());
+        }
+        int callNext = message.indexOf("Call getNextException");
+        if (callNext >= 0) {
+            message = message.substring(0, callNext);
+        }
+        return message.trim();
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/providers/LocationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/LocationProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -298,6 +300,7 @@ public class LocationProvider implements IResourceProvider {
             @OptionalParam(name = Location.SP_PARTOF) ReferenceAndListParam partOf,
             @OptionalParam(name = "_tag") TokenAndListParam tag,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.LOCATION_PARTOF_INCLUDE }) HashSet<Include> includes,
             @IncludeParam(reverse = true, allow = {
                     FhirConstants.LOCATION_PARTOF_INCLUDE }) HashSet<Include> revIncludes,
@@ -309,7 +312,7 @@ public class LocationProvider implements IResourceProvider {
         try {
             LocationSearchParams params = new LocationSearchParams(id, identifier, name, status, partOf, tag,
                     lastUpdated, sort, includes, revIncludes);
-            return locationSearchService.searchLocations(params);
+            return FhirProviderUtils.withPaging(locationSearchService.searchLocations(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/ObservationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/ObservationProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -387,6 +389,7 @@ public class ObservationProvider implements IResourceProvider {
             @OptionalParam(name = Observation.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = Observation.SP_DATE) DateRangeParam date,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.OBSERVATION_PATIENT_INCLUDE,
                     FhirConstants.OBSERVATION_SUBJECT_INCLUDE, FhirConstants.OBSERVATION_BASED_ON_INCLUDE,
                     FhirConstants.OBSERVATION_SPECIMEN_INCLUDE,
@@ -402,7 +405,7 @@ public class ObservationProvider implements IResourceProvider {
             ObservationSearchParams params = new ObservationSearchParams(id, identifier,
                     FhirProviderUtils.merge(patient, subject), basedOn, specimen, code, status, date, lastUpdated, sort,
                     includes, revIncludes);
-            return observationSearchService.searchObservations(params);
+            return FhirProviderUtils.withPaging(observationSearchService.searchObservations(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/OrganizationProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -286,6 +288,7 @@ public class OrganizationProvider implements IResourceProvider {
             @OptionalParam(name = Organization.SP_ADDRESS_CITY) StringAndListParam addressCity,
             @OptionalParam(name = Organization.SP_ADDRESS_STATE) StringAndListParam addressState,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.ORGANIZATION_PARTOF_INCLUDE }) HashSet<Include> includes,
             @IncludeParam(reverse = true, allow = {
                     FhirConstants.ORGANIZATION_PARTOF_INCLUDE }) HashSet<Include> revIncludes,
@@ -297,7 +300,7 @@ public class OrganizationProvider implements IResourceProvider {
         try {
             OrganizationSearchParams params = new OrganizationSearchParams(id, identifier, name, active, type, partOf,
                     addressCity, addressState, lastUpdated, sort, includes, revIncludes);
-            return organizationSearchService.searchOrganizations(params);
+            return FhirProviderUtils.withPaging(organizationSearchService.searchOrganizations(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/PatientProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PatientProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -235,6 +237,7 @@ public class PatientProvider implements IResourceProvider {
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_BIRTHDATE) DateRangeParam birthdate,
             @OptionalParam(name = org.hl7.fhir.r4.model.Patient.SP_GENDER) TokenAndListParam gender,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_PATIENT_REV_INCLUDE,
                     FhirConstants.SERVICE_REQUEST_SUBJECT_REV_INCLUDE, FhirConstants.SPECIMEN_PATIENT_REV_INCLUDE,
                     FhirConstants.SPECIMEN_SUBJECT_REV_INCLUDE, FhirConstants.OBSERVATION_PATIENT_REV_INCLUDE,
@@ -248,7 +251,7 @@ public class PatientProvider implements IResourceProvider {
         try {
             PatientSearchParams params = new PatientSearchParams(id, identifier, name, given, family, birthdate, gender,
                     lastUpdated, sort, revIncludes);
-            return patientSearchService.searchPatients(params);
+            return FhirProviderUtils.withPaging(patientSearchService.searchPatients(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/PractitionerProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -265,7 +267,7 @@ public class PractitionerProvider implements IResourceProvider {
 
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated,
 
-            @Sort SortSpec sort,
+            @Sort SortSpec sort, @Offset Integer offset, @Count Integer count,
 
             @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_REQUESTER_REV_INCLUDE,
                     FhirConstants.OBSERVATION_PERFORMER_REV_INCLUDE }) HashSet<Include> revIncludes,
@@ -280,7 +282,7 @@ public class PractitionerProvider implements IResourceProvider {
             PractitionerSearchParams params = new PractitionerSearchParams(identifier, name, given, family, city, state,
                     postalCode, country, telecom, email, phone, id, lastUpdated, sort, revIncludes);
 
-            return practitionerSearchService.searchPractitioners(params);
+            return FhirProviderUtils.withPaging(practitionerSearchService.searchPractitioners(params), offset, count);
 
         } catch (InvalidRequestException exception) {
             throw exception;

--- a/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/ServiceRequestProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -554,6 +556,7 @@ public class ServiceRequestProvider implements IResourceProvider {
             @OptionalParam(name = ServiceRequest.SP_CODE) TokenAndListParam code,
             @OptionalParam(name = ServiceRequest.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.SERVICE_REQUEST_PATIENT_INCLUDE,
                     FhirConstants.SERVICE_REQUEST_SUBJECT_INCLUDE, FhirConstants.SERVICE_REQUEST_REQUESTER_INCLUDE,
                     FhirConstants.SERVICE_REQUEST_SPECIMEN_INCLUDE }) HashSet<Include> includes,
@@ -568,7 +571,8 @@ public class ServiceRequestProvider implements IResourceProvider {
             ServiceRequestSearchParams params = new ServiceRequestSearchParams(id, identifier,
                     FhirProviderUtils.merge(patient, subject), requester, specimen, code, status, lastUpdated, sort,
                     includes, revIncludes);
-            return serviceRequestSearchService.searchServiceRequests(params);
+            return FhirProviderUtils.withPaging(serviceRequestSearchService.searchServiceRequests(params), offset,
+                    count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/providers/SpecimenProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/providers/SpecimenProvider.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.fhir.providers;
 
 import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.annotation.Count;
 import ca.uhn.fhir.rest.annotation.Create;
 import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
+import ca.uhn.fhir.rest.annotation.Offset;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
@@ -355,6 +357,7 @@ public class SpecimenProvider implements IResourceProvider {
             @OptionalParam(name = Specimen.SP_STATUS) TokenAndListParam status,
             @OptionalParam(name = Specimen.SP_COLLECTED) DateRangeParam collected,
             @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+            @Offset Integer offset, @Count Integer count,
             @IncludeParam(allow = { FhirConstants.SPECIMEN_PATIENT_INCLUDE,
                     FhirConstants.SPECIMEN_SUBJECT_INCLUDE }) HashSet<Include> includes,
             @IncludeParam(reverse = true, allow = { FhirConstants.SERVICE_REQUEST_SPECIMEN_REV_INCLUDE,
@@ -369,7 +372,7 @@ public class SpecimenProvider implements IResourceProvider {
             SpecimenSearchParams params = new SpecimenSearchParams(id, identifier, accession,
                     FhirProviderUtils.merge(patient, subject), type, status, collected, lastUpdated, sort, includes,
                     revIncludes);
-            return specimenSearchService.searchSpecimens(params);
+            return FhirProviderUtils.withPaging(specimenSearchService.searchSpecimens(params), offset, count);
         } catch (InvalidRequestException e) {
             throw e;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/BaseFhirBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/BaseFhirBundleProvider.java
@@ -1,6 +1,5 @@
 package org.openelisglobal.fhir.search.bundleProviders;
 
-import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import java.util.Collections;
 import java.util.Date;
@@ -18,7 +17,7 @@ import org.openelisglobal.common.util.ConfigurationProperties;
  * @param <E> OpenELIS persistence entity type
  * @param <R> FHIR resource type
  */
-public abstract class BaseFhirBundleProvider<E, R extends IBaseResource> implements IBundleProvider {
+public abstract class BaseFhirBundleProvider<E, R extends IBaseResource> implements PagedBundleProvider {
 
     private static final int DEFAULT_PAGE_SIZE = resolveDefaultPageSize();
 
@@ -43,6 +42,17 @@ public abstract class BaseFhirBundleProvider<E, R extends IBaseResource> impleme
      * Preferred page size returned to HAPI FHIR.
      */
     private int preferredPageSize = DEFAULT_PAGE_SIZE;
+
+    /**
+     * Offset requested with {@code _offset}, or null when the client did not ask
+     * for one.
+     */
+    private Integer currentPageOffset;
+
+    /**
+     * Page size that goes with {@link #currentPageOffset}.
+     */
+    private Integer currentPageSize;
 
     /**
      * Loads entities from the database for the requested range.
@@ -72,19 +82,28 @@ public abstract class BaseFhirBundleProvider<E, R extends IBaseResource> impleme
      * Loads and transforms only the range requested by HAPI FHIR.
      *
      * HAPI treats {@code fromIndex} as inclusive and {@code toIndex} as exclusive.
+     *
+     * <p>
+     * Once {@code _offset} is in play HAPI stops asking for a range at all: it
+     * calls this with the whole of {@code 0..MAX_VALUE} and returns whatever comes
+     * back, because in that mode the provider owns the paging. The requested range
+     * is therefore ignored in favour of the offset the client asked for - reading
+     * it literally is what made every page after the first return the entire result
+     * set.
      */
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
         validateRange(fromIndex, toIndex);
 
-        int pageSize = toIndex - fromIndex;
+        int from = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
 
         if (pageSize == 0) {
             return Collections.emptyList();
         }
 
-        List<E> entities = loadEntities(fromIndex, pageSize);
+        List<E> entities = loadEntities(from, pageSize);
 
         if (entities == null || entities.isEmpty()) {
 
@@ -133,6 +152,64 @@ public abstract class BaseFhirBundleProvider<E, R extends IBaseResource> impleme
     @Override
     public Integer preferredPageSize() {
         return preferredPageSize;
+    }
+
+    /**
+     * Declares which page of results this provider is serving.
+     *
+     * <p>
+     * HAPI builds the {@code next} and {@code previous} links from these, so a
+     * provider that does not report them hands the client links it will not honour.
+     * Passing a null offset leaves the provider in its unpaged mode.
+     *
+     * @param offset zero-based offset requested with {@code _offset}
+     * @param count  page size requested with {@code _count}
+     */
+    @Override
+    public void setCurrentPage(Integer offset, Integer count) {
+        if (offset == null) {
+            currentPageOffset = null;
+            currentPageSize = null;
+            return;
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("_offset must be zero or greater");
+        }
+        int size = count == null || count <= 0 ? preferredPageSize : count;
+        currentPageOffset = offset;
+        currentPageSize = size;
+    }
+
+    @Override
+    public Integer getCurrentPageOffset() {
+        return currentPageOffset;
+    }
+
+    @Override
+    public Integer getCurrentPageSize() {
+        return currentPageSize;
+    }
+
+    /**
+     * First row a subclass should load for the range HAPI asked for.
+     *
+     * <p>
+     * Subclasses override {@code getResources} to attach includes, and must resolve
+     * the range through this and {@link #effectivePageSize(int, int)} rather than
+     * subtracting the arguments: in offset mode HAPI asks for everything and
+     * expects the provider to have applied {@code _offset} and {@code _count}.
+     */
+    protected int effectiveOffset(int fromIndex) {
+        return currentPageOffset == null ? fromIndex : currentPageOffset;
+    }
+
+    /**
+     * Number of rows a subclass should load for the range HAPI asked for.
+     *
+     * @see #effectiveOffset(int)
+     */
+    protected int effectivePageSize(int fromIndex, int toIndex) {
+        return currentPageOffset == null ? toIndex - fromIndex : currentPageSize;
     }
 
     /**

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DiagnosticReportBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/DiagnosticReportBundleProvider.java
@@ -71,12 +71,13 @@ public class DiagnosticReportBundleProvider extends BaseFhirBundleProvider<Analy
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<Analysis> analyses = loadEntities(fromIndex, pageSize);
+        List<Analysis> analyses = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         for (Analysis analysis : analyses) {
             DiagnosticReport report = transformEntity(analysis);

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ObservationBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ObservationBundleProvider.java
@@ -14,7 +14,6 @@ import org.hl7.fhir.r4.model.Observation;
 import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.IStatusService;
-import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.fhir.FhirConstants;
@@ -79,12 +78,13 @@ public class ObservationBundleProvider extends BaseFhirBundleProvider<Result, Ob
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<Result> results = loadEntities(fromIndex, pageSize);
+        List<Result> results = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         for (Result result : results) {
             Observation observation = transformEntity(result);
@@ -149,9 +149,6 @@ public class ObservationBundleProvider extends BaseFhirBundleProvider<Result, Ob
         }
         if (searchParams.hasRevInclude(FhirConstants.DIAGNOSTIC_REPORT_RESULT_REV_INCLUDE)) {
             for (Analysis analysis : analyses.values()) {
-                if (!statusService.matches(analysis.getStatusId(), AnalysisStatus.Finalized)) {
-                    continue;
-                }
                 try {
                     resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
                 } catch (FhirTransformationException e) {

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/OrganizationBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/OrganizationBundleProvider.java
@@ -61,12 +61,13 @@ public class OrganizationBundleProvider
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<Organization> matches = loadEntities(fromIndex, pageSize);
+        List<Organization> matches = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         for (Organization organization : matches) {
             org.hl7.fhir.r4.model.Organization resource = transformEntity(organization);

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PagedBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PagedBundleProvider.java
@@ -1,0 +1,24 @@
+package org.openelisglobal.fhir.search.bundleProviders;
+
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+
+/**
+ * A search result that can be told which page of itself it is serving.
+ *
+ * <p>
+ * Once a request carries {@code _offset}, HAPI hands the whole range to the
+ * bundle provider and returns whatever it gets back, so the provider - not HAPI
+ * - decides what a page contains. A result that cannot be told this serves the
+ * entire set for every page, and the {@code next} link it advertises never
+ * advances.
+ */
+public interface PagedBundleProvider extends IBundleProvider {
+
+    /**
+     * @param offset zero-based offset requested with {@code _offset}, null when the
+     *               client sent none
+     * @param count  page size requested with {@code _count}, null when the client
+     *               sent none
+     */
+    void setCurrentPage(Integer offset, Integer count);
+}

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PatientBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PatientBundleProvider.java
@@ -78,12 +78,13 @@ public class PatientBundleProvider extends BaseFhirBundleProvider<Patient, org.h
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<Patient> patients = loadEntities(fromIndex, pageSize);
+        List<Patient> patients = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         patients.stream().map(this::transformEntity).filter(Objects::nonNull).forEach(resources::add);
         resources.forEach(

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PractitionerBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/PractitionerBundleProvider.java
@@ -86,7 +86,8 @@ public class PractitionerBundleProvider extends BaseFhirBundleProvider<Provider,
             throw new IllegalArgumentException("toIndex must be greater than or equal to fromIndex");
         }
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
 
         if (pageSize == 0) {
             return List.of();
@@ -95,7 +96,7 @@ public class PractitionerBundleProvider extends BaseFhirBundleProvider<Provider,
         /*
          * Step 1: Load only the current page of matching Providers.
          */
-        List<Provider> providers = practitionerSearchDao.search(searchParams, fromIndex, pageSize);
+        List<Provider> providers = practitionerSearchDao.search(searchParams, offset, pageSize);
 
         List<IBaseResource> resources = new ArrayList<>();
         providers.stream().map(this::transformEntity).filter(Objects::nonNull).forEach(resources::add);

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ServiceRequestBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/ServiceRequestBundleProvider.java
@@ -12,7 +12,6 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openelisglobal.analysis.valueholder.Analysis;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.services.IStatusService;
-import org.openelisglobal.common.services.StatusService.AnalysisStatus;
 import org.openelisglobal.dataexchange.fhir.exception.FhirTransformationException;
 import org.openelisglobal.dataexchange.fhir.service.FhirTransformService;
 import org.openelisglobal.fhir.FhirConstants;
@@ -77,12 +76,13 @@ public class ServiceRequestBundleProvider extends BaseFhirBundleProvider<Analysi
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<Analysis> analyses = loadEntities(fromIndex, pageSize);
+        List<Analysis> analyses = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         for (Analysis analysis : analyses) {
             ServiceRequest serviceRequest = transformEntity(analysis);
@@ -149,9 +149,6 @@ public class ServiceRequestBundleProvider extends BaseFhirBundleProvider<Analysi
         }
         if (wantsReports) {
             for (Analysis analysis : analyses) {
-                if (!statusService.matches(analysis.getStatusId(), AnalysisStatus.Finalized)) {
-                    continue;
-                }
                 try {
                     resources.add(fhirTransformService.transformResultToDiagnosticReport(analysis));
                 } catch (FhirTransformationException e) {

--- a/src/main/java/org/openelisglobal/fhir/search/bundleProviders/SpecimenBundleProvider.java
+++ b/src/main/java/org/openelisglobal/fhir/search/bundleProviders/SpecimenBundleProvider.java
@@ -71,12 +71,13 @@ public class SpecimenBundleProvider extends BaseFhirBundleProvider<SampleItem, S
     @Override
     public List<IBaseResource> getResources(int fromIndex, int toIndex) {
 
-        int pageSize = toIndex - fromIndex;
+        int offset = effectiveOffset(fromIndex);
+        int pageSize = effectivePageSize(fromIndex, toIndex);
         if (pageSize <= 0) {
             return List.of();
         }
 
-        List<SampleItem> sampleItems = loadEntities(fromIndex, pageSize);
+        List<SampleItem> sampleItems = loadEntities(offset, pageSize);
         List<IBaseResource> resources = new ArrayList<>();
         for (SampleItem sampleItem : sampleItems) {
             Specimen specimen = transformEntity(sampleItem);

--- a/src/main/java/org/openelisglobal/fhir/service/DeviceTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/DeviceTransformServiceImpl.java
@@ -290,6 +290,15 @@ public class DeviceTransformServiceImpl implements DeviceTransformService {
         return analyzer;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The id falls back to the row id rather than {@code ensureFhirUuid()}, which
+     * invents a UUID when the column is null. This is a read-only path, so that
+     * invented value was never persisted: every request handed the client a
+     * different id for the same analyzer, and none of them resolved.
+     */
     @Override
     public Device transformAnalyzerToDevice(Analyzer analyzer) {
         Device device = new Device();
@@ -302,7 +311,7 @@ public class DeviceTransformServiceImpl implements DeviceTransformService {
 
         final String TRANSPORT_EXTENSION = "http://openelis.org/fhir/StructureDefinition/analyzer-transport-details";
 
-        String fhirUuid = analyzer.ensureFhirUuid();
+        String fhirUuid = analyzer.getFhirUuid() == null ? analyzer.getId() : analyzer.getFhirUuidAsString();
         device.setId(fhirUuid);
         device.getMeta().setLastUpdated(analyzer.getLastupdated());
         if (analyzer.getStatus() != null) {

--- a/src/main/java/org/openelisglobal/fhir/service/FhirCommonTransformService.java
+++ b/src/main/java/org/openelisglobal/fhir/service/FhirCommonTransformService.java
@@ -2,6 +2,7 @@ package org.openelisglobal.fhir.service;
 
 import java.text.ParseException;
 import java.util.List;
+import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.DateType;
@@ -45,4 +46,10 @@ public interface FhirCommonTransformService {
     void addHumanNameToPerson(HumanName humanName, Person person);
 
     void addTelecomToPerson(List<ContactPoint> telecoms, Person person);
+
+    /** Copies a FHIR address onto the person's address columns. */
+    void addAddressToPerson(Address address, Person person);
+
+    /** Renders the person's address columns as a FHIR address. */
+    Address transformToAddress(Person person);
 }

--- a/src/main/java/org/openelisglobal/fhir/service/FhirCommonTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/FhirCommonTransformServiceImpl.java
@@ -8,6 +8,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.ContactPoint.ContactPointSystem;
@@ -18,6 +20,7 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.ResourceType;
+import org.hl7.fhir.r4.model.StringType;
 import org.openelisglobal.common.log.LogEvent;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.common.util.DateUtil;
@@ -219,6 +222,17 @@ public class FhirCommonTransformServiceImpl implements FhirCommonTransformServic
         person.setLastName(humanName.getFamily() == null ? "" : humanName.getFamily().strip());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * {@code ContactPoint.use} is optional in FHIR. A phone that omits it - or
+     * carries a use this method does not map to a dedicated column - is still
+     * stored as the primary phone, so that a resource created with such a telecom
+     * can afterwards be found by {@code ?phone=} and {@code ?telecom=}. Dropping it
+     * used to make those parameters unable to match anything the facade had just
+     * accepted.
+     */
     @Override
     public void addTelecomToPerson(List<ContactPoint> telecoms, Person person) {
         for (ContactPoint contact : telecoms) {
@@ -227,23 +241,78 @@ public class FhirCommonTransformServiceImpl implements FhirCommonTransformServic
                 person.setEmail(contactValue);
             } else if (ContactPointSystem.FAX.equals(contact.getSystem())) {
                 person.setFax(contactValue);
-            } else if (ContactPointSystem.PHONE.equals(contact.getSystem())
-                    && ContactPointUse.MOBILE.equals(contact.getUse())) {
-                person.setCellPhone(contactValue);
-                person.setPrimaryPhone(contactValue);
-            } else if (ContactPointSystem.PHONE.equals(contact.getSystem())
-                    && ContactPointUse.HOME.equals(contact.getUse())) {
-                person.setHomePhone(contactValue);
-                if (GenericValidator.isBlankOrNull(person.getPrimaryPhone())) {
-                    person.setPrimaryPhone(contactValue);
-                }
-            } else if (ContactPointSystem.PHONE.equals(contact.getSystem())
-                    && ContactPointUse.WORK.equals(contact.getUse())) {
-                person.setWorkPhone(contactValue);
-                if (GenericValidator.isBlankOrNull(person.getPrimaryPhone())) {
-                    person.setPrimaryPhone(contactValue);
-                }
+            } else if (ContactPointSystem.PHONE.equals(contact.getSystem())) {
+                addPhoneToPerson(contact.getUse(), contactValue, person);
             }
         }
+    }
+
+    private void addPhoneToPerson(ContactPointUse use, String contactValue, Person person) {
+        if (ContactPointUse.MOBILE.equals(use)) {
+            person.setCellPhone(contactValue);
+            person.setPrimaryPhone(contactValue);
+            return;
+        }
+        if (ContactPointUse.HOME.equals(use)) {
+            person.setHomePhone(contactValue);
+        } else if (ContactPointUse.WORK.equals(use)) {
+            person.setWorkPhone(contactValue);
+        }
+        if (GenericValidator.isBlankOrNull(person.getPrimaryPhone())) {
+            person.setPrimaryPhone(contactValue);
+        }
+    }
+
+    @Override
+    public void addAddressToPerson(Address address, Person person) {
+        if (address == null || address.isEmpty()) {
+            return;
+        }
+        if (address.hasLine()) {
+            person.setStreetAddress(
+                    address.getLine().stream().map(StringType::getValue).collect(Collectors.joining(", ")));
+        }
+        if (address.hasCity()) {
+            person.setCity(address.getCity());
+        }
+        if (address.hasState()) {
+            person.setState(address.getState());
+        }
+        if (address.hasPostalCode()) {
+            person.setZipCode(address.getPostalCode());
+        }
+        if (address.hasCountry()) {
+            person.setCountry(address.getCountry());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * Values are trimmed on the way out because {@code PERSON.ZIP_CODE} is a fixed
+     * width {@code character(10)}: read back unchanged, a five character postal
+     * code would be published with five trailing spaces, so what a client stored is
+     * not what it gets back.
+     */
+    @Override
+    public Address transformToAddress(Person person) {
+        Address address = new Address();
+        if (!GenericValidator.isBlankOrNull(person.getStreetAddress())) {
+            address.addLine(person.getStreetAddress().trim());
+        }
+        if (!GenericValidator.isBlankOrNull(person.getCity())) {
+            address.setCity(person.getCity().trim());
+        }
+        if (!GenericValidator.isBlankOrNull(person.getState())) {
+            address.setState(person.getState().trim());
+        }
+        if (!GenericValidator.isBlankOrNull(person.getZipCode())) {
+            address.setPostalCode(person.getZipCode().trim());
+        }
+        if (!GenericValidator.isBlankOrNull(person.getCountry())) {
+            address.setCountry(person.getCountry().trim());
+        }
+        return address;
     }
 }

--- a/src/main/java/org/openelisglobal/fhir/service/OrganizationTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/OrganizationTransformServiceImpl.java
@@ -1,9 +1,11 @@
 package org.openelisglobal.fhir.service;
 
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Identifier;
@@ -21,6 +23,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class OrganizationTransformServiceImpl implements OrganizationTransformService {
+
+    /** Widths of the ORGANIZATION address columns, which are narrow and legacy. */
+    private static final int STREET_ADDRESS_LIMIT = 30;
+
+    private static final int CITY_LIMIT = 30;
+
+    private static final int STATE_LIMIT = 2;
+
+    private static final int POSTAL_CODE_LIMIT = 10;
 
     @Autowired
     private FhirConfig fhirConfig;
@@ -157,16 +168,39 @@ public class OrganizationTransformServiceImpl implements OrganizationTransformSe
         }
     }
 
+    /**
+     * Copies the address onto the organization, rejecting any part that the column
+     * behind it cannot hold.
+     *
+     * <p>
+     * These are narrow legacy columns - {@code STATE} in particular is a two
+     * character US state code - and writing through them unchecked made the
+     * database abort the whole insert, which reached the caller as a 422 carrying
+     * the entire generated SQL statement and no indication of which field was at
+     * fault. Naming the field and its limit up front is the difference between a
+     * client being able to correct the payload and not.
+     */
     private void setOeOrganizationAddressInfo(Organization organization,
             org.hl7.fhir.r4.model.Organization fhirOrganization) {
         LogEvent.logTrace(this.getClass().getSimpleName(), "setOeOrganizationAddressInfo",
                 "setOeOrganizationAddressInfo called");
 
-        organization.setStreetAddress(fhirOrganization.getAddressFirstRep().getLine().stream()
-                .map(e -> e.asStringValue()).collect(Collectors.joining("\\n")));
-        organization.setCity(fhirOrganization.getAddressFirstRep().getCity());
-        organization.setState(fhirOrganization.getAddressFirstRep().getState());
-        organization.setZipCode(fhirOrganization.getAddressFirstRep().getPostalCode());
+        Address address = fhirOrganization.getAddressFirstRep();
+        organization.setStreetAddress(requireFits("Organization.address.line",
+                address.getLine().stream().map(e -> e.asStringValue()).collect(Collectors.joining("\\n")),
+                STREET_ADDRESS_LIMIT));
+        organization.setCity(requireFits("Organization.address.city", address.getCity(), CITY_LIMIT));
+        organization.setState(requireFits("Organization.address.state", address.getState(), STATE_LIMIT));
+        organization
+                .setZipCode(requireFits("Organization.address.postalCode", address.getPostalCode(), POSTAL_CODE_LIMIT));
+    }
+
+    private String requireFits(String fhirPath, String value, int limit) {
+        if (value != null && value.length() > limit) {
+            throw new UnprocessableEntityException(fhirPath + " is limited to " + limit
+                    + " characters in this database, but was " + value.length() + " characters");
+        }
+        return value;
     }
 
     private void setFhirAddressInfo(org.hl7.fhir.r4.model.Organization fhirOrganization, Organization organization) {

--- a/src/main/java/org/openelisglobal/fhir/service/PractitionerTransformServiceImpl.java
+++ b/src/main/java/org/openelisglobal/fhir/service/PractitionerTransformServiceImpl.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.fhir.service;
 
 import java.util.UUID;
+import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Practitioner;
@@ -27,13 +28,21 @@ public class PractitionerTransformServiceImpl implements PractitionerTransformSe
         return transformProviderToPractitioner(providerService.get(providerId));
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * A provider without a FHIR uuid still has to come back carrying an id: HAPI
+     * rejects a whole bundle over one id-less resource, so a single such row would
+     * otherwise make every Practitioner search fail.
+     */
     @Override
     public Practitioner transformProviderToPractitioner(Provider provider) {
         LogEvent.logTrace(this.getClass().getSimpleName(), "transformProviderToPractitioner",
                 "transformProviderToPractitioner called");
 
         Practitioner practitioner = new Practitioner();
-        practitioner.setId(provider.getFhirUuidAsString());
+        practitioner.setId(provider.getFhirUuid() == null ? provider.getId() : provider.getFhirUuidAsString());
         practitioner.getMeta().setLastUpdated(provider.getLastupdated());
         practitioner.addIdentifier(common.createIdentifier(fhirConfig.getOeFhirSystem() + "/provider_uuid",
                 provider.getFhirUuidAsString()));
@@ -44,6 +53,10 @@ public class PractitionerTransformServiceImpl implements PractitionerTransformSe
         practitioner.addName(new HumanName().setFamily(provider.getPerson().getLastName())
                 .addGiven(provider.getPerson().getFirstName()));
         practitioner.setTelecom(common.transformToTelecom(provider.getPerson()));
+        Address address = common.transformToAddress(provider.getPerson());
+        if (!address.isEmpty()) {
+            practitioner.addAddress(address);
+        }
         practitioner.setActive(provider.getActive());
 
         return practitioner;
@@ -75,6 +88,16 @@ public class PractitionerTransformServiceImpl implements PractitionerTransformSe
         return practitioner;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The address is carried across because {@code address-city},
+     * {@code address-state}, {@code address-postalcode} and {@code address-country}
+     * are declared search parameters that read the person's address columns;
+     * leaving them unpopulated made those four parameters unable to match a
+     * practitioner created through this facade.
+     */
     @Override
     public Provider transformToProvider(Practitioner practitioner) {
         Provider provider = new Provider();
@@ -84,6 +107,7 @@ public class PractitionerTransformServiceImpl implements PractitionerTransformSe
         provider.setPerson(new Person());
         common.addHumanNameToPerson(practitioner.getNameFirstRep(), provider.getPerson());
         common.addTelecomToPerson(practitioner.getTelecom(), provider.getPerson());
+        common.addAddressToPerson(practitioner.getAddressFirstRep(), provider.getPerson());
 
         return provider;
     }

--- a/src/main/java/org/openelisglobal/search/dao/SpecimenSearchDao.java
+++ b/src/main/java/org/openelisglobal/search/dao/SpecimenSearchDao.java
@@ -107,6 +107,14 @@ public class SpecimenSearchDao extends BaseFhirDao {
         addPredicate(context, createLastUpdatedPredicate(context, params.getLastUpdated()));
     }
 
+    /**
+     * Matches the accession as the resource publishes it.
+     *
+     * <p>
+     * {@code accessionIdentifier} carries {@code accession[-sortOrder]}, so a
+     * client searching with the value it was just given has to get a hit; a bare
+     * accession still matches every item of the sample.
+     */
     private <R> Optional<Predicate> createAccessionPredicate(FhirCriteriaContext<SampleItem, R> context,
             TokenAndListParam accession) {
 
@@ -114,9 +122,13 @@ public class SpecimenSearchDao extends BaseFhirDao {
             return Optional.empty();
         }
         CriteriaBuilder criteriaBuilder = requireCriteriaBuilder(context);
-        Expression<String> expression = resolveStringExpression(context, ACCESSION_PROPERTY);
-        return handleTokenAndListParam(criteriaBuilder, accession,
-                token -> createTokenValuePredicate(criteriaBuilder, expression, token));
+        return handleTokenAndListParam(criteriaBuilder, accession, token -> {
+            String value = token.getValue() == null ? "" : token.getValue().trim();
+            if (value.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(labNumberPredicate(context, value));
+        });
     }
 
     /**

--- a/src/main/java/org/openelisglobal/search/service/LocationSearchService.java
+++ b/src/main/java/org/openelisglobal/search/service/LocationSearchService.java
@@ -25,6 +25,7 @@ import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Location;
 import org.openelisglobal.common.fhir.dao.DateParamBounds;
 import org.openelisglobal.fhir.FhirConstants;
+import org.openelisglobal.fhir.search.bundleProviders.PagedBundleProvider;
 import org.openelisglobal.fhir.search.searchparams.LocationSearchParams;
 import org.openelisglobal.storage.fhir.StorageLocationFhirTransform;
 import org.openelisglobal.storage.service.StorageBoxService;
@@ -111,11 +112,13 @@ public class LocationSearchService {
      * carries the included parents and children, mirroring how the database-backed
      * bundle providers append their includes.
      */
-    static final class HierarchyBundleProvider implements IBundleProvider {
+    static final class HierarchyBundleProvider implements PagedBundleProvider {
 
         private final List<IBaseResource> matches;
         private final List<IBaseResource> includes;
         private final InstantDt published = InstantDt.withCurrentTime();
+        private Integer currentPageOffset;
+        private Integer currentPageSize;
 
         HierarchyBundleProvider(List<IBaseResource> matches, List<IBaseResource> includes) {
             this.matches = matches;
@@ -123,9 +126,27 @@ public class LocationSearchService {
         }
 
         @Override
+        public void setCurrentPage(Integer offset, Integer count) {
+            currentPageOffset = offset;
+            currentPageSize = offset == null || count == null || count <= 0 ? null : count;
+        }
+
+        @Override
+        public Integer getCurrentPageOffset() {
+            return currentPageOffset;
+        }
+
+        @Override
+        public Integer getCurrentPageSize() {
+            return currentPageSize;
+        }
+
+        @Override
         public List<IBaseResource> getResources(int fromIndex, int toIndex) {
-            int from = Math.max(0, Math.min(fromIndex, matches.size()));
-            int to = Math.max(from, Math.min(toIndex, matches.size()));
+            int requestedFrom = currentPageOffset == null ? fromIndex : currentPageOffset;
+            int requestedTo = currentPageSize == null ? toIndex : requestedFrom + currentPageSize;
+            int from = Math.max(0, Math.min(requestedFrom, matches.size()));
+            int to = Math.max(from, Math.min(requestedTo, matches.size()));
             List<IBaseResource> page = new ArrayList<>(matches.subList(from, to));
             page.addAll(includes);
             return page;

--- a/src/main/resources/liquibase/3.5.x.x/091-backfill-fhir-uuids.xml
+++ b/src/main/resources/liquibase/3.5.x.x/091-backfill-fhir-uuids.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!--
+    Organizations and providers seeded before fhir_uuid existed still have a null
+    one. The FHIR transforms fall back to the local numeric id so the resource is
+    not dropped, but that id resolves nowhere: the resource comes back in a search
+    bundle and then GET /fhir/Organization/<id> answers 500 and _id finds nothing,
+    which breaks the basic contract that anything in a bundle can be read back.
+
+    Both are created with a uuid today (OrganizationRestController,
+    ProviderServiceImpl), so this is a one-off backfill of legacy rows rather
+    than an ongoing gap.
+    -->
+    <changeSet id="backfill-organization-fhir-uuid" author="OGC">
+        <comment>Give every organization a FHIR uuid so it can be read back</comment>
+        <sql>update clinlims.organization set fhir_uuid = gen_random_uuid() where fhir_uuid is null;</sql>
+        <rollback>
+            <!-- The previous nulls are not recoverable, and re-nulling would only
+                 restore the unreadable-resource bug. -->
+            <empty/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="backfill-provider-fhir-uuid" author="OGC">
+        <comment>Give every provider a FHIR uuid so Practitioner can be read back</comment>
+        <sql>update clinlims.provider set fhir_uuid = gen_random_uuid() where fhir_uuid is null;</sql>
+        <rollback>
+            <empty/>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="backfill-analyzer-fhir-uuid" author="OGC">
+        <comment>Give every analyzer a FHIR uuid so Device ids stay stable</comment>
+        <sql>update clinlims.analyzer set fhir_uuid = gen_random_uuid() where fhir_uuid is null;</sql>
+        <rollback>
+            <empty/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -378,6 +378,7 @@
   <!-- Unified Results Entry worklist on by default (flips the flag seeded off by 059). -->
   <include relativeToChangelogFile="true" file="089-results-unified-route-default-on.xml"/>
   <include relativeToChangelogFile="true" file="090-patient-search-trigram-indexes.xml"/>
+  <include relativeToChangelogFile="true" file="091-backfill-fhir-uuids.xml"/>
 
 
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/fhir/FhirSearchRegressionTest.java
+++ b/src/test/java/org/openelisglobal/fhir/FhirSearchRegressionTest.java
@@ -1,0 +1,316 @@
+package org.openelisglobal.fhir;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.server.IResourceProvider;
+import ca.uhn.fhir.rest.server.RestfulServer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.fhir.providers.DeviceProvider;
+import org.openelisglobal.fhir.providers.ObservationProvider;
+import org.openelisglobal.fhir.providers.PractitionerProvider;
+import org.openelisglobal.fhir.providers.ServiceRequestProvider;
+import org.openelisglobal.fhir.providers.SpecimenProvider;
+import org.openelisglobal.person.service.PersonService;
+import org.openelisglobal.person.valueholder.Person;
+import org.openelisglobal.provider.service.ProviderService;
+import org.openelisglobal.provider.valueholder.Provider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Search behaviour that regressed in ways a caller notices: a resource type
+ * that could not be searched at all, reverse includes that silently dropped
+ * what they were asked for, and ids that did not survive being read back.
+ *
+ * <p>
+ * Each test here pins one of those. The bundle assertions look at
+ * {@code search.mode}, because a reverse include failing looks exactly like a
+ * successful search until you check whether anything was actually included.
+ */
+public class FhirSearchRegressionTest extends BaseWebContextSensitiveTest {
+
+    /** result-facade.xml seeds these with statuses that are NOT Finalized. */
+    private static final String ANALYSIS_1_UUID = "f8b9e2c1-7a2d-4e8b-b3a4-9c1e7f6d2b01";
+
+    private static final String SERUM_ITEM_UUID = "68438220-5cef-44c4-9e6f-9f88e6b93270";
+
+    @Autowired
+    private ServiceRequestProvider serviceRequestProvider;
+
+    @Autowired
+    private ObservationProvider observationProvider;
+
+    @Autowired
+    private SpecimenProvider specimenProvider;
+
+    @Autowired
+    private PractitionerProvider practitionerProvider;
+
+    @Autowired
+    private DeviceProvider deviceProvider;
+
+    @Autowired
+    private PersonService personService;
+
+    @Autowired
+    private ProviderService providerService;
+
+    private RestfulServer fhirServlet;
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        fhirServlet = new RestfulServer(FhirContext.forR4());
+        fhirServlet.setResourceProviders(Arrays.<IResourceProvider>asList(serviceRequestProvider, observationProvider,
+                specimenProvider, practitionerProvider, deviceProvider));
+        MockServletConfig servletConfig = new MockServletConfig(new MockServletContext());
+        servletConfig.addInitParameter("name", "FhirServlet");
+        fhirServlet.init(servletConfig);
+        objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * The reverse include used to emit a report only for a Finalized analysis,
+     * while a direct DiagnosticReport search returned it whatever the status. A
+     * reverse include has to return what the equivalent direct search returns.
+     */
+    @Test
+    public void serviceRequest_revIncludesDiagnosticReport_whateverTheAnalysisStatus() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+
+        JsonNode bundle = search("/ServiceRequest", "_id", ANALYSIS_1_UUID, "_revinclude", "DiagnosticReport:based-on");
+
+        assertEquals(List.of(ANALYSIS_1_UUID), matchedIds(bundle, "ServiceRequest"));
+        assertFalse("the DiagnosticReport based on this ServiceRequest was not reverse-included",
+                includedIds(bundle, "DiagnosticReport").isEmpty());
+    }
+
+    @Test
+    public void observation_revIncludesDiagnosticReport_whateverTheAnalysisStatus() throws Exception {
+        executeDataSetWithStateManagement("testdata/result-facade.xml");
+
+        JsonNode bundle = search("/Observation", "_revinclude", "DiagnosticReport:result");
+
+        assertFalse("no DiagnosticReport was reverse-included from Observation",
+                includedIds(bundle, "DiagnosticReport").isEmpty());
+    }
+
+    /**
+     * accessionIdentifier is published as {@code accession[-sortOrder]}, so a
+     * client searching with the value it was just given has to get a hit.
+     */
+    @Test
+    public void specimen_accessionAcceptsTheValueTheResourcePublishes() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-specimen.xml");
+
+        JsonNode published = search("/Specimen", "_id", SERUM_ITEM_UUID);
+        String accession = published.get("entry").get(0).get("resource").get("accessionIdentifier").get("value")
+                .asText();
+        assertTrue("expected the item suffix in " + accession, accession.contains("-"));
+
+        assertEquals(List.of(SERUM_ITEM_UUID), matchedIds(search("/Specimen", "accession", accession), "Specimen"));
+        assertFalse("the bare accession must still match every item of the sample",
+                matchedIds(search("/Specimen", "accession", accession.substring(0, accession.lastIndexOf('-'))),
+                        "Specimen").isEmpty());
+    }
+
+    /**
+     * A provider with no FHIR uuid used to yield a Practitioner with no id, and
+     * HAPI rejects a whole bundle over one id-less resource - so a single such row
+     * made every Practitioner search fail.
+     */
+    @Test
+    public void practitioner_searchSurvivesAProviderWithoutAFhirUuid() throws Exception {
+        resyncSequence("person_seq", "person");
+        resyncSequence("provider_seq", "provider");
+
+        Person person = new Person();
+        person.setFirstName("Nouuid");
+        person.setLastName("Practitioner");
+        person.setSysUserId("1");
+        personService.save(person);
+
+        Provider provider = new Provider();
+        provider.setPerson(person);
+        provider.setFhirUuid(null);
+        provider.setSysUserId("1");
+        providerService.insert(provider);
+
+        JsonNode bundle = search("/Practitioner");
+
+        assertEquals("Bundle", bundle.get("resourceType").asText());
+        assertFalse("the uuid-less provider should still come back with an id",
+                matchedIds(bundle, "Practitioner").isEmpty());
+        assertFalse("a resource in a bundle must carry an id", matchedIds(bundle, "Practitioner").contains(""));
+    }
+
+    /**
+     * The Device id was minted per request on a read-only path, so the same
+     * analyzer answered with a different id every time and none of them resolved.
+     */
+    @Test
+    public void device_idIsStableAcrossRequests() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-device.xml");
+        resyncSequence("clinlims.analyzer_seq", "clinlims.analyzer");
+
+        List<String> first = matchedIds(search("/Device"), "Device");
+        List<String> second = matchedIds(search("/Device"), "Device");
+
+        assertFalse("no Device to compare", first.isEmpty());
+        assertEquals("the same analyzer must keep the same id between requests", first, second);
+    }
+
+    /**
+     * Walking a search one page at a time has to visit each resource once.
+     *
+     * <p>
+     * HAPI advertises the next page as {@code _offset}, and in that mode it hands
+     * the provider the whole range and returns whatever comes back. Reading that
+     * range literally made every page after the first serve the entire result set,
+     * so a client following the links saw the same rows over and over.
+     */
+    @Test
+    public void search_pagesThroughEveryResultExactlyOnce() throws Exception {
+        executeDataSetWithStateManagement("testdata/facade-specimen.xml");
+
+        List<String> everything = matchedIds(search("/Specimen"), "Specimen");
+        assertTrue("need at least two specimens to page through", everything.size() >= 2);
+
+        List<String> walked = new ArrayList<>();
+        for (int offset = 0; offset < everything.size(); offset++) {
+            List<String> page = matchedIds(search("/Specimen", "_count", "1", "_offset", String.valueOf(offset)),
+                    "Specimen");
+            assertEquals("_count=1 must return one match at offset " + offset, 1, page.size());
+            walked.add(page.get(0));
+        }
+
+        assertEquals("paging must not repeat a resource", everything.size(), Set.copyOf(walked).size());
+        assertEquals("paging must reach every resource the unpaged search returns", Set.copyOf(everything),
+                Set.copyOf(walked));
+    }
+
+    /**
+     * {@code ContactPoint.use} is optional in FHIR, and a phone that omitted it
+     * used to be dropped on the way in - so the resource the facade had just
+     * accepted could not be found by the very parameters that search phone numbers.
+     */
+    @Test
+    public void practitioner_phoneWithoutAUseIsStoredAndSearchable() throws Exception {
+        resyncSequence("person_seq", "person");
+        resyncSequence("provider_seq", "provider");
+
+        String phone = "0700111222";
+        String id = createPractitioner("{\"resourceType\":\"Practitioner\",\"name\":[{\"family\":\"Nousetest\","
+                + "\"given\":[\"Phone\"]}],\"telecom\":[{\"system\":\"phone\",\"value\":\"" + phone + "\"}]}");
+
+        assertEquals(List.of(id), matchedIds(search("/Practitioner", "phone", phone), "Practitioner"));
+        assertEquals(List.of(id), matchedIds(search("/Practitioner", "telecom", phone), "Practitioner"));
+    }
+
+    /**
+     * address-city, address-state, address-postalcode and address-country are
+     * declared search parameters reading the person's address columns, but nothing
+     * on the write path populated them, so all four could only ever return nothing.
+     */
+    @Test
+    public void practitioner_addressIsStoredAndSearchableByEveryAddressParam() throws Exception {
+        resyncSequence("person_seq", "person");
+        resyncSequence("provider_seq", "provider");
+
+        String id = createPractitioner("{\"resourceType\":\"Practitioner\",\"name\":[{\"family\":\"Addrtest\","
+                + "\"given\":[\"Live\"]}],\"address\":[{\"city\":\"Testcity\",\"state\":\"Teststate\","
+                + "\"postalCode\":\"90210\",\"country\":\"Testcountry\"}]}");
+
+        assertEquals(List.of(id), matchedIds(search("/Practitioner", "address-city", "Testcity"), "Practitioner"));
+        assertEquals(List.of(id), matchedIds(search("/Practitioner", "address-state", "Teststate"), "Practitioner"));
+        assertEquals(List.of(id), matchedIds(search("/Practitioner", "address-postalcode", "90210"), "Practitioner"));
+        assertEquals(List.of(id),
+                matchedIds(search("/Practitioner", "address-country", "Testcountry"), "Practitioner"));
+        JsonNode address = read("/Practitioner/" + id).path("address").get(0);
+        assertEquals("the stored address must come back on a read", "Testcity", address.path("city").asText());
+        assertEquals("PERSON.ZIP_CODE is a fixed width column, so the padding must not reach the client", "90210",
+                address.path("postalCode").asText());
+    }
+
+    // ==================== helpers ====================
+
+    private String createPractitioner(String json) throws Exception {
+        MockHttpServletResponse response = post("/Practitioner", json);
+        assertEquals(response.getContentAsString(), 201, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString()).path("id").asText();
+    }
+
+    private MockHttpServletResponse post(String path, String json) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("POST", path);
+        request.setContent(json.getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        return response;
+    }
+
+    private JsonNode read(String path) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", path);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private JsonNode search(String path, String... params) throws Exception {
+        MockHttpServletRequest request = buildFhirRequest("GET", path);
+        StringBuilder query = new StringBuilder();
+        for (int i = 0; i + 1 < params.length; i += 2) {
+            request.addParameter(params[i], params[i + 1]);
+            query.append(query.length() == 0 ? "" : "&").append(params[i]).append("=").append(params[i + 1]);
+        }
+        request.setQueryString(query.toString());
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        fhirServlet.service(request, response);
+        assertEquals(response.getContentAsString(), 200, response.getStatus());
+        return objectMapper.readTree(response.getContentAsString());
+    }
+
+    private List<String> matchedIds(JsonNode bundle, String resourceType) {
+        return idsWithMode(bundle, resourceType, "match");
+    }
+
+    private List<String> includedIds(JsonNode bundle, String resourceType) {
+        return idsWithMode(bundle, resourceType, "include");
+    }
+
+    private List<String> idsWithMode(JsonNode bundle, String resourceType, String mode) {
+        List<String> ids = new ArrayList<>();
+        JsonNode entries = bundle.get("entry");
+        if (entries == null) {
+            return ids;
+        }
+        for (JsonNode entry : entries) {
+            JsonNode resource = entry.get("resource");
+            if (resource == null || !resourceType.equals(resource.path("resourceType").asText())) {
+                continue;
+            }
+            String entryMode = entry.path("search").path("mode").asText("match");
+            if (mode.equals(entryMode)) {
+                ids.add(resource.path("id").asText());
+            }
+        }
+        return ids;
+    }
+}

--- a/src/test/java/org/openelisglobal/fhir/OrganizationFacadeTest.java
+++ b/src/test/java/org/openelisglobal/fhir/OrganizationFacadeTest.java
@@ -276,13 +276,23 @@ public class OrganizationFacadeTest extends BaseWebContextSensitiveTest {
         assertEquals("OperationOutcome", outcome.get("resourceType").asText());
     }
 
+    /**
+     * STATE is a two character US state code. The rejection has to name the field
+     * and its limit: it used to surface as the entire generated INSERT with every
+     * bound value inlined, which told a client nothing it could act on.
+     */
     @Test
     public void createOrganization_withOverlongState_returns422NotServerError() throws Exception {
         JsonNode outcome = post("/Organization", """
                 {"resourceType": "Organization", "active": true, "name": "Wide State Clinic",
                  "address": [{"city": "Kampala", "state": "Central Region"}]}
                 """, 422);
-        assertTrue(outcome.get("issue").get(0).get("diagnostics").asText().contains("could not be stored"));
+        String diagnostics = outcome.get("issue").get(0).get("diagnostics").asText();
+        assertTrue("the error should name the field, but was: " + diagnostics,
+                diagnostics.contains("Organization.address.state"));
+        assertTrue("the error should state the limit, but was: " + diagnostics, diagnostics.contains("2 characters"));
+        assertFalse("the error should not carry the generated SQL, but was: " + diagnostics,
+                diagnostics.contains("insert into"));
     }
 
     private JsonNode post(String path, String json, int expectedStatus) throws Exception {


### PR DESCRIPTION
## What

Audited all nine resources the FHIR facade exposes, parameter by parameter, against a running instance. Nine defects surfaced; eight are fixed here.

- **Paging** (all resources): HAPI advertises the next page as `_offset`, and in that mode it hands the bundle provider the whole range and returns whatever comes back. Every provider read the range literally, so following the server's own `next` link re-served the entire result set. Searches also now fall back to ordering by the root identifier, since an offset is only meaningful over a defined order.
- **`_revinclude=DiagnosticReport:based-on` / `:result`**: the report was dropped unless the analysis was Finalized, while a direct `DiagnosticReport` search returned it at any status. This is the reported bug.
- **Device**: ids were minted per request on a read-only path, so the same analyzer answered with a different id every time and none resolved.
- **Practitioner**: one provider with a null `fhir_uuid` made every Practitioner search fail (HAPI rejects a bundle over one id-less resource). Liquibase `091` backfills the legacy nulls on organization, provider and analyzer.
- **Specimen `accession`**: did not match the `accession-sortOrder` value the resource itself publishes.
- **Practitioner address**: `address-city|state|postalcode|country` are declared but nothing on the write path stored an address, so all four could only return nothing.
- **Telecom**: a phone with no `ContactPoint.use` was silently discarded, so `?phone=` and `?telecom=` could not find what had just been stored. Shared with Patient.
- **Errors**: a create violating a column width answered with the entire generated `INSERT`; it now names the field and its limit.

## Why

An integrator reported that some search params did not work. They were right, and the audit found more than the one reported.

## How tested

- 196 live checks against the dev compose stack, all passing: every declared parameter on every resource called with values read from real rows, plus negative controls, `_include`/`_revinclude` asserted on `search.mode`, and a full paging walk per resource (each visits every resource exactly once, no duplicates).
- Create/read/search/update round trips for Organization, Patient, Practitioner and Location.
- New `FhirSearchRegressionTest` (7 tests) pins each defect; `OrganizationFacadeTest` strengthened.
- Full backend suite: 5941 tests, 0 failures, 0 errors. `spotless:check` green in a Linux container.

## Notes

`_sort` is accepted and silently ignored on every resource. Left out deliberately: doing it properly means mapping each resource's sortable parameters to entity properties, and a partial version honouring only `_lastUpdated` would be a subtler trap. The default ordering added here makes paging correct in the meantime.