### PR TITLE
docs(eqa): restore the CPHL cutover checklist and programme registry template (OGC-935)

### DIFF
--- a/docs/eqa/cphl-cutover.md
+++ b/docs/eqa/cphl-cutover.md
@@ -1,0 +1,117 @@
+# CPHL EQA cutover checklist — Access/Excel to OpenELIS
+
+**Scope.** OGC-935 (PNG Phase II, contract item 18). This checklist confirms
+that OpenELIS replaces the two systems CPHL Port Moresby uses to run its
+national EQA programme: the Access database that produces performance reports,
+and the Excel workbooks that track sample distribution to provincial
+laboratories. Cutover is complete when every row in §2 and §3 is checked and a
+CPHL stakeholder signs §6.
+
+**How to use this document.** Work through it on a CPHL instance with the
+programme registry loaded (§4). Each unchecked row is either a task or a
+question for CPHL — there are no other states.
+
+---
+
+## 1. Programme registry (confirm with CPHL)
+
+The registry file (`docs/eqa/cphl-eqa-programs.csv`, loaded per §4) defines six
+provider-side schemes, one per ePT-validated test domain (AC-V2.1-23). The
+domains are the best available registry; CPHL confirms or corrects each row at
+sign-off. Every value is editable afterwards on **Schemes & Programs**.
+
+| Programme                            | Test section      | Frequency | CPHL confirms                |
+| ------------------------------------ | ----------------- | --------- | ---------------------------- |
+| CPHL National HIV Serology EQA       | Serology          | Quarterly | ☐ name ☐ section ☐ frequency |
+| CPHL National HIV Viral Load EQA     | Molecular Biology | Quarterly | ☐ name ☐ section ☐ frequency |
+| CPHL National EID EQA                | Molecular Biology | Quarterly | ☐ name ☐ section ☐ frequency |
+| CPHL National HIV Recency EQA        | Serology          | Quarterly | ☐ name ☐ section ☐ frequency |
+| CPHL National COVID-19 Molecular EQA | Molecular Biology | Quarterly | ☐ name ☐ section ☐ frequency |
+| CPHL National TB Microscopy EQA      | Microbiology      | Quarterly | ☐ name ☐ section ☐ frequency |
+
+Open questions for CPHL:
+
+- ☐ Are there programmes CPHL runs that are missing from this list (for example
+  syphilis, malaria microscopy, CD4)?
+- ☐ Which international or regional schemes does CPHL _participate in_ (as
+  opposed to provide)? Those are entered as `INTERNATIONAL_PT` schemes with the
+  external provider named — none are seeded, because no authoritative list
+  exists in the project record.
+- ☐ The provincial laboratory register (name, province, contact, delivery
+  address, FHIR endpoint if any) — entered as Organizations, then enrolled per
+  scheme on the **Participants** page.
+
+## 2. Excel sample distribution → OpenELIS
+
+Each row maps one thing the Excel workbooks do today to the screen that replaces
+it. Verify each by doing it once on the seeded instance.
+
+| Excel artifact today                                            | OpenELIS replacement                                                                                                                 | FRS        | Verified |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- |
+| Round planning sheet (which labs get which panel, when)         | Cycle wizard: cycle details, panel samples, participant roster, distribution method (**Provider Cycles → Create new cycle + panel**) | FR-V2.5-02 | ☐        |
+| Aliquot count arithmetic (needed vs produced, reserve)          | Prep workbench: aliquots produced vs needed gauge, homogeneity QC gate                                                               | FR-V2.5-12 | ☐        |
+| Dispatch register (courier, tracking number, date sent per lab) | Shipment workbench: per-participant box, courier details, mark shipped                                                               | FR-V2.5-13 | ☐        |
+| Receipt tracking (phone/email follow-up, arrival dates)         | Receipt monitor: delivery status, overdue rule, temperature-excursion flag                                                           | FR-V2.5-14 | ☐        |
+| Replacement sample notes (damaged/lost panels)                  | Reprovision action ("Send repeat"): reserve decrement, linked repeat shipment                                                        | FR-V2.5-15 | ☐        |
+| Results collection workbook (per-lab result entry)              | Receipt monitor → **Enter results**: keyed per participant (numbers or words such as Reactive) or the participant's export-bundle CSV pasted in; results from a participant OpenELIS arrive through the provider's FHIR store on their own | FR-V2.5-03 | ☐        |
+
+## 3. Access reporting → OpenELIS
+
+| Access artifact today                          | OpenELIS replacement                                                                                             | FRS           | Verified |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| Per-lab performance report (scores, pass/fail) | Printed CPHL-format performance report: section- and programme-level summaries, z-score table, cycle identifiers | OGC-933       | ☐        |
+| Standard interpretive commentary               | Interpretive comments on the report (pre-approved picker)                                                        | OGC-934       | ☐        |
+| Programme-level summary across labs            | Provider scoring view + participant performance dashboard                                                        | FR-V2.5-04/05 | ☐        |
+| Chase list of poor performers                  | Follow-up register: unacceptable-score auto-enqueue, triage actions                                              | FR-V2.5-06/07 | ☐        |
+
+## 4. Loading the programme registry
+
+The registry is a CSV config file, not code — edit the file, not the database.
+On the CPHL instance, copy `docs/eqa/cphl-eqa-programs.csv` into the backend
+configuration directory:
+
+```
+/var/lib/openelis-global/configuration/backend/eqa-programs/cphl-eqa-programs.csv
+```
+
+Restart the webapp, or call `POST /rest/configuration/domains/reload` to load it
+without a restart. The loader runs the file only when its checksum changes, and
+rows upsert by programme name: a new name inserts, an existing name updates the
+columns the file names — so correcting the CSV and reloading is the whole
+maintenance workflow. A `testSection` value missing from the instance's catalog
+leaves that programme's section blank instead of failing the file (assign it on
+**Schemes & Programs**).
+
+Verify with:
+
+```sql
+SELECT name, provider, scheme_type, frequency FROM clinlims.eqa_program
+WHERE provider LIKE 'Central Public Health Laboratory%';
+```
+
+Six rows are expected.
+
+**Visibility note:** the provider scheme board lists a scheme only after its
+first active participant enrollment, matching the cycle wizard's own
+precondition (a cycle needs enrolled labs). Directly after loading, the six
+programmes appear on the **Participants** page's programme selector — enroll the
+provincial labs there first (§1), and each scheme joins the board as its first
+lab enrolls.
+
+## 5. Data migration decision
+
+Historical Access/Excel records are **not** migrated. Past cycles stay in Access
+as an archive; OpenELIS starts with the first live cycle after cutover. If CPHL
+requires historical scores inside OpenELIS, that is new scope to raise on
+OGC-935 — record the decision here: ☐ archive stands / ☐ migration requested.
+
+## 6. Sign-off
+
+Run one seeded scheme's cycle end-to-end (wizard → prep → ship → receipt →
+results → scoring → printed report) with CPHL staff driving.
+
+| Role                    | Name | Date | Signature |
+| ----------------------- | ---- | ---- | --------- |
+| CPHL EQA coordinator    |      |      |           |
+| CPHL laboratory manager |      |      |           |
+| Implementation team     |      |      |           |

--- a/docs/eqa/cphl-cutover.md
+++ b/docs/eqa/cphl-cutover.md
@@ -75,9 +75,10 @@ configuration directory, which the container sees at:
 ```
 
 On a Compose deployment that is the host path `./configuration/backend/eqa-programs/`,
-because `docker-compose.yml` mounts `./configuration` there. That directory is
-not in the repository — the deployment owns it, which is why this template
-travels with the checklist.
+because `docker-compose.yml` mounts `./configuration` there. The repository
+carries no such directory and no files under it, so it is created when the
+instance is deployed — which is why this template travels with the checklist
+rather than being read out of the repository.
 
 **Do not mistake the development copy for an installed one.** The repository also
 carries this registry at `volume/configuration/backend/eqa-programs/`, and

--- a/docs/eqa/cphl-cutover.md
+++ b/docs/eqa/cphl-cutover.md
@@ -68,11 +68,23 @@ it. Verify each by doing it once on the seeded instance.
 
 The registry is a CSV config file, not code — edit the file, not the database.
 On the CPHL instance, copy `docs/eqa/cphl-eqa-programs.csv` into the backend
-configuration directory:
+configuration directory, which the container sees at:
 
 ```
 /var/lib/openelis-global/configuration/backend/eqa-programs/cphl-eqa-programs.csv
 ```
+
+On a Compose deployment that is the host path `./configuration/backend/eqa-programs/`,
+because `docker-compose.yml` mounts `./configuration` there. That directory is
+not in the repository — the deployment owns it, which is why this template
+travels with the checklist.
+
+**Do not mistake the development copy for an installed one.** The repository also
+carries this registry at `volume/configuration/backend/eqa-programs/`, and
+`dev.docker-compose.yml` mounts `volume/configuration` instead. That copy feeds
+the development stack only; on a Compose deployment it is never read, so the file
+being present in the repository does not mean the instance has loaded it. The
+check below is what settles it.
 
 Restart the webapp, or call `POST /rest/configuration/domains/reload` as an
 administrator to load it without a restart. An empty body reloads every

--- a/docs/eqa/cphl-cutover.md
+++ b/docs/eqa/cphl-cutover.md
@@ -46,13 +46,13 @@ Open questions for CPHL:
 Each row maps one thing the Excel workbooks do today to the screen that replaces
 it. Verify each by doing it once on the seeded instance.
 
-| Excel artifact today                                            | OpenELIS replacement                                                                                                                 | FRS        | Verified |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- |
-| Round planning sheet (which labs get which panel, when)         | Cycle wizard: cycle details, panel samples, participant roster, distribution method (**Provider Cycles → Create new cycle + panel**) | FR-V2.5-02 | ☐        |
-| Aliquot count arithmetic (needed vs produced, reserve)          | Prep workbench: aliquots produced vs needed gauge, homogeneity QC gate                                                               | FR-V2.5-12 | ☐        |
-| Dispatch register (courier, tracking number, date sent per lab) | Shipment workbench: per-participant box, courier details, mark shipped                                                               | FR-V2.5-13 | ☐        |
-| Receipt tracking (phone/email follow-up, arrival dates)         | Receipt monitor: delivery status, overdue rule, temperature-excursion flag                                                           | FR-V2.5-14 | ☐        |
-| Replacement sample notes (damaged/lost panels)                  | Reprovision action ("Send repeat"): reserve decrement, linked repeat shipment                                                        | FR-V2.5-15 | ☐        |
+| Excel artifact today                                            | OpenELIS replacement                                                                                                                                                                                                                       | FRS        | Verified |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- |
+| Round planning sheet (which labs get which panel, when)         | Cycle wizard: cycle details, panel samples, participant roster, distribution method (**Provider Cycles → Create new cycle + panel**)                                                                                                       | FR-V2.5-02 | ☐        |
+| Aliquot count arithmetic (needed vs produced, reserve)          | Prep workbench: aliquots produced vs needed gauge, homogeneity QC gate                                                                                                                                                                     | FR-V2.5-12 | ☐        |
+| Dispatch register (courier, tracking number, date sent per lab) | Shipment workbench: per-participant box, courier details, mark shipped                                                                                                                                                                     | FR-V2.5-13 | ☐        |
+| Receipt tracking (phone/email follow-up, arrival dates)         | Receipt monitor: delivery status, overdue rule, temperature-excursion flag                                                                                                                                                                 | FR-V2.5-14 | ☐        |
+| Replacement sample notes (damaged/lost panels)                  | Reprovision action ("Send repeat"): reserve decrement, linked repeat shipment                                                                                                                                                              | FR-V2.5-15 | ☐        |
 | Results collection workbook (per-lab result entry)              | Receipt monitor → **Enter results**: keyed per participant (numbers or words such as Reactive) or the participant's export-bundle CSV pasted in; results from a participant OpenELIS arrive through the provider's FHIR store on their own | FR-V2.5-03 | ☐        |
 
 ## 3. Access reporting → OpenELIS
@@ -74,15 +74,52 @@ configuration directory:
 /var/lib/openelis-global/configuration/backend/eqa-programs/cphl-eqa-programs.csv
 ```
 
-Restart the webapp, or call `POST /rest/configuration/domains/reload` to load it
-without a restart. The loader runs the file only when its checksum changes, and
-rows upsert by programme name: a new name inserts, an existing name updates the
-columns the file names — so correcting the CSV and reloading is the whole
-maintenance workflow. A `testSection` value missing from the instance's catalog
-leaves that programme's section blank instead of failing the file (assign it on
-**Schemes & Programs**).
+Restart the webapp, or call `POST /rest/configuration/domains/reload` as an
+administrator to load it without a restart. An empty body reloads every
+configuration domain; to reload only this one, post
+`{"domains": ["eqa-programs"]}`.
 
-Verify with:
+The loader runs the file only when its checksum changes, and rows upsert by
+programme name: a new name inserts, an existing name updates every column the
+file gives a value for. So correcting the CSV and reloading is the whole
+maintenance workflow. Three consequences worth knowing before cutover:
+
+- A **blank cell leaves the existing value alone** rather than clearing it, so
+  the file cannot be used to empty a field. Clear it on **Schemes & Programs**.
+- Re-posting an **unchanged** file does nothing, because its checksum still
+  matches. To re-apply one as it stands, post `{"force": true}` with it.
+- A value edited on **Schemes & Programs** is **overwritten the next time the
+  CSV changes**, if the file gives that column a value. Treat the CSV as the
+  source of truth for the columns it fills, and the screen as the place for
+  everything it does not.
+
+A `testSection` value missing from the instance's catalog leaves that
+programme's section blank instead of failing the file (assign it on **Schemes &
+Programs**). A row the server rejects is logged and skipped, and the rest of the
+file still loads.
+
+The reload answers with what it did to each file, which is the first thing to
+check:
+
+```json
+{
+  "files": [
+    {
+      "domain": "eqa-programs",
+      "fileName": "cphl-eqa-programs.csv",
+      "status": "SKIPPED",
+      "skippedReason": "checksum matches"
+    }
+  ]
+}
+```
+
+`SKIPPED` with `checksum matches` means the file is in the right place and
+already loaded — the expected answer on a second call. A first load reports the
+file as processed instead. An empty `files` list means the loader found nothing,
+which points at the path rather than at the file's contents.
+
+Then verify the rows:
 
 ```sql
 SELECT name, provider, scheme_type, frequency FROM clinlims.eqa_program

--- a/docs/eqa/cphl-eqa-programs.csv
+++ b/docs/eqa/cphl-eqa-programs.csv
@@ -1,0 +1,7 @@
+name,description,provider,schemeType,frequency,testSection,active
+CPHL National HIV Serology EQA,Proficiency testing for HIV rapid/serology testing sites (national programme),"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Serology,Y
+CPHL National HIV Viral Load EQA,Proficiency testing for HIV viral load testing laboratories,"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Molecular Biology,Y
+CPHL National EID EQA,Proficiency testing for early infant diagnosis (HIV DNA PCR) laboratories,"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Molecular Biology,Y
+CPHL National HIV Recency EQA,Proficiency testing for HIV recency (RTRI) testing sites,"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Serology,Y
+CPHL National COVID-19 Molecular EQA,Proficiency testing for SARS-CoV-2 molecular testing laboratories,"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Molecular Biology,Y
+CPHL National TB Microscopy EQA,Proficiency testing for tuberculosis smear microscopy sites,"Central Public Health Laboratory (CPHL), Port Moresby",REGIONAL_PT,Quarterly,Microbiology,Y


### PR DESCRIPTION
## Why this is open again

The CPHL cutover checklist and the programme-registry CSV were written for #4146 and
dropped when the configuration moved under `volume/`, so the cutover instrument — the one
carrying CPHL's sign-off block — was never on the branch. #4169 restored them and was
closed unmerged with no review and no comment, which left the finding and its register
row open. Both files come back here, rebased onto the current tip.

## The restore is faithful, and that is checkable

`upstream/task/T-30` no longer exists. Both files were recovered from #4146's **first**
commit `6a96d9852` — its second commit, which moved the CPHL configuration under
`volume/`, is what dropped them.

Against that commit:

- `docs/eqa/cphl-eqa-programs.csv` is **byte-identical**;
- `docs/eqa/cphl-cutover.md` differs only in the results-collection row (rewritten to name
  what shipped after it was written), the loading section below, and prettier's table
  padding. Nothing else was lost or altered in the recovery.

## What is different from #4169

The loading section is the part a reader follows literally, and a wrong path or a wrong
endpoint there is worse than no document. So every claim in it was checked against
`EQAProgramConfigurationHandler` and `ConfigurationInitializationService`, and then
against a running instance that already carries this registry.

**Confirmed, not changed:**

- the configuration path `…/configuration/backend/eqa-programs/cphl-eqa-programs.csv` —
  the deployed file on that instance is byte-identical to the copy in this PR
  (`sha256 c9a4dcbb…`), and the domain's checksums file records that same hash;
- the six-row SQL check — it returns exactly six rows;
- the note that a scheme reaches the provider board only on its first **active**
  enrollment. `findProviderSchemeRows` inner-joins active enrollments, and on that
  instance all six programmes exist while only the two with enrolled laboratories appear
  on the board. Four deliberately absent, two present.

**Added, each confirmed live:**

- the reload endpoint takes an administrator, and `{"domains": ["eqa-programs"]}` scopes
  it to this registry instead of reloading every configuration domain;
- what the reload answers, so a reader can tell "found and already loaded" from an empty
  `files` list, which points at the path rather than at the file. The scoped call returned
  `{"domain":"eqa-programs","fileName":"cphl-eqa-programs.csv","status":"SKIPPED","skippedReason":"checksum matches"}`;
- a **blank cell leaves the existing value alone** rather than clearing it, so the file
  cannot be used to empty a field;
- an unchanged file is skipped on its checksum, so re-applying one as it stands needs
  `{"force": true}`;
- a value edited on **Schemes & Programs** is **overwritten** the next time the file gives
  that column a value — which is what decides, per column, whether the CSV or the screen
  is the source of truth;
- a row the server rejects is logged and skipped without stopping the rest of the file.

The reload driven for this was scoped to `eqa-programs` and answered `SKIPPED`, so it
changed no row on that instance.

## What the verification does not cover

The instance it was verified on is the **development** stack, which mounts
`./volume/configuration`. So the six programmes loading there is not evidence that a
production deployment would load them, and the `./configuration` mount in
`docker-compose.yml` is the one part of §4 that no instance here exercises.

What the verification does establish is stack-independent, because it concerns the loader
and the container path rather than which host directory is mounted: the domain name, the
file's location under the config directory, the checksum skip, the upsert behaviour, the
six-row check, and the board's enrollment gate.

That asymmetry is the same trap as §4's, seen from the other side, and it is why the
template has to travel with the checklist rather than be read out of the repository.

## Considered and deliberately not added

A step to assign each scheme's tests after loading. `EQAProgramTest` is read only by the
programmes dialog — nothing in the ordering, blinding, or scoring path consumes it — so it
is not a precondition for the end-to-end run in §6, and adding it would send CPHL chasing
a step they do not need.

## Scope

Docs only, no code and no schema. The §2 table is re-padded by prettier and otherwise
untouched.
