### PR TITLE
test(eqa): scope the enrolment audit assertions to the rows the test writes (OGC-935)

### DIFF
--- a/src/test/java/org/openelisglobal/eqa/EQALabEnrollmentStatusIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQALabEnrollmentStatusIntegrationTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,6 +72,43 @@ public class EQALabEnrollmentStatusIntegrationTest extends EQASpineTestBase {
                 referenceTableId);
         rows.sort((left, right) -> Integer.compare(Integer.parseInt(left.getId()), Integer.parseInt(right.getId())));
         return rows;
+    }
+
+    private Set<String> auditRowIds(Long enrollmentId) {
+        return audit(enrollmentId).stream().map(History::getId).collect(Collectors.toSet());
+    }
+
+    /**
+     * The rows written since a snapshot of the ids. {@code history} keeps every row
+     * ever written against a reference id, and no fixture in this suite empties it,
+     * so counting the whole result measures the run rather than the transition
+     * under test.
+     */
+    private List<History> auditRowsSince(Long enrollmentId, Set<String> before) {
+        return audit(enrollmentId).stream().filter(row -> !before.contains(row.getId())).collect(Collectors.toList());
+    }
+
+    /**
+     * Every row the query returned, not only the one an assertion picked. A row
+     * whose content is unexpected and a row that was never ours read identically
+     * from a message carrying one of them, and telling those apart after the fact
+     * has cost this suite a full CI cycle.
+     */
+    private String describe(Long enrollmentId) {
+        // The reference table id belongs in the dump too. A history row stores the
+        // id the write resolved the name to, and the read resolves the name again,
+        // so a row can be missed because that id moved rather than because the
+        // write was wrong.
+        StringBuilder detail = new StringBuilder("audit rows for enrolment ").append(enrollmentId)
+                .append(" (reference table id ")
+                .append(referenceTablesService.getReferenceTableByName("eqa_lab_program_enrollment").getId())
+                .append("):");
+        for (History row : audit(enrollmentId)) {
+            detail.append("\n  id=").append(row.getId()).append(" activity=").append(row.getActivity())
+                    .append(" sysUserId=").append(row.getSysUserId()).append(" changes=")
+                    .append(row.getChanges() == null ? "<null>" : changesOf(row).replace('\n', ' '));
+        }
+        return detail.toString();
     }
 
     private String changesOf(History row) {
@@ -152,26 +190,27 @@ public class EQALabEnrollmentStatusIntegrationTest extends EQASpineTestBase {
     public void theAuditKeepsThePriorStatusTheReasonAndTheUser() {
         EQALabProgramEnrollment enrolled = enrol("Lifecycle audit");
 
+        Set<String> beforeSuspension = auditRowIds(enrolled.getId());
         enrollmentService.updateStatus(enrolled.getId(), "Suspended", "Analyser away for repair", EFFECTIVE, USER);
 
-        List<History> rows = audit(enrolled.getId());
-        assertEquals(1, rows.size());
+        List<History> suspension = auditRowsSince(enrolled.getId(), beforeSuspension);
+        assertEquals(describe(enrolled.getId()), 1, suspension.size());
         // The history row carries the values the enrolment held before the move,
         // which is the half a status column on its own cannot answer.
-        String recorded = changesOf(rows.get(0));
-        assertTrue(recorded, recorded.contains("status") && recorded.contains("Active"));
-        assertEquals("U", rows.get(0).getActivity());
-        assertNotNull(rows.get(0).getTimestamp());
+        String recorded = changesOf(suspension.get(0));
+        assertTrue(describe(enrolled.getId()), recorded.contains("status") && recorded.contains("Active"));
+        assertEquals("U", suspension.get(0).getActivity());
+        assertEquals(USER, suspension.get(0).getSysUserId());
+        assertNotNull(suspension.get(0).getTimestamp());
 
+        Set<String> beforeWithdrawal = auditRowIds(enrolled.getId());
         enrollmentService.updateStatus(enrolled.getId(), "Withdrawn", "Laboratory left the programme", EFFECTIVE, USER);
 
-        List<History> afterWithdrawal = audit(enrolled.getId());
-        assertEquals(2, afterWithdrawal.size());
-        String second = changesOf(afterWithdrawal.get(1));
-        assertTrue(second, second.contains("Suspended"));
-        assertTrue(second, second.contains("Analyser away for repair"));
-
-        assertEquals(List.of(USER, USER),
-                afterWithdrawal.stream().map(History::getSysUserId).collect(Collectors.toList()));
+        List<History> withdrawal = auditRowsSince(enrolled.getId(), beforeWithdrawal);
+        assertEquals(describe(enrolled.getId()), 1, withdrawal.size());
+        String second = changesOf(withdrawal.get(0));
+        assertTrue(describe(enrolled.getId()), second.contains("Suspended"));
+        assertTrue(describe(enrolled.getId()), second.contains("Analyser away for repair"));
+        assertEquals(USER, withdrawal.get(0).getSysUserId());
     }
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not
      applicable: the change is test-only and has no user-visible surface.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

`EQALabEnrollmentStatusIntegrationTest.theAuditKeepsThePriorStatusTheReasonAndTheUser`
passes on its own and in the EQA selection, and fails in the full backend run.
Two assumptions in the test are wrong, and both hide which one broke.

- The test counted every history row the enrolment had, then picked one by
  index. The `history` table keeps rows for the life of the run and no fixture
  in the suite empties it, so the count measures the run and the index can
  point at a row the test never wrote.
- A failure message carried only the row an assertion picked. A row with
  unexpected content and a row belonging to something else read the same way
  from that message.

The test now snapshots the history row ids before each status change and
asserts on the difference, so each assertion covers the row that transition
wrote. Every assertion carries a dump of all rows the query returned: id,
activity, `sys_user_id`, and the full change XML, plus the reference table id
the read resolved against. A history row stores the id that the write resolved
the table name to, and the read resolves that name again, so the dump separates
a wrong write from a read that looked at the wrong rows.

No production code changes.

## Screenshots

Not applicable. The change is test-only.

## Related Issue

OGC-935

## Other

`EQALabEnrollmentStatusIntegrationTest` passes (6 tests), and the EQA selection
passes (596 tests). The failure this targets reproduces only in the full
backend run, so this change is an instrument for that run rather than a fix
proven against it.
