### PR TITLE
feat(eqa): let an operator close a finished cycle, and make closing stick (OGC-935)

### DIFF
--- a/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ReceiptMonitor.jsx
@@ -26,6 +26,7 @@ import {
   distributeScores,
   fetchIntake,
   fetchReceiptRows,
+  closeCycle,
   fetchScoreRows,
   importIntakeCsv,
   markDelivered,
@@ -88,6 +89,8 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
   const [overrideNote, setOverrideNote] = useState("");
   const [busy, setBusy] = useState(null);
   const [openingSubmissions, setOpeningSubmissions] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [closeReason, setCloseReason] = useState("");
   const [openReason, setOpenReason] = useState("");
 
   // The cycle status is a dependency, not decoration: dispatching from the
@@ -191,6 +194,21 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
         "eqa.receipt.submissionsOpened",
         "Submissions are open.",
         "eqa.receipt.submissionsOpenFailed",
+        "qa.manage.eqa",
+      );
+    });
+  };
+
+  const handleCloseCycle = () => {
+    setBusy("close");
+    closeCycle(cycleId, closeReason, (response) => {
+      setClosing(false);
+      setCloseReason("");
+      report(
+        response,
+        "eqa.cycle.closedCopy",
+        "Cycle closed.",
+        "eqa.cycle.closeFailed",
         "qa.manage.eqa",
       );
     });
@@ -382,6 +400,19 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
             {canManage && SCORABLE.includes(cycleStatus) && (
               <Button size="sm" disabled={busy !== null} onClick={handleScore}>
                 {t("eqa.score.scoreCycle", "Score cycle")}
+              </Button>
+            )}
+            {canManage && cycleStatus === "SCORED" && (
+              <Button
+                size="sm"
+                kind="tertiary"
+                disabled={busy !== null}
+                onClick={() => {
+                  setClosing(true);
+                  setCloseReason("");
+                }}
+              >
+                {t("eqa.cycle.close", "Close cycle")}
               </Button>
             )}
             {canManage &&
@@ -678,6 +709,33 @@ const ReceiptMonitor = ({ cycleId, cycleStatus, onChanged, onNotice }) => {
           >
             {t("eqa.intake.import", "Import CSV")}
           </Button>
+        </Modal>
+      )}
+
+      {closing && (
+        <Modal
+          open
+          modalHeading={t("eqa.cycle.closeHeading", "Close this cycle")}
+          primaryButtonText={t("eqa.cycle.close", "Close cycle")}
+          secondaryButtonText={t("eqa.queue.cancel", "Cancel")}
+          primaryButtonDisabled={busy !== null || !closeReason.trim()}
+          onRequestClose={() => setClosing(false)}
+          onSecondarySubmit={() => setClosing(false)}
+          onRequestSubmit={handleCloseCycle}
+        >
+          <p style={{ ...hintStyle, marginBottom: "1rem" }}>
+            {t(
+              "eqa.cycle.closeHelp",
+              "A closed cycle is final: participants see it as closed and no further verdicts are recorded against it. Closing is refused while a follow-up is open or a missed-deadline result is still waiting on an answer.",
+            )}
+          </p>
+          <TextArea
+            id="eqa-close-cycle-reason"
+            labelText={t("eqa.receipt.openSubmissionsReason", "Reason")}
+            value={closeReason}
+            onChange={(event) => setCloseReason(event.target.value)}
+            rows={3}
+          />
         </Modal>
       )}
 

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ReceiptMonitor.test.jsx
@@ -9,6 +9,7 @@ import ReceiptMonitor from "../ReceiptMonitor";
 import UserSessionDetailsContext from "../../../../../UserSessionDetailsContext";
 import {
   getFromOpenElisServer,
+  patchToOpenElisServerFullResponse,
   postToOpenElisServerFullResponse,
 } from "../../../../utils/Utils";
 
@@ -17,6 +18,7 @@ vi.mock("../../../../utils/Utils", async () => {
   return {
     ...actual,
     getFromOpenElisServer: vi.fn(),
+    patchToOpenElisServerFullResponse: vi.fn(),
     postToOpenElisServerFullResponse: vi.fn(),
   };
 });
@@ -322,6 +324,47 @@ describe("ReceiptMonitor", () => {
         text: "Cycle scored, but 3 result(s) got no verdict, on Haemoglobin. Those analytes carry no sealed target and the cycle has too few peers to place them against.",
       }),
     );
