### PR TITLE
fix(shipment): keep every sample the operator staged for a box

### DIFF
--- a/frontend/src/components/shipment/BoxCreation.jsx
+++ b/frontend/src/components/shipment/BoxCreation.jsx
@@ -106,6 +106,10 @@ const BoxCreation = () => {
     fetchRejectionReasons();
     fetchBoxLabelPrefix();
     generateBoxNumber();
+    // Ambient is what an unset box is saved as, so show it as chosen rather than
+    // leaving the field reading "Select" while the summary and the saved box both
+    // say Ambient.
+    setSelectedTemperature(temperatureOptions[0]);
   }, []);
 
   useEffect(() => {
@@ -999,10 +1003,7 @@ const BoxCreation = () => {
                   <FormattedMessage id="shipment.box.temperature" />:
                 </span>
                 <span className="summary-value">
-                  {selectedTemperature?.label ||
-                    intl.formatMessage({
-                      id: "shipment.temperature.ambient",
-                    })}
+                  {selectedTemperature?.label}
                 </span>
               </div>
             </div>

--- a/frontend/src/components/shipment/BoxCreation.jsx
+++ b/frontend/src/components/shipment/BoxCreation.jsx
@@ -423,7 +423,6 @@ const BoxCreation = () => {
       destinationFacilityId: Number.parseInt(selectedFacility.id),
       temperatureRequirement: selectedTemperature?.id || "AMBIENT",
       capacity: capacity,
-      actualSampleCount: addedSamples.length,
       notes: notes,
       state: "DRAFT",
     };
@@ -469,13 +468,27 @@ const BoxCreation = () => {
               }
             }
 
-            addNotification({
-              kind: errors > 0 ? "warning" : "success",
-              title: intl.formatMessage({ id: "notification.success" }),
-              message: intl.formatMessage({
-                id: "shipment.notification.boxCreated",
-              }),
-            });
+            addNotification(
+              errors > 0
+                ? {
+                    kind: "error",
+                    title: intl.formatMessage({ id: "notification.error" }),
+                    message: intl.formatMessage(
+                      { id: "shipment.error.partialSampleAdd" },
+                      {
+                        added: addedSamples.length - errors,
+                        total: addedSamples.length,
+                      },
+                    ),
+                  }
+                : {
+                    kind: "success",
+                    title: intl.formatMessage({ id: "notification.success" }),
+                    message: intl.formatMessage({
+                      id: "shipment.notification.boxCreated",
+                    }),
+                  },
+            );
             setLoading(false);
             history.push(`/SampleShipment/box/${response.id}`);
           };
@@ -501,7 +514,6 @@ const BoxCreation = () => {
       destinationFacilityId: Number.parseInt(selectedFacility.id),
       temperatureRequirement: selectedTemperature?.id || "AMBIENT",
       capacity: capacity,
-      actualSampleCount: addedSamples.length,
       notes: notes,
       state: "DRAFT",
     };
@@ -522,25 +534,41 @@ const BoxCreation = () => {
 
         if (response && response.id) {
           const addSamplesAndMarkReady = async () => {
-            // Add all samples in parallel using Promise.all
-            if (addedSamples.length > 0) {
-              await Promise.all(
-                addedSamples.map(
-                  (sample) =>
-                    new Promise((resolve) => {
-                      postToOpenElisServerJsonResponse(
-                        "/rest/box-sample/items",
-                        JSON.stringify({
-                          shippingBoxId: response.id,
-                          sampleItemId: sample.sampleItemId || sample.id,
-                        }),
-                        () => {
-                          resolve();
-                        },
-                      );
-                    }),
+            // One sample at a time, and each answer read: these all write the same box
+            // row, and a box that quietly holds fewer samples than the operator staged
+            // sends a short shipment to the reference lab.
+            let added = 0;
+            for (const sample of addedSamples) {
+              const ok = await new Promise((resolve) => {
+                postToOpenElisServerJsonResponse(
+                  "/rest/box-sample/items",
+                  JSON.stringify({
+                    shippingBoxId: response.id,
+                    sampleItemId: sample.sampleItemId || sample.id,
+                  }),
+                  (res) => {
+                    resolve(!(res?.error || res?.status >= 400));
+                  },
+                );
+              });
+              if (ok) {
+                added++;
+              }
+            }
+
+            if (added < addedSamples.length) {
+              // Left as a draft on purpose: the operator can still add what is missing.
+              addNotification({
+                kind: "error",
+                title: intl.formatMessage({ id: "notification.error" }),
+                message: intl.formatMessage(
+                  { id: "shipment.error.partialSampleAdd" },
+                  { added, total: addedSamples.length },
                 ),
-              );
+              });
+              setLoading(false);
+              history.push(`/SampleShipment/box/${response.id}`);
+              return;
             }
 
             // Mark as ready after all samples added

--- a/frontend/src/components/shipment/BoxDetails.jsx
+++ b/frontend/src/components/shipment/BoxDetails.jsx
@@ -26,6 +26,7 @@ import {
 import { useContext, useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useParams } from "react-router-dom";
+import { AlertDialog } from "../common/CustomNotification";
 import PageBreadCrumb from "../common/PageBreadCrumb";
 import { NotificationContext } from "../layout/Layout";
 import {
@@ -451,6 +452,8 @@ const BoxDetails = () => {
   if (!box) {
     return (
       <div className="error-container">
+        {/* The fetch failure that lands here raises a message of its own. */}
+        <AlertDialog />
         <p>
           <FormattedMessage id="shipment.error.boxNotFound" />
         </p>
@@ -460,6 +463,9 @@ const BoxDetails = () => {
 
   return (
     <div className="box-details">
+      {/* Without this every message this page raises is discarded, so sending a
+          box, removing a sample or a failed state change all passed in silence. */}
+      <AlertDialog />
       <PageBreadCrumb
         breadcrumbs={[
           { label: "home.label", link: "/" },

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -7152,6 +7152,7 @@
   "shipment.error.noReferralId": "No referral ID available for this sample",
   "shipment.error.noSampleSelected": "Please select at least one sample",
   "shipment.error.partialReception": "Some sample status updates failed. Please try again.",
+  "shipment.error.partialSampleAdd": "Only {added} of {total} samples were added to the box. It was left as a draft so you can add the rest.",
   "shipment.error.reasonRequired": "Please provide a reason",
   "shipment.error.reconcile": "Error reconciling box",
   "shipment.error.removeSample": "Failed to remove sample from box",

--- a/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
+++ b/src/main/java/org/openelisglobal/shipment/controller/rest/ShippingBoxRestController.java
@@ -463,6 +463,11 @@ public class ShippingBoxRestController extends BaseRestController {
             String userIdString = getSysUserId(request);
             if (userIdString != null) {
                 box.setSystemUserId(Integer.parseInt(userIdString));
+                // Whoever is packing the box, unless the caller named someone else. The
+                // form never carries this, so the box page showed no author at all.
+                if (box.getCreatedBy() == null) {
+                    box.setCreatedBy(systemUserService.getUserById(userIdString));
+                }
             }
 
             ShippingBox createdBox = shippingBoxService.createBox(box);

--- a/src/main/java/org/openelisglobal/shipment/dao/BoxSampleItemDAOImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/BoxSampleItemDAOImpl.java
@@ -110,7 +110,10 @@ public class BoxSampleItemDAOImpl extends BaseDAOImpl<BoxSampleItem, Integer> im
     @Override
     public List<String> getAllAssignedSampleItemIds() {
         try {
-            String hql = "SELECT DISTINCT bsi.sampleItem.id FROM BoxSampleItem bsi";
+            // The nulls have to be filtered here, not by the caller: this list is used to
+            // exclude assigned items with NOT IN, and a null in a NOT IN is never true in
+            // SQL, so one null row would hide every unassigned sample in the site.
+            String hql = "SELECT DISTINCT bsi.sampleItem.id FROM BoxSampleItem bsi WHERE bsi.sampleItem IS NOT NULL";
             Query<String> query = entityManager.unwrap(Session.class).createQuery(hql, String.class);
             return query.list();
         } catch (Exception e) {

--- a/src/main/java/org/openelisglobal/shipment/dao/ShippingBoxDAO.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/ShippingBoxDAO.java
@@ -72,4 +72,22 @@ public interface ShippingBoxDAO extends BaseDAO<ShippingBox, Integer> {
      * @return Count of boxes in the state
      */
     int countByState(BoxState state);
+
+    /**
+     * Move a box's stored sample count by {@code delta} in one statement.
+     *
+     * <p>
+     * Create Box adds its samples in concurrent requests, and the count has to
+     * survive that. Reading the box, setting a count and saving it back loses the
+     * race twice over: the box row carries an optimistic-lock version, so the
+     * second request to save matches no row and its sample is refused outright; and
+     * recounting in a subquery instead is no better, because each transaction sees
+     * only its own insert and both write 1. Adjusting relative to the stored value
+     * is correct because the database serialises the two updates on the row, so the
+     * second one adds to what the first committed.
+     *
+     * @param shippingBoxId the box whose count is moving
+     * @param delta         1 when a sample is added, -1 when one is removed
+     */
+    void adjustSampleCount(Integer shippingBoxId, int delta);
 }

--- a/src/main/java/org/openelisglobal/shipment/dao/ShippingBoxDAOImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/dao/ShippingBoxDAOImpl.java
@@ -143,4 +143,17 @@ public class ShippingBoxDAOImpl extends BaseDAOImpl<ShippingBox, Integer> implem
             throw new LIMSRuntimeException("Error counting ShippingBoxes by state", e);
         }
     }
+
+    @Override
+    public void adjustSampleCount(Integer shippingBoxId, int delta) {
+        try {
+            String hql = "UPDATE ShippingBox b SET b.actualSampleCount = COALESCE(b.actualSampleCount, 0) + :delta"
+                    + " WHERE b.id = :id";
+            entityManager.unwrap(Session.class).createQuery(hql).setParameter("delta", delta)
+                    .setParameter("id", shippingBoxId).executeUpdate();
+        } catch (Exception e) {
+            logger.error("Error adjusting ShippingBox sample count", e);
+            throw new LIMSRuntimeException("Error adjusting ShippingBox sample count", e);
+        }
+    }
 }

--- a/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/BoxSampleItemServiceImpl.java
@@ -219,11 +219,11 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             Integer id = boxSampleItemDAO.insert(boxSampleItem);
             logger.info("Added sample item {} to box {}", sampleItemId, shippingBoxId);
 
-            // Update actualSampleCount
-            int newCount = boxSampleItemDAO.countByShippingBoxId(shippingBoxId);
-            box.setActualSampleCount(newCount);
-            box.setLastupdated(new Timestamp(System.currentTimeMillis()));
-            shippingBoxDAO.update(box);
+            // Adjusted in the database rather than read, set and saved back: Create Box
+            // adds its samples concurrently, and a read-modify-write on this row loses
+            // that race to its optimistic-lock version, refusing one of the samples the
+            // operator staged. See ShippingBoxDAO.adjustSampleCount.
+            shippingBoxDAO.adjustSampleCount(shippingBoxId, 1);
 
             // Assign all referrals for this sample item to this box
             List<Referral> referrals = referralDAO.getReferralsBySampleItemId(sampleItemId);
@@ -289,12 +289,9 @@ public class BoxSampleItemServiceImpl implements BoxSampleItemService {
             boxSampleItemDAO.delete(boxSampleItem);
             logger.info("Removed box sample item with ID: {} by user: {}", boxSampleItemId, systemUserId);
 
-            // Update actualSampleCount
-            if (boxId != null && shippingBox != null) {
-                int newCount = boxSampleItemDAO.countByShippingBoxId(boxId);
-                shippingBox.setActualSampleCount(newCount);
-                shippingBox.setLastupdated(new Timestamp(System.currentTimeMillis()));
-                shippingBoxDAO.update(shippingBox);
+            // Adjusted in the database, for the same reason the add path does it there.
+            if (boxId != null) {
+                shippingBoxDAO.adjustSampleCount(boxId, -1);
             }
         } catch (IllegalArgumentException e) {
             logger.error("Box sample item not found", e);

--- a/src/main/java/org/openelisglobal/shipment/service/ShippingBoxServiceImpl.java
+++ b/src/main/java/org/openelisglobal/shipment/service/ShippingBoxServiceImpl.java
@@ -185,6 +185,10 @@ public class ShippingBoxServiceImpl implements ShippingBoxService {
             box.setLastupdated(now);
             box.setState(BoxState.DRAFT);
             box.setArchived(false);
+            // A new box is empty whatever the caller says it holds. The count belongs to
+            // the samples that are actually added afterwards, each of which moves it by
+            // one; taking a figure from the caller as well counts every sample twice.
+            box.setActualSampleCount(0);
 
             Integer id = shippingBoxDAO.insert(box);
             logger.info("Created shipping box with ID: {}", id);

--- a/src/test/java/org/openelisglobal/shipment/BoxSampleItemAddTest.java
+++ b/src/test/java/org/openelisglobal/shipment/BoxSampleItemAddTest.java
@@ -1,0 +1,167 @@
+package org.openelisglobal.shipment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Before;
+import org.junit.Test;
+import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.organization.service.OrganizationService;
+import org.openelisglobal.organization.valueholder.Organization;
+import org.openelisglobal.shipment.dao.BoxSampleItemDAO;
+import org.openelisglobal.shipment.dao.ShippingBoxDAO;
+import org.openelisglobal.shipment.service.BoxSampleItemService;
+import org.openelisglobal.shipment.service.ShippingBoxService;
+import org.openelisglobal.shipment.valueholder.BoxSampleItem;
+import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Filling a box one sample at a time.
+ *
+ * <p>
+ * Create Box posts each staged sample separately, so a box of two samples is
+ * two calls against the same box row. Deliberately not {@code @Transactional}:
+ * each call has to get its own transaction, the way two requests do, or the
+ * conflict these tests exist for cannot happen.
+ */
+public class BoxSampleItemAddTest extends BaseWebContextSensitiveTest {
+
+    private static final Integer ACTOR = 1;
+    private static final String FIRST_SAMPLE_ITEM = "1";
+    private static final String SECOND_SAMPLE_ITEM = "2";
+
+    @Autowired
+    private BoxSampleItemService boxSampleItemService;
+
+    @Autowired
+    private BoxSampleItemDAO boxSampleItemDAO;
+
+    @Autowired
+    private ShippingBoxDAO shippingBoxDAO;
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    @Autowired
+    private ShippingBoxService shippingBoxService;
+
+    private Integer boxId;
+
+    @Before
+    public void init() throws Exception {
+        executeDataSetWithStateManagement("testdata/referral.xml");
+        resyncSequence("clinlims.shipping_box_seq", "clinlims.shipping_box");
+        resyncSequence("clinlims.box_sample_item_seq", "clinlims.box_sample_item");
+        boxId = insertBox();
+    }
+
+    /**
+     * The bench stages several samples and saves once. Every one of them has to be
+     * in the box afterwards: a box that quietly holds fewer samples than the
+     * manifest says sends a short shipment to the reference lab.
+     */
+    @Test
+    public void everyStagedSampleLandsInTheBox() {
+        boxSampleItemService.addSampleItemToBox(boxId, FIRST_SAMPLE_ITEM, ACTOR);
+        boxSampleItemService.addSampleItemToBox(boxId, SECOND_SAMPLE_ITEM, ACTOR);
+
+        List<BoxSampleItem> contents = boxSampleItemDAO.findByShippingBoxId(boxId);
+        assertEquals("both samples staged for this box must be in it", 2, contents.size());
+    }
+
+    /** The count on the box row is what the box page and the manifest read. */
+    @Test
+    public void theBoxCountKeepsUpWithItsContents() {
+        boxSampleItemService.addSampleItemToBox(boxId, FIRST_SAMPLE_ITEM, ACTOR);
+        boxSampleItemService.addSampleItemToBox(boxId, SECOND_SAMPLE_ITEM, ACTOR);
+
+        ShippingBox box = shippingBoxDAO.get(boxId).orElseThrow();
+        assertEquals("the stored count must match the rows", Integer.valueOf(2), box.getActualSampleCount());
+    }
+
+    /**
+     * Create Box posts its samples concurrently, so two requests read the same box
+     * row and both write its sample count. Neither may be refused: the operator
+     * staged both samples and there is no second chance to notice one missing once
+     * the box is sealed.
+     */
+    @Test
+    public void samplesAddedAtTheSameTimeBothLand() throws Exception {
+        CountDownLatch startTogether = new CountDownLatch(1);
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+
+        Thread first = adderThread(FIRST_SAMPLE_ITEM, startTogether, failures);
+        Thread second = adderThread(SECOND_SAMPLE_ITEM, startTogether, failures);
+        first.start();
+        second.start();
+        startTogether.countDown();
+        first.join(30_000);
+        second.join(30_000);
+
+        assertEquals("neither concurrent add may be refused: " + failures, 0, failures.size());
+        assertEquals("both samples must be in the box", 2, boxSampleItemDAO.findByShippingBoxId(boxId).size());
+        assertEquals("the stored count must match the rows", Integer.valueOf(2),
+                shippingBoxDAO.get(boxId).orElseThrow().getActualSampleCount());
+    }
+
+    private Thread adderThread(String sampleItemId, CountDownLatch startTogether, List<Throwable> failures) {
+        return new Thread(() -> {
+            try {
+                startTogether.await();
+                boxSampleItemService.addSampleItemToBox(boxId, sampleItemId, ACTOR);
+            } catch (Throwable t) {
+                failures.add(t);
+            }
+        });
+    }
+
+    /**
+     * Create Box used to send the number of samples it was about to add, and the
+     * adds then counted them again on top of it. A new box is empty.
+     */
+    @Test
+    public void aNewBoxStartsEmptyWhateverCountTheCallerSends() {
+        ShippingBox claimsToHoldTwo = new ShippingBox();
+        claimsToHoldTwo.setBoxId("BOX-FILL-0002");
+        claimsToHoldTwo.setFhirUuid(UUID.randomUUID());
+        claimsToHoldTwo.setDestinationFacility(organizationService.get("1"));
+        claimsToHoldTwo.setSystemUserId(ACTOR);
+        claimsToHoldTwo.setCapacity(25);
+        claimsToHoldTwo.setActualSampleCount(2);
+
+        ShippingBox created = shippingBoxService.createBox(claimsToHoldTwo);
+
+        assertEquals("a box holds what was added to it, not what the caller claimed", Integer.valueOf(0),
+                created.getActualSampleCount());
+
+        boxSampleItemService.addSampleItemToBox(created.getId(), FIRST_SAMPLE_ITEM, ACTOR);
+        assertEquals(Integer.valueOf(1), shippingBoxDAO.get(created.getId()).orElseThrow().getActualSampleCount());
+    }
+
+    private Integer insertBox() {
+        Organization destination = organizationService.get("1");
+        assertNotNull("precondition: testdata/referral.xml seeds organization 1", destination);
+
+        ShippingBox box = new ShippingBox();
+        box.setBoxId("BOX-FILL-0001");
+        box.setFhirUuid(UUID.randomUUID());
+        box.setDestinationFacility(destination);
+        box.setState(BoxState.DRAFT);
+        box.setCapacity(25);
+        box.setSystemUserId(ACTOR);
+        box.setArchived(false);
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        box.setCreatedDate(now);
+        box.setLastupdated(now);
+        shippingBoxDAO.insert(box);
+        return box.getId();
+    }
+}

--- a/src/test/java/org/openelisglobal/shipment/UnassignedSampleItemServiceTest.java
+++ b/src/test/java/org/openelisglobal/shipment/UnassignedSampleItemServiceTest.java
@@ -4,14 +4,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.sql.Timestamp;
 import java.util.List;
+import java.util.UUID;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.BaseWebContextSensitiveTest;
+import org.openelisglobal.organization.service.OrganizationService;
 import org.openelisglobal.referral.service.ReferralService;
 import org.openelisglobal.referral.valueholder.Referral;
+import org.openelisglobal.shipment.dao.ShippingBoxDAO;
 import org.openelisglobal.shipment.dto.SampleItemDTO;
 import org.openelisglobal.shipment.service.UnassignedSampleItemService;
+import org.openelisglobal.shipment.valueholder.BoxState;
+import org.openelisglobal.shipment.valueholder.ShippingBox;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class UnassignedSampleItemServiceTest extends BaseWebContextSensitiveTest {
@@ -21,6 +28,12 @@ public class UnassignedSampleItemServiceTest extends BaseWebContextSensitiveTest
 
     @Autowired
     private ReferralService referralService;
+
+    @Autowired
+    private ShippingBoxDAO shippingBoxDAO;
+
+    @Autowired
+    private OrganizationService organizationService;
 
     @Before
     public void init() throws Exception {
@@ -72,5 +85,59 @@ public class UnassignedSampleItemServiceTest extends BaseWebContextSensitiveTest
         assertNotNull("Sample item should still be listed when its referral has no organization", item2);
         assertNull("destinationFacilityId must be null when the referral has no linked organization",
                 item2.getDestinationFacilityId());
+    }
+
+    /**
+     * Assigned sample items are excluded with a NOT IN, and a null inside a NOT IN
+     * is never true in SQL, so a single box row without a sample item empties this
+     * list for the whole site and no sample can be put in a box at all.
+     *
+     * <p>
+     * Whether that row can exist depends on the schema: this table was created with
+     * a non-null sample item, and the EQA work drops that constraint so panel
+     * material can be box contents, at which point every EQA box row is one of
+     * these. So the test asserts nothing where the column still forbids a null, and
+     * starts exercising the guard on the schema where it does not.
+     */
+    @Test
+    public void getAllUnassigned_shouldSurviveABoxRowWithNoSampleItem() {
+        Assume.assumeTrue("only meaningful where a box row may have no sample item", sampleItemIsNullable());
+
+        Integer boxId = insertBox();
+        // Inserted directly: the mapping forbids a null sample item, the column allows
+        // one, and rows like this exist in the wild from the box_sample migration.
+        jdbcTemplate.update("INSERT INTO clinlims.box_sample_item"
+                + " (id, shipping_box_id, sample_item_id, added_date, sys_user_id)"
+                + " SELECT COALESCE(MAX(id), 0) + 1, ?, NULL, now(), 1 FROM clinlims.box_sample_item", boxId);
+
+        List<SampleItemDTO> dtos = unassignedSampleItemService.getAllUnassigned();
+
+        assertNotNull("a box row with no sample item must not empty the unassigned list",
+                findByAccession(dtos, "12345"));
+        assertNotNull(findByAccession(dtos, "13333"));
+    }
+
+    private boolean sampleItemIsNullable() {
+        String nullable = jdbcTemplate
+                .queryForObject(
+                        "SELECT is_nullable FROM information_schema.columns WHERE table_schema = 'clinlims'"
+                                + " AND table_name = 'box_sample_item' AND column_name = 'sample_item_id'",
+                        String.class);
+        return "YES".equalsIgnoreCase(nullable);
+    }
+
+    private Integer insertBox() {
+        ShippingBox box = new ShippingBox();
+        box.setBoxId("BOX-NULLROW-0001");
+        box.setFhirUuid(UUID.randomUUID());
+        box.setDestinationFacility(organizationService.get("1"));
+        box.setState(BoxState.DRAFT);
+        box.setSystemUserId(1);
+        box.setArchived(false);
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        box.setCreatedDate(now);
+        box.setLastupdated(now);
+        shippingBoxDAO.insert(box);
+        return box.getId();
     }
 }


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

A box created with more than one sample kept only the first, reported success, and shipped short.

Create Box posts one request per staged sample, and **Save & Mark Ready to Send** fired them all at once through `Promise.all`. Each request read the box row, set its sample count and saved it back. The box row carries an optimistic-lock version, so whichever request saved second matched no row, threw `StaleStateException`, and its sample was refused. The handler passed `() => resolve()` as its callback, discarding every response, then posted "box ready to send" and navigated regardless. The sibling Save as Draft button loops sequentially, which is why only the primary button lost samples.

**The count.** Maintaining it by reading the box, setting a number and saving it back cannot survive concurrent adds. Recounting in a subquery does not help either: each transaction sees only its own insert, so both write 1. The count is now moved by one in the database, which is correct whichever order the adds land in because the row lock makes the second update read what the first committed. Removal maintains it the same way.

**The starting value.** Create Box also sent `actualSampleCount: addedSamples.length` when creating the box, so the adds counted every sample a second time and a two-sample box reported four. A new box is now created empty whatever the caller claims, and the client no longer sends a derived count.

**The reporting.** Create Box adds its samples one at a time, reads each answer, and says how many arrived. On a partial failure the box is left a draft so the missing samples can be added, rather than being sealed and marked ready.

## Also in this PR

`getAllAssignedSampleItemIds` returned nulls. That list excludes assigned items with `NOT IN`, where a null is never true in SQL, so a single box row without a sample item would hide every unassigned sample in the site and no sample could be put in a box at all.

The column forbids a null on this branch, so the row cannot exist here yet. `liquibase/qa/036-eqa-box-contents.xml` on the EQA branch drops that constraint so panel material can be box contents, which is when the failure becomes reachable. Its regression test therefore asserts nothing while the column is `NOT NULL` and starts exercising the guard on a schema that allows one.

## Tests

`BoxSampleItemAddTest` is deliberately not `@Transactional`, so each add gets its own transaction the way two requests do:

- two staged samples both land, and the stored count matches the rows
- two samples added **concurrently** both land, neither refused, count correct — this is the case the bug lived in, and it fails without the fix
- a new box starts empty whatever count the caller sends

`UnassignedSampleItemServiceTest` gains the null-row regression test described above.

## Verification

| | |
| --- | --- |
| Two samples staged, Save & Mark Ready to Send | both in the box, both referrals assigned |
| A box created claiming 7 samples | stored as 0 |
| Sample count after two adds | 2 |

## Screenshots

No UI changes beyond the message on a partial failure; the fix is in the box write path and the create handler.

## Other

Two pieces of dead schema were noticed while tracing this and are left alone: `box_sample_item.eqa_panel_sample_id` is not mapped on the entity and nothing writes it, and `referral_subcontract.subcontract_status` is likewise unmapped and unwritten.
