### PR TITLE
feat(eqa): warn when an EQA order names a test the enrolment does not cover (OGC-935)

### DIFF
--- a/frontend/src/components/addOrder/Index.jsx
+++ b/frontend/src/components/addOrder/Index.jsx
@@ -25,6 +25,7 @@ import OrderEntryAdditionalQuestions from "./OrderEntryAdditionalQuestions";
 import OrderSuccessMessage from "./OrderSuccessMessage";
 import EQASampleEntry from "../eqa/EQASampleEntry";
 import EQAOrderForm, { eqaReceiptNoteMissing } from "../eqa/EQAOrderForm";
+import EQAEnrollmentCoverageNotice from "../eqa/EQAEnrollmentCoverageNotice";
 import { FormattedMessage, useIntl } from "react-intl";
 import { createOrderEntryValidationSchema } from "../formModel/validationSchema/OrderEntryValidationSchema";
 import config from "../../config.json";
@@ -914,11 +915,21 @@ const Index = () => {
                 />
               ))}
             {page === samplePageNumber && (
-              <AddSample
-                error={elementError}
-                setSamples={setSamples}
-                samples={samples}
-              />
+              <>
+                {orderFormValues?.sampleOrderItems?.isEQASample && (
+                  <EQAEnrollmentCoverageNotice
+                    enrollmentId={
+                      orderFormValues?.sampleOrderItems?.eqaProgramId
+                    }
+                    samples={samples}
+                  />
+                )}
+                <AddSample
+                  error={elementError}
+                  setSamples={setSamples}
+                  samples={samples}
+                />
+              </>
             )}
             {page === orderPageNumber && (
               <AddOrder

--- a/frontend/src/components/eqa/EQAEnrollmentCoverageNotice.jsx
+++ b/frontend/src/components/eqa/EQAEnrollmentCoverageNotice.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+import { InlineNotification } from "@carbon/react";
+import { useIntl } from "react-intl";
+import { getFromOpenElisServer } from "../utils/Utils";
+
+const idSet = (rows) => new Set((rows || []).map((row) => String(row.id)));
+
+const panelTestIds = (panel) =>
+  String(panel.testIds || "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+
+/**
+ * What the laboratory has picked for this EQA order that its enrolment in the
+ * programme does not cover. A warning only: an order outside the enrolment is
+ * still a valid order, and nothing here refuses one.
+ */
+export const testsOutsideEnrollment = (samples, enrollment) => {
+  const mappedTests = idSet(enrollment.tests);
+  const mappedPanels = idSet(enrollment.panels);
+
+  // A panel the enrolment covers brings its own tests with it, so those tests
+  // are covered too even when the enrolment does not name them one by one.
+  const coveredByPanel = new Set();
+  const outsidePanels = [];
+  for (const sample of samples || []) {
+    for (const panel of sample.panels || []) {
+      if (mappedPanels.has(String(panel.id))) {
+        panelTestIds(panel).forEach((id) => coveredByPanel.add(id));
+      } else {
+        outsidePanels.push(panel.name);
+      }
+    }
+  }
+
+  const outsideTests = [];
+  for (const sample of samples || []) {
+    for (const test of sample.tests || []) {
+      const id = String(test.id);
+      if (!mappedTests.has(id) && !coveredByPanel.has(id)) {
+        outsideTests.push(test.name);
+      }
+    }
+  }
+
+  return [...new Set([...outsidePanels, ...outsideTests])];
+};
+
+const EQAEnrollmentCoverageNotice = ({ enrollmentId, samples }) => {
+  const intl = useIntl();
+  const [enrollment, setEnrollment] = useState(null);
+
+  useEffect(() => {
+    if (!enrollmentId) {
+      setEnrollment(null);
+      return undefined;
+    }
+    let mounted = true;
+    getFromOpenElisServer(
+      `/rest/eqa/my-programs/${enrollmentId}`,
+      (response) => {
+        if (mounted) {
+          setEnrollment(response && response.id ? response : null);
+        }
+      },
+    );
+    return () => {
+      mounted = false;
+    };
+  }, [enrollmentId]);
+
+  if (!enrollment) {
+    return null;
+  }
+
+  const outside = testsOutsideEnrollment(samples, enrollment);
+  if (outside.length === 0) {
+    return null;
+  }
+
+  return (
+    <InlineNotification
+      kind="warning"
+      lowContrast
+      hideCloseButton
+      title={intl.formatMessage({ id: "eqa.order.coverage.title" })}
+      subtitle={intl.formatMessage(
+        { id: "eqa.order.coverage.subtitle" },
+        { tests: outside.join(", ") },
+      )}
+    />
+  );
+};
+
+export default EQAEnrollmentCoverageNotice;

--- a/frontend/src/components/eqa/__tests__/EQAEnrollmentCoverageNotice.test.jsx
+++ b/frontend/src/components/eqa/__tests__/EQAEnrollmentCoverageNotice.test.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import messages from "../../../languages/en.json";
+import EQAEnrollmentCoverageNotice, {
+  testsOutsideEnrollment,
+} from "../EQAEnrollmentCoverageNotice";
+import { getFromOpenElisServer } from "../../utils/Utils";
+
+vi.mock("../../utils/Utils", () => ({
+  getFromOpenElisServer: vi.fn(),
+}));
+
+// One sample type carrying the glucose test on its own, plus a panel that
+// brings creatinine with it.
+const samples = [
+  {
+    tests: [
+      { id: "100", name: "Glucose" },
+      { id: "101", name: "Creatinine" },
+    ],
+    panels: [{ id: "200", name: "Basic Metabolic Panel", testIds: "101" }],
+  },
+];
+
+const enrollment = (tests, panels) => ({
+  id: 7,
+  tests: tests.map((id) => ({ id })),
+  panels: panels.map((id) => ({ id })),
+});
+
+const renderNotice = (enrollmentId = 7) =>
+  render(
+    <IntlProvider locale="en" messages={messages}>
+      <EQAEnrollmentCoverageNotice
+        enrollmentId={enrollmentId}
+        samples={samples}
+      />
+    </IntlProvider>,
+  );
+
+describe("testsOutsideEnrollment", () => {
+  test("names the tests and panels the enrolment does not cover", () => {
+    expect(testsOutsideEnrollment(samples, enrollment([], []))).toEqual([
+      "Basic Metabolic Panel",
+      "Glucose",
+      "Creatinine",
+    ]);
+  });
+
+  test("a test a covered panel brings with it is covered too", () => {
+    // The enrolment names the panel but not creatinine, and the panel is what
+    // put creatinine on the order.
+    expect(
+      testsOutsideEnrollment(samples, enrollment(["100"], ["200"])),
+    ).toEqual([]);
+  });
+
+  test("the same selection is flagged once the panel is not covered", () => {
+    // The inverse of the case above: drop the panel from the enrolment and both
+    // it and the test it carries have to be named.
+    expect(testsOutsideEnrollment(samples, enrollment(["100"], []))).toEqual([
+      "Basic Metabolic Panel",
+      "Creatinine",
+    ]);
+  });
+});
+
+describe("EQAEnrollmentCoverageNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("warns about the test outside the enrolment without refusing the order", () => {
+    getFromOpenElisServer.mockImplementation((url, callback) => {
+      expect(url).toBe("/rest/eqa/my-programs/7");
+      callback(enrollment(["100"], []));
+    });
+
+    renderNotice();
+
+    expect(
+      screen.getByText("Outside this laboratory's enrolment"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "The enrolment for this programme does not cover: Basic Metabolic Panel, Creatinine. You can still save the order.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("says nothing when the enrolment covers everything picked", () => {
+    getFromOpenElisServer.mockImplementation((url, callback) =>
+      callback(enrollment(["100", "101"], ["200"])),
+    );
+
+    renderNotice();
+
+    expect(getFromOpenElisServer).toHaveBeenCalled();
+    expect(
+      screen.queryByText("Outside this laboratory's enrolment"),
+    ).toBeNull();
+  });
+
+  test("asks for nothing until a programme is chosen", () => {
+    renderNotice("");
+
+    expect(getFromOpenElisServer).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("Outside this laboratory's enrolment"),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8624,5 +8624,7 @@
   "eqa.performance.empty": "No laboratory is enrolled in this scheme yet.",
   "eqa.performance.loadFailed": "Could not load participant performance",
   "eqa.myPrograms.group.active": "Active enrolments ({count})",
-  "eqa.myPrograms.group.inactive": "Inactive enrolments ({count})"
+  "eqa.myPrograms.group.inactive": "Inactive enrolments ({count})",
+  "eqa.order.coverage.title": "Outside this laboratory's enrolment",
+  "eqa.order.coverage.subtitle": "The enrolment for this programme does not cover: {tests}. You can still save the order."
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
      Screenshot below instead.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

The enrolment test map was not consulted at order entry at all, so a laboratory
could put a test on an EQA order that its enrolment in that programme says
nothing about, with nothing on screen to say so.

The Add Sample step now reads the chosen enrolment and names what it does not
cover. **A test that a covered panel brings with it counts as covered**, so
choosing a panel the enrolment names does not raise a warning about the tests
inside it — the panel's own `testIds` are what the selection carries.

**It is a warning and nothing more.** The order still saves and Next stays
enabled: nothing that was permitted before is refused now.

The notice is a Carbon `InlineNotification` above the sample step, so it sits
where the choice is made rather than at the end of the wizard.

## Screenshots

The warning naming an unmapped test, with the step's Next button still enabled.

## Related Issue

OGC-935. Register row D-LIVE-7.

## Other

**Tests.** The coverage rule is a pure function and is tested as one:
`testsOutsideEnrollment` names the tests and panels an enrolment does not cover;
a test a covered panel brings with it is covered; and — the inverse of that case
— the same selection is flagged once the panel itself is not covered, so the
exemption cannot silently swallow everything. Three render tests cover the
warning appearing, the notice staying away when the enrolment covers what was
picked, and nothing being fetched before a programme is chosen.
