### PR TITLE
feat(eqa): suspend, resume and withdraw a laboratory's own EQA enrolment (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/EnrollmentStatusModal.jsx
+++ b/frontend/src/components/eqa/EnrollmentStatusModal.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import {
+  DatePicker,
+  DatePickerInput,
+  Modal,
+  Stack,
+  TextArea,
+} from "@carbon/react";
+import { useIntl } from "react-intl";
+import { toLocalIsoDate } from "../utils/Utils";
+import { calendarOnlyInput } from "./eqaCommon";
+
+/**
+ * Moves one of this laboratory's EQA enrolments between Active, Suspended and
+ * Withdrawn. Both fields are required: the status the enrolment lands in is only
+ * half the record, and the reason and the date it takes effect from are what a
+ * later reader needs.
+ */
+const ACTION_LABEL = {
+  Active: "eqa.enrollment.resume",
+  Suspended: "eqa.enrollment.suspend",
+  Withdrawn: "eqa.enrollment.withdraw",
+};
+
+const EnrollmentStatusModal = ({
+  enrollment,
+  nextStatus,
+  onClose,
+  onConfirm,
+}) => {
+  const intl = useIntl();
+  const [reason, setReason] = useState("");
+  const [effectiveDate, setEffectiveDate] = useState("");
+
+  const actionLabel = intl.formatMessage({
+    id: ACTION_LABEL[nextStatus] || "eqa.enrollment.suspend",
+  });
+
+  return (
+    <Modal
+      open
+      danger={nextStatus === "Withdrawn"}
+      modalHeading={actionLabel}
+      primaryButtonText={actionLabel}
+      secondaryButtonText={intl.formatMessage({ id: "label.button.cancel" })}
+      primaryButtonDisabled={!reason.trim() || !effectiveDate}
+      onRequestClose={onClose}
+      onRequestSubmit={() => onConfirm(reason, effectiveDate)}
+    >
+      <Stack gap={5}>
+        {enrollment && (
+          <p style={{ fontWeight: 600 }}>
+            {enrollment.programName} — {enrollment.provider}
+          </p>
+        )}
+        {nextStatus === "Withdrawn" && (
+          <p>{intl.formatMessage({ id: "eqa.enrollment.withdrawIsFinal" })}</p>
+        )}
+        <TextArea
+          id="enrollment-status-reason"
+          labelText={intl.formatMessage({
+            id: "eqa.enrollment.statusReason",
+          })}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder={intl.formatMessage({
+            id: "eqa.enrollment.statusReasonPlaceholder",
+          })}
+        />
+        <DatePicker
+          datePickerType="single"
+          dateFormat="Y-m-d"
+          value={effectiveDate ? [effectiveDate] : []}
+          onChange={(dates) =>
+            setEffectiveDate(dates.length ? toLocalIsoDate(dates[0]) : "")
+          }
+        >
+          <DatePickerInput
+            {...calendarOnlyInput}
+            id="enrollment-status-effective-date"
+            labelText={intl.formatMessage({
+              id: "eqa.enrollment.statusEffectiveDate",
+            })}
+            placeholder="yyyy-mm-dd"
+          />
+        </DatePicker>
+      </Stack>
+    </Modal>
+  );
+};
+
+export default EnrollmentStatusModal;

