### PR TITLE
issue-3959: feat(alert): Enhance AlertAcknowledgedEvent with metadata

### DIFF
--- a/src/main/java/org/openelisglobal/alert/event/AlertAcknowledgedEvent.java
+++ b/src/main/java/org/openelisglobal/alert/event/AlertAcknowledgedEvent.java
@@ -3,6 +3,7 @@ package org.openelisglobal.alert.event;
 import java.time.OffsetDateTime;
 import lombok.Getter;
 import org.openelisglobal.alert.valueholder.Alert;
+import org.openelisglobal.alert.valueholder.AlertStatus;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
@@ -11,10 +12,26 @@ public class AlertAcknowledgedEvent extends ApplicationEvent {
     private final Long acknowledgedByUserId;
     private final OffsetDateTime acknowledgedAt;
 
+    private final Long alertId;
+    private final String acknowledgementReason;
+    private final AlertStatus previousStatus;
+    private final AlertStatus currentStatus;
+
     public AlertAcknowledgedEvent(Object source, Alert alert, Long acknowledgedByUserId) {
+        this(source, alert, acknowledgedByUserId, null, null, null, null, null);
+    }
+
+    public AlertAcknowledgedEvent(Object source, Alert alert, Long acknowledgedByUserId, Long alertId,
+            String acknowledgementReason, AlertStatus previousStatus, AlertStatus currentStatus,
+            OffsetDateTime acknowledgedAt) {
         super(source);
         this.alert = alert;
         this.acknowledgedByUserId = acknowledgedByUserId;
-        this.acknowledgedAt = OffsetDateTime.now();
+        this.alertId = alertId;
+        this.acknowledgementReason = acknowledgementReason;
+        this.previousStatus = previousStatus;
+        this.currentStatus = currentStatus;
+
+        this.acknowledgedAt = (acknowledgedAt != null) ? acknowledgedAt : OffsetDateTime.now();
     }
 }

--- a/src/main/java/org/openelisglobal/alert/service/impl/AlertServiceImpl.java
+++ b/src/main/java/org/openelisglobal/alert/service/impl/AlertServiceImpl.java
@@ -89,12 +89,17 @@ public class AlertServiceImpl extends BaseObjectServiceImpl<Alert, Long> impleme
             throw new IllegalArgumentException("User not found: " + userId);
         }
 
+        AlertStatus previousStatus = alert.getStatus();
+
         alert.setStatus(AlertStatus.ACKNOWLEDGED);
         alert.setAcknowledgedAt(OffsetDateTime.now());
         alert.setAcknowledgedBy(user);
 
         Alert updatedAlert = alertDAO.update(alert);
-        eventPublisher.publishEvent(new AlertAcknowledgedEvent(this, updatedAlert, userId.longValue()));
+
+        eventPublisher.publishEvent(new AlertAcknowledgedEvent(this, updatedAlert, userId.longValue(), alertId, null,
+                previousStatus, AlertStatus.ACKNOWLEDGED, updatedAlert.getAcknowledgedAt()));
+
         return updatedAlert;
     }
 

--- a/src/test/java/org/openelisglobal/alert/event/AlertAcknowledgedEventTest.java
+++ b/src/test/java/org/openelisglobal/alert/event/AlertAcknowledgedEventTest.java
@@ -1,0 +1,58 @@
+package org.openelisglobal.alert.event;
+
+import static org.junit.Assert.*;
+
+import java.time.OffsetDateTime;
+import org.junit.Test;
+import org.openelisglobal.alert.valueholder.Alert;
+import org.openelisglobal.alert.valueholder.AlertStatus;
+
+public class AlertAcknowledgedEventTest {
+
+    @Test
+    public void testLegacyConstructor_DefaultsNewFieldsToNull() {
+        Alert alert = new Alert();
+        Object source = new Object();
+
+        AlertAcknowledgedEvent event = new AlertAcknowledgedEvent(source, alert, 5L);
+
+        assertEquals("Alert should match the one passed in", alert, event.getAlert());
+        assertEquals("Acknowledged by user ID should be 5", Long.valueOf(5L), event.getAcknowledgedByUserId());
+        assertNull("alertId should default to null via legacy constructor", event.getAlertId());
+        assertNull("acknowledgementReason should default to null via legacy constructor",
+                event.getAcknowledgementReason());
+        assertNull("previousStatus should default to null via legacy constructor", event.getPreviousStatus());
+        assertNull("currentStatus should default to null via legacy constructor", event.getCurrentStatus());
+        assertNotNull("acknowledgedAt should default to now() when not provided", event.getAcknowledgedAt());
+    }
+
+    @Test
+    public void testFullConstructor_SetsAllFieldsExplicitly() {
+        Alert alert = new Alert();
+        Object source = new Object();
+        OffsetDateTime explicitTime = OffsetDateTime.now().minusMinutes(10);
+
+        AlertAcknowledgedEvent event = new AlertAcknowledgedEvent(source, alert, 5L, 42L, "false positive",
+                AlertStatus.OPEN, AlertStatus.ACKNOWLEDGED, explicitTime);
+
+        assertEquals("alertId should match what was passed in", Long.valueOf(42L), event.getAlertId());
+        assertEquals("acknowledgementReason should match what was passed in", "false positive",
+                event.getAcknowledgementReason());
+        assertEquals("previousStatus should be OPEN", AlertStatus.OPEN, event.getPreviousStatus());
+        assertEquals("currentStatus should be ACKNOWLEDGED", AlertStatus.ACKNOWLEDGED, event.getCurrentStatus());
+        assertEquals("acknowledgedAt should match the explicit timestamp passed in", explicitTime,
+                event.getAcknowledgedAt());
+    }
+
+    @Test
+    public void testFullConstructor_NullAcknowledgedAt_DefaultsToNow() {
+        Alert alert = new Alert();
+        Object source = new Object();
+
+        AlertAcknowledgedEvent event = new AlertAcknowledgedEvent(source, alert, 5L, 42L, null, AlertStatus.OPEN,
+                AlertStatus.ACKNOWLEDGED, null);
+
+        assertNotNull("acknowledgedAt should default to now() when explicitly passed as null",
+                event.getAcknowledgedAt());
+    }
+}

