### PR TITLE
feat(eqa): say which results went unjudged, and fix a scheme's type once a cycle is running (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -116,11 +116,15 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
     successText,
     failKey,
     grant,
+    successValues,
   ) => {
     setBusy(null);
     if (ok && body?.success !== false) {
       refresh();
-      onNotice({ kind: "success", text: t(successKey, successText) });
+      onNotice({
+        kind: "success",
+        text: t(successKey, successText, successValues),
+      });
       return;
     }
     // A refusal names the action and the grant that carries it. The actions are
@@ -297,15 +301,27 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
 
   const handleScore = () => {
     setBusy("score");
-    scoreCycle(cycleId, (response) =>
+    scoreCycle(cycleId, (response) => {
+      // A result whose analyte carries no sealed target and whose test has too few
+      // peers to place it against reaches SCORED with no verdict on it. Saying so
+      // is the difference between a gap and a silent null.
+      const unjudged = response?.body?.unjudgedCount ?? 0;
       report(
         response,
-        "eqa.score.scored",
-        "Cycle scored. Unacceptable participants are in the follow-up register.",
+        unjudged ? "eqa.score.scoredWithUnjudged" : "eqa.score.scored",
+        unjudged
+          ? "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against."
+          : "Cycle scored. Unacceptable participants are in the follow-up register.",
         "eqa.score.scoreFailed",
         "qa.manage.eqa",
-      ),
-    );
+        unjudged
+          ? {
+              count: unjudged,
+              tests: (response?.body?.unjudgedTests ?? []).join(", "),
+            }
+          : undefined,
+      );
+    });
   };
 
   const handleDistribute = (row) => {

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -296,6 +296,34 @@ describe("ReceiptMonitor", () => {
     );
   });
 
+  it("says which results the score left without a verdict", async () => {
+    // An analyte with no sealed target on a cycle below the peer floor reaches
+    // SCORED with performance_status NULL. The score still succeeds; the point is
+    // that the operator is told rather than left with a silent null.
+    postToOpenElisServerFullResponse.mockImplementation((_url, _body, cb) =>
+      cb(
+        jsonResponse(true, {
+          cycleStatus: "SCORED",
+          followupCount: 0,
+          unjudgedCount: 3,
+          unjudgedTests: ["Haemoglobin"],
+        }),
+      ),
+    );
+    const onNotice = vi.fn();
+    renderTab("SUBMISSIONS_OPEN", { onNotice });
+
+    await screen.findByText("Mbeya Regional Lab");
+    fireEvent.click(screen.getByRole("button", { name: "Score cycle" }));
+
+    await waitFor(() =>
+      expect(onNotice).toHaveBeenCalledWith({
+        kind: "success",
+        text: "Cycle scored, but 3 result(s) got no verdict, on Haemoglobin. Those analytes carry no sealed target and the cycle has too few peers to place them against.",
+      }),
+    );
+  });
+
   test("Enter results keys a participant's reported values and posts them per test", async () => {
     renderTab();
     getFromOpenElisServer.mockImplementation((url, cb) => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8634,5 +8634,6 @@
   "eqa.enrollment.statusEffectiveDate": "Effective from",
   "eqa.enrollment.withdrawIsFinal": "Withdrawing is final. To take part again, this laboratory enrols in the programme afresh.",
   "eqa.enrollment.statusChanged": "This enrolment is now {status}",
-  "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status"
+  "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status",
+  "eqa.score.scoredWithUnjudged": "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against."
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
@@ -71,21 +71,23 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
      * caller would only move the hole to the quieter one.
      *
      * <p>
-     * Closed cycles are history and reinterpreting them costs nothing, which is
-     * what makes the rule "no live cycle" rather than "no cycle at all". A
-     * deployment upgraded from V1 carries a backfilled CLOSED cycle for every
-     * completed legacy distribution, and those schemes all took the
-     * INTERNATIONAL_PT default; barring a type change outright would strand every
-     * one of them outside in-house blinding, with no route out from any screen.
+     * A closed cycle cannot be worked on again, which is what makes the rule "no
+     * live cycle" rather than "no cycle at all". A deployment upgraded from V1
+     * carries a backfilled CLOSED cycle for every completed legacy distribution,
+     * and those schemes all took the INTERNATIONAL_PT default; barring a type
+     * change outright would strand every one of them outside in-house blinding,
+     * with no route out from any screen.
      *
      * <p>
-     * SCORED is deliberately not treated as closed. It is still on the scoring
-     * path, scores are distributed from it, and it feeds the rolling window that
-     * decides persistent failure, so reinterpreting the scheme underneath it would
-     * move live work. That makes this rule strict in practice: nothing in the
-     * product closes a cycle today, so a scheme that has run a V2 cycle keeps its
-     * type. The V1 backfill writes CLOSED directly, which is the case the rule
-     * exists to admit.
+     * SCORED is deliberately not treated as closed. The line between them is that a
+     * SCORED cycle is still workable and a CLOSED one is only readable: SCORED is
+     * on the scoring path and scores are distributed from it, while CLOSED has no
+     * outgoing edge on any of the three machines. Both are still read — the rolling
+     * window that decides persistent failure selects SCORED and CLOSED alike — so
+     * being unread is not the distinction and must not be argued as one. That makes
+     * this rule strict in practice: nothing in the product closes a cycle today, so
+     * a scheme that has run a V2 cycle keeps its type. The V1 backfill writes
+     * CLOSED directly, which is the case the rule exists to admit.
      *
      * <p>
      * The comparison reads the stored row rather than trusting the argument: both

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
@@ -1,11 +1,14 @@
 package org.openelisglobal.eqa.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQAProgramDAO;
 import org.openelisglobal.eqa.dao.EQAProgramTestDAO;
 import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
@@ -26,6 +29,9 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
 
     @Autowired
     private EQASchemeAnalystDAO eqaSchemeAnalystDAO;
+
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
 
     public EQAProgramServiceImpl() {
         super(EQAProgram.class);
@@ -52,7 +58,49 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
     @Override
     public EQAProgram update(EQAProgram program) {
         validateProviderRequired(program);
+        validateSchemeTypeNotChangedUnderLiveCycles(program);
         return super.update(program);
+    }
+
+    /**
+     * The scheme type decides whether a provider organization is required, which
+     * blinding lane the scheme travels and which cycle state machine applies, so
+     * changing it reinterprets everything already underneath it. This sits on
+     * update() rather than on the endpoint because the configuration loader writes
+     * the same field on its upsert branch, as the daemon user; a guard on one
+     * caller would only move the hole to the quieter one.
+     *
+     * <p>
+     * Closed cycles are history and reinterpreting them costs nothing, which is
+     * what makes the rule "no live cycle" rather than "no cycle at all". A
+     * deployment upgraded from V1 carries a backfilled CLOSED cycle for every
+     * completed legacy distribution, and those schemes all took the
+     * INTERNATIONAL_PT default; barring a type change outright would strand every
+     * one of them outside in-house blinding, with no route out from any screen.
+     *
+     * <p>
+     * The comparison reads the stored row rather than trusting the argument: both
+     * callers mutate a detached scheme in place, so by the time update() sees it
+     * the previous type is gone from the object.
+     */
+    private void validateSchemeTypeNotChangedUnderLiveCycles(EQAProgram program) {
+        if (program.getId() == null) {
+            return;
+        }
+        EQASchemeType stored = eqaProgramDAO.get(program.getId()).map(EQAProgram::getSchemeType).orElse(null);
+        if (stored == null || stored == program.getSchemeType()) {
+            return;
+        }
+        // Named by number, not by name: cycle_name is nullable and the number is what
+        // the provider scheme list shows.
+        List<String> live = eqaCycleDAO.findBySchemeIds(List.of(program.getId())).stream()
+                .filter(cycle -> cycle.getStatus() != EQACycleStatus.CLOSED)
+                .map(cycle -> "cycle " + cycle.getCycleNumber()).collect(Collectors.toList());
+        if (!live.isEmpty()) {
+            throw new LIMSRuntimeException("This scheme's type cannot change from " + stored + " to "
+                    + program.getSchemeType() + " while " + String.join(", ", live)
+                    + " is still running. Close it first, or create a new scheme of the type you need.");
+        }
     }
 
     private void validateProviderRequired(EQAProgram program) {

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
@@ -79,6 +79,15 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
      * one of them outside in-house blinding, with no route out from any screen.
      *
      * <p>
+     * SCORED is deliberately not treated as closed. It is still on the scoring
+     * path, scores are distributed from it, and it feeds the rolling window that
+     * decides persistent failure, so reinterpreting the scheme underneath it would
+     * move live work. That makes this rule strict in practice: nothing in the
+     * product closes a cycle today, so a scheme that has run a V2 cycle keeps its
+     * type. The V1 backfill writes CLOSED directly, which is the case the rule
+     * exists to admit.
+     *
+     * <p>
      * The comparison reads the stored row rather than trusting the argument: both
      * callers mutate a detached scheme in place, so by the time update() sees it
      * the previous type is gone from the object.
@@ -97,9 +106,14 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
                 .filter(cycle -> cycle.getStatus() != EQACycleStatus.CLOSED)
                 .map(cycle -> "cycle " + cycle.getCycleNumber()).collect(Collectors.toList());
         if (!live.isEmpty()) {
+            // The message offers the new scheme and nothing else on purpose. Closing a
+            // cycle would also lift the bar, but nothing in the product asks for CLOSED
+            // — the edge is legal on all three machines and unreachable in practice — so
+            // telling an operator to close it first is advice nobody can take.
             throw new LIMSRuntimeException("This scheme's type cannot change from " + stored + " to "
-                    + program.getSchemeType() + " while " + String.join(", ", live)
-                    + " is still running. Close it first, or create a new scheme of the type you need.");
+                    + program.getSchemeType() + ": " + String.join(", ", live)
+                    + " has run under the current type and its results are still read against it."
+                    + " Create a new scheme of the type you need.");
         }
     }
 

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.analyte.service.AnalyteService;
@@ -168,6 +169,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         // acceptable. Where the panel sealed a target, that target is the verdict.
         eqaStatisticsService.calculateAndUpdateStatistics(distribution.getId());
         judgeAgainstPanelTargets(cycle, distribution.getId());
+        List<EQAResult> unjudged = unjudgedResults(distribution.getId());
         advanceToScored(cycle, sysUserId);
 
         int followups = 0;
@@ -185,6 +187,9 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         summary.put("distributionId", distribution.getId());
         summary.put("scoredCount", (int) reported);
         summary.put("followupCount", followups);
+        summary.put("unjudgedCount", unjudged.size());
+        summary.put("unjudgedTests", unjudged.stream().map(result -> testName(result.getTestId()))
+                .filter(name -> name != null).distinct().sorted().collect(Collectors.toList()));
         summary.put("cycleStatus",
                 eqaCycleDAO.get(cycleId).map(EQACycle::getStatus).map(EQACycleStatus::name).orElse(null));
         return summary;
@@ -445,6 +450,20 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             result.setPerformanceStatus(EqaPanelVerdict.of(target, reported));
             eqaResultDAO.update(result);
         }
+    }
+
+    /**
+     * The reported results that reached SCORED with no verdict on them. Neither
+     * pass covers them: the peer statistic skips a test with fewer than
+     * {@code MIN_PARTICIPANTS_FOR_STATS} numeric results and never places a
+     * qualitative one at any roster size, and the target pass only touches analytes
+     * the panel sealed a target for. Before this the row simply kept a null
+     * performance_status and the only trace was an info line in the statistics log.
+     */
+    private List<EQAResult> unjudgedResults(Long distributionId) {
+        return eqaResultDAO.findByDistributionId(distributionId).stream()
+                .filter(result -> result.getResultValue() != null || result.getResultText() != null)
+                .filter(result -> result.getPerformanceStatus() == null).collect(Collectors.toList());
     }
 
     private static Object reportedOf(EQAResult result) {

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -37,6 +39,13 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
     private static final long TEST_CD4 = 9927L;
     private static final long ANALYTE_CD4 = 9828L;
     private static final int TEST_ANALYTE_LINK = 99827;
+    /**
+     * A second analyte on the same cycle, so a panel can target one and not the
+     * other.
+     */
+    private static final long TEST_HB = 9929L;
+    private static final long ANALYTE_HB = 9830L;
+    private static final int TEST_ANALYTE_LINK_HB = 99829;
 
     @Autowired
     private EQAProviderScoringService scoringService;
@@ -61,9 +70,19 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
         jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
                 TEST_ANALYTE_LINK, TEST_CD4, ANALYTE_CD4);
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE_HB, "Tolerance HB");
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                TEST_HB, "Tolerance HB test", "Tolerance HB test", UUID.randomUUID().toString(), TEST_HB);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK_HB);
+        jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
+                TEST_ANALYTE_LINK_HB, TEST_HB, ANALYTE_HB);
 
         EQAProgram scheme = insertScheme("Tolerance scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
         eqaProgramService.assignTest(scheme.getId(), TEST_CD4);
+        eqaProgramService.assignTest(scheme.getId(), TEST_HB);
         cycle = readBack(insertCycle(scheme, 1));
         jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
         panel = insertPanel(scheme, p -> {
@@ -80,9 +99,10 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
         super.cleanEqaTables();
         if (jdbc != null) {
-            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
-            jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST_CD4);
-            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE_CD4);
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id IN (?, ?)", TEST_ANALYTE_LINK,
+                    TEST_ANALYTE_LINK_HB);
+            jdbc.update("DELETE FROM clinlims.test WHERE id IN (?, ?)", TEST_CD4, TEST_HB);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id IN (?, ?)", ANALYTE_CD4, ANALYTE_HB);
             jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_ORG, FIRST_ORG + 5);
         }
     }