--- a/frontend/src/components/eqa/InlineEnrollmentForm.jsx
+++ b/frontend/src/components/eqa/InlineEnrollmentForm.jsx
@@ -4,7 +4,6 @@ import {
   Column,
   TextInput,
   TextArea,
-  Toggle,
   Button,
   FilterableMultiSelect,
   Select,
@@ -34,9 +33,6 @@ const InlineEnrollmentForm = ({
   );
   const [description, setDescription] = useState(
     enrollment ? enrollment.description || "" : "",
-  );
-  const [isActive, setIsActive] = useState(
-    enrollment ? enrollment.isActive : true,
   );
   const [selectedLabUnits, setSelectedLabUnits] = useState([]);
   const [selectedTests, setSelectedTests] = useState([]);
@@ -144,7 +140,6 @@ const InlineEnrollmentForm = ({
       programName,
       provider,
       description,
-      isActive,
       labUnitIds: selectedLabUnits.map((u) => Number(u.id)),
       testIds: selectedTests.map((t) => Number(t.id)),
       panelIds: selectedPanels.map((p) => Number(p.id)),
@@ -372,19 +367,11 @@ const InlineEnrollmentForm = ({
       <div
         style={{
           display: "flex",
-          justifyContent: "space-between",
+          justifyContent: "flex-end",
           alignItems: "center",
           marginTop: "1rem",
         }}
       >
-        <Toggle
-          id="enrollment-active-toggle"
-          labelText={intl.formatMessage({ id: "eqa.enrollment.status" })}
-          labelA={intl.formatMessage({ id: "eqa.status.inactive" })}
-          labelB={intl.formatMessage({ id: "eqa.status.active" })}
-          toggled={isActive}
-          onToggle={(checked) => setIsActive(checked)}
-        />
         <div style={{ display: "flex", gap: "0.5rem" }}>
           <Button kind="secondary" size="sm" onClick={onCancel}>
             {intl.formatMessage({ id: "label.button.cancel" })}

--- a/frontend/src/components/eqa/MyProgramsPage.jsx
+++ b/frontend/src/components/eqa/MyProgramsPage.jsx
@@ -28,10 +28,45 @@ import {
   getFromOpenElisServer,
   postToOpenElisServerJsonResponse,
   putToOpenElisServer,
+  putToOpenElisServerFullResponse,
+  resolveApiErrorMessage,
 } from "../utils/Utils";
 import { NotificationContext } from "../layout/Layout";
 import { NotificationKinds } from "../common/CustomNotification";
 import InlineEnrollmentForm from "./InlineEnrollmentForm";
+import EnrollmentStatusModal from "./EnrollmentStatusModal";
+
+/** The heading each status group carries, and the colour its tag takes. */
+const STATUS_GROUP_KEY = {
+  Active: "eqa.myPrograms.group.active",
+  Suspended: "eqa.myPrograms.group.suspended",
+  Withdrawn: "eqa.myPrograms.group.withdrawn",
+};
+
+const STATUS_LABEL_KEY = {
+  Active: "eqa.enrollment.status.active",
+  Suspended: "eqa.enrollment.status.suspended",
+  Withdrawn: "eqa.enrollment.status.withdrawn",
+};
+
+const STATUS_TAG_TYPE = {
+  Active: "green",
+  Suspended: "cyan",
+  Withdrawn: "gray",
+};
+
+/** Where an enrolment in each status may go next. */
+const NEXT_STATUSES = {
+  Active: ["Suspended", "Withdrawn"],
+  Suspended: ["Active", "Withdrawn"],
+  Withdrawn: [],
+};
+
+const STATUS_ACTION_KEY = {
+  Active: "eqa.enrollment.resume",
+  Suspended: "eqa.enrollment.suspend",
+  Withdrawn: "eqa.enrollment.withdraw",
+};
 
 const breadcrumbs = [
   { label: "home.label", link: "/" },
@@ -47,6 +82,7 @@ const MyProgramsPage = () => {
   const [loading, setLoading] = useState(true);
   const [showNewForm, setShowNewForm] = useState(false);
   const [editingId, setEditingId] = useState(null);
+  const [statusChange, setStatusChange] = useState(null);
 
   useEffect(() => {
     fetchEnrollments();
@@ -119,33 +155,49 @@ const MyProgramsPage = () => {
     );
   };
 
-  const handleDeactivate = (enrollment) => {
-    const payload = {
-      programName: enrollment.programName,
-      provider: enrollment.provider,
-      description: enrollment.description,
-      isActive: !enrollment.isActive,
-      labUnitIds: (enrollment.labUnits || []).map((u) => u.id),
-      testIds: (enrollment.tests || []).map((t) => t.id),
-      panelIds: (enrollment.panels || []).map((p) => p.id),
-    };
-    putToOpenElisServer(
-      `/rest/eqa/my-programs/${enrollment.id}`,
-      JSON.stringify(payload),
-      (status) => {
-        if (status === 200) {
+  const handleStatusChange = (reason, effectiveDate) => {
+    const { enrollment, nextStatus } = statusChange;
+    putToOpenElisServerFullResponse(
+      `/rest/eqa/my-programs/${enrollment.id}/status`,
+      JSON.stringify({ status: nextStatus, reason, effectiveDate }),
+      (response) => {
+        setStatusChange(null);
+        if (response && response.ok) {
           addNotification({
             kind: NotificationKinds.success,
             title: intl.formatMessage({ id: "notification.title" }),
-            subtitle: intl.formatMessage({
-              id: enrollment.isActive
-                ? "eqa.enrollment.deactivated"
-                : "eqa.enrollment.reactivated",
-            }),
+            subtitle: intl.formatMessage(
+              { id: "eqa.enrollment.statusChanged" },
+              {
+                status: intl.formatMessage({
+                  id: STATUS_LABEL_KEY[nextStatus],
+                }),
+              },
+            ),
             message: "",
           });
           fetchEnrollments();
+          return;
         }
+        const report = (body) =>
+          addNotification({
+            kind: NotificationKinds.error,
+            title: intl.formatMessage({ id: "notification.title" }),
+            subtitle: resolveApiErrorMessage(
+              intl,
+              body,
+              "eqa.enrollment.statusChangeFailed",
+            ),
+            message: "",
+          });
+        if (!response) {
+          report(null);
+          return;
+        }
+        response
+          .json()
+          .then(report)
+          .catch(() => report(null));
       },
     );
   };
@@ -184,7 +236,9 @@ const MyProgramsPage = () => {
     labUnits: (e.labUnits || []).length,
     tests: (e.tests || []).length,
     panels: (e.panels || []).length,
-    status: e.isActive ? "Active" : "Inactive",
+    // An enrolment made before the lifecycle columns existed is read from the
+    // flag the rest of the module still keys on.
+    status: e.status || (e.isActive ? "Active" : "Suspended"),
   }));
 
   const statusOf = (row) =>
@@ -291,12 +345,7 @@ const MyProgramsPage = () => {
                               >
                                 <strong>
                                   {intl.formatMessage(
-                                    {
-                                      id:
-                                        status === "Active"
-                                          ? "eqa.myPrograms.group.active"
-                                          : "eqa.myPrograms.group.inactive",
-                                    },
+                                    { id: STATUS_GROUP_KEY[status] },
                                     {
                                       count: tableRows.filter(
                                         (r) => statusOf(r) === status,
@@ -313,18 +362,11 @@ const MyProgramsPage = () => {
                                 return (
                                   <TableCell key={cell.id}>
                                     <Tag
-                                      type={
-                                        cell.value === "Active"
-                                          ? "green"
-                                          : "gray"
-                                      }
+                                      type={STATUS_TAG_TYPE[cell.value]}
                                       size="sm"
                                     >
                                       {intl.formatMessage({
-                                        id:
-                                          cell.value === "Active"
-                                            ? "eqa.status.active"
-                                            : "eqa.status.inactive",
+                                        id: STATUS_LABEL_KEY[cell.value],
                                       })}
                                     </Tag>
                                   </TableCell>
@@ -386,17 +428,24 @@ const MyProgramsPage = () => {
                                     setShowNewForm(false);
                                   }}
                                 />
-                                <OverflowMenuItem
-                                  itemText={intl.formatMessage({
-                                    id:
-                                      enrollment && enrollment.isActive
-                                        ? "eqa.action.deactivate"
-                                        : "eqa.action.reactivate",
-                                  })}
-                                  onClick={() =>
-                                    enrollment && handleDeactivate(enrollment)
-                                  }
-                                />
+                                {(NEXT_STATUSES[status] || []).map(
+                                  (nextStatus) => (
+                                    <OverflowMenuItem
+                                      key={nextStatus}
+                                      isDelete={nextStatus === "Withdrawn"}
+                                      itemText={intl.formatMessage({
+                                        id: STATUS_ACTION_KEY[nextStatus],
+                                      })}
+                                      onClick={() =>
+                                        enrollment &&
+                                        setStatusChange({
+                                          enrollment,
+                                          nextStatus,
+                                        })
+                                      }
+                                    />
+                                  ),
+                                )}
                               </OverflowMenu>
                             </TableCell>
                           </TableRow>
@@ -427,6 +476,15 @@ const MyProgramsPage = () => {
           </DataTable>
         </Column>
       </Grid>
+
+      {statusChange && (
+        <EnrollmentStatusModal
+          enrollment={statusChange.enrollment}
+          nextStatus={statusChange.nextStatus}
+          onClose={() => setStatusChange(null)}
+          onConfirm={handleStatusChange}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
+++ b/frontend/src/components/eqa/__tests__/MyProgramsPage.test.jsx
@@ -3,12 +3,21 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { IntlProvider } from "react-intl";
 import messages from "../../../languages/en.json";
 import MyProgramsPage from "../MyProgramsPage";
-import { getFromOpenElisServer } from "../../utils/Utils";
+import {
+  getFromOpenElisServer,
+  putToOpenElisServerFullResponse,
+} from "../../utils/Utils";
 
 vi.mock("../../utils/Utils", () => ({
   getFromOpenElisServer: vi.fn(),
   postToOpenElisServerJsonResponse: vi.fn(),
   putToOpenElisServer: vi.fn(),
+  putToOpenElisServerFullResponse: vi.fn(),
+  resolveApiErrorMessage: (_intl, _body, fallbackId) => fallbackId,
+  toLocalIsoDate: (date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+      date.getDate(),
+    ).padStart(2, "0")}`,
 }));
 
 vi.mock("../../layout/Layout", () => {
@@ -39,6 +48,13 @@ vi.mock("../../common/PageBreadCrumb", () => {
 
 // Replaced inline utils require
 
+// Carbon's floating menu stays visibility:hidden under jsdom, which takes its
+// items out of the accessibility tree that getByRole walks.
+const menuItem = (label) =>
+  screen
+    .queryAllByRole("menuitem", { hidden: true })
+    .find((item) => item.textContent.startsWith(label));
+
 const renderPage = () => {
   return render(
     <IntlProvider locale="en" messages={messages}>
@@ -59,6 +75,7 @@ describe("MyProgramsPage", () => {
             provider: "WHO",
             description: "Chemistry proficiency testing",
             isActive: true,
+            status: "Active",
             labUnits: [{ id: 10 }],
             tests: [{ id: 100 }, { id: 101 }],
             panels: [{ id: 200 }],
@@ -69,6 +86,7 @@ describe("MyProgramsPage", () => {
             provider: "CDC",
             description: "Hematology proficiency testing",
             isActive: false,
+            status: "Suspended",
             labUnits: [],
             tests: [],
             panels: [],
@@ -130,10 +148,10 @@ describe("MyProgramsPage", () => {
     expect(screen.getByText("Actions")).toBeTruthy();
   });
 
-  test("renders Active and Inactive status tags", () => {
+  test("renders a tag per lifecycle status", () => {
     renderPage();
     expect(screen.getByText("Active")).toBeTruthy();
-    expect(screen.getByText("Inactive")).toBeTruthy();
+    expect(screen.getByText("Suspended")).toBeTruthy();
   });
 
   test("groups the rows under a heading per status, counted", () => {
@@ -142,7 +160,7 @@ describe("MyProgramsPage", () => {
     // The fixture holds one active and one inactive enrolment, so each heading
     // carries a count of one rather than a total of both.
     expect(screen.getByText("Active enrolments (1)")).toBeTruthy();
-    expect(screen.getByText("Inactive enrolments (1)")).toBeTruthy();
+    expect(screen.getByText("Suspended enrolments (1)")).toBeTruthy();
   });
 
   test("each heading precedes the rows it covers", () => {
@@ -151,7 +169,7 @@ describe("MyProgramsPage", () => {
     const text = document.body.textContent;
     const activeHeading = text.indexOf("Active enrolments (1)");
     const chemistry = text.indexOf("Chemistry PT");
-    const inactiveHeading = text.indexOf("Inactive enrolments (1)");
+    const inactiveHeading = text.indexOf("Suspended enrolments (1)");
     const hematology = text.indexOf("Hematology PT");
 
     // A heading below its own rows would read as covering the group after it.
@@ -172,6 +190,41 @@ describe("MyProgramsPage", () => {
   test("renders breadcrumb navigation", () => {
     renderPage();
     expect(screen.getByTestId("breadcrumb")).toBeTruthy();
+  });
+
+  test("offers only the transitions each enrolment's status allows", () => {
+    renderPage();
+
+    const triggers = screen.getAllByRole("button", { name: /options/i });
+    // Active first, so the first row is Chemistry PT and the second the
+    // suspended Hematology PT.
+    fireEvent.click(triggers[0]);
+    expect(menuItem("Suspend")).toBeTruthy();
+    expect(menuItem("Withdraw")).toBeTruthy();
+    expect(menuItem("Resume")).toBeUndefined();
+
+    fireEvent.click(triggers[1]);
+    expect(menuItem("Resume")).toBeTruthy();
+    expect(menuItem("Suspend")).toBeUndefined();
+  });
+
+  test("a transition is refused until it carries a reason and a date", () => {
+    renderPage();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /options/i })[0]);
+    fireEvent.click(menuItem("Suspend"));
+
+    const confirm = screen
+      .getAllByRole("button", { name: "Suspend" })
+      .find((button) => button.classList.contains("cds--btn--primary"));
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText("Reason"), {
+      target: { value: "Analyser down for repair" },
+    });
+    // Still short of an effective date, so the transition stays refused.
+    expect(confirm.disabled).toBe(true);
+    expect(putToOpenElisServerFullResponse).not.toHaveBeenCalled();
   });
 
   test("shows inline enrollment form when Enroll in Program is clicked", () => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8624,7 +8624,15 @@
   "eqa.performance.empty": "No laboratory is enrolled in this scheme yet.",
   "eqa.performance.loadFailed": "Could not load participant performance",
   "eqa.myPrograms.group.active": "Active enrolments ({count})",
-  "eqa.myPrograms.group.inactive": "Inactive enrolments ({count})",
   "eqa.order.coverage.title": "Outside this laboratory's enrolment",
-  "eqa.order.coverage.subtitle": "The enrolment for this programme does not cover: {tests}. You can still save the order."
+  "eqa.order.coverage.subtitle": "The enrolment for this programme does not cover: {tests}. You can still save the order.",
+  "eqa.myPrograms.group.suspended": "Suspended enrolments ({count})",
+  "eqa.myPrograms.group.withdrawn": "Withdrawn enrolments ({count})",
+  "eqa.enrollment.resume": "Resume",
+  "eqa.enrollment.statusReason": "Reason",
+  "eqa.enrollment.statusReasonPlaceholder": "Why is this enrolment changing status?",
+  "eqa.enrollment.statusEffectiveDate": "Effective from",
+  "eqa.enrollment.withdrawIsFinal": "Withdrawing is final. To take part again, this laboratory enrols in the programme afresh.",
+  "eqa.enrollment.statusChanged": "This enrolment is now {status}",
+  "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status"
 }

--- a/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
+++ b/src/main/java/org/openelisglobal/eqa/controller/rest/EQAMyProgramsRestController.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.openelisglobal.analyte.service.AnalyteService;
-import org.openelisglobal.common.util.ControllerUtills;
+import org.openelisglobal.common.rest.BaseRestController;
 import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
 import org.openelisglobal.eqa.valueholder.EQALabEnrollmentTestMap;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rest/eqa/my-programs")
 @PreAuthorize(EQAGuards.READ)
-public class EQAMyProgramsRestController extends ControllerUtills {
+public class EQAMyProgramsRestController extends BaseRestController {
 
     @Autowired
     private EQALabProgramEnrollmentService enrollmentService;
@@ -105,7 +105,6 @@ public class EQAMyProgramsRestController extends ControllerUtills {
             updated.setProgramName(programName);
             updated.setProvider(provider);
             updated.setDescription((String) body.get("description"));
-            updated.setIsActive(body.get("isActive") != null ? (Boolean) body.get("isActive") : true);
             updated.setSysUserId(getSysUserId(request));
 
             List<Long> labUnitIds = toLongList(body.get("labUnitIds"));
@@ -120,6 +119,19 @@ public class EQAMyProgramsRestController extends ControllerUtills {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
         } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping(value = "/{id}/status", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize(EQAGuards.PARTICIPANT)
+    public ResponseEntity<?> updateMyProgramStatus(HttpServletRequest request, @PathVariable Long id,
+            @RequestBody Map<String, Object> body) {
+        try {
+            EQALabProgramEnrollment updated = enrollmentService.updateStatus(id, stringField(body, "status"),
+                    stringField(body, "reason"), dateField(body, "effectiveDate"), getSysUserId(request));
+            return ResponseEntity.ok(toDto(updated));
+        } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
     }
@@ -165,6 +177,10 @@ public class EQAMyProgramsRestController extends ControllerUtills {
         dto.put("provider", enrollment.getProvider());
         dto.put("description", enrollment.getDescription());
         dto.put("isActive", enrollment.getIsActive());
+        dto.put("status", enrollment.getStatus());
+        dto.put("statusReason", enrollment.getStatusReason());
+        dto.put("statusEffectiveDate", enrollment.getStatusEffectiveDate());
+        dto.put("statusChangedDate", enrollment.getStatusChangedDate());
         dto.put("createdDate", enrollment.getCreatedDate());
         dto.put("lastModified", enrollment.getLastModified());
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentService.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentService.java
@@ -1,11 +1,21 @@
 package org.openelisglobal.eqa.service;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.openelisglobal.common.service.BaseObjectService;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 
 public interface EQALabProgramEnrollmentService extends BaseObjectService<EQALabProgramEnrollment, Long> {
+
+    /**
+     * The three spellings the provider side already uses on eqa_program_enrollment.
+     */
+    String STATUS_ACTIVE = "Active";
+
+    String STATUS_SUSPENDED = "Suspended";
+
+    String STATUS_WITHDRAWN = "Withdrawn";
 
     List<EQALabProgramEnrollment> findAll();
 
@@ -22,6 +32,15 @@ public interface EQALabProgramEnrollmentService extends BaseObjectService<EQALab
 
     EQALabProgramEnrollment updateEnrollment(Long id, EQALabProgramEnrollment updated, List<Long> labUnitIds,
             List<Long> testIds, List<Long> panelIds, Map<Long, Long> testAnalytes);
+
+    /**
+     * Moves an enrolment between Active, Suspended and Withdrawn. Withdrawn is
+     * terminal, as it is for a provider's enrolment: a laboratory that comes back
+     * enrols again. The reason and the effective date are both required, and the
+     * prior status, the user and the time are written to the audit history.
+     */
+    EQALabProgramEnrollment updateStatus(Long id, String newStatus, String reason, Date effectiveDate,
+            String sysUserId);
 
     void softDelete(Long id);
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceImpl.java
@@ -7,11 +7,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openelisglobal.audittrail.dao.AuditTrailService;
+import org.openelisglobal.common.action.IActionConstants;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
 import org.openelisglobal.eqa.dao.EQALabProgramEnrollmentDAO;
 import org.openelisglobal.eqa.valueholder.EQALabEnrollmentLabUnit;
 import org.openelisglobal.eqa.valueholder.EQALabEnrollmentTestMap;
 import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +29,9 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
 
     @Autowired
     private EQALabProgramEnrollmentDAO enrollmentDAO;
+
+    @Autowired
+    private AuditTrailService auditTrailService;
 
     public EQALabProgramEnrollmentServiceImpl() {
         super(EQALabProgramEnrollment.class);
@@ -54,6 +60,7 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
 
         enrollment.setCreatedDate(new Date());
         enrollment.setIsActive(enrollment.getIsActive() != null ? enrollment.getIsActive() : true);
+        enrollment.setStatus(Boolean.FALSE.equals(enrollment.getIsActive()) ? STATUS_SUSPENDED : STATUS_ACTIVE);
 
         setMappings(enrollment, labUnitIds, testIds, panelIds, testAnalytes);
 
@@ -78,7 +85,9 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
         existing.setProgramName(updated.getProgramName());
         existing.setProvider(updated.getProvider());
         existing.setDescription(updated.getDescription());
-        existing.setIsActive(updated.getIsActive() != null ? updated.getIsActive() : existing.getIsActive());
+        // Editing an enrolment's details leaves its lifecycle alone. Suspending,
+        // resuming and withdrawing all need a reason and an effective date, so they
+        // go through updateStatus rather than riding on a plain save.
         existing.setLastModified(new Date());
         existing.setSysUserId(updated.getSysUserId());
 
@@ -96,12 +105,67 @@ public class EQALabProgramEnrollmentServiceImpl extends BaseObjectServiceImpl<EQ
     }
 
     @Override
+    public EQALabProgramEnrollment updateStatus(Long id, String newStatus, String reason, Date effectiveDate,
+            String sysUserId) {
+
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("A reason is required to change an enrollment's status");
+        }
+        if (effectiveDate == null) {
+            throw new IllegalArgumentException("An effective date is required to change an enrollment's status");
+        }
+
+        EQALabProgramEnrollment enrollment = enrollmentDAO.get(id)
+                .orElseThrow(() -> new IllegalArgumentException("Enrollment not found: " + id));
+        validateStatusTransition(enrollment.getStatus(), newStatus);
+
+        // The audit records the difference between two objects, so the state before
+        // the change needs an object of its own. Reading the row twice would not do
+        // it: the session hands back the same instance both times, and the second
+        // read would follow the first one's edits.
+        EQALabProgramEnrollment prior = new EQALabProgramEnrollment();
+        BeanUtils.copyProperties(enrollment, prior);
+
+        enrollment.setStatus(newStatus);
+        enrollment.setStatusReason(reason);
+        enrollment.setStatusEffectiveDate(effectiveDate);
+        enrollment.setStatusChangedDate(new Date());
+        enrollment.setStatusChangedBy(Long.valueOf(sysUserId));
+        enrollment.setIsActive(STATUS_ACTIVE.equals(newStatus));
+        enrollment.setLastModified(new Date());
+        enrollment.setSysUserId(sysUserId);
+
+        auditTrailService.saveHistory(enrollment, prior, sysUserId, IActionConstants.AUDIT_TRAIL_UPDATE,
+                "eqa_lab_program_enrollment");
+
+        return enrollmentDAO.update(enrollment);
+    }
+
+    @Override
     public void softDelete(Long id) {
         EQALabProgramEnrollment enrollment = enrollmentDAO.get(id)
                 .orElseThrow(() -> new IllegalArgumentException("Enrollment not found: " + id));
         enrollment.setIsActive(false);
+        enrollment.setStatus(STATUS_SUSPENDED);
         enrollment.setLastModified(new Date());
         enrollmentDAO.update(enrollment);
+    }
+
+    /**
+     * Active and Suspended swap either way, both lead to Withdrawn, and Withdrawn
+     * is the end of the row. A laboratory that comes back enrols again, which is
+     * how the provider's own enrolment behaves.
+     */
+    private void validateStatusTransition(String currentStatus, String newStatus) {
+        boolean valid = false;
+        if (STATUS_ACTIVE.equals(currentStatus)) {
+            valid = STATUS_SUSPENDED.equals(newStatus) || STATUS_WITHDRAWN.equals(newStatus);
+        } else if (STATUS_SUSPENDED.equals(currentStatus)) {
+            valid = STATUS_ACTIVE.equals(newStatus) || STATUS_WITHDRAWN.equals(newStatus);
+        }
+        if (!valid) {
+            throw new IllegalArgumentException("Cannot move an enrollment from " + currentStatus + " to " + newStatus);
+        }
     }
 
     @Override

--- a/src/main/java/org/openelisglobal/eqa/valueholder/EQALabProgramEnrollment.java
+++ b/src/main/java/org/openelisglobal/eqa/valueholder/EQALabProgramEnrollment.java
@@ -40,8 +40,28 @@ public class EQALabProgramEnrollment extends BaseObject<Long> {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
+    /**
+     * Whether the laboratory is taking part. Follows {@link #status}: only an
+     * Active enrolment sets it. The cycle gate, the submission bridge and the order
+     * screens all read this flag rather than the status spelling.
+     */
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status = "Active";
+
+    @Column(name = "status_reason", columnDefinition = "TEXT")
+    private String statusReason;
+
+    @Column(name = "status_effective_date")
+    private Date statusEffectiveDate;
+
+    @Column(name = "status_changed_date")
+    private Date statusChangedDate;
+
+    @Column(name = "status_changed_by")
+    private Long statusChangedBy;
 
     @Column(name = "created_date", nullable = false)
     private Date createdDate;

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -152,6 +152,8 @@
   <include file="liquibase/qa/038-eqa-panel-receipt-shipping-box.xml" />
   <!-- EQA V2.5 — OGC-613: qualitative participant results on the provider side (qa-078) -->
   <include file="liquibase/qa/039-eqa-result-text.xml" />
+  <!-- EQA V2.2 — OGC-935: lifecycle status on a laboratory's own enrolment (qa-081) -->
+  <include file="liquibase/qa/042-eqa-lab-enrollment-status.xml" />
 
   <!-- Clears an eqa-v2-start tag that an earlier version of qa/040 recorded without
        applying. Last on purpose: it repairs a changelog row, so it has to run after

--- a/src/main/resources/liquibase/qa/042-eqa-lab-enrollment-status.xml
+++ b/src/main/resources/liquibase/qa/042-eqa-lab-enrollment-status.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.2 (OGC-935): a laboratory's own enrolment carried only an is_active
+    flag, so it could be switched off but never suspended, and nothing recorded
+    why or from when. The provider side already models this on
+    eqa_program_enrollment; these columns give the participant side the same
+    vocabulary (Active, Suspended, Withdrawn) with the reason and the effective
+    date the transition was asked for.
+
+    is_active stays and follows the status: it is what the cycle gate, the
+    submission bridge and the order screens read, and none of them need to learn
+    a new spelling for "not taking part".
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-081-eqa-lab-enrollment-status">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status" />
+            </not>
+        </preConditions>
+        <comment>Lifecycle status, reason and effective date on a laboratory's EQA enrolment</comment>
+        <addColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment">
+            <column name="status" type="VARCHAR(20)" defaultValue="Active">
+                <constraints nullable="false" />
+            </column>
+            <column name="status_reason" type="TEXT" />
+            <column name="status_effective_date" type="DATE" />
+            <column name="status_changed_date" type="TIMESTAMP" />
+            <column name="status_changed_by" type="numeric(10,0)" />
+        </addColumn>
+        <!-- An enrolment switched off before this changeset was deactivated, which is
+             reversible. Withdrawn is terminal, so reading those rows as withdrawn would
+             strand every one of them. -->
+        <update schemaName="clinlims" tableName="eqa_lab_program_enrollment">
+            <column name="status" value="Suspended" />
+            <where>is_active = false</where>
+        </update>
+        <rollback>
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status_changed_by" />
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status_changed_date" />
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status_effective_date" />
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status_reason" />
+            <dropColumn schemaName="clinlims" tableName="eqa_lab_program_enrollment" columnName="status" />
+        </rollback>
+    </changeSet>
+
+    <!-- The transition writes a history row so the audit carries the prior status, the
+         user and the timestamp. AuditTrailServiceImpl.saveHistory THROWS (rolling back
+         the write) when a table has no reference_tables row, so this lands with the
+         columns, not later. -->
+    <changeSet author="openelisglobal" id="qa-081-register-lab-enrollment-audit-ref-table">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM clinlims.reference_tables WHERE LOWER(name) = 'eqa_lab_program_enrollment'</sqlCheck>
+        </preConditions>
+        <comment>Register eqa_lab_program_enrollment for audit history</comment>
+        <insert schemaName="clinlims" tableName="reference_tables">
+            <column name="id" valueSequenceNext="reference_tables_seq" />
+            <column name="name" value="eqa_lab_program_enrollment" />
+            <column name="keep_history" value="Y" />
+            <column name="lastupdated" valueDate="now()" />
+        </insert>
+        <rollback>
+            <delete schemaName="clinlims" tableName="reference_tables">
+                <where>LOWER(name) = 'eqa_lab_program_enrollment'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/EQALabEnrollmentStatusIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQALabEnrollmentStatusIntegrationTest.java
@@ -1,0 +1,177 @@
+package org.openelisglobal.eqa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.audittrail.daoimpl.AuditTrailServiceImpl;
+import org.openelisglobal.audittrail.valueholder.History;
+import org.openelisglobal.eqa.service.EQALabProgramEnrollmentService;
+import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
+import org.openelisglobal.history.service.HistoryService;
+import org.openelisglobal.referencetables.service.ReferenceTablesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * A laboratory suspends, resumes and withdraws its own EQA enrolment. Each move
+ * carries a reason and the date it takes effect, and the prior status reaches
+ * the audit history so a later reader can see what the enrolment was before.
+ */
+public class EQALabEnrollmentStatusIntegrationTest extends EQASpineTestBase {
+
+    private static final String PROVIDER = "Lifecycle test provider";
+
+    private static final Date EFFECTIVE = Date.valueOf("2026-09-30");
+
+    @Autowired
+    private EQALabProgramEnrollmentService enrollmentService;
+
+    @Autowired
+    private HistoryService historyService;
+
+    @Autowired
+    private ReferenceTablesService referenceTablesService;
+
+    /**
+     * AppTestConfig supplies a mock audit trail, which records nothing. The history
+     * assertions below need the real one, wired the way the container wires it.
+     */
+    @Before
+    public void useTheRealAuditTrail() {
+        AuditTrailServiceImpl realAuditTrail = new AuditTrailServiceImpl();
+        ReflectionTestUtils.setField(realAuditTrail, "referenceTablesService", referenceTablesService);
+        ReflectionTestUtils.setField(realAuditTrail, "historyService", historyService);
+        Object target = AopTestUtils.getUltimateTargetObject(enrollmentService);
+        ReflectionTestUtils.setField(target, "auditTrailService", realAuditTrail);
+    }
+
+    private EQALabProgramEnrollment enrol(String programName) {
+        EQALabProgramEnrollment enrollment = new EQALabProgramEnrollment();
+        enrollment.setProgramName(programName);
+        enrollment.setProvider(PROVIDER);
+        enrollment.setSysUserId(USER);
+        return enrollmentService.createEnrollment(enrollment, null, null, null, null);
+    }
+
+    /** Every audit row this table holds for one enrolment, oldest first. */
+    private List<History> audit(Long enrollmentId) {
+        String referenceTableId = referenceTablesService.getReferenceTableByName("eqa_lab_program_enrollment").getId();
+        List<History> rows = historyService.getHistoryByRefIdAndRefTableId(String.valueOf(enrollmentId),
+                referenceTableId);
+        rows.sort((left, right) -> Integer.compare(Integer.parseInt(left.getId()), Integer.parseInt(right.getId())));
+        return rows;
+    }
+
+    private String changesOf(History row) {
+        return new String(row.getChanges(), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void anEnrolmentIsCreatedActiveAndTakingPart() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle new enrolment");
+
+        assertEquals("Active", enrolled.getStatus());
+        assertTrue(enrolled.getIsActive());
+    }
+
+    @Test
+    public void suspendingRecordsTheReasonTheDateAndTakesTheLaboratoryOutOfPlay() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle suspend");
+
+        enrollmentService.updateStatus(enrolled.getId(), "Suspended", "Analyser away for repair", EFFECTIVE, USER);
+
+        EQALabProgramEnrollment reloaded = enrollmentService.get(enrolled.getId());
+        assertEquals("Suspended", reloaded.getStatus());
+        assertEquals("Analyser away for repair", reloaded.getStatusReason());
+        assertEquals(EFFECTIVE.toString(),
+                new SimpleDateFormat("yyyy-MM-dd").format(reloaded.getStatusEffectiveDate()));
+        assertEquals(Long.valueOf(USER), reloaded.getStatusChangedBy());
+        assertNotNull(reloaded.getStatusChangedDate());
+        // The rest of the module reads the flag, so a suspended laboratory has to
+        // fall out of the active enrolments the cycle gate sizes itself by.
+        assertFalse(reloaded.getIsActive());
+        assertFalse(
+                enrollmentService.findActiveEnrollments().stream().anyMatch(e -> e.getId().equals(enrolled.getId())));
+    }
+
+    @Test
+    public void aSuspendedEnrolmentResumesAndTakesPartAgain() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle resume");
+        enrollmentService.updateStatus(enrolled.getId(), "Suspended", "Analyser away for repair", EFFECTIVE, USER);
+
+        enrollmentService.updateStatus(enrolled.getId(), "Active", "Analyser back in service", EFFECTIVE, USER);
+
+        EQALabProgramEnrollment reloaded = enrollmentService.get(enrolled.getId());
+        assertEquals("Active", reloaded.getStatus());
+        assertEquals("Analyser back in service", reloaded.getStatusReason());
+        assertTrue(reloaded.getIsActive());
+        assertTrue(
+                enrollmentService.findActiveEnrollments().stream().anyMatch(e -> e.getId().equals(enrolled.getId())));
+    }
+
+    @Test
+    public void withdrawnIsTheEndOfTheRow() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle withdraw");
+
+        enrollmentService.updateStatus(enrolled.getId(), "Withdrawn", "Laboratory left the programme", EFFECTIVE, USER);
+
+        assertEquals("Withdrawn", enrollmentService.get(enrolled.getId()).getStatus());
+        // A laboratory that comes back enrols again rather than reviving this row,
+        // which is how a provider's own enrolment behaves.
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> enrollmentService.updateStatus(enrolled.getId(), "Active", "Changed our minds", EFFECTIVE, USER));
+        assertTrue(refused.getMessage(), refused.getMessage().contains("Withdrawn"));
+        assertEquals("Withdrawn", enrollmentService.get(enrolled.getId()).getStatus());
+    }
+
+    @Test
+    public void aTransitionWithoutAReasonOrADateIsRefused() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle required fields");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> enrollmentService.updateStatus(enrolled.getId(), "Suspended", "  ", EFFECTIVE, USER));
+        assertThrows(IllegalArgumentException.class,
+                () -> enrollmentService.updateStatus(enrolled.getId(), "Suspended", "No date given", null, USER));
+
+        // Neither attempt may have moved the enrolment.
+        assertEquals("Active", enrollmentService.get(enrolled.getId()).getStatus());
+    }
+
+    @Test
+    public void theAuditKeepsThePriorStatusTheReasonAndTheUser() {
+        EQALabProgramEnrollment enrolled = enrol("Lifecycle audit");
+
+        enrollmentService.updateStatus(enrolled.getId(), "Suspended", "Analyser away for repair", EFFECTIVE, USER);
+
+        List<History> rows = audit(enrolled.getId());
+        assertEquals(1, rows.size());
+        // The history row carries the values the enrolment held before the move,
+        // which is the half a status column on its own cannot answer.
+        String recorded = changesOf(rows.get(0));
+        assertTrue(recorded, recorded.contains("status") && recorded.contains("Active"));
+        assertEquals("U", rows.get(0).getActivity());
+        assertNotNull(rows.get(0).getTimestamp());
+
+        enrollmentService.updateStatus(enrolled.getId(), "Withdrawn", "Laboratory left the programme", EFFECTIVE, USER);
+
+        List<History> afterWithdrawal = audit(enrolled.getId());
+        assertEquals(2, afterWithdrawal.size());
+        String second = changesOf(afterWithdrawal.get(1));
+        assertTrue(second, second.contains("Suspended"));
+        assertTrue(second, second.contains("Analyser away for repair"));
+
+        assertEquals(List.of(USER, USER),
+                afterWithdrawal.stream().map(History::getSysUserId).collect(Collectors.toList()));
+    }
+}

--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardMatrixTest.java
@@ -110,6 +110,8 @@ public class EQARestGuardMatrixTest {
         // Participant lane — bench work, so the legacy roles still admit it
         WRITE_GUARDS.put("EQAMyProgramsRestController#createMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAMyProgramsRestController#updateMyProgram", EQAGuards.PARTICIPANT);
+        // A laboratory suspends, resumes and withdraws its own enrolment.
+        WRITE_GUARDS.put("EQAMyProgramsRestController#updateMyProgramStatus", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAMyProgramsRestController#deleteMyProgram", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQAPanelReceiptRestController#recordReceipt", EQAGuards.PARTICIPANT);
         WRITE_GUARDS.put("EQASubmissionRestController#submitManually", EQAGuards.PARTICIPANT);

--- a/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/service/EQALabProgramEnrollmentServiceTest.java
@@ -169,9 +169,9 @@ public class EQALabProgramEnrollmentServiceTest {
     }
 
     /**
-     * A status toggle sends no reporting-analyte map, and the update clears and
-     * rebuilds the test maps — so the stored analyte has to survive it. The
-     * participant's submission bridge resolves the analyte through this map.
+     * An edit that sends no reporting-analyte map clears and rebuilds the test
+     * maps, so the stored analyte has to survive it. The participant's submission
+     * bridge resolves the analyte through this map.
      */
     @Test
     public void testUpdateEnrollment_AbsentTestAnalytesKeepsStoredAnalyte() {
@@ -183,16 +183,42 @@ public class EQALabProgramEnrollmentServiceTest {
         EQALabProgramEnrollment updated = new EQALabProgramEnrollment();
         updated.setProgramName("Viral Load PT");
         updated.setProvider("CPHL");
-        updated.setIsActive(false);
         updated.setSysUserId("1");
 
         EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, null, List.of(191L), null, null);
 
-        assertFalse(result.getIsActive());
         assertEquals(1, result.getTestMaps().size());
         EQALabEnrollmentTestMap map = result.getTestMaps().iterator().next();
         assertEquals(Long.valueOf(191L), map.getTestId());
         assertEquals(Long.valueOf(103L), map.getAnalyteId());
+    }
+
+    /**
+     * Editing an enrolment's details leaves its lifecycle alone. Suspending,
+     * resuming and withdrawing all need a reason and an effective date, so they go
+     * through updateStatus; a save that carried a status with them would be a
+     * second, unreasoned way to move an enrolment.
+     */
+    @Test
+    public void testUpdateEnrollment_DoesNotMoveTheLifecycle() {
+        EQALabProgramEnrollment existing = enrollmentWithTestAnalyte(191L, 103L);
+        existing.setIsActive(true);
+        existing.setStatus("Active");
+
+        when(enrollmentDAO.get(1L)).thenReturn(Optional.of(existing));
+        when(enrollmentDAO.update(any(EQALabProgramEnrollment.class))).thenReturn(existing);
+
+        EQALabProgramEnrollment updated = new EQALabProgramEnrollment();
+        updated.setProgramName("Viral Load PT");
+        updated.setProvider("CPHL");
+        updated.setIsActive(false);
+        updated.setStatus("Withdrawn");
+        updated.setSysUserId("1");
+
+        EQALabProgramEnrollment result = service.updateEnrollment(1L, updated, null, List.of(191L), null, null);
+
+        assertTrue(result.getIsActive());
+        assertEquals("Active", result.getStatus());
     }
 
     /**


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
      Screenshots below instead.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

A laboratory's own EQA enrolment carried only an active flag, so it could be
switched off but never suspended, and nothing recorded why or from when. The
provider side already models this on `eqa_program_enrollment`; this gives the
participant side the same vocabulary.

**Schema** — `eqa_lab_program_enrollment` gains `status`, `status_reason`,
`status_effective_date`, `status_changed_date` and `status_changed_by`
(liquibase `qa/042`, changeset id `qa-081`). The changeset also registers the
table for audit history, because `AuditTrailServiceImpl.saveHistory` throws and
rolls the write back when a table has no `reference_tables` row.

**`is_active` stays and follows the status.** It is what the cycle gate, the
submission bridge and the order screens read, so none of them had to learn a new
spelling for "not taking part".

**The state rules mirror the provider's.** Active and Suspended swap either way,
both lead to Withdrawn, and Withdrawn is terminal — a laboratory that comes back
enrols again, which is what `PUT` back to Active already answers 400 for on
`eqa_program_enrollment`. The reason and the effective date are both required,
at the service and in the modal.

**An enrolment switched off before this change reads as Suspended**, not
Withdrawn. Withdrawn is terminal, so reading those rows as withdrawn would
strand every one of them.

**The audit carries the prior state.** The transition writes a `history` row
through the product's own audit trail, so the status the enrolment held before
the change is recorded with the user and the timestamp; the reason is on the row.

**One thing removed rather than added:** the active toggle in the edit form and
the Deactivate menu item both moved an enrolment's status with no reason
attached. Editing details now leaves the lifecycle alone, so a status can only
move through a path that records why.

## Screenshots

| | |
| --- | --- |
| Row menu | Edit / Suspend / Withdraw on an Active enrolment; Edit / Resume / Withdraw on a Suspended one |
| Modal | reason and effective date, confirm disabled until both are filled |
| Table | headings and counts per status group |

## Related Issue

OGC-935. Acceptance criterion AC-V2.2-E04.

## Other

**Tests.** `EQALabEnrollmentStatusIntegrationTest` covers the six behaviours
against a real database: creation is Active and taking part; a suspension stores
the reason, the date and the user and drops the row out of the active enrolments;
a resume puts it back; Withdrawn refuses every onward transition and the row is
unchanged after the refusal; a blank reason and a missing effective date are both
refused and move nothing; and the audit holds the prior status, the reason and
the user across two transitions.

`MyProgramsPage.test.jsx` covers the menu offering only the transitions each
status allows, and the modal refusing a transition that carries a reason but no
date — the control that shows the date is required in its own right.

**Two notes for anyone extending the tests.** `AppTestConfig` supplies a mock
`AuditTrailService`, and a field named `auditTrailService` binds to it by name, so
a test asserting on history has to wire the real one in — `PatientMultiFieldAuditTrailIntegrationTest`
is the pattern. And `getChanges` compares two objects: reading the row twice hands
back the same instance, so the diff comes out empty and no history row is written,
with no error to say so.
