### PR TITLE
feat(eqa): group a laboratory's EQA enrolments by status (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/MyProgramsPage.jsx
+++ b/frontend/src/components/eqa/MyProgramsPage.jsx
@@ -187,6 +187,9 @@ const MyProgramsPage = () => {
     status: e.isActive ? "Active" : "Inactive",
   }));
 
+  const statusOf = (row) =>
+    row.cells.find((c) => c.info.header === "status")?.value;
+
   const getEnrollmentById = (id) => {
     return enrollments.find((e) => String(e.id) === String(id));
   };
@@ -270,10 +273,40 @@ const MyProgramsPage = () => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {tableRows.map((row) => {
+                    {tableRows.map((row, index) => {
                       const enrollment = getEnrollmentById(row.id);
+                      // The rows arrive grouped, active first, so a heading is due
+                      // wherever the status changes from the row above.
+                      const status = statusOf(row);
+                      const startsGroup =
+                        index === 0 ||
+                        statusOf(tableRows[index - 1]) !== status;
                       return (
                         <React.Fragment key={row.id}>
+                          {startsGroup && (
+                            <TableRow>
+                              <TableCell
+                                colSpan={hdrs.length + 1}
+                                className="eqa-my-programs-group"
+                              >
+                                <strong>
+                                  {intl.formatMessage(
+                                    {
+                                      id:
+                                        status === "Active"
+                                          ? "eqa.myPrograms.group.active"
+                                          : "eqa.myPrograms.group.inactive",
+                                    },
+                                    {
+                                      count: tableRows.filter(
+                                        (r) => statusOf(r) === status,
+                                      ).length,
+                                    },
+                                  )}
+                                </strong>
+                              </TableCell>
+                            </TableRow>
+                          )}
                           <TableRow {...getRowProps({ row })}>
                             {row.cells.map((cell) => {
                               if (cell.info.header === "status") {

--- a/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
+++ b/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
@@ -136,6 +136,30 @@ describe("MyProgramsPage", () => {
     expect(screen.getByText("Inactive")).toBeTruthy();
   });
 
+  test("groups the rows under a heading per status, counted", () => {
+    renderPage();
+
+    // The fixture holds one active and one inactive enrolment, so each heading
+    // carries a count of one rather than a total of both.
+    expect(screen.getByText("Active enrolments (1)")).toBeTruthy();
+    expect(screen.getByText("Inactive enrolments (1)")).toBeTruthy();
+  });
+
+  test("each heading precedes the rows it covers", () => {
+    renderPage();
+
+    const text = document.body.textContent;
+    const activeHeading = text.indexOf("Active enrolments (1)");
+    const chemistry = text.indexOf("Chemistry PT");
+    const inactiveHeading = text.indexOf("Inactive enrolments (1)");
+    const hematology = text.indexOf("Hematology PT");
+
+    // A heading below its own rows would read as covering the group after it.
+    expect(activeHeading).toBeLessThan(chemistry);
+    expect(chemistry).toBeLessThan(inactiveHeading);
+    expect(inactiveHeading).toBeLessThan(hematology);
+  });
+
   test("renders count tags for enrolled program", () => {
     renderPage();
     // Chemistry PT has: 1 lab unit, 2 tests, 1 panel

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8622,5 +8622,7 @@
   "eqa.performance.noRate": "No scored cycle yet",
   "eqa.performance.noCycles": "This laboratory has not reported into a scored cycle yet.",
   "eqa.performance.empty": "No laboratory is enrolled in this scheme yet.",
-  "eqa.performance.loadFailed": "Could not load participant performance"
+  "eqa.performance.loadFailed": "Could not load participant performance",
+  "eqa.myPrograms.group.active": "Active enrolments ({count})",
+  "eqa.myPrograms.group.inactive": "Inactive enrolments ({count})"
 }

--- a/src/main/java/org/openelisglobal/eqa/daoimpl/EQALabProgramEnrollmentDAOImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/daoimpl/EQALabProgramEnrollmentDAOImpl.java
@@ -29,7 +29,10 @@ public class EQALabProgramEnrollmentDAOImpl extends BaseDAOImpl<EQALabProgramEnr
     @Transactional(readOnly = true)
     public List<EQALabProgramEnrollment> findAll() {
         try {
-            String hql = "FROM EQALabProgramEnrollment e ORDER BY e.programName";
+            // Active enrollments first, so the page can group them under a heading
+            // and a laboratory reads what it is currently enrolled in without
+            // picking it out from among the ones it has left.
+            String hql = "FROM EQALabProgramEnrollment e ORDER BY e.isActive DESC, e.programName";
             Query<EQALabProgramEnrollment> query = entityManager.unwrap(Session.class).createQuery(hql,
                     EQALabProgramEnrollment.class);
             return query.list();

--- a/src/test/java/org/openelisglobal/eqa/EQAMyProgramsOrderingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAMyProgramsOrderingIntegrationTest.java
@@ -1,0 +1,68 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
+import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * My EQA Programs lists a laboratory's enrolments grouped by status, which the
+ * page can only do if they arrive grouped. The names here are chosen so that
+ * ordering by name alone produces the opposite order: the active enrolment
+ * sorts last alphabetically and must still be listed first.
+ */
+public class EQAMyProgramsOrderingIntegrationTest extends EQASpineTestBase {
+
+    @Autowired
+    private EQALabProgramEnrollmentService enrollmentService;
+
+    private EQALabProgramEnrollment enrol(String programName, boolean active) {
+        EQALabProgramEnrollment enrollment = new EQALabProgramEnrollment();
+        enrollment.setProgramName(programName);
+        enrollment.setProvider("Ordering test provider");
+        enrollment.setIsActive(active);
+        enrollment.setSysUserId(USER);
+        return enrollmentService.createEnrollment(enrollment, null, null, null, null);
+    }
+
+    @Test
+    public void activeEnrolmentsAreListedBeforeInactiveOnes() {
+        enrol("Zeta ordering active", true);
+        enrol("Alpha ordering inactive", false);
+        enrol("Beta ordering active", true);
+
+        List<String> listed = enrollmentService.findAll().stream()
+                .filter(e -> "Ordering test provider".equals(e.getProvider()))
+                .map(EQALabProgramEnrollment::getProgramName).collect(Collectors.toList());
+
+        // Both active ones first and alphabetical within the group, so the page
+        // can start a heading wherever the status changes.
+        assertEquals(List.of("Beta ordering active", "Zeta ordering active", "Alpha ordering inactive"), listed);
+    }
+
+    @Test
+    public void theStatusGroupsAreContiguousAcrossEveryEnrolment() {
+        enrol("Zeta contiguity active", true);
+        enrol("Alpha contiguity inactive", false);
+
+        List<Boolean> statuses = enrollmentService.findAll().stream().map(EQALabProgramEnrollment::getIsActive)
+                .collect(Collectors.toList());
+
+        // A heading per status only reads correctly if the status changes once
+        // across the whole list, whatever else the database already holds.
+        long changes = 0;
+        for (int i = 1; i < statuses.size(); i++) {
+            if (!statuses.get(i).equals(statuses.get(i - 1))) {
+                changes++;
+            }
+        }
+        assertTrue("expected active rows then inactive rows, saw " + changes + " status changes in " + statuses,
+                changes <= 1);
+        assertTrue("expected the list to start with the active enrolments", statuses.get(0));
+    }
+}


### PR DESCRIPTION
## The gap

My EQA Programs listed every enrolment in one block ordered by programme name, with nothing grouping or ordering them by status. A laboratory had to pick the programmes it is currently enrolled in out from among the ones it has left.

Seen on the rig, where a retired enrolment named to sort first appears above both active ones:

```
AAA retired grouping fixture   Inactive
CPHL National HIV Serology EQA  Active
CPHL National HIV Viral Load EQA  Active
```

## The change

Two halves.

`EQALabProgramEnrollmentDAOImpl.findAll` orders by `isActive DESC, programName`, so active enrolments arrive first and alphabetically within each status. The sibling `findByActive` query is left alone: it filters to a single status, so a status term there would be noise.

`MyProgramsPage` starts a heading wherever the status changes from the row above, carrying that group's count. The table has no sorting enabled, so server order holds and the headings cannot drift away from the rows they cover.

## Scope note

Grouping is by the active flag, which is the only status this page holds today, so the groups are Active and Inactive. Suspension and withdrawal with a reason and an effective date are not built. If they are added later, the headings follow the statuses they bring, and the sort term is where that change lands.

## Tests

`EQAMyProgramsOrderingIntegrationTest` persists three enrolments through the service against a real database and asserts the exact returned order. The names are chosen so ordering by name alone produces the opposite result: the active enrolments sort last alphabetically and must still come first. A second case asserts the status changes at most once across the whole list, which is the property the headings depend on. Both fail against the previous query, with the reversed order in the failure message.

`MyProgramsPage` gains two cases: each heading renders with its own count, and each heading precedes the rows it covers. Both fail when the heading block is removed.

Frontend gate from `frontend/`: prettier clean, eslint clean, vitest 181 files / 1243 passing. `spotless:apply` clean.

## Verification

The headings were driven on a live instance with a disposable retired enrolment, which rendered as `Inactive enrolments (1)` above its row and `Active enrolments (2)` above the other two. That instance serves a WAR built before this change, so the row order there is still the old one; the ordering half is covered by the integration test rather than on the rig. The fixture has been removed.