@@ -146,13 +166,48 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
     }
 
+    @Test
+    public void anAnalyteWithNoSealedTargetIsCountedAndNamed() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        reportBoth("40", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("CD4 carries the sealed target, so it is judged", "ACCEPTABLE", verdict(FIRST_ORG, TEST_CD4));
+        assertEquals("UNACCEPTABLE", verdict(FIRST_ORG + 2, TEST_CD4));
+        assertNull("HB has no target, and three laboratories is below the peer floor", verdict(FIRST_ORG, TEST_HB));
+
+        assertEquals("one unjudged result per laboratory", 3, summary.get("unjudgedCount"));
+        assertEquals("and the operator is told which test they sit on", List.of("Tolerance HB test"),
+                summary.get("unjudgedTests"));
+    }
+
+    @Test
+    public void everyAnalyteJudgedLeavesNothingToReport() {
+        // The control. Without it the assertions above cannot tell "counted the
+        // unjudged" from "counted every result on the second test".
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        sealTargetFor(ANALYTE_HB, "T02", "12", new BigDecimal("11"), new BigDecimal("13"));
+        reportBoth("40", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("HB now carries a target of its own", "ACCEPTABLE", verdict(FIRST_ORG, TEST_HB));
+        assertEquals(0, summary.get("unjudgedCount"));
+        assertEquals(List.of(), summary.get("unjudgedTests"));
+    }
+
     // ---- helpers ----
 
     private void sealTarget(String targetValue, BigDecimal low, BigDecimal high) {
+        sealTargetFor(ANALYTE_CD4, "T01", targetValue, low, high);
+    }
+
+    private void sealTargetFor(long analyteId, String sampleCode, String targetValue, BigDecimal low, BigDecimal high) {
         EQAPanelSample sample = new EQAPanelSample();
         sample.setPanel(panel);
-        sample.setSampleCode("T01");
-        sample.setAnalyteId(ANALYTE_CD4);
+        sample.setSampleCode(sampleCode);
+        sample.setAnalyteId(analyteId);
         sample.setTargetValue(targetValue);
         sample.setAcceptanceRangeLow(low);
         sample.setAcceptanceRangeHigh(high);
@@ -167,11 +222,25 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
     }
 
+    /**
+     * The same CD4 values, each laboratory also reporting the untargeted HB test.
+     */
+    private void reportBoth(String... values) {
+        for (int i = 0; i < values.length; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i, Map.of(TEST_CD4, values[i], TEST_HB, "12"),
+                    EQASubmissionMethod.MANUAL, USER);
+        }
+    }
+
     private String verdict(long organizationId) {
+        return verdict(organizationId, TEST_CD4);
+    }
+
+    private String verdict(long organizationId, long testId) {
         return jdbc.queryForObject(
                 "SELECT performance_status FROM clinlims.eqa_result"
                         + " WHERE participant_organization_id = ? AND test_id = ?",
-                String.class, organizationId, TEST_CD4);
+                String.class, organizationId, testId);
     }
 
     private BigDecimal targetValue(long organizationId) {

--- a/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
@@ -103,6 +103,54 @@ public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
     }
 
     @Test
