### PR TITLE
feat(eqa): fix a scheme's type once one of its cycles is running (OGC-935)

### DIFF
--- a/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAProgramServiceImpl.java
@@ -1,11 +1,14 @@
 package org.openelisglobal.eqa.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.openelisglobal.common.exception.LIMSRuntimeException;
 import org.openelisglobal.common.service.BaseObjectServiceImpl;
+import org.openelisglobal.eqa.dao.EQACycleDAO;
 import org.openelisglobal.eqa.dao.EQAProgramDAO;
 import org.openelisglobal.eqa.dao.EQAProgramTestDAO;
 import org.openelisglobal.eqa.dao.EQASchemeAnalystDAO;
+import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramTest;
 import org.openelisglobal.eqa.valueholder.EQASchemeAnalyst;
@@ -26,6 +29,9 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
 
     @Autowired
     private EQASchemeAnalystDAO eqaSchemeAnalystDAO;
+
+    @Autowired
+    private EQACycleDAO eqaCycleDAO;
 
     public EQAProgramServiceImpl() {
         super(EQAProgram.class);
@@ -52,7 +58,65 @@ public class EQAProgramServiceImpl extends BaseObjectServiceImpl<EQAProgram, Lon
     @Override
     public EQAProgram update(EQAProgram program) {
         validateProviderRequired(program);
+        validateSchemeTypeNotChangedUnderLiveCycles(program);
         return super.update(program);
+    }
+
+    /**
+     * The scheme type decides whether a provider organization is required, which
+     * blinding lane the scheme travels and which cycle state machine applies, so
+     * changing it reinterprets everything already underneath it. This sits on
+     * update() rather than on the endpoint because the configuration loader writes
+     * the same field on its upsert branch, as the daemon user; a guard on one
+     * caller would only move the hole to the quieter one.
+     *
+     * <p>
+     * A closed cycle cannot be worked on again, which is what makes the rule "no
+     * live cycle" rather than "no cycle at all". A deployment upgraded from V1
+     * carries a backfilled CLOSED cycle for every completed legacy distribution,
+     * and those schemes all took the INTERNATIONAL_PT default; barring a type
+     * change outright would strand every one of them outside in-house blinding,
+     * with no route out from any screen.
+     *
+     * <p>
+     * SCORED is deliberately not treated as closed. The line between them is that a
+     * SCORED cycle is still workable and a CLOSED one is only readable: SCORED is
+     * on the scoring path and scores are distributed from it, while CLOSED has no
+     * outgoing edge on any of the three machines. Both are still read — the rolling
+     * window that decides persistent failure selects SCORED and CLOSED alike — so
+     * being unread is not the distinction and must not be argued as one. That makes
+     * this rule strict in practice: nothing in the product closes a cycle today, so
+     * a scheme that has run a V2 cycle keeps its type. The V1 backfill writes
+     * CLOSED directly, which is the case the rule exists to admit.
+     *
+     * <p>
+     * The comparison reads the stored row rather than trusting the argument: both
+     * callers mutate a detached scheme in place, so by the time update() sees it
+     * the previous type is gone from the object.
+     */
+    private void validateSchemeTypeNotChangedUnderLiveCycles(EQAProgram program) {
+        if (program.getId() == null) {
+            return;
+        }
+        EQASchemeType stored = eqaProgramDAO.get(program.getId()).map(EQAProgram::getSchemeType).orElse(null);
+        if (stored == null || stored == program.getSchemeType()) {
+            return;
+        }
+        // Named by number, not by name: cycle_name is nullable and the number is what
+        // the provider scheme list shows.
+        List<String> live = eqaCycleDAO.findBySchemeIds(List.of(program.getId())).stream()
+                .filter(cycle -> cycle.getStatus() != EQACycleStatus.CLOSED)
+                .map(cycle -> "cycle " + cycle.getCycleNumber()).collect(Collectors.toList());
+        if (!live.isEmpty()) {
+            // The message offers the new scheme and nothing else on purpose. Closing a
+            // cycle would also lift the bar, but nothing in the product asks for CLOSED
+            // — the edge is legal on all three machines and unreachable in practice — so
+            // telling an operator to close it first is advice nobody can take.
+            throw new LIMSRuntimeException("This scheme's type cannot change from " + stored + " to "
+                    + program.getSchemeType() + ": " + String.join(", ", live)
+                    + " has run under the current type and its results are still read against it."
+                    + " Create a new scheme of the type you need.");
+        }
     }
 
     private void validateProviderRequired(EQAProgram program) {

--- a/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQASchemeAdministrationIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -103,6 +104,61 @@ public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
     }
 
     @Test
+    public void updateProgram_refusesATypeChangeWhileACycleIsStillRunning() {
+        Long id = created(Map.of("name", "Has a live cycle " + System.nanoTime(), "schemeType", "REGIONAL_PT",
+                "provider", "CPHL"));
+        insertCycle(eqaProgramService.get(id), 4);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id, Map.of("schemeType", "IN_HOUSE"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue("the refusal names the cycle that blocks it: " + errorOf(response),
+                errorOf(response).contains("cycle 4"));
+        assertTrue("and offers the only route an operator actually has: " + errorOf(response),
+                errorOf(response).toLowerCase().contains("create a new scheme"));
+        // Nothing in the product closes a cycle: the SCORED to CLOSED edge is legal on
+        // all three machines and no caller asks for it. Advice to close this one first
+        // would be advice nobody can follow, so the message must not give it.
+        assertFalse("and does not tell them to close it, which no screen can do: " + errorOf(response),
+                errorOf(response).toLowerCase().contains("close"));
+        assertEquals("and the stored type is untouched", EQASchemeType.REGIONAL_PT,
+                eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void updateProgram_allowsATypeChangeWhenEveryCycleIsClosed() {
+        // The V1 upgrade path. Every completed legacy distribution was backfilled a
+        // CLOSED cycle, and those schemes all took the INTERNATIONAL_PT default, so
+        // refusing on any cycle at all would strand them outside in-house blinding.
+        Long id = created(Map.of("name", "Legacy V1 scheme " + System.nanoTime(), "schemeType", "INTERNATIONAL_PT",
+                "provider", "CPHL"));
+        Long cycleId = insertCycle(eqaProgramService.get(id), 1);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycleId);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "IN_HOUSE", "provider", ""));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(EQASchemeType.IN_HOUSE, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
+    public void updateProgram_letsAnEditResendTheSameTypeUnderALiveCycle() {
+        // The Programs form sends every field it displays, so an edit to the name or
+        // the review gate carries schemeType with it. That is not a type change.
+        Long id = created(
+                Map.of("name", "Unchanged type " + System.nanoTime(), "schemeType", "REGIONAL_PT", "provider", "CPHL"));
+        insertCycle(eqaProgramService.get(id), 2);
+
+        ResponseEntity<?> response = controller.updateProgram(request(), id,
+                Map.of("schemeType", "REGIONAL_PT", "provider", "CPHL", "description", "Second round"));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("Second round", eqaProgramService.get(id).getDescription());
+        assertEquals(EQASchemeType.REGIONAL_PT, eqaProgramService.get(id).getSchemeType());
+    }
+
+    @Test
     public void updateTestAssignments_writesTheMapProviderIntakeReads() {
         seedTest(TEST_SERO, "Scheme admin serology");
         seedTest(TEST_VL, "Scheme admin viral load");
@@ -124,6 +180,11 @@ public class EQASchemeAdministrationIntegrationTest extends EQASpineTestBase {
     }
 
     // ---- helpers ----
+
+    private String errorOf(ResponseEntity<?> response) {
+        Object error = ((Map<?, ?>) response.getBody()).get("error");
+        return error == null ? "" : String.valueOf(error);
+    }
 
     private Long created(Map<String, Object> body) {
         ResponseEntity<?> response = controller.createProgram(request(), body);


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not applicable: the change is a backend guard with no user-visible surface.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

The scheme type decides whether a provider organization is required, which
blinding lane the scheme travels and which cycle state machine applies.
`EQAProgramRestController.updateProgram` set it whenever the key was present,
with no check for existing cycles.

**The check sits on `EQAProgramService.update`, not on the endpoint.**
`EQAProgramConfigurationHandler` writes the same field on its upsert branch as
the daemon user, and it is the only other caller in the tree. A guard on the
endpoint alone would have moved the hole to the quieter of the two paths.

**The rule is "no live cycle", not "no cycle at all".** A deployment upgraded
from V1 carries a backfilled CLOSED cycle for every completed legacy
distribution (`qa-073`), and those schemes all took the `INTERNATIONAL_PT`
default. Since `inHouseApi.js` admits a scheme to in-house blinding on
`schemeType === "IN_HOUSE"`, barring the change outright would strand every
legacy scheme outside in-house blinding with no route out from any screen.

**SCORED is deliberately not treated as closed.** A SCORED cycle is still
*workable* and a CLOSED one is only *readable*: SCORED sits on `SCORING_PATH`
and scores are distributed from it, while CLOSED has no outgoing edge on any of
the three machines. Being unread is **not** the distinction — the rolling
persistent-failure window selects `SCORED || CLOSED` alike.

**Nothing in the product closes a cycle today.** `SCORED → CLOSED` is legal on
all three machines but no caller asks for it, and the reference deployment
carries zero CLOSED cycles out of 38. So the refusal offers a new scheme rather
than telling an operator to close one, which would be advice nobody can follow,
and the test asserts it does not say "close".

An edit that resends the same type is not a type change, which matters because
the Programs form sends every field it displays.

## Screenshots

Not applicable. No user-visible surface changes.

## Related Issue

OGC-935. Split from #4249; review note recorded when #4182 merged.


## Other

**Split from #4249.** That pull request carried this change and the other half
together, and its `Build + Test` failed twice, deterministically, on
`EQALabEnrollmentStatusIntegrationTest` — a test in neither half's diff. The
two halves share no file, so they are separated here to find which one moves
that failure, and so the clean half can land rather than waiting behind it.

The failure does not reproduce locally: the full backend suite passes on this
base with either half applied.

**Proved by inversion:**

| Break | Fails |
| --- | --- |
| Drop the guard | `updateProgram_refusesATypeChangeWhileACycleIsStillRunning` (400 to 200) |
| Treat closed cycles as live | `updateProgram_allowsATypeChangeWhenEveryCycleIsClosed` (200 to 400) |
| Restore "Close it first" to the refusal | `updateProgram_refusesATypeChangeWhileACycleIsStillRunning` |
