### PR TITLE
fix(OGC-1054): remove external CI dependency from testing deployment

### DIFF
--- a/.github/scripts/check-readiness.py
+++ b/.github/scripts/check-readiness.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Require a real HTTP 200 JSON health response before accepting a deployment."""
+
+import argparse
+import json
+import math
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, response, code, message, headers, url):
+        return None
+
+
+def validate_contract(url, timeout=300, interval=5, request_timeout=10, key="status", **_options):
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError("Readiness URL must be HTTP(S) without embedded credentials")
+    if not key or any(not part for part in key.split(".")):
+        raise ValueError("Readiness requires a JSON field name")
+    if any(not math.isfinite(value) or value <= 0 for value in (timeout, interval, request_timeout)):
+        raise ValueError("Readiness timeout and polling intervals must be positive")
+
+
+def probe(url, key="status", expected="UP", insecure=False, timeout=10):
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError("Readiness URL must be HTTP(S) without embedded credentials")
+    context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
+    opener = urllib.request.build_opener(NoRedirect(), urllib.request.HTTPSHandler(context=context))
+    try:
+        request = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with opener.open(request, timeout=timeout) as response:
+            if response.status != 200:
+                return False, f"HTTP {response.status}"
+            content_type = response.headers.get_content_type()
+            if content_type != "application/json" and not content_type.endswith("+json"):
+                return False, f"Expected JSON, received {content_type}"
+            body = response.read(65537)
+            if len(body) > 65536:
+                return False, "Health response exceeds 64 KiB"
+            value = json.loads(body)
+            for part in key.split("."):
+                if not isinstance(value, dict) or part not in value:
+                    return False, f"Missing health field: {key}"
+                value = value[part]
+            if type(value) is not type(expected) or value != expected:
+                return False, f"Health field {key} does not equal the expected value"
+            return True, "HTTP 200 and expected JSON health value"
+    except urllib.error.HTTPError as error:
+        return False, f"HTTP {error.code}"
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as error:
+        return False, type(error).__name__
+
+
+def wait_until_ready(url, timeout=300, interval=5, request_timeout=10, key="status", expected="UP",
+                     insecure=False, clock=time.monotonic, sleep=time.sleep, check=probe):
+    validate_contract(url, timeout, interval, request_timeout, key)
+    deadline = clock() + timeout
+    attempts = 0
+    reason = "No response before deadline"
+    while clock() < deadline:
+        attempts += 1
+        ready, reason = check(url, key, expected, insecure, min(request_timeout, deadline - clock()))
+        print(f"Readiness attempt {attempts}: {reason}", flush=True)
+        if ready:
+            return {"ready": True, "attempts": attempts, "reason": reason}
+        remaining = deadline - clock()
+        if remaining > 0:
+            sleep(min(interval, remaining))
+    return {"ready": False, "attempts": attempts, "reason": reason}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--timeout", type=float, default=300)
+    parser.add_argument("--interval", type=float, default=5)
+    parser.add_argument("--request-timeout", type=float, default=10)
+    parser.add_argument("--json-key", default="status")
+    parser.add_argument("--expected-value", default='"UP"', help="Expected value encoded as JSON")
+    parser.add_argument("--insecure", action="store_true", help="Explicitly allow a self-signed TLS certificate")
+    parser.add_argument("--output", help="Write the readiness outcome as JSON")
+    args = parser.parse_args()
+    try:
+        expected = json.loads(args.expected_value)
+        report = wait_until_ready(args.url, args.timeout, args.interval, args.request_timeout,
+                                  args.json_key, expected, args.insecure)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as output:
+            json.dump(report, output)
+    return 0 if report["ready"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/deploy-published-testing.py
+++ b/.github/scripts/deploy-published-testing.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Deploy published images using the server's existing Compose configuration."""
+
+import argparse
+import datetime
+import fcntl
+import importlib.util
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+
+APP_REPOSITORY = "https://github.com/DIGI-UW/OpenELIS-Global-2.git"
+SERVICES = {
+    "oe.openelis.org": "itechuw/openelis-global-2",
+    "db.openelis.org": "itechuw/openelis-global-2-database",
+    "fhir.openelis.org": "itechuw/openelis-global-2-fhir",
+    "frontend.openelis.org": "itechuw/openelis-global-2-frontend",
+    "proxy": "itechuw/openelis-global-2-proxy",
+}
+
+
+def validate_manifest(manifest):
+    if not re.fullmatch(r"[0-9a-f]{40}", manifest.get("appSha", "")):
+        raise ValueError("Manifest must identify the tested application commit")
+    if manifest.get("appBranch") != "develop":
+        raise ValueError("Testing requires a develop image manifest")
+    if set(manifest.get("images", {})) != set(SERVICES):
+        raise ValueError("Manifest must include exactly the five application images")
+    for service, repository in SERVICES.items():
+        if not re.fullmatch(re.escape(repository) + r"@sha256:[0-9a-f]{64}", manifest["images"][service]):
+            raise ValueError(f"{service} must use a published DockerHub image digest")
+    return manifest
+
+
+def run(args, cwd, capture=False):
+    return subprocess.run(args, cwd=cwd, check=True, text=True,
+                          stdout=subprocess.PIPE if capture else None).stdout
+
+
+def require_current_candidate(sha, cwd):
+    head = run(["git", "ls-remote", APP_REPOSITORY, "refs/heads/develop"], cwd, True).split()
+    if len(head) != 2 or head != [sha, "refs/heads/develop"]:
+        raise ValueError("Candidate is no longer develop HEAD; refusing an obsolete deployment")
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def deploy(request, diagnostics):
+    manifest = validate_manifest(request["manifest"])
+    spec = importlib.util.spec_from_file_location("readiness", pathlib.Path(__file__).with_name("check-readiness.py"))
+    readiness = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(readiness)
+    contract = request["readiness"]
+    readiness.validate_contract(**contract)
+    app_dir = pathlib.Path(request["deploy_path"]).resolve()
+    if not (app_dir / ".env").is_file():
+        raise ValueError("The server must have an existing configured .env")
+    state_dir = app_dir / ".openelis-ci"
+    override = state_dir / "deployment-images.json"
+    base_compose = ["docker", "compose", "-f", "docker-compose.yml"]
+    compose = base_compose + ["-f", str(override)]
+    try:
+        # Called under the host deployment lock, then repeated after slow pulls.
+        require_current_candidate(manifest["appSha"], app_dir)
+        run(["git", "fetch", "origin", "main"], app_dir)
+        run(["git", "merge", "--ff-only", "origin/main"], app_dir)
+        infra_sha = run(["git", "rev-parse", "HEAD"], app_dir, True).strip()
+        state_dir.mkdir(exist_ok=True)
+        write_json(override, {"services": {service: {"image": image}
+                                          for service, image in manifest["images"].items()}})
+        run(compose + ["pull", *SERVICES], app_dir)
+        require_current_candidate(manifest["appSha"], app_dir)
+        target_path = state_dir / "target.json"
+        if target_path.is_file():
+            shutil.copy2(target_path, diagnostics / "previous-target.json")
+            target_path.unlink()
+        run(compose + ["up", "-d"], app_dir)
+        images = {}
+        for service, reference in manifest["images"].items():
+            container = run(compose + ["ps", "-q", service], app_dir, True).strip()
+            if not container or "\n" in container:
+                raise ValueError(f"Expected one running container for {service}")
+            actual = json.loads(run(["docker", "inspect", container], app_dir, True))[0]
+            expected = json.loads(run(["docker", "image", "inspect", reference], app_dir, True))[0]
+            if not actual["State"]["Running"] or actual["Image"] != expected["Id"]:
+                raise ValueError(f"Running {service} does not match the published image")
+            images[service] = {"reference": reference, "imageId": actual["Image"]}
+        report = readiness.wait_until_ready(**contract)
+        write_json(diagnostics / "readiness.json", report)
+        if not report["ready"]:
+            raise RuntimeError("Application did not become ready; inspect deployment diagnostics")
+        target = {"instance": "testing", "state": "ready", "appSha": manifest["appSha"],
+                  "appBranch": manifest["appBranch"], "infraSha": infra_sha, "images": images,
+                  "deploymentId": request["run_id"],
+                  "deployedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                  "verification": {"readiness": report, "url": contract["url"]}}
+        write_json(target_path, target)
+        write_json(diagnostics / "target.json", target)
+        print(f"Testing is ready at {manifest['appSha']}", flush=True)
+    finally:
+        # The base configuration also works when validation/pulling failed before
+        # an override was available. Status/logs do not need the candidate images.
+        for filename, args in [("compose-status.txt", ["ps", "--all"]),
+                               ("service-logs.txt", ["logs", "--no-color", "--tail", "250", "oe.openelis.org", "proxy"])]:
+            with (diagnostics / filename).open("w", encoding="utf-8") as output:
+                subprocess.run(base_compose + args, cwd=app_dir, stdout=output, stderr=subprocess.STDOUT, check=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("request", type=pathlib.Path)
+    args = parser.parse_args()
+    diagnostics = args.request.resolve().parent / "diagnostics"
+    diagnostics.mkdir(exist_ok=True)
+    try:
+        request = json.loads(args.request.read_text(encoding="utf-8"))
+        with open("/tmp/openelis-testing-deploy.lock", "w", encoding="utf-8") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            deploy(request, diagnostics)
+    except Exception as error:
+        (diagnostics / "failure.txt").write_text(str(error) + "\n", encoding="utf-8")
+        print(f"Deployment failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/deploy-published-testing.py
+++ b/.github/scripts/deploy-published-testing.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 
 
 APP_REPOSITORY = "https://github.com/DIGI-UW/OpenELIS-Global-2.git"
@@ -74,10 +75,15 @@ def deploy(request, diagnostics):
         run(["git", "merge", "--ff-only", "origin/main"], app_dir)
         infra_sha = run(["git", "rev-parse", "HEAD"], app_dir, True).strip()
         state_dir.mkdir(exist_ok=True)
-        write_json(override, {"services": {service: {"image": image}
-                                          for service, image in manifest["images"].items()}})
-        run(compose + ["pull", *SERVICES], app_dir)
-        require_current_candidate(manifest["appSha"], app_dir)
+        # Leave the saved image selection untouched if pulling or freshness
+        # validation fails. Stage on the same filesystem for atomic promotion.
+        with tempfile.TemporaryDirectory(prefix="candidate-", dir=state_dir) as candidate_dir:
+            candidate_override = pathlib.Path(candidate_dir) / override.name
+            write_json(candidate_override, {"services": {service: {"image": image}
+                                                        for service, image in manifest["images"].items()}})
+            run(base_compose + ["-f", str(candidate_override), "pull", *SERVICES], app_dir)
+            require_current_candidate(manifest["appSha"], app_dir)
+            candidate_override.replace(override)
         target_path = state_dir / "target.json"
         if target_path.is_file():
             shutil.copy2(target_path, diagnostics / "previous-target.json")

--- a/.github/scripts/publish-checkpoints.cjs
+++ b/.github/scripts/publish-checkpoints.cjs
@@ -1,5 +1,4 @@
 const BACKEND = "01 Checkpoint - Backend";
-const E2E = "03 Checkpoint - E2E";
 
 module.exports = async function waitForPublishCheckpoints({
   github,
@@ -7,11 +6,20 @@ module.exports = async function waitForPublishCheckpoints({
   owner,
   repo,
   sha,
+  buildRunId,
+  buildRunAttempt,
   timeoutMs = 45 * 60 * 1000,
   pollMs = 30 * 1000,
   now = Date.now,
   sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 }) {
+  if (
+    !/^[1-9][0-9]*$/.test(String(buildRunId)) ||
+    !/^[1-9][0-9]*$/.test(String(buildRunAttempt))
+  ) {
+    throw new Error("Publication requires the source build run and attempt");
+  }
+  const E2E = `03 Checkpoint - E2E / build-${buildRunId}-${buildRunAttempt}`;
   const started = now();
   while (now() - started < timeoutMs) {
     const [statuses, checks] = await Promise.all([
@@ -47,7 +55,7 @@ module.exports = async function waitForPublishCheckpoints({
       backend.conclusion === "success"
     ) {
       core.info(
-        `Backend (including existing-data upgrades) and E2E passed for ${sha}.`,
+        `Backend and E2E passed for ${sha}, build ${buildRunId}, attempt ${buildRunAttempt}.`,
       );
       return;
     }

--- a/.github/scripts/publish-checkpoints.test.cjs
+++ b/.github/scripts/publish-checkpoints.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const wait = require("./publish-checkpoints.cjs");
 const sha = "a".repeat(40);
+const buildContext = "03 Checkpoint - E2E / build-123-2";
 const backend = (conclusion, id = 1, head_sha = sha) => ({
   name: "01 Checkpoint - Backend",
   id,
@@ -11,12 +12,14 @@ const backend = (conclusion, id = 1, head_sha = sha) => ({
   conclusion,
 });
 
-async function run(checks, state = "success") {
+async function run(checks, state = "success", context = buildContext) {
   let clock = 0;
   return wait({
     owner: "test",
     repo: "test",
     sha,
+    buildRunId: 123,
+    buildRunAttempt: 2,
     core: { info() {} },
     github: {
       rest: {
@@ -24,7 +27,7 @@ async function run(checks, state = "success") {
           async listCommitStatusesForRef(request) {
             assert.equal(request.ref, sha);
             return {
-              data: state ? [{ context: "03 Checkpoint - E2E", state }] : [],
+              data: state ? [{ context, state }] : [],
             };
           },
         },
@@ -73,6 +76,25 @@ test("missing, pending, and skipped backend checks cannot authorize publication"
 test("failed or missing E2E checks cannot authorize publication", async () => {
   await assert.rejects(run([backend("success")], "failure"), /E2E.*failure/);
   await assert.rejects(run([backend("success")], null), /Timed out/);
+});
+test("another build or attempt cannot authorize publishing rebuilt images", async () => {
+  for (const context of [
+    "03 Checkpoint - E2E",
+    "03 Checkpoint - E2E / build-122-2",
+    "03 Checkpoint - E2E / build-123-1",
+  ]) {
+    await assert.rejects(
+      run([backend("success")], "success", context),
+      /Timed out/,
+    );
+    await assert.rejects(
+      run([backend("success")], "failure", context),
+      /Timed out/,
+    );
+  }
+});
+test("a missing source build identity fails closed", async () => {
+  await assert.rejects(wait({ sha }), /requires the source build/);
 });
 test("release publication produces the backend checkpoint required by the gate", () => {
   const workflow = fs.readFileSync(".github/workflows/backend.yml", "utf8");

--- a/.github/scripts/test_deployment.py
+++ b/.github/scripts/test_deployment.py
@@ -1,0 +1,122 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import test_readiness
+
+spec = importlib.util.spec_from_file_location("deployment", Path(__file__).with_name("deploy-published-testing.py"))
+deployment = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(deployment)
+
+
+class DeploymentTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        (self.root / ".env").write_text("SERVER_SECRET=keep-existing-value\n")
+        self.diagnostics = self.root / "diagnostics"
+        self.diagnostics.mkdir()
+        self.target = self.root / ".openelis-ci/target.json"
+        self.target.parent.mkdir(parents=True)
+        self.target.write_text('{"deploymentId":"previous-ready"}')
+        self.sha = "a" * 40
+        self.request = {"manifest": {"appSha": self.sha, "appBranch": "develop", "images": {
+            service: repository + "@sha256:" + "b" * 64 for service, repository in deployment.SERVICES.items()}},
+            "deploy_path": str(self.root), "run_id": "123-1",
+            "readiness": {"url": "http://127.0.0.1:1/health", "timeout": 0.02, "interval": 0.01}}
+        self.wrong_image = False
+        self.branch_head = self.sha
+        self.commands = []
+
+    def command(self, args, _cwd, capture=False):
+        self.commands.append(args)
+        if args[:2] == ["git", "ls-remote"]:
+            return self.branch_head + "\trefs/heads/develop\n"
+        if args == ["git", "rev-parse", "HEAD"]:
+            return self.sha
+        if "ps" in args:
+            return "container-id"
+        if args[:2] == ["docker", "inspect"]:
+            return json.dumps([{"State": {"Running": True}, "Image": "wrong" if self.wrong_image else "sha256:actual"}])
+        if args[:3] == ["docker", "image", "inspect"]:
+            return json.dumps([{"Id": "sha256:actual"}])
+        return ""
+
+    def test_mutable_missing_and_foreign_images_are_rejected(self):
+        manifest = self.request["manifest"]
+        for value in ["itechuw/openelis-global-2:develop", "attacker/image@sha256:" + "b" * 64]:
+            manifest["images"]["oe.openelis.org"] = value
+            with self.assertRaises(ValueError):
+                deployment.validate_manifest(manifest)
+        del manifest["images"]["oe.openelis.org"]
+        with self.assertRaises(ValueError):
+            deployment.validate_manifest(manifest)
+
+    def test_invalid_readiness_contract_is_rejected_before_deployment(self):
+        self.request["readiness"]["timeout"] = 0
+        with patch.object(deployment, "run") as command:
+            with self.assertRaises(ValueError):
+                deployment.deploy(self.request, self.diagnostics)
+            command.assert_not_called()
+
+    def test_old_build_cannot_overwrite_a_newer_deployment(self):
+        self.branch_head = "c" * 40
+        with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
+            with self.assertRaisesRegex(ValueError, "obsolete deployment"):
+                deployment.deploy(self.request, self.diagnostics)
+        self.assertFalse(any("up" in command or "pull" in command for command in self.commands))
+        self.assertEqual("previous-ready", json.loads(self.target.read_text())["deploymentId"])
+        self.assertTrue((self.diagnostics / "compose-status.txt").exists())
+
+    def test_candidate_is_rechecked_after_image_pull_before_restart(self):
+        def advance_during_pull(args, cwd, capture=False):
+            result = self.command(args, cwd, capture)
+            if "pull" in args:
+                self.branch_head = "c" * 40
+            return result
+
+        with patch.object(deployment, "run", side_effect=advance_during_pull), patch.object(deployment.subprocess, "run"):
+            with self.assertRaisesRegex(ValueError, "obsolete deployment"):
+                deployment.deploy(self.request, self.diagnostics)
+        self.assertFalse(any("up" in command for command in self.commands))
+        self.assertEqual("previous-ready", json.loads(self.target.read_text())["deploymentId"])
+
+    def test_failed_startup_withdraws_stale_ready_identity_and_keeps_it_in_diagnostics(self):
+        with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
+            with self.assertRaisesRegex(RuntimeError, "did not become ready"):
+                deployment.deploy(self.request, self.diagnostics)
+        self.assertFalse(self.target.exists())
+        self.assertEqual("previous-ready",
+                         json.loads((self.diagnostics / "previous-target.json").read_text())["deploymentId"])
+        self.assertFalse(json.loads((self.diagnostics / "readiness.json").read_text())["ready"])
+        self.assertTrue((self.diagnostics / "compose-status.txt").exists())
+        self.assertTrue((self.diagnostics / "service-logs.txt").exists())
+        self.assertIn("keep-existing-value", (self.root / ".env").read_text())
+
+    def test_wrong_running_image_cannot_publish_ready(self):
+        self.wrong_image = True
+        with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                deployment.deploy(self.request, self.diagnostics)
+        self.assertFalse(self.target.exists())
+
+    def test_ready_identity_requires_both_running_digests_and_health(self):
+        # Exercise the same HTTP probe as deployment, without a live VM or Docker.
+        test_readiness.ReadinessTest.setUpClass()
+        self.addCleanup(test_readiness.ReadinessTest.tearDownClass)
+        test_readiness.ReadinessTest.server.response = (200, "application/json", b'{"status": "UP"}')
+        self.request["readiness"].update(url=test_readiness.ReadinessTest.url, timeout=1)
+        with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
+            deployment.deploy(self.request, self.diagnostics)
+        target = json.loads(self.target.read_text())
+        self.assertEqual(self.sha, target["appSha"])
+        self.assertEqual(5, len(target["images"]))
+        self.assertTrue(target["verification"]["readiness"]["ready"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_deployment.py
+++ b/.github/scripts/test_deployment.py
@@ -23,6 +23,11 @@ class DeploymentTest(unittest.TestCase):
         self.target = self.root / ".openelis-ci/target.json"
         self.target.parent.mkdir(parents=True)
         self.target.write_text('{"deploymentId":"previous-ready"}')
+        self.override = self.target.with_name("deployment-images.json")
+        self.previous_override = json.dumps({"services": {
+            service: {"image": repository + "@sha256:" + "d" * 64}
+            for service, repository in deployment.SERVICES.items()}})
+        self.override.write_text(self.previous_override)
         self.sha = "a" * 40
         self.request = {"manifest": {"appSha": self.sha, "appBranch": "develop", "images": {
             service: repository + "@sha256:" + "b" * 64 for service, repository in deployment.SERVICES.items()}},
@@ -79,11 +84,39 @@ class DeploymentTest(unittest.TestCase):
                 self.branch_head = "c" * 40
             return result
 
-        with patch.object(deployment, "run", side_effect=advance_during_pull), patch.object(deployment.subprocess, "run"):
-            with self.assertRaisesRegex(ValueError, "obsolete deployment"):
+        for existing_override in (True, False):
+            with self.subTest(existing_override=existing_override):
+                if not existing_override:
+                    self.override.unlink()
+                self.branch_head = self.sha
+                self.commands.clear()
+                with patch.object(deployment, "run", side_effect=advance_during_pull), patch.object(deployment.subprocess, "run"):
+                    with self.assertRaisesRegex(ValueError, "obsolete deployment"):
+                        deployment.deploy(self.request, self.diagnostics)
+                self.assertFalse(any("up" in command for command in self.commands))
+                self.assertEqual("previous-ready", json.loads(self.target.read_text())["deploymentId"])
+                if existing_override:
+                    self.assertEqual(self.previous_override, self.override.read_text())
+                else:
+                    self.assertFalse(self.override.exists())
+                self.assertEqual({"target.json"} | ({"deployment-images.json"} if existing_override else set()),
+                                 {path.name for path in self.target.parent.iterdir()})
+
+    def test_failed_image_pull_preserves_the_previous_override(self):
+        def fail_pull(args, cwd, capture=False):
+            result = self.command(args, cwd, capture)
+            if "pull" in args:
+                raise deployment.subprocess.CalledProcessError(1, args)
+            return result
+
+        with patch.object(deployment, "run", side_effect=fail_pull), patch.object(deployment.subprocess, "run"):
+            with self.assertRaises(deployment.subprocess.CalledProcessError):
                 deployment.deploy(self.request, self.diagnostics)
         self.assertFalse(any("up" in command for command in self.commands))
+        self.assertEqual(self.previous_override, self.override.read_text())
         self.assertEqual("previous-ready", json.loads(self.target.read_text())["deploymentId"])
+        self.assertEqual({"target.json", "deployment-images.json"},
+                         {path.name for path in self.target.parent.iterdir()})
 
     def test_failed_startup_withdraws_stale_ready_identity_and_keeps_it_in_diagnostics(self):
         with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
@@ -110,12 +143,28 @@ class DeploymentTest(unittest.TestCase):
         self.addCleanup(test_readiness.ReadinessTest.tearDownClass)
         test_readiness.ReadinessTest.server.response = (200, "application/json", b'{"status": "UP"}')
         self.request["readiness"].update(url=test_readiness.ReadinessTest.url, timeout=1)
-        with patch.object(deployment, "run", side_effect=self.command), patch.object(deployment.subprocess, "run"):
+        expected_override = {"services": {service: {"image": reference}
+                                          for service, reference in self.request["manifest"]["images"].items()}}
+
+        def check_selected_images(args, cwd, capture=False):
+            if "pull" in args or "up" in args:
+                selected_override = Path(args[args.index("-f", 4) + 1])
+                self.assertEqual(expected_override, json.loads(selected_override.read_text()))
+                if "pull" in args:
+                    self.assertEqual(self.previous_override, self.override.read_text())
+                else:
+                    self.assertEqual(self.override, selected_override)
+            return self.command(args, cwd, capture)
+
+        with patch.object(deployment, "run", side_effect=check_selected_images), patch.object(deployment.subprocess, "run"):
             deployment.deploy(self.request, self.diagnostics)
         target = json.loads(self.target.read_text())
         self.assertEqual(self.sha, target["appSha"])
         self.assertEqual(5, len(target["images"]))
         self.assertTrue(target["verification"]["readiness"]["ready"])
+        self.assertEqual(expected_override, json.loads(self.override.read_text()))
+        self.assertEqual({"target.json", "deployment-images.json"},
+                         {path.name for path in self.target.parent.iterdir()})
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_publication_workflow.py
+++ b/.github/scripts/test_publication_workflow.py
@@ -1,0 +1,50 @@
+"""Guard the candidate publication workflow, which workflow_run PR checks do not execute."""
+
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class PublicationWorkflowTest(unittest.TestCase):
+    def test_publication_does_not_require_an_external_workflow_interface(self):
+        workflow = yaml.load((ROOT / ".github/workflows/publish-images.yml").read_text(), Loader=yaml.BaseLoader)
+        for name, job in workflow["jobs"].items():
+            with self.subTest(job=name):
+                if "uses" in job:
+                    self.assertTrue(job["uses"].startswith("./.github/workflows/"),
+                                    "External workflow inputs must not prevent publication from loading")
+
+    def test_reporter_posts_the_build_status_consumed_by_publication(self):
+        workflow = yaml.load((ROOT / ".github/workflows/e2e-tests.yml").read_text(), Loader=yaml.BaseLoader)
+        for job in ("set-pending-status", "report-status"):
+            script = workflow["jobs"][job]["steps"][0]["with"]["script"]
+            script = script.replace("${{ github.event.workflow_run.id }}", "123")
+            script = script.replace("${{ github.event.workflow_run.run_attempt }}", "2")
+            script = script.replace("${{ needs.e2e-gate.result }}", "success")
+            script = script.replace("${{ needs.setup.outputs.artifact_source_mode }}", "cross_run")
+            script = script.replace("${{ needs.setup.outputs.is_fork }}", "false")
+            harness = """
+const assert = require('node:assert/strict');
+const posted = [];
+const context = {serverUrl:'https://github.com', repo:{owner:'test',repo:'test'}, runId:456};
+const github = {rest:{repos:{createCommitStatus:async status => posted.push(status)}}};
+(async () => {
+""" + script + """
+assert.deepEqual(posted.map(status => status.context),
+  ['03 Checkpoint - E2E', '03 Checkpoint - E2E / build-123-2']);
+assert.ok(posted.every(status => status.state === process.env.EXPECTED_STATE));
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
+            with self.subTest(job=job):
+                subprocess.run([os.environ.get("NODE_BINARY", "node"), "-e", harness], check=True,
+                               env={**os.environ, "EXPECTED_STATE": "pending" if job == "set-pending-status" else "success"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_readiness.py
+++ b/.github/scripts/test_readiness.py
@@ -1,0 +1,91 @@
+import contextlib
+import http.server
+import importlib.util
+import io
+from pathlib import Path
+import threading
+import unittest
+
+spec = importlib.util.spec_from_file_location("readiness", Path(__file__).with_name("check-readiness.py"))
+readiness = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(readiness)
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        code, content_type, body = self.server.response
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+class ReadinessTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.url = f"http://127.0.0.1:{cls.server.server_port}/health"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join()
+
+    def test_only_successful_json_health_is_accepted(self):
+        cases = [
+            (200, "application/json", b'{"status":"UP"}', True),
+            (200, "application/json", b'{\n "status": "UP"\n}', True),
+            (200, "text/html", b'<html>expected "status":"UP"</html>', False),
+            (200, "application/json", b'<html>"status":"UP"</html>', False),
+            (302, "application/json", b'{"status":"UP"}', False),
+            (500, "application/json", b'{"status":"UP"}', False),
+            (200, "application/json", b'{"status":"DOWN"}', False),
+            (200, "application/json", b'{}', False),
+        ]
+        for code, content_type, body, expected in cases:
+            with self.subTest(code=code, content_type=content_type, body=body):
+                self.server.response = (code, content_type, body)
+                self.assertEqual(expected, readiness.probe(self.url)[0])
+
+    def test_contract_can_use_a_nested_boolean_health_field(self):
+        self.server.response = (200, "application/health+json", b'{"database":{"ready":true}}')
+        self.assertTrue(readiness.probe(self.url, "database.ready", True)[0])
+
+    def test_failure_stops_at_the_deadline(self):
+        clock = [0]
+        requests = []
+
+        def check(*args):
+            requests.append(args[-1])
+            return False, "HTTP 503"
+
+        def sleep(seconds):
+            clock[0] += seconds
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = readiness.wait_until_ready(self.url, timeout=3, interval=2, request_timeout=10,
+                                                clock=lambda: clock[0], sleep=sleep, check=check)
+        self.assertFalse(result["ready"])
+        self.assertEqual(3, clock[0])
+        self.assertEqual([3, 1], requests)
+
+    def test_retry_can_succeed(self):
+        outcomes = iter([(False, "HTTP 503"), (True, "ready")])
+        with contextlib.redirect_stdout(io.StringIO()):
+            report = readiness.wait_until_ready(self.url, check=lambda *_args: next(outcomes), sleep=lambda _: None)
+        self.assertTrue(report["ready"])
+        self.assertEqual(2, report["attempts"])
+
+    def test_invalid_timeout_is_rejected(self):
+        with self.assertRaises(ValueError):
+            readiness.wait_until_ready(self.url, timeout=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/testing-deployment.md
+++ b/.github/scripts/testing-deployment.md
@@ -1,0 +1,39 @@
+Testing deployment is owned by the application's `Publish Images` workflow. It
+uses the existing `/home/ubuntu/openelis-docker/docker-compose.yml` on the VM;
+no reusable workflow or pending change in that repository is required.
+
+The publication gate requires backend success for the application commit and E2E
+success for the particular image build run and attempt. Testing deployment
+checks that the candidate is still `develop` HEAD under a host lock, deploys the
+five published image digests, verifies the running images, then requires JSON
+application health. A candidate superseded during image pulls fails before
+restarting containers. The server's configured `.env` and data volumes are
+preserved; a conflicting infrastructure fast-forward fails without resetting
+local files.
+
+The existing `TESTING_VM_SSH_KEY` secret and `DEPLOY_HOST`, `TESTING_VM_USER`,
+`DEPLOY_PORT`, and `DEPLOY_PATH` variables still configure access. Optional
+readiness variables are:
+
+| Variable                     | Default                                                          |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `TESTING_READINESS_URL`      | `https://testing.openelis-global.org/api/OpenELIS-Global/health` |
+| `TESTING_READINESS_TIMEOUT`  | `300` seconds                                                    |
+| `TESTING_READINESS_JSON_KEY` | `status` (supports dotted nested keys)                           |
+| `TESTING_READINESS_EXPECTED` | `"UP"` (JSON-encoded value)                                      |
+
+Redirects, HTML responses, and unexpected JSON values fail readiness. Compose
+status, bounded backend/proxy logs, and readiness results are attached to the
+workflow. A verified `target.json` is retained in the artifact and on the host
+at `.openelis-ci/target.json`; it is not a public endpoint. Review widget
+installation is a separate follow-up.
+
+Run the focused checks from the repository root:
+
+```sh
+node --test .github/scripts/publish-checkpoints.test.cjs
+python3 -m unittest discover -s .github/scripts -p 'test_*.py' -v
+```
+
+The Python tests require PyYAML and use temporary localhost HTTP servers. Docker
+operations are mocked; the tests do not deploy to the testing VM.

--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -1,0 +1,30 @@
+name: Validate publication and deployment
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/**"
+  push:
+    branches: [develop]
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  deployment-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 -m pip install PyYAML==6.0.2
+      - run: node --test .github/scripts/publish-checkpoints.test.cjs
+      - run: python3 -m unittest discover -s .github/scripts -p 'test_*.py' -v

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -130,10 +130,11 @@ jobs:
         with:
           script: |
             const sha = '${{ needs.setup.outputs.status_sha }}';
-            const contextName = '03 Checkpoint - E2E';
+            const contexts = ['03 Checkpoint - E2E',
+              '03 Checkpoint - E2E / build-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}'];
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
-            await github.rest.repos.createCommitStatus({
+            for (const contextName of contexts) await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha,
@@ -377,7 +378,8 @@ jobs:
         with:
           script: |
             const sha = '${{ needs.setup.outputs.status_sha }}';
-            const contextName = '03 Checkpoint - E2E';
+            const contexts = ['03 Checkpoint - E2E',
+              '03 Checkpoint - E2E / build-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}'];
             const gateResult = '${{ needs.e2e-gate.result }}';
             const artifactSourceMode = '${{ needs.setup.outputs.artifact_source_mode }}';
             const isFork = '${{ needs.setup.outputs.is_fork }}' === 'true';
@@ -396,7 +398,7 @@ jobs:
               state = 'failure';
               description = 'One or more E2E suites failed';
             }
-            await github.rest.repos.createCommitStatus({
+            for (const contextName of contexts) await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha,

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -26,6 +26,7 @@ jobs:
       head_branch: ${{ steps.context.outputs.head_branch }}
       image_transfer: ${{ steps.context.outputs.image_transfer }}
       build_run_id: ${{ github.event.workflow_run.id }}
+      build_run_attempt: ${{ github.event.workflow_run.run_attempt }}
     steps:
       - name: Capture publish context from triggering workflow
         id: context
@@ -65,11 +66,15 @@ jobs:
         uses: actions/github-script@v8
         env:
           CANDIDATE_SHA: ${{ needs.setup.outputs.head_sha }}
+          BUILD_RUN_ID: ${{ needs.setup.outputs.build_run_id }}
+          BUILD_RUN_ATTEMPT: ${{ needs.setup.outputs.build_run_attempt }}
         with:
           script: |
             const wait = require('./.github/scripts/publish-checkpoints.cjs');
             await wait({ github, core, owner: context.repo.owner, repo: context.repo.repo,
-              sha: process.env.CANDIDATE_SHA });
+              sha: process.env.CANDIDATE_SHA,
+              buildRunId: process.env.BUILD_RUN_ID,
+              buildRunAttempt: process.env.BUILD_RUN_ATTEMPT });
 
   publish-images:
     name: Publish ${{ matrix.dockerhub_suffix || 'backend' }}
@@ -299,11 +304,78 @@ jobs:
     name: Deploy to testing VM
     needs: [setup, deployment-manifest]
     if: needs.setup.outputs.event_name == 'push' && needs.setup.outputs.head_branch == 'develop'
-    uses: DIGI-UW/openelis-docker/.github/workflows/deploy-testing.yml@main
-    with:
-      image_manifest: ${{ needs.deployment-manifest.outputs.manifest }}
-      enable_review: ${{ vars.TESTING_REVIEW_ENABLED == 'true' }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: deploy-testing
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    env:
+      DEPLOY_HOST: ${{ vars.DEPLOY_HOST || 'testing.openelis-global.org' }}
+      DEPLOY_USER: ${{ vars.TESTING_VM_USER || 'ubuntu' }}
+      DEPLOY_PORT: ${{ vars.DEPLOY_PORT || '22' }}
+      DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/home/ubuntu/openelis-docker' }}
+      REMOTE_RUN: /tmp/openelis-deploy-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout deployment scripts with the application
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.setup.outputs.head_sha }}
+          sparse-checkout: .github/scripts
+      - name: Validate deployment request
+        env:
+          IMAGE_MANIFEST: ${{ needs.deployment-manifest.outputs.manifest }}
+          READINESS_URL: ${{ vars.TESTING_READINESS_URL || 'https://testing.openelis-global.org/api/OpenELIS-Global/health' }}
+          READINESS_TIMEOUT: ${{ vars.TESTING_READINESS_TIMEOUT || '300' }}
+          READINESS_JSON_KEY: ${{ vars.TESTING_READINESS_JSON_KEY || 'status' }}
+          READINESS_EXPECTED: ${{ vars.TESTING_READINESS_EXPECTED || '"UP"' }}
+        run: |
+          python3 - <<'PY'
+          import importlib.util, json, os, pathlib, re
+          env = os.environ
+          for key, pattern in [('DEPLOY_HOST', r'[A-Za-z0-9][A-Za-z0-9.-]*'), ('DEPLOY_USER', r'[A-Za-z_][A-Za-z0-9_-]*'), ('DEPLOY_PORT', r'[0-9]+')]:
+              if not re.fullmatch(pattern, env[key]):
+                  raise SystemExit(f'Invalid {key}')
+          spec = importlib.util.spec_from_file_location('deploy', '.github/scripts/deploy-published-testing.py')
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+          request = {'manifest': module.validate_manifest(json.loads(env['IMAGE_MANIFEST'])),
+                     'deploy_path': env['DEPLOY_PATH'], 'run_id': env['GITHUB_RUN_ID'] + '-' + env['GITHUB_RUN_ATTEMPT'],
+                     'readiness': {'url': env['READINESS_URL'], 'timeout': float(env['READINESS_TIMEOUT']),
+                                   'key': env['READINESS_JSON_KEY'], 'expected': json.loads(env['READINESS_EXPECTED'])}}
+          pathlib.Path('request.json').write_text(json.dumps(request))
+          PY
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.TESTING_VM_SSH_KEY }}
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p "$DEPLOY_PORT" -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+      - name: Deploy published images and require readiness
+        run: |
+          ssh -i ~/.ssh/id_deploy -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p $REMOTE_RUN/diagnostics"
+          scp -i ~/.ssh/id_deploy -P "$DEPLOY_PORT" request.json .github/scripts/deploy-published-testing.py .github/scripts/check-readiness.py "$DEPLOY_USER@$DEPLOY_HOST:$REMOTE_RUN/"
+          set -o pipefail
+          ssh -i ~/.ssh/id_deploy -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" "python3 $REMOTE_RUN/deploy-published-testing.py $REMOTE_RUN/request.json" 2>&1 | tee deployment.log
+      - name: Collect deployment diagnostics
+        if: always()
+        run: |
+          mkdir -p diagnostics
+          if [ -f ~/.ssh/id_deploy ]; then
+            scp -i ~/.ssh/id_deploy -P "$DEPLOY_PORT" -r "$DEPLOY_USER@$DEPLOY_HOST:$REMOTE_RUN/diagnostics/." diagnostics/ || true
+          fi
+          if [ -f deployment.log ]; then cp deployment.log diagnostics/; fi
+      - name: Attach deployment diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: testing-deployment-${{ github.run_id }}-${{ github.run_attempt }}
+          path: diagnostics/
+          if-no-files-found: warn
+          retention-days: 7
 
   deployment-summary:
     name: Explain deployment outcome


### PR DESCRIPTION
`Publish Images` fails at startup because it passes unsupported inputs to an external reusable workflow. Move testing deployment into this repository so published images can reach the VM.

Deploy the tested image digests using the existing Compose configuration, preserve site `.env` settings, and require matching running images and JSON health. Reject obsolete commits and competing stacks. Publish E2E statuses independently with retries and validate images against the configured DockerHub namespace. Keep deployment diagnostics and previous image references; rollback remains manual because startup can apply database migrations.

Validation: 32 focused checks, Actionlint, repository formatting, and Java build/install.
