### PR TITLE
feat(eqa): say which results a scored cycle left without a verdict (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -116,11 +116,15 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
     successText,
     failKey,
     grant,
+    successValues,
   ) => {
     setBusy(null);
     if (ok && body?.success !== false) {
       refresh();
-      onNotice({ kind: "success", text: t(successKey, successText) });
+      onNotice({
+        kind: "success",
+        text: t(successKey, successText, successValues),
+      });
       return;
     }
     // A refusal names the action and the grant that carries it. The actions are
@@ -297,15 +301,27 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
 
   const handleScore = () => {
     setBusy("score");
-    scoreCycle(cycleId, (response) =>
+    scoreCycle(cycleId, (response) => {
+      // A result whose analyte carries no sealed target and whose test has too few
+      // peers to place it against reaches SCORED with no verdict on it. Saying so
+      // is the difference between a gap and a silent null.
+      const unjudged = response?.body?.unjudgedCount ?? 0;
       report(
         response,
-        "eqa.score.scored",
-        "Cycle scored. Unacceptable participants are in the follow-up register.",
+        unjudged ? "eqa.score.scoredWithUnjudged" : "eqa.score.scored",
+        unjudged
+          ? "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against."
+          : "Cycle scored. Unacceptable participants are in the follow-up register.",
         "eqa.score.scoreFailed",
         "qa.manage.eqa",
-      ),
-    );
+        unjudged
+          ? {
+              count: unjudged,
+              tests: (response?.body?.unjudgedTests ?? []).join(", "),
+            }
+          : undefined,
+      );
+    });
   };
 
   const handleDistribute = (row) => {

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -296,6 +296,34 @@ describe("ReceiptMonitor", () => {
     );
   });
 
+  it("says which results the score left without a verdict", async () => {
+    // An analyte with no sealed target on a cycle below the peer floor reaches
+    // SCORED with performance_status NULL. The score still succeeds; the point is
+    // that the operator is told rather than left with a silent null.
+    postToOpenElisServerFullResponse.mockImplementation((_url, _body, cb) =>
+      cb(
+        jsonResponse(true, {
+          cycleStatus: "SCORED",
+          followupCount: 0,
+          unjudgedCount: 3,
+          unjudgedTests: ["Haemoglobin"],
+        }),
+      ),
+    );
+    const onNotice = vi.fn();
+    renderTab("SUBMISSIONS_OPEN", { onNotice });
+
+    await screen.findByText("Mbeya Regional Lab");
+    fireEvent.click(screen.getByRole("button", { name: "Score cycle" }));
+
+    await waitFor(() =>
+      expect(onNotice).toHaveBeenCalledWith({
+        kind: "success",
+        text: "Cycle scored, but 3 result(s) got no verdict, on Haemoglobin. Those analytes carry no sealed target and the cycle has too few peers to place them against.",
+      }),
+    );
+  });
+
   test("Enter results keys a participant's reported values and posts them per test", async () => {
     renderTab();
     getFromOpenElisServer.mockImplementation((url, cb) => {

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8634,5 +8634,6 @@
   "eqa.enrollment.statusEffectiveDate": "Effective from",
   "eqa.enrollment.withdrawIsFinal": "Withdrawing is final. To take part again, this laboratory enrols in the programme afresh.",
   "eqa.enrollment.statusChanged": "This enrolment is now {status}",
-  "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status"
+  "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status",
+  "eqa.score.scoredWithUnjudged": "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against."
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProviderScoringServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.commons.validator.GenericValidator;
 import org.hibernate.ObjectNotFoundException;
 import org.openelisglobal.analyte.service.AnalyteService;
@@ -168,6 +169,7 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         // acceptable. Where the panel sealed a target, that target is the verdict.
         eqaStatisticsService.calculateAndUpdateStatistics(distribution.getId());
         judgeAgainstPanelTargets(cycle, distribution.getId());
+        List<EQAResult> unjudged = unjudgedResults(distribution.getId());
         advanceToScored(cycle, sysUserId);
 
         int followups = 0;
@@ -185,6 +187,9 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
         summary.put("distributionId", distribution.getId());
         summary.put("scoredCount", (int) reported);
         summary.put("followupCount", followups);
+        summary.put("unjudgedCount", unjudged.size());
+        summary.put("unjudgedTests", unjudged.stream().map(result -> testName(result.getTestId()))
+                .filter(name -> name != null).distinct().sorted().collect(Collectors.toList()));
         summary.put("cycleStatus",
                 eqaCycleDAO.get(cycleId).map(EQACycle::getStatus).map(EQACycleStatus::name).orElse(null));
         return summary;
@@ -445,6 +450,20 @@ public class EQAProviderScoringServiceImpl implements EQAProviderScoringService 
             result.setPerformanceStatus(EqaPanelVerdict.of(target, reported));
             eqaResultDAO.update(result);
         }
+    }
+
+    /**
+     * The reported results that reached SCORED with no verdict on them. Neither
+     * pass covers them: the peer statistic skips a test with fewer than
+     * {@code MIN_PARTICIPANTS_FOR_STATS} numeric results and never places a
+     * qualitative one at any roster size, and the target pass only touches analytes
+     * the panel sealed a target for. Before this the row simply kept a null
+     * performance_status and the only trace was an info line in the statistics log.
+     */
+    private List<EQAResult> unjudgedResults(Long distributionId) {
+        return eqaResultDAO.findByDistributionId(distributionId).stream()
+                .filter(result -> result.getResultValue() != null || result.getResultText() != null)
+                .filter(result -> result.getPerformanceStatus() == null).collect(Collectors.toList());
     }
 
     private static Object reportedOf(EQAResult result) {

--- a/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAProviderTargetToleranceIntegrationTest.java
@@ -1,10 +1,12 @@
 package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -37,6 +39,13 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
     private static final long TEST_CD4 = 9927L;
     private static final long ANALYTE_CD4 = 9828L;
     private static final int TEST_ANALYTE_LINK = 99827;
+    /**
+     * A second analyte on the same cycle, so a panel can target one and not the
+     * other.
+     */
+    private static final long TEST_HB = 9929L;
+    private static final long ANALYTE_HB = 9830L;
+    private static final int TEST_ANALYTE_LINK_HB = 99829;
 
     @Autowired
     private EQAProviderScoringService scoringService;
@@ -61,9 +70,19 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
         jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
                 TEST_ANALYTE_LINK, TEST_CD4, ANALYTE_CD4);
+        jdbc.update("INSERT INTO clinlims.analyte (id, name, is_active, lastupdated) VALUES (?, ?, 'Y', now())"
+                + " ON CONFLICT (id) DO NOTHING", ANALYTE_HB, "Tolerance HB");
+        jdbc.update(
+                "INSERT INTO clinlims.test (id, name, description, is_active, guid, lastupdated)"
+                        + " SELECT ?, ?, ?, 'Y', ?, now() WHERE NOT EXISTS (SELECT 1 FROM clinlims.test WHERE id = ?)",
+                TEST_HB, "Tolerance HB test", "Tolerance HB test", UUID.randomUUID().toString(), TEST_HB);
+        jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK_HB);
+        jdbc.update("INSERT INTO clinlims.test_analyte (id, test_id, analyte_id, lastupdated) VALUES (?, ?, ?, now())",
+                TEST_ANALYTE_LINK_HB, TEST_HB, ANALYTE_HB);
 
         EQAProgram scheme = insertScheme("Tolerance scheme " + System.nanoTime(), EQASchemeType.REGIONAL_PT, "CPHL");
         eqaProgramService.assignTest(scheme.getId(), TEST_CD4);
+        eqaProgramService.assignTest(scheme.getId(), TEST_HB);
         cycle = readBack(insertCycle(scheme, 1));
         jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SUBMISSIONS_OPEN' WHERE id = ?", cycle.getId());
         panel = insertPanel(scheme, p -> {
@@ -80,9 +99,10 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
         super.cleanEqaTables();
         if (jdbc != null) {
-            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id = ?", TEST_ANALYTE_LINK);
-            jdbc.update("DELETE FROM clinlims.test WHERE id = ?", TEST_CD4);
-            jdbc.update("DELETE FROM clinlims.analyte WHERE id = ?", ANALYTE_CD4);
+            jdbc.update("DELETE FROM clinlims.test_analyte WHERE id IN (?, ?)", TEST_ANALYTE_LINK,
+                    TEST_ANALYTE_LINK_HB);
+            jdbc.update("DELETE FROM clinlims.test WHERE id IN (?, ?)", TEST_CD4, TEST_HB);
+            jdbc.update("DELETE FROM clinlims.analyte WHERE id IN (?, ?)", ANALYTE_CD4, ANALYTE_HB);
             jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_ORG, FIRST_ORG + 5);
         }
     }
@@ -146,13 +166,48 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
     }
 
