### PR TITLE
test(eqa): drive the enrollment status guard with a real request (OGC-935)

### DIFF
--- a/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
+++ b/src/test/java/org/openelisglobal/eqa/controller/EQARestGuardSecuritySliceTest.java
@@ -2,11 +2,13 @@ package org.openelisglobal.eqa.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +28,7 @@ import org.openelisglobal.eqa.service.EQALabelPDFService;
 import org.openelisglobal.eqa.service.EQAPanelService;
 import org.openelisglobal.eqa.service.EQAProgramEnrollmentService;
 import org.openelisglobal.eqa.service.EQAProgramService;
+import org.openelisglobal.eqa.valueholder.EQALabProgramEnrollment;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.login.valueholder.UserSessionData;
@@ -128,6 +131,27 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
                 .andExpect(status().isForbidden());
     }
 
+    @Test
+    public void enrollmentStatus_readUmbrellaCannotChangeStatus() throws Exception {
+        // Suspend, resume and withdraw are participant-lane writes. The endpoint
+        // shipped inheriting only the class-level read umbrella, which would have
+        // let a qa.view.eqa holder change a status; the positive case below proves
+        // the route exists, so the 403 here can only come from the method guard.
+        mockMvc.perform(put("/rest/eqa/my-programs/9/status").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"status\":\"SUSPENDED\",\"reason\":\"instrument down\"}")
+                .with(user("viewer").authorities(new SimpleGrantedAuthority("qa.view.eqa"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void enrollmentStatus_participantTierReturns200() throws Exception {
+        mockMvc.perform(put("/rest/eqa/my-programs/9/status").contentType(MediaType.APPLICATION_JSON)
+                .content("{\"status\":\"SUSPENDED\",\"reason\":\"instrument down\"}")
+                .sessionAttr(IActionConstants.USER_SESSION_DATA, sessionUser())
+                .with(user("qaofficer").authorities(new SimpleGrantedAuthority("qa.eqa.participant"))))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.status").value("SUSPENDED"));
+    }
+
     // ---- provider-lane writes ----
 
     @Test
@@ -205,6 +229,10 @@ public class EQARestGuardSecuritySliceTest extends SecuritySliceMockMvcTest {
         EQALabProgramEnrollmentService labProgramEnrollmentService() {
             EQALabProgramEnrollmentService service = Mockito.mock(EQALabProgramEnrollmentService.class);
             Mockito.when(service.findAll()).thenReturn(List.of());
+            EQALabProgramEnrollment suspended = new EQALabProgramEnrollment();
+            suspended.setId(9L);
+            suspended.setStatus("SUSPENDED");
+            Mockito.when(service.updateStatus(anyLong(), anyString(), anyString(), any(), any())).thenReturn(suspended);
             return service;
         }
 


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not
      applicable: the change is a backend test, with no user-visible surface.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

`PUT /rest/eqa/my-programs/{id}/status` lets a laboratory suspend, resume or
withdraw its own EQA enrollment. It declares `EQAGuards.PARTICIPANT`, and until
now the only thing asserting that was `EQARestGuardMatrixTest`, which reflects
over the controllers and reads the `@PreAuthorize` annotation as text. It never
issues a request. Its eight `my-programs` siblings each carry a case in
`EQARestGuardSecuritySliceTest`; this endpoint carried none, so the guard had no
runtime negative anywhere.

This adds two cases to that slice:

| Case | Principal | Expected |
| --- | --- | --- |
| `enrollmentStatus_readUmbrellaCannotChangeStatus` | `qa.view.eqa` only | 403 |
| `enrollmentStatus_participantTierReturns200` | `qa.eqa.participant` | 200 |

The positive case is the control. Without it a 403 could come from a missing
route rather than from the guard, and the negative would be an absence read as
a pass.

The mock enrollment service gains a stub for `updateStatus` so the positive case
reaches a real response body.

**Inversion check.** With `@PreAuthorize(EQAGuards.PARTICIPANT)` removed from
`updateMyProgramStatus`, the negative returns 500 instead of 403 and the
positive returns 403 instead of 200. Both cases fail, so both measure the
annotation rather than something else. The annotation was restored afterwards
and is untouched by this diff.

Test-only change. The full `EQA*` run is 596 tests, all green.

## Screenshots

Not applicable. No user-visible surface changes.

## Related Issue

OGC-935. Follow-up to #4246, which introduced the endpoint and added its row to
the guard matrix.

## Other

A `qa.view.eqa`-only role is not creatable through any screen today, so this
negative cannot be driven against a live instance: every persona that holds
`qa.view.eqa` also holds `qa.eqa.participant`. That is why the case belongs in
the security slice, where the authority set is chosen directly.