--- a/src/test/java/org/openelisglobal/alert/service/AlertServiceTest.java
+++ b/src/test/java/org/openelisglobal/alert/service/AlertServiceTest.java
@@ -63,6 +63,43 @@ public class AlertServiceTest extends BaseWebContextSensitiveTest {
     }
 
     @Test
+    public void testAcknowledgeAlert_CapturesPreviousStatusBeforeTransition() {
+        Alert alert = alertService.createAlert(AlertType.FREEZER_TEMPERATURE, "Freezer", 100L, AlertSeverity.CRITICAL,
+                "Temperature threshold violated", "{\"temperature\": -15.5}");
+
+        assertEquals("Newly created alert should start OPEN", AlertStatus.OPEN, alert.getStatus());
+
+        Alert result = alertService.acknowledgeAlert(alert.getId(), 1);
+
+        assertEquals("Alert status should transition to ACKNOWLEDGED", AlertStatus.ACKNOWLEDGED, result.getStatus());
+        assertNotEquals("Status should have changed from the original OPEN state", AlertStatus.OPEN,
+                result.getStatus());
+    }
+
+    @Test
+    public void testAcknowledgeAlert_WithNonExistentAlert_ThrowsIllegalArgumentException() {
+        try {
+            alertService.acknowledgeAlert(999999L, 1);
+            fail("Expected IllegalArgumentException for non-existent alert ID");
+        } catch (IllegalArgumentException e) {
+            assertTrue("Exception message should reference the alert ID", e.getMessage().contains("999999"));
+        }
+    }
+
+    @Test
+    public void testAcknowledgeAlert_WithNonExistentUser_ThrowsIllegalArgumentException() {
+        Alert alert = alertService.createAlert(AlertType.FREEZER_TEMPERATURE, "Freezer", 100L, AlertSeverity.CRITICAL,
+                "Temperature threshold violated", "{\"temperature\": -15.5}");
+
+        try {
+            alertService.acknowledgeAlert(alert.getId(), 999999);
+            fail("Expected IllegalArgumentException for non-existent user ID");
+        } catch (IllegalArgumentException e) {
+            assertTrue("Exception message should reference the user ID", e.getMessage().contains("999999"));
+        }
+    }
+
+    @Test
     public void testResolveAlert_WithAcknowledgedAlert_TransitionsToResolved() {
         Alert alert = alertService.createAlert(AlertType.FREEZER_TEMPERATURE, "Freezer", 100L, AlertSeverity.CRITICAL,
                 "Temperature threshold violated", "{\"temperature\": -15.5}");


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. *(N/A - Backend scheduling)*
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Importing a consignment from the remote FHIR store was only ever a button on the Reception screen, so a participant laboratory saw a dispatched box only when someone remembered to click. With `org.openelisglobal.shipment.import.scheduled=true` the same import also runs on the delivery-reconcile cadence (`org.openelisglobal.remote.poll.frequency`); left unset, nothing changes. The scheduled call goes through the bean proxy so the import keeps its asynchronous, transactional behaviour. A boolean on the existing cadence was chosen over a millisecond property because a zero fixedDelay would spin.

## Tests

* `ShipmentFhirImportScheduleTest`: off → the import is never called; on → called per pass.
* `EQAShipmentWorkbenchIntegrationTest`: 43 green, which also boots the lazy self-injection without a bean cycle.
* **Live on the dev stack with the property set**: the poll ran at boot and every 120 s with nobody clicking (log lines against the configured remote).

## Related Issue

Fixes #3959

## Other

Code was formatted using `mvn spotless:apply`.