+    @Test
+    public void anAnalyteWithNoSealedTargetIsCountedAndNamed() {
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        reportBoth("40", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("CD4 carries the sealed target, so it is judged", "ACCEPTABLE", verdict(FIRST_ORG, TEST_CD4));
+        assertEquals("UNACCEPTABLE", verdict(FIRST_ORG + 2, TEST_CD4));
+        assertNull("HB has no target, and three laboratories is below the peer floor", verdict(FIRST_ORG, TEST_HB));
+
+        assertEquals("one unjudged result per laboratory", 3, summary.get("unjudgedCount"));
+        assertEquals("and the operator is told which test they sit on", List.of("Tolerance HB test"),
+                summary.get("unjudgedTests"));
+    }
+
+    @Test
+    public void everyAnalyteJudgedLeavesNothingToReport() {
+        // The control. Without it the assertions above cannot tell "counted the
+        // unjudged" from "counted every result on the second test".
+        sealTarget("40", new BigDecimal("36"), new BigDecimal("44"));
+        sealTargetFor(ANALYTE_HB, "T02", "12", new BigDecimal("11"), new BigDecimal("13"));
+        reportBoth("40", "41", "80");
+
+        Map<String, Object> summary = scoringService.scoreCycle(cycle.getId(), USER);
+
+        assertEquals("HB now carries a target of its own", "ACCEPTABLE", verdict(FIRST_ORG, TEST_HB));
+        assertEquals(0, summary.get("unjudgedCount"));
+        assertEquals(List.of(), summary.get("unjudgedTests"));
+    }
+
     // ---- helpers ----
 
     private void sealTarget(String targetValue, BigDecimal low, BigDecimal high) {
+        sealTargetFor(ANALYTE_CD4, "T01", targetValue, low, high);
+    }
+
+    private void sealTargetFor(long analyteId, String sampleCode, String targetValue, BigDecimal low, BigDecimal high) {
         EQAPanelSample sample = new EQAPanelSample();
         sample.setPanel(panel);
-        sample.setSampleCode("T01");
-        sample.setAnalyteId(ANALYTE_CD4);
+        sample.setSampleCode(sampleCode);
+        sample.setAnalyteId(analyteId);
         sample.setTargetValue(targetValue);
         sample.setAcceptanceRangeLow(low);
         sample.setAcceptanceRangeHigh(high);
@@ -167,11 +222,25 @@ public class EQAProviderTargetToleranceIntegrationTest extends EQASpineTestBase 
         }
     }
 
+    /**
+     * The same CD4 values, each laboratory also reporting the untargeted HB test.
+     */
+    private void reportBoth(String... values) {
+        for (int i = 0; i < values.length; i++) {
+            scoringService.takeIn(cycle.getId(), FIRST_ORG + i, Map.of(TEST_CD4, values[i], TEST_HB, "12"),
+                    EQASubmissionMethod.MANUAL, USER);
+        }
+    }
+
     private String verdict(long organizationId) {
+        return verdict(organizationId, TEST_CD4);
+    }
+
+    private String verdict(long organizationId, long testId) {
         return jdbc.queryForObject(
                 "SELECT performance_status FROM clinlims.eqa_result"
                         + " WHERE participant_organization_id = ? AND test_id = ?",
-                String.class, organizationId, TEST_CD4);
+                String.class, organizationId, testId);
     }
 
     private BigDecimal targetValue(long organizationId) {


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not supplied: the one visible change is an inline notification string on an existing action, asserted in full by a unit test.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

A result reaches `SCORED` with `performance_status` NULL whenever its analyte
carries no sealed target **and** it has no peer statistic. Two ways in:

| Result | Why no peer statistic |
| --- | --- |
| Numeric | Its test has fewer than `MIN_PARTICIPANTS_FOR_STATS` numeric results, so `EQAStatisticsServiceImpl` skips the whole group |
| Qualitative | `result_text` never enters the peer grouping at any roster size |

`judgeAgainstPanelTargets` only touches analytes the panel sealed a target for,
so neither pass reaches these rows. The only trace was an info line in the
statistics log.

`scoreCycle` now counts them where the judgement already runs and returns
`unjudgedCount` with the distinct `unjudgedTests` they sit on. The provider
workbench reports it on an otherwise successful score.

It still scores. Refusing until an operator acknowledges it was the other option
on the card, and it would block scoring that is legitimate today.

## Screenshots

Not supplied. The one visible change is the text of an inline notification,
asserted in full by `ReceiptMonitor.test.jsx`.

## Related Issue

OGC-935. Split from #4249; review note recorded when #4181 merged.


## Other

**Split from #4249.** That pull request carried this change and the other half
together, and its `Build + Test` failed twice, deterministically, on
`EQALabEnrollmentStatusIntegrationTest` — a test in neither half's diff. The
two halves share no file, so they are separated here to find which one moves
that failure, and so the clean half can land rather than waiting behind it.

The failure does not reproduce locally: the full backend suite passes on this
base with either half applied.

**Proved by inversion**, because a case that cannot fail is not evidence:

| Break | Fails |
| --- | --- |
| Count nothing as unjudged | `anAnalyteWithNoSealedTargetIsCountedAndNamed` (3 to 0) |
| Ignore `unjudgedCount` in the workbench | `says which results the score left without a verdict` |

`everyAnalyteJudgedLeavesNothingToReport` is the control: without it the count
cannot be told apart from "counted every result on the second test".
