### PR TITLE
fix(eqa): take the shipment and cycle dates from the calendar alone (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/Provider/CycleWizard.jsx
+++ b/frontend/src/components/eqa/Provider/CycleWizard.jsx
@@ -33,7 +33,7 @@ import {
   resolveApiErrorMessage,
 } from "../../utils/Utils";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
-import { hintStyle } from "../eqaCommon";
+import { calendarOnlyInput, hintStyle } from "../eqaCommon";
 import { createProviderCycle } from "./Workbench/workbenchApi";
 // The same test list T-21's in-house wizard picks from: the standard catalog
 // narrowed to tests that carry an analyte, since a panel target is stored
@@ -332,6 +332,7 @@ const CycleWizard = () => {
                   }}
                 >
                   <DatePickerInput
+                    {...calendarOnlyInput}
                     id="cycle-planned-start"
                     labelText={t(
                       "eqa.provider.wizard.distributionDate",
@@ -340,6 +341,7 @@ const CycleWizard = () => {
                     placeholder="dd/mm/yyyy"
                   />
                   <DatePickerInput
+                    {...calendarOnlyInput}
                     id="cycle-planned-end"
                     labelText={t(
                       "eqa.provider.wizard.submissionDeadline",
@@ -650,6 +652,7 @@ const CycleWizard = () => {
                     }
                   >
                     <DatePickerInput
+                      {...calendarOnlyInput}
                       id="panel-expiration"
                       labelText={t(
                         "eqa.provider.wizard.expiration",

--- a/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
@@ -20,7 +20,7 @@ import {
   resolveApiErrorMessage,
   toLocalIsoDate,
 } from "../../../utils/Utils";
-import { hintStyle } from "../../eqaCommon";
+import { calendarOnlyInput, hintStyle } from "../../eqaCommon";
 import {
   generateLabelPDF,
   generateManifestPDF,
@@ -397,6 +397,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                           size="sm"
                           placeholder="dd/mm/yyyy"
                           disabled={isDispatched}
+                          {...calendarOnlyInput}
                         />
                       </DatePicker>
                     </TableCell>

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { IntlProvider } from "react-intl";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -206,6 +207,20 @@ describe("ProviderWorkbenchPage", () => {
     expect(
       screen.getByLabelText("Tracking number for District Lab A"),
     ).toBeInTheDocument();
+  });
+
+  test("the expected-delivery field refuses typed text, which the row never saved", async () => {
+    renderWorkbench();
+    fireEvent.click(screen.getByRole("tab", { name: "Shipments" }));
+
+    // Typing rendered a date on screen that the request then sent as an empty
+    // string, so the row reported a successful save and stored no date. The
+    // calendar is the only path that reaches the draft, so text entry is
+    // refused rather than accepted and dropped.
+    const field = screen.getByLabelText("Expected delivery for District Lab B");
+    await userEvent.type(field, "10/09/2026");
+
+    expect(field).toHaveValue("");
   });
 
   test("a pack list is refused rather than produced empty when samples cannot be read", async () => {

--- a/frontend/src/components/eqa/eqaCommon.jsx
+++ b/frontend/src/components/eqa/eqaCommon.jsx
@@ -37,6 +37,23 @@ const STATUS_TAG = {
   closed: "gray",
 };
 
+/**
+ * Props that make a Carbon date picker take its value from the calendar alone.
+ * flatpickr never parses what is typed into these fields, so text entry left a
+ * date on screen that the save then sent as an empty string. Refusing the
+ * keystrokes is honest about it. Modifier combinations pass through, so copy
+ * and keyboard navigation are unaffected, and the calendar still opens on focus.
+ */
+export const calendarOnlyInput = {
+  onKeyDown: (e) => {
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    if (e.key.length === 1 || e.key === "Backspace" || e.key === "Delete") {
+      e.preventDefault();
+    }
+  },
+  onPaste: (e) => e.preventDefault(),
+};
+
 /** RFC 4180 cell: everything quoted, embedded quotes doubled. */
 export const csvCell = (value) =>
   `"${String(value ?? "").replace(/"/g, '""')}"`;


### PR DESCRIPTION
## The defect

A date **typed** into the Shipments picker rendered on screen, the row reported *"Shipment details saved."*, and the request carried `estimatedDeliveryDate: ""`, so the shipment stored none. The courier and tracking number from the same request saved correctly, so the write landed and only the date was dropped.

Driven on the shipments workbench with a control, before the fix:

| leg | field shows | request | stored |
| --- | --- | --- | --- |
| typed `11/09/2026` | `11/09/2026` | `""` | NULL |
| typed with the calendar open | `11/09/202612/09/2026` (the text accumulates) | `""` | NULL |
| **chosen from the calendar** | `18/09/2026` | `2026-09-18` | **`2026-09-18`** |

The control proves the write path is sound, so the fault is entirely in the picker.

Two corrections to how this was first reported. It is **not** limited to unusual date formats: nothing typed commits, `d/m/Y` included. And it is **not** limited to Shipments: the cycle wizard's distribution date, submission deadline and panel expiry are the same construction with the same silent loss, and the expiry has no validity guard to catch it.

## Why a Carbon prop does not close it

flatpickr commits through its calendar alone. It never parses the typed text, so `onChange` — the only thing that writes the draft — never fires for a keystroke.

- `readOnly` on `DatePicker` sets `noCalendar: true` and `clickOpens: false`. It removes the calendar along with the typing, which is the one path that works.
- `allowInput={false}` is undone by Carbon itself: flatpickr sets the attribute at init, then Carbon's `onReady` hook writes `input.readOnly` back to the parent's `readOnly`, which is `false`.

## The change

`calendarOnlyInput` in `eqaCommon.jsx`, spread onto the four date inputs. It prevents text-mutating keys and paste, and lets modifier combinations through, so copy and keyboard navigation are unaffected and the calendar still opens on focus.

After the fix, on the same row: typing and Backspace are refused, and a date chosen from the calendar is sent as `2026-09-29` and stored.

Keyboard reachability was measured against the base rather than assumed. `Enter` does not open the calendar on the base either — flatpickr opens on focus — so nothing regresses there.

## Scope

Four inputs, all in the EQA provider screens. 40 Carbon date pickers exist across the frontend and none sets `allowInput`, so the same latent behaviour is app-wide; that is left alone here.

## Tests

`ProviderWorkbenchPage` gains one case: the expected-delivery field refuses typed text. It fails when the spread is removed.

Frontend gate run from `frontend/`, as CI runs it: prettier clean, eslint clean, vitest 181 files / 1241 passing.