+  });
+
+  it("closes a scored cycle through the transition endpoint, with the reason", async () => {
+    patchToOpenElisServerFullResponse.mockImplementation((_url, _body, cb) =>
+      cb(jsonResponse(true, { status: "CLOSED" })),
+    );
+    renderTab("SCORED");
+
+    await screen.findByText("Iringa District Lab");
+    fireEvent.click(screen.getByRole("button", { name: "Close cycle" }));
+    fireEvent.change(screen.getByLabelText("Reason"), {
+      target: { value: "Round finished, scores returned" },
+    });
+    // Two buttons carry this label once the modal is open: the trigger behind it
+    // and the modal's own primary. Scope to the dialog.
+    fireEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Close cycle",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(patchToOpenElisServerFullResponse).toHaveBeenCalledWith(
+        "/rest/eqa/cycles/9/transition",
+        JSON.stringify({
+          newState: "CLOSED",
+          stateMachine: "PROVIDER",
+          reason: "Round finished, scores returned",
+        }),
+        expect.any(Function),
+      ),
+    );
+  });
+
+  it("offers no close action until the cycle is scored", async () => {
+    renderTab("SUBMISSIONS_OPEN");
+
+    await screen.findByText("Mbeya Regional Lab");
+    expect(
+      screen.queryByRole("button", { name: "Close cycle" }),
+    ).not.toBeInTheDocument();
   });
 
   test("Enter results keys a participant's reported values and posts them per test", async () => {

--- a/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
+++ b/frontend/src/components/eqa/Provider/Workbench/workbenchApi.js
@@ -174,6 +174,23 @@ export const openSubmissions = (cycleId, reason, callback) =>
     withBody(callback),
   );
 
+/**
+ * Closing ends the cycle: a participant's derived state short-circuits to CLOSED,
+ * and the late-score sweep stops taking verdicts on it. The service refuses while
+ * a follow-up is open or a missed-deadline result is still waiting on an answer,
+ * so the reason recorded here is the operator's, not a substitute for that gate.
+ */
+export const closeCycle = (cycleId, reason, callback) =>
+  patchToOpenElisServerFullResponse(
+    `/rest/eqa/cycles/${cycleId}/transition`,
+    JSON.stringify({
+      newState: "CLOSED",
+      stateMachine: "PROVIDER",
+      reason,
+    }),
+    withBody(callback),
+  );
+
 export const scoreCycle = (cycleId, callback) =>
   postToOpenElisServerFullResponse(
     `/rest/eqa/cycles/${cycleId}/score`,

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8635,5 +8635,9 @@
   "eqa.enrollment.withdrawIsFinal": "Withdrawing is final. To take part again, this laboratory enrols in the programme afresh.",
   "eqa.enrollment.statusChanged": "This enrolment is now {status}",
   "eqa.enrollment.statusChangeFailed": "Could not change this enrolment's status",
-  "eqa.score.scoredWithUnjudged": "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against."
+  "eqa.score.scoredWithUnjudged": "Cycle scored, but {count} result(s) got no verdict, on {tests}. Those analytes carry no sealed target and the cycle has too few peers to place them against.",
+  "eqa.cycle.close": "Close cycle",
+  "eqa.cycle.closeHeading": "Close this cycle",
+  "eqa.cycle.closeHelp": "A closed cycle is final: participants see it as closed and no further verdicts are recorded against it. Closing is refused while a follow-up is open or a missed-deadline result is still waiting on an answer.",
+  "eqa.cycle.closeFailed": "Could not close this cycle"
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQABlindingServiceImpl.java
@@ -441,6 +441,15 @@ public class EQABlindingServiceImpl implements EQABlindingService {
             if (target == null || target.getPanel() == null || target.getPanel().getUnblindedAt() == null) {
                 continue; // the panel is still blinded, so nothing is late yet
             }
+            // A closed cycle takes no more verdicts. This pass is driven from the
+            // missed rows and never looked at the cycle, so without this a cycle went
+            // on gaining verdicts after it was closed, on a sweep with no actor behind
+            // it. The close gate already refuses while any of these rows is unanswered,
+            // so reaching here means the answer landed after the operator closed it.
+            EQACycle cycle = target.getPanel().getCycle();
+            if (cycle != null && cycle.getStatus() == EQACycleStatus.CLOSED) {
+                continue;
+            }
             String reported = reportedValueOf(result);
             if (GenericValidator.isBlankOrNull(reported)) {
                 continue; // still unanswered — genuinely a missed deadline

--- a/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQACycleServiceImpl.java
@@ -35,6 +35,7 @@ import org.openelisglobal.eqa.dao.EQACycleStateTransitionDAO;
 import org.openelisglobal.eqa.dao.EQAPanelDAO;
 import org.openelisglobal.eqa.dao.EQAPanelReceiptDAO;
 import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
 import org.openelisglobal.eqa.dao.EQAParticipantResultDAO;
 import org.openelisglobal.eqa.dao.EQARoundDAO;
 import org.openelisglobal.eqa.service.EQAPrepGate.PanelRequirement;
@@ -43,9 +44,11 @@ import org.openelisglobal.eqa.valueholder.EQACycleParticipant;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
 import org.openelisglobal.eqa.valueholder.EQADistributionMethod;
+import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
 import org.openelisglobal.eqa.valueholder.EQAPanel;
 import org.openelisglobal.eqa.valueholder.EQAPanelSample;
 import org.openelisglobal.eqa.valueholder.EQAPanelSourceType;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
 import org.openelisglobal.eqa.valueholder.EQAParticipantResult;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQAProgramEnrollment;
@@ -130,6 +133,8 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
 
     @Autowired
     private EQAParticipantResultDAO eqaParticipantResultDAO;
+    @Autowired
+    private EQAParticipantFollowupDAO eqaParticipantFollowupDAO;
 
     @Autowired
     private EQAPanelSampleDAO eqaPanelSampleDAO;
@@ -302,6 +307,7 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
         }
 
         enforcePrepGate(cycle, priorState, newState, machine);
+        enforceCloseGate(cycle, priorState, newState);
 
         cycle.setStatus(newState);
         stampActualDates(cycle, priorState, newState);
@@ -330,6 +336,43 @@ public class EQACycleServiceImpl extends BaseObjectServiceImpl<EQACycle, Long> i
      * gate's own blockers, so the operator reads the same sentences the prep
      * workbench shows.
      */
+    /**
+     * Closing is the one transition that ends a cycle, so it refuses while work is
+     * still hanging off it and names what. Two things outlive SCORED: a provider
+     * follow-up that nobody has resolved, and a missed-deadline result the
+     * late-score sweep is still watching for an answer.
+     *
+     * <p>
+     * Only rows carrying a panel sample count. An external-PT missed row has no
+     * sealed target and {@code scoreLateResults} skips it, so nothing will ever
+     * give it a verdict; blocking on one would make the cycle uncloseable for good
+     * rather than until the work is done.
+     */
+    private void enforceCloseGate(EQACycle cycle, EQACycleStatus priorState, EQACycleStatus newState) {
+        if (newState != CLOSED) {
+            return;
+        }
+        List<String> blockers = new ArrayList<>();
+        long openFollowups = eqaParticipantFollowupDAO.getAllMatching("cycle.id", cycle.getId()).stream()
+                .map(EQAParticipantFollowup::getFollowupStatus).filter(status -> status != EQAFollowupStatus.RESOLVED
+                        && status != EQAFollowupStatus.REMOVED_FROM_PROGRAM)
+                .count();
+        if (openFollowups > 0) {
+            blockers.add(openFollowups + " follow-up" + (openFollowups == 1 ? "" : "s") + " still open");
+        }
+        long unanswered = eqaParticipantResultDAO.getAllMatching("cycle.id", cycle.getId()).stream()
+                .filter(result -> result.getSubmissionStatus() == EQASubmissionStatus.MISSED_DEADLINE)
+                .filter(result -> result.getPanelSampleId() != null && result.getPerformanceStatus() == null).count();
+        if (unanswered > 0) {
+            blockers.add(unanswered + " missed-deadline result" + (unanswered == 1 ? "" : "s")
+                    + " still waiting on an answer");
+        }
+        if (!blockers.isEmpty()) {
+            throw new EQAInvalidTransitionException(priorState, newState,
+                    "Cannot close yet: " + String.join("; ", blockers));
+        }
+    }
+
     private void enforcePrepGate(EQACycle cycle, EQACycleStatus priorState, EQACycleStatus newState,
             EQAStateMachine machine) {
         if (machine != EQAStateMachine.PROVIDER || priorState != PREP_IN_PROGRESS || newState != READY_TO_SHIP) {

--- a/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQABlindingIntegrationTest.java
@@ -714,6 +714,38 @@ public class EQABlindingIntegrationTest extends EQASpineTestBase {
         assertEquals("the pass is idempotent", 0, blindingService.scoreLateResults(USER));
     }
 
+    /**
+     * T-96. The pass is driven from the missed rows and never looked at the cycle,
+     * so a closed cycle went on gaining verdicts on the next sweep, silently and
+     * with no actor behind it. Closing is meant to end the cycle, and the close
+     * gate refuses while any of these rows is unanswered, so an answer that lands
+     * here arrived after the operator closed it.
+     */
+    @Test
+    public void lateResults_areNotScoredOnceTheCycleIsClosed() {
+        seedEnrollment(9903, "IH Closed Scheme");
+        EQAProgram scheme = inHouseScheme("IH Closed Scheme");
+        EQACycle cycle = readBack(insertCycle(scheme, 1));
+        Long roundId = insertRound(cycle, 1, "OPEN");
+        EQAPanel panel = panelWith(scheme, cycle, EQAPanelStatus.DISTRIBUTED, LocalDate.now().minusDays(1));
+        Long sample = insertPanelSample(panel, "IH-01", "IHCLOSED-1", NUMERIC_ANALYTE, "100", "95", "105");
+        Long late = insertResult(cycle, roundId, 9903, NUMERIC_ANALYTE, EQASubmissionStatus.DRAFT, null, 1L, sample);
+
+        blindingService.unblindAndScore(panel.getId(), USER, EQAUnblindMethod.MANUAL);
+        assertEquals("MISSED_DEADLINE", resultRow(late).get("submission_status"));
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET result_value = '102' WHERE id = ?", late);
+
+        // The control first: on an open cycle this same row is exactly what the pass
+        // picks up, so a zero below means the status stopped it and not the fixture.
+        assertEquals("the row is scorable while the cycle is open", 1, blindingService.scoreLateResults(USER));
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET performance_status = NULL, result_value = '102'"
+                + " WHERE id = ?", late);
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'CLOSED' WHERE id = ?", cycle.getId());
+
+        assertEquals("a closed cycle takes no more verdicts", 0, blindingService.scoreLateResults(USER));
+        assertNull("and the row is left as it was", resultRow(late).get("performance_status"));
+    }
+
     @Test
     public void unblind_secondRunConflictsAndNeverRescores() {
         seedEnrollment(9902, "IH Idempotency Scheme");

--- a/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQACycleStateMachineIntegrationTest.java
@@ -16,11 +16,17 @@ import java.util.regex.Pattern;
 import org.junit.Before;
 import org.junit.Test;
 import org.openelisglobal.eqa.controller.rest.EQACycleRestController;
+import org.openelisglobal.eqa.dao.EQAPanelSampleDAO;
+import org.openelisglobal.eqa.dao.EQAParticipantFollowupDAO;
 import org.openelisglobal.eqa.service.EQACycleService;
 import org.openelisglobal.eqa.service.EQAInvalidTransitionException;
 import org.openelisglobal.eqa.valueholder.EQACycle;
 import org.openelisglobal.eqa.valueholder.EQACycleStateTransition;
 import org.openelisglobal.eqa.valueholder.EQACycleStatus;
+import org.openelisglobal.eqa.valueholder.EQAFollowupStatus;
+import org.openelisglobal.eqa.valueholder.EQAPanel;
+import org.openelisglobal.eqa.valueholder.EQAPanelSample;
+import org.openelisglobal.eqa.valueholder.EQAParticipantFollowup;
 import org.openelisglobal.eqa.valueholder.EQAProgram;
 import org.openelisglobal.eqa.valueholder.EQARound;
 import org.openelisglobal.eqa.valueholder.EQASchemeType;
@@ -40,9 +46,18 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
     private static final long ENROLLMENT_ID = 9905L;
     private static final long OTHER_ENROLLMENT_ID = 9906L;
     private static final long ANALYTE_HIV_VL = 9802L;
+    /**
+     * Follow-up rows reference a real organisation, one per row: the table is
+     * unique on (cycle, org).
+     */
+    private static final long FIRST_FOLLOWUP_ORG = 9940L;
 
     @Autowired
     private EQACycleService cycleService;
+    @Autowired
+    private EQAPanelSampleDAO eqaPanelSampleDAO;
+    @Autowired
+    private EQAParticipantFollowupDAO eqaParticipantFollowupDAO;
 
     @Before
     @Override
@@ -50,6 +65,13 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
         super.setUp();
         seedEnrollment(ENROLLMENT_ID, "Cycle machine enrollment");
         seedEnrollment(OTHER_ENROLLMENT_ID, "Second lab enrollment");
+        for (long id = FIRST_FOLLOWUP_ORG; id < FIRST_FOLLOWUP_ORG + 3; id++) {
+            jdbc.update(
+                    "INSERT INTO clinlims.organization (id, name, mls_sentinel_lab_flag, is_active, lastupdated)"
+                            + " VALUES (?, ?, 'N', 'Y', now()) ON CONFLICT (id) DO NOTHING",
+                    id, "Close gate lab " + id);
+        }
+        followups = FIRST_FOLLOWUP_ORG;
     }
 
     // ---- FR-V2.1-04 / FR-V2.1-18: legal and illegal edges ----
@@ -418,7 +440,149 @@ public class EQACycleStateMachineIntegrationTest extends EQASpineTestBase {
         assertEquals(EQACycleStatus.CLOSED, cycleService.deriveParticipantState(cycle.getId(), ENROLLMENT_ID));
     }
 
+    // ---- T-96: closing refuses while work is still hanging off the cycle ----
+
+    @Test
+    public void closingRefusesWhileAFollowUpIsStillOpen() {
+        EQACycle cycle = scoredCycle();
+        insertFollowup(cycle, EQAFollowupStatus.UNDER_INVESTIGATION);
+
+        try {
+            close(cycle);
+            fail("a cycle with an unresolved follow-up is not finished");
+        } catch (EQAInvalidTransitionException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("1 follow-up still open"));
+        }
+        assertEquals("and the cycle is left where it was", EQACycleStatus.SCORED, readBack(cycle.getId()).getStatus());
+    }
+
+    @Test
+    public void closingRefusesWhileAMissedDeadlineResultIsUnanswered() {
+        EQACycle cycle = scoredCycle();
+        missedResultOnAPanelSample(cycle);
+
+        try {
+            close(cycle);
+            fail("the late-score sweep is still watching that row for an answer");
+        } catch (EQAInvalidTransitionException expected) {
+            assertTrue(expected.getMessage(),
+                    expected.getMessage().contains("1 missed-deadline result still waiting on an answer"));
+        }
+    }
+
+    @Test
+    public void closingNamesEveryBlockerAtOnce() {
+        EQACycle cycle = scoredCycle();
+        insertFollowup(cycle, EQAFollowupStatus.NOTIFIED);
+        insertFollowup(cycle, EQAFollowupStatus.ESCALATED);
+        missedResultOnAPanelSample(cycle);
+
+        try {
+            close(cycle);
+            fail("both kinds of outstanding work block a close");
+        } catch (EQAInvalidTransitionException expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("2 follow-ups still open"));
+            assertTrue(
+                    "one refusal lists everything, so the operator does not clear them one round trip at a time: "
+                            + expected.getMessage(),
+                    expected.getMessage().contains("1 missed-deadline result still waiting on an answer"));
+        }
+    }
+
+    @Test
+    public void closingSucceedsOnceTheWorkIsDone() {
+        // The control. Without it the refusals above cannot be told apart from
+        // "closing never works".
+        EQACycle cycle = scoredCycle();
+        insertFollowup(cycle, EQAFollowupStatus.RESOLVED);
+        insertFollowup(cycle, EQAFollowupStatus.REMOVED_FROM_PROGRAM);
+        Long answered = missedResultOnAPanelSample(cycle);
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET performance_status = 'ACCEPTABLE' WHERE id = ?",
+                answered);
+
+        close(cycle);
+
+        assertEquals(EQACycleStatus.CLOSED, readBack(cycle.getId()).getStatus());
+    }
+
+    @Test
+    public void anExternalMissedRowDoesNotBlockCloseForEver() {
+        // No panel sample means no sealed target, and scoreLateResults skips the row,
+        // so nothing will ever give it a verdict. Blocking on it would make the cycle
+        // uncloseable permanently rather than until the work is done.
+        EQACycle cycle = scoredCycle();
+        insertParticipantResult(cycle, roundFor(cycle), ENROLLMENT_ID, ANALYTE_HIV_VL,
+                EQASubmissionStatus.MISSED_DEADLINE, null);
+
+        close(cycle);
+
+        assertEquals(EQACycleStatus.CLOSED, readBack(cycle.getId()).getStatus());
+    }
+
+    @Override
+    protected void cleanEqaTables() {
+        if (jdbc != null) {
+            // A participant result's panel_sample_id outlives the base order, which
+            // clears panel samples before results.
+            jdbc.update("UPDATE clinlims.eqa_participant_result SET panel_sample_id = NULL");
+        }
+        super.cleanEqaTables();
+        if (jdbc != null) {
+            jdbc.update("DELETE FROM clinlims.organization WHERE id BETWEEN ? AND ?", FIRST_FOLLOWUP_ORG,
+                    FIRST_FOLLOWUP_ORG + 3);
+        }
+    }
+
     // ---- helpers ----
+
+    private long followups = FIRST_FOLLOWUP_ORG;
+
+    private EQARound roundFor(EQACycle cycle) {
+        return eqaRoundDAO.get(insertRound(cycle, 1, "OPEN")).orElseThrow(AssertionError::new);
+    }
+
+    private EQACycle scoredCycle() {
+        EQACycle cycle = newCycle();
+        jdbc.update("UPDATE clinlims.eqa_cycle SET status = 'SCORED' WHERE id = ?", cycle.getId());
+        return readBack(cycle.getId());
+    }
+
+    private void close(EQACycle cycle) {
+        cycleService.transition(cycle.getId(), EQACycleStatus.CLOSED, EQAStateMachine.PROVIDER, EQATriggerType.MANUAL,
+                EQATriggerEvent.MANUAL_OVERRIDE, ADMIN_USER_ID, "Round finished", USER);
+    }
+
+    private void insertFollowup(EQACycle cycle, EQAFollowupStatus status) {
+        EQAParticipantFollowup followup = new EQAParticipantFollowup();
+        followup.setScheme(cycle.getScheme());
+        followup.setCycle(cycle);
+        // One row per cycle per organisation is a unique constraint, so each call
+        // needs its own organisation for the two-blocker case to be reachable.
+        followup.setParticipantOrgId(followups++);
+        followup.setFollowupStatus(status);
+        followup.setSysUserId(USER);
+        eqaParticipantFollowupDAO.insert(followup);
+    }
+
+    /**
+     * A missed row the late-score sweep would still pick up: it carries a target.
+     */
+    private Long missedResultOnAPanelSample(EQACycle cycle) {
+        EQAPanel panel = insertPanel(cycle.getScheme(), p -> {
+            p.setCycle(cycle);
+            p.setPanelName("Close gate panel " + cycle.getId());
+        });
+        EQAPanelSample sample = new EQAPanelSample();
+        sample.setPanel(panel);
+        sample.setSampleCode("CG01");
+        sample.setAnalyteId(ANALYTE_HIV_VL);
+        sample.setSysUserId(USER);
+        Long sampleId = eqaPanelSampleDAO.insert(sample);
+        Long resultId = insertParticipantResult(cycle, roundFor(cycle), ENROLLMENT_ID, ANALYTE_HIV_VL,
+                EQASubmissionStatus.MISSED_DEADLINE, null);
+        jdbc.update("UPDATE clinlims.eqa_participant_result SET panel_sample_id = ? WHERE id = ?", sampleId, resultId);
+        return resultId;
+    }
 
     private EQACycle newCycle() {
         EQAProgram scheme = insertScheme("Machine scheme " + System.nanoTime(), EQASchemeType.INTERNATIONAL_PT, "NHLS");


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done. Not
      supplied: the visible change is one action and its confirmation modal,
      covered by unit tests that assert the request and the guard on visibility.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

**`CLOSED` is the terminal state on all three cycle state machines, and nothing
in the product ever reaches it.** No screen, no endpoint caller, no i18n key,
and zero CLOSED cycles out of 38 on the reference deployment. Its only writer is
`qa-073`, during the V1 backfill.

That gap was found while building the scheme-type guard (#4252), whose rule
admits a type change only when every cycle is CLOSED — which, for a scheme that
has run a cycle under V2, currently means never.

### The action

A **Close cycle** action on a SCORED cycle, with a recorded reason, through the
transition endpoint that already exists. The edge, the audit row and the
`qa.manage.eqa` guard were all already there; only the caller was missing.

### The gate

Closing refuses while work is still hanging off the cycle, and names every
blocker in one refusal rather than one round trip at a time:

| Blocker | Why it counts |
| --- | --- |
| Unresolved provider follow-ups | The register still has open rows for this cycle |
| Missed-deadline results with no verdict | The late-score sweep is still watching them for an answer |

Rows carrying no panel sample are **exempt**: they have no sealed target and
`scoreLateResults` skips them, so blocking on one would make the cycle
uncloseable permanently rather than until the work is done.

### Making it stick

`scoreLateResults` is driven from the missed rows and never read the cycle, so a
closed cycle went on **gaining verdicts on the next sweep**, silently and with
no actor behind it. It now skips closed cycles. The refusal makes it the
operator's decision; the filter makes the decision hold.

## Screenshots

Not supplied. One button on the provider workbench and a reason modal, both
asserted in `ReceiptMonitor.test.jsx`.

## Related Issue

OGC-935. Follows #4252, which depends on CLOSED being reachable.

## Other

**Proved by inversion**, because a case that cannot fail is not evidence:

| Break | Fails |
| --- | --- |
| Drop the close gate | the three refusal cases turn into successes |
| Treat every cycle as live | `closingSucceedsOnceTheWorkIsDone` |
| Count rows with no panel sample | `anExternalMissedRowDoesNotBlockCloseForEver` |
| Remove the cycle check from the sweep | `lateResults_areNotScoredOnceTheCycleIsClosed` |

`closingSucceedsOnceTheWorkIsDone` is the control: without it the refusals
cannot be told apart from "closing never works". The sweep test drives its own
control first — the same row scores while the cycle is open — so a zero
afterwards means the status stopped it and not the fixture.

Backend: 604 `EQA*` tests green. Frontend gate run from `frontend/` the way CI
runs it: prettier, eslint, 1254 vitest tests.