+    public void updateProgram_refusesATypeChangeWhileACycleIsStillRunning() {
+        Long id = created(Map.of("name", "Has a live cycle " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+        insertCycle(eqaProgramService.get(id), 4);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id, Map.of("schemeType", "IN_HOUSE"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue("the refusal names the cycle that blocks it: " + errorOf(response),
+                errorOf(response).contains("cycle 4"));
+        assertEquals("and the stored type is untouched", EQASchemeType.REGIONAL_PT,
+                eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void updateProgram_allowsATypeChangeWhenEveryCycleIsClosed() {
+        // The V1 upgrade path. Every completed legacy distribution was backfilled a
+        // CLOSED cycle, and those schemes all took the INTERNATIONAL_PT default, so
+        // refusing on any cycle at all would strand them outside in-house blinding.
+        Long id = created(Map.of("name", "Legacy V1 scheme " + System.nanoTime(), "schemeType", "INTERNATIONAL_PT",
+                "provider", "CPHL"));
+        Long cycleId = insertCycle(eqaProgramService.get(id), 1);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycleId);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "IN_HOUSE", "provider", ""));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(EQASchemeType.IN_HOUSE, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void updateProgram_letsAnEditResendTheSameTypeUnderALiveCycle() {
+        // The Programs form sends every field it displays, so an edit to the name or
+        // the review gate carries schemeType with it. That is not a type change.
+        Long id = created(
+                Map.of("name", "Unchanged type " + System.nanoTime(), "schemeType", "REGIONAL_PT", "provider", "CPHL"));
+        insertCycle(eqaProgramService.get(id), 2);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "REGIONAL_PT", "provider", "CPHL", "description", "Second round"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Second round", eqaProgramService.get(id).getDescription());
+        assertEquals(EQASchemeType.REGIONAL_PT, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
     public void updateTestAssignments_writesTheMapProviderIntakeReads() {
         seedTest(TEST_SERO, "Scheme admin serology");
         seedTest(TEST_VL, "Scheme admin viral load");
@@ -124,6 +172,11 @@ public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
     }
 
     // ---- helpers ----
+
+    private String errorOf(ResponseEntity<?> response) {
+        Object error = ((Map<?, ?>) response.getBody()).get("error");
+        return error == null ? "" : String.valueOf(error);
+    }
 
     private Long created(Map<String, Object> body) {
         ResponseEntity<?> response = controller.createProgram(request(), body);

--- a/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -113,6 +114,13 @@ public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertTrue("the refusal names the cycle that blocks it: " + errorOf(response),
                 errorOf(response).contains("cycle 4"));
+        assertTrue("and offers the only route an operator actually has: " + errorOf(response),
+                errorOf(response).toLowerCase().contains("create a new scheme"));
+        // Nothing in the product closes a cycle: the SCORED to CLOSED edge is legal on
+        // all three machines and no caller asks for it. Advice to close this one first
+        // would be advice nobody can follow, so the message must not give it.
+        assertFalse("and does not tell them to close it, which no screen can do: " + errorOf(response),
+                errorOf(response).toLowerCase().contains("close"));
         assertEquals("and the stored type is untouched", EQASchemeType.REGIONAL_PT,
                 eqaProgramService.get(id).getSchemeType());
     }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not
      supplied: the visible half is one inline notification string on an
      existing action, covered by a unit test that asserts the rendered text.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

Two guards left open when the target-verdict and scheme-type work merged, both
recorded at the time as non-blocking review notes on #4181 and #4182.

### A scored cycle no longer hides its unjudged results

A result reaches `SCORED` with `performance_status` NULL whenever its analyte
carries no sealed target **and** it has no peer statistic. Two ways in:

| Result | Why no peer statistic |
| --- | --- |
| Numeric | Its test has fewer than `MIN_PARTICIPANTS_FOR_STATS` numeric results, so `EQAStatisticsServiceImpl` skips the whole group |
| Qualitative | `result_text` never enters the peer grouping at any roster size; it is judged by match against a sealed target or not at all |

`judgeAgainstPanelTargets` only touches analytes the panel sealed a target for,
so neither pass reaches these rows. The only trace was an info line in the
statistics log.

`scoreCycle` now counts them where the judgement already runs and returns
`unjudgedCount` with the distinct `unjudgedTests` they sit on. The provider
workbench reports it on an otherwise successful score.

It still scores. Refusing until an operator acknowledges it was the other option
on the card, and it would block scoring that is legitimate today.

### A scheme's type is fixed while a cycle is running

The type decides whether a provider organization is required, which blinding
lane the scheme travels and which cycle state machine applies.
`EQAProgramRestController.updateProgram` set it whenever the key was present,
with no check for existing cycles.

**The check sits on `EQAProgramService.update`, not on the endpoint.**
`EQAProgramConfigurationHandler` writes the same field on its upsert branch as
the daemon user, and it is the only other caller in the tree. A guard on the
endpoint alone would have moved the hole to the quieter of the two paths.

**The rule is "no live cycle", not "no cycle at all".** A deployment upgraded
from V1 carries a backfilled CLOSED cycle for every completed legacy
distribution (`qa-073`), and those schemes all took the `INTERNATIONAL_PT`
default. Since `inHouseApi.js` admits a scheme to in-house blinding on
`schemeType === "IN_HOUSE"`, barring the change outright would strand every
legacy scheme outside in-house blinding with no route out from any screen.
Closed cycles are history; reinterpreting them costs nothing.

An edit that resends the same type is not a type change, which matters because
the Programs form sends every field it displays.

**SCORED is deliberately not treated as closed.** The line is that a SCORED
cycle is still *workable* and a CLOSED one is only *readable*: SCORED sits on
`SCORING_PATH` and scores are distributed from it, while CLOSED has no outgoing
edge on any of the three machines.

Being unread is **not** the distinction, and it is worth saying so because the
obvious reading is wrong: the rolling window that decides persistent failure
selects `SCORED || CLOSED` alike, so a closed cycle is still read. The argument
rests on what can still be done to a cycle, not on what still reads it.

That makes the rule strict in practice, and the strictness is worth stating
plainly: **nothing in the product closes a cycle.** `SCORED → CLOSED` is a legal
edge on all three state machines, but no screen or endpoint caller asks for it,
and the reference deployment carries **zero CLOSED cycles out of 38**. So a
scheme that has run a cycle under V2 keeps its type until someone builds a close
action. The V1 backfill writes CLOSED directly, which is the case the rule
exists to admit.

Because of that, the refusal message does **not** say "close it first" — that
would be advice nobody can follow. It states why the type is fixed and offers
the only route that exists. The test asserts both halves, so a regression to the
unfollowable wording fails rather than passing quietly.

## Screenshots

Not supplied. The one visible change is the text of an existing inline
notification, asserted in full by `ReceiptMonitor.test.jsx`.

## Related Issue

OGC-935. Follow-up to #4181 and #4182, whose review notes recorded both gaps.

## Other

**Every new case is proved by inversion**, because a case that cannot fail is
not evidence:

| Break | Fails |
| --- | --- |
| Count nothing as unjudged | `anAnalyteWithNoSealedTargetIsCountedAndNamed` (3 to 0) |
| Drop the scheme-type guard | `updateProgram_refusesATypeChangeWhileACycleIsStillRunning` (400 to 200) |
| Treat closed cycles as live | `updateProgram_allowsATypeChangeWhenEveryCycleIsClosed` (200 to 400) |
| Ignore `unjudgedCount` in the workbench | `says which results the score left without a verdict` |
| Restore "Close it first" to the refusal | `updateProgram_refusesATypeChangeWhileACycleIsStillRunning` |

Each break fails exactly its own case and nothing else.

`everyAnalyteJudgedLeavesNothingToReport` is the control for the first: without
it the count cannot be told apart from "counted every result on the second
test".

Backend `EQA*` run: 601 tests, all green. Frontend gate run from `frontend/` the
way CI runs it: `npx prettier ./ --check`, `npm run lint`, `npm test` (182
files, 1252 tests).
