### PR TITLE
fix(referrals): refer out a test whose result is already saved

### DIFF
--- a/frontend/src/components/referenceLabResults/ReferenceLabResults.jsx
+++ b/frontend/src/components/referenceLabResults/ReferenceLabResults.jsx
@@ -39,6 +39,7 @@ import React, {
 } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useHistory, useLocation } from "react-router-dom";
+import { AlertDialog } from "../common/CustomNotification";
 import PageBreadCrumb from "../common/PageBreadCrumb";
 import { NotificationContext } from "../layout/Layout";
 import ShipmentNavigation from "../shipment/ShipmentNavigation";
@@ -313,6 +314,10 @@ const ReferenceLabResults = () => {
 
   return (
     <div className="reference-lab-results">
+      {/* Without this the page's own messages are created and thrown away: every
+          accept, reject, mark-lost and notify said nothing at all, whether it
+          worked or failed. */}
+      <AlertDialog />
       <PageBreadCrumb
         breadcrumbs={[
           { label: "home.label", link: "/" },

--- a/frontend/src/components/referenceLabResults/ReferenceLabResults.jsx
+++ b/frontend/src/components/referenceLabResults/ReferenceLabResults.jsx
@@ -830,7 +830,7 @@ const OutstandingTable = ({
               <TableCell>{row.referenceLabName || "—"}</TableCell>
               <TableCell>
                 {row.boxId ? (
-                  <CarbonLink href={`/SampleShipment/box/${row.boxId}`}>
+                  <CarbonLink href={`/SampleShipment/box/${row.boxKey}`}>
                     {row.boxId}
                   </CarbonLink>
                 ) : (
@@ -1098,7 +1098,7 @@ const ExpandPanel = ({
           label={intl.formatMessage({ id: "referral.expand.detail.boxId" })}
           value={
             row.boxId ? (
-              <CarbonLink href={`/SampleShipment/box/${row.boxId}`}>
+              <CarbonLink href={`/SampleShipment/box/${row.boxKey}`}>
                 {row.boxId}
               </CarbonLink>
             ) : null

--- a/frontend/src/components/resultPage/unified/UnifiedResults.tsx
+++ b/frontend/src/components/resultPage/unified/UnifiedResults.tsx
@@ -49,6 +49,7 @@ import {
   RowEditState,
   initialRowState,
   isModifyingSavedResult,
+  writesResultValue,
   isRowEditable,
   nextRowState,
   showEdit,
@@ -563,6 +564,21 @@ const UnifiedResults: React.FC = () => {
     setEditingAnalysisId(target.analysisId);
   }, []);
 
+  // Referring a test out is not a change to its result, so it makes an already
+  // saved row savable without unlocking the value or recording the save as a
+  // revision. Without this a confirmation referral, which is raised precisely
+  // when a result already exists, could not be saved at all.
+  const markDispositionPending = useCallback((target: WorklistRow) => {
+    const key = worklistRowKey(target);
+    setRowStates((current) => ({
+      ...current,
+      [key]: nextRowState(current[key] || "EMPTY", {
+        type: "DISPOSITION_CHANGED",
+      }),
+    }));
+    setEditingAnalysisId(target.analysisId);
+  }, []);
+
   const handleReferralDraftChange = useCallback(
     (target: WorklistRow, draft: ReferralDraft | null) => {
       const key = worklistRowKey(target);
@@ -576,10 +592,10 @@ const UnifiedResults: React.FC = () => {
         return next;
       });
       if (draft) {
-        markRowDirty(target);
+        markDispositionPending(target);
       }
     },
-    [markRowDirty],
+    [markDispositionPending],
   );
 
   const handleRejectDraftChange = useCallback(
@@ -827,6 +843,12 @@ const UnifiedResults: React.FC = () => {
       // FR-O1: the payload names and carries exactly this analysis — never
       // the page. Untouched rows cannot be re-submitted or defaulted.
       const item: Record<string, unknown> = { ...row, isModified: true };
+      // A referral saved against an already-saved result must leave that result
+      // exactly as stored. The row carries the value the test reports, which is
+      // rounded, so posting it back would quietly rewrite the stored one.
+      if (!writesResultValue(rowStates[worklistRowKey(row)] || "EMPTY")) {
+        item.resultValue = row.rawResultValue ?? row.resultValue;
+      }
       delete item.result;
       delete item.analysisNotes;
       // attachments live in order_attachment now (OGC-811); round-tripping
@@ -1361,7 +1383,10 @@ const UnifiedResults: React.FC = () => {
                               recordType="RESULT"
                               recordId={row.analysisId}
                               onSign={() => handleSave(row)}
-                              disabled={blocksSaveOnPrecision(row)}
+                              disabled={
+                                writesResultValue(state) &&
+                                blocksSaveOnPrecision(row)
+                              }
                               size="sm"
                             >
                               <FormattedMessage id="label.results.save" />
@@ -1476,7 +1501,10 @@ const UnifiedResults: React.FC = () => {
                                       recordType="RESULT"
                                       recordId={row.analysisId}
                                       onSign={() => handleSave(row)}
-                                      disabled={blocksSaveOnPrecision(row)}
+                                      disabled={
+                                        writesResultValue(state) &&
+                                        blocksSaveOnPrecision(row)
+                                      }
                                       size="sm"
                                     >
                                       <FormattedMessage id="label.results.save" />

--- a/frontend/src/components/resultPage/unified/editState.test.ts
+++ b/frontend/src/components/resultPage/unified/editState.test.ts
@@ -6,6 +6,7 @@ import {
   nextRowState,
   showEdit,
   showSave,
+  writesResultValue,
 } from "./editState";
 
 /**
@@ -80,6 +81,61 @@ describe("editState machine", () => {
     expect(isModifyingSavedResult("EMPTY")).toBe(false);
     expect(isModifyingSavedResult("DIRTY")).toBe(false);
     expect(isModifyingSavedResult("SAVED")).toBe(false);
+  });
+
+  /**
+   * Referring a test out is not a revision of its result. A confirmation
+   * referral is raised precisely when an in-house result already exists, and
+   * that row is SAVED, where a value change is deliberately ignored — so Save
+   * never appeared and the referral could not be raised at all. Clicking Edit
+   * first worked, but recorded the save as a result modification and, under
+   * electronic signatures, asked for a binding signature on a revision nobody
+   * had made.
+   */
+  describe("a referral on a row whose result is already saved", () => {
+    const pending = nextRowState(initialRowState(true), {
+      type: "DISPOSITION_CHANGED",
+    });
+
+    it("offers Save without unlocking the result", () => {
+      expect(pending).toBe("DISPOSITION_PENDING");
+      expect(showSave(pending)).toBe(true);
+      expect(isRowEditable(pending)).toBe(false);
+    });
+
+    it("is not a revision of the result", () => {
+      expect(isModifyingSavedResult(pending)).toBe(false);
+    });
+
+    it("still lets the result be edited as well", () => {
+      expect(showEdit(pending)).toBe(true);
+      expect(nextRowState(pending, { type: "EDIT_CLICKED" })).toBe(
+        "EDITING_DIRTY",
+      );
+    });
+
+    it("writes back the stored value, not the reported one", () => {
+      expect(writesResultValue(pending)).toBe(false);
+      expect(writesResultValue("EDITING_DIRTY")).toBe(true);
+      expect(writesResultValue("DIRTY")).toBe(true);
+    });
+
+    it("relocks on save", () => {
+      expect(nextRowState(pending, { type: "SAVE_SUCCEEDED" })).toBe("SAVED");
+    });
+
+    it("leaves the untouched-row rule alone", () => {
+      // A value change on a saved row is still ignored: only Edit unlocks it.
+      expect(nextRowState("SAVED", { type: "VALUE_CHANGED" })).toBe("SAVED");
+      // And a disposition on a row being entered for the first time is simply
+      // part of that entry.
+      expect(nextRowState("EMPTY", { type: "DISPOSITION_CHANGED" })).toBe(
+        "DIRTY",
+      );
+      expect(nextRowState("EDITING", { type: "DISPOSITION_CHANGED" })).toBe(
+        "EDITING_DIRTY",
+      );
+    });
   });
 
   it("save relocks the row read-only", () => {

--- a/frontend/src/components/resultPage/unified/editState.ts
+++ b/frontend/src/components/resultPage/unified/editState.ts
@@ -17,10 +17,18 @@ export type RowEditState =
   | "DIRTY"
   | "SAVED"
   | "EDITING"
-  | "EDITING_DIRTY";
+  | "EDITING_DIRTY"
+  // A saved result with a referral waiting to be saved alongside it. Savable,
+  // but the result itself stays locked and the save is not a revision of it.
+  | "DISPOSITION_PENDING";
 
 export type RowEditEvent =
   | { type: "VALUE_CHANGED" }
+  // Something recorded about the analysis that is not its result: referring the
+  // test out. Kept separate from a value change because a saved result must
+  // stay read-only until Edit, and because signing this is not signing a
+  // revision.
+  | { type: "DISPOSITION_CHANGED" }
   | { type: "EDIT_CLICKED" }
   | { type: "SAVE_SUCCEEDED" }
   | { type: "SAVE_REJECTED_STALE" };
@@ -42,12 +50,33 @@ export function isRowEditable(state: RowEditState): boolean {
 
 /** Save is offered once there is something to save (FR-A3). */
 export function showSave(state: RowEditState): boolean {
-  return state === "DIRTY" || state === "EDITING_DIRTY";
+  return (
+    state === "DIRTY" ||
+    state === "EDITING_DIRTY" ||
+    state === "DISPOSITION_PENDING"
+  );
 }
 
-/** Edit is offered only on a saved, read-only row (FR-A2). */
+/**
+ * Edit is offered on a saved, read-only row, including one with a referral
+ * waiting: referring a test out does not stop the bench correcting its result.
+ */
 export function showEdit(state: RowEditState): boolean {
-  return state === "SAVED";
+  return state === "SAVED" || state === "DISPOSITION_PENDING";
+}
+
+/**
+ * Whether this save writes a result value at all.
+ *
+ * <p>A referral saved against an already-saved result does not: the value stays
+ * exactly as stored. That matters twice over, because the value the row carries
+ * is the one the test *reports* (95.00 for a stored 95 on a test reporting to
+ * one place), so a save that means to leave the result alone has to write back
+ * what was stored and not what was displayed, and the precision guard that
+ * blocks a too-fine value has nothing to block.
+ */
+export function writesResultValue(state: RowEditState): boolean {
+  return state !== "DISPOSITION_PENDING";
 }
 
 /**
@@ -74,7 +103,23 @@ export function nextRowState(
       // A row opened for editing becomes savable at the first actual change,
       // and not before.
       return state === "EDITING" ? "EDITING_DIRTY" : state;
+    case "DISPOSITION_CHANGED":
+      // On a row still being entered, a referral is part of that entry. On one
+      // already saved it stands on its own, so the result stays locked and the
+      // save is not recorded as a revision of it.
+      if (state === "SAVED") {
+        return "DISPOSITION_PENDING";
+      }
+      if (state === "EMPTY") {
+        return "DIRTY";
+      }
+      return state === "EDITING" ? "EDITING_DIRTY" : state;
     case "EDIT_CLICKED":
+      if (state === "DISPOSITION_PENDING") {
+        // The referral is already pending, so the row is savable either way;
+        // unlocking the result makes this a revision as well.
+        return "EDITING_DIRTY";
+      }
       return state === "SAVED" ? "EDITING" : state;
     case "SAVE_SUCCEEDED":
       return "SAVED";

--- a/src/main/java/org/openelisglobal/referral/dto/ReferenceLabReferralDTO.java
+++ b/src/main/java/org/openelisglobal/referral/dto/ReferenceLabReferralDTO.java
@@ -15,6 +15,7 @@ public class ReferenceLabReferralDTO {
     private String referenceLabId;
     private String referenceLabName;
     private String boxId;
+    private Integer boxKey;
     private String sentDate;
     private String boxReceivedDate;
     private String fhirTaskUuid;
@@ -118,6 +119,19 @@ public class ReferenceLabReferralDTO {
 
     public void setBoxId(String boxId) {
         this.boxId = boxId;
+    }
+
+    /**
+     * The box's primary key, which is what the shipping-box endpoint takes. The
+     * label in {@link #getBoxId()} is for people to read; linking with it gave a
+     * "Box not found" page.
+     */
+    public Integer getBoxKey() {
+        return boxKey;
+    }
+
+    public void setBoxKey(Integer boxKey) {
+        this.boxKey = boxKey;
     }
 
     public String getSentDate() {

--- a/src/main/java/org/openelisglobal/referral/service/ReferenceLabResultsServiceImpl.java
+++ b/src/main/java/org/openelisglobal/referral/service/ReferenceLabResultsServiceImpl.java
@@ -237,6 +237,7 @@ public class ReferenceLabResultsServiceImpl implements ReferenceLabResultsServic
         ShippingBox box = referral.getAssignedBox();
         if (box != null) {
             dto.setBoxId(box.getBoxId());
+            dto.setBoxKey(box.getId());
         }
 
         if (view == DashboardView.OUTSTANDING && referral.getSentDate() != null) {


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

> **Base branch:** stacked on `fix/reference-lab-dashboard-truth` (#4267), which is itself stacked on #4242. Review the top commit only.

## A test whose result is already saved could not be referred out

A confirmation referral is raised exactly when an in-house result exists. On such a row the referral form opened, took a destination and a reason, and offered no Save at all.

The row state machine ignores a value change on a saved row on purpose: Save used to appear the moment Edit opened, so pressing it wrote the reported value over the stored one and, with electronic signatures on, demanded a binding signature for a revision the signer had not made. Raising a referral was routed through that same value-changed event, so it was ignored too.

Clicking Edit first did work, which is what made this look like a nuisance rather than a defect. It also recorded the save as a result *modification* and asked for that same signature on a revision nobody had made.

**Referring a test out is now its own event.** It makes a saved row savable without unlocking the result, and `isModifyingSavedResult` stays false so the note context and the signature both read as an entry rather than a revision. Editing the result as well is still offered from that state. Rejecting a result deliberately keeps the old path, because a rejection does void the value.

Two consequences had to be handled, and both were found by running it rather than by reading it:

- **The row carries the reported value, not the stored one.** A test reporting to one decimal place stores `95` and reports `95.00`. A referral-only save posted the whole row, so it would have rewritten the stored value as `95.00` — the very bug the precision work fixed. A save that writes no new result now writes back the stored value.
- **The precision guard was blocking a save that writes no value.** With Save finally offered, it appeared disabled, because that row's reported value exceeds the test's configured precision. The guard now applies only to saves that actually write a value.

## The Box ID links were dead

Every Box ID link on the Reference Lab Results page was built from the box's label while `/rest/shipping-box/{id}` takes its primary key:

```
GET /rest/shipping-box/BOX-2026-0001  ->  400 MethodArgumentTypeMismatchException
GET /rest/shipping-box/287            ->  200
```

So the page always read "Box not found". Every other caller in the app already links by id; the referral now carries the key alongside the label and these two links use it.

## Tests

`editState.test.ts` gains a group for a referral on an already-saved row: Save offered, result not unlocked, not a revision, Edit still available, relocks on save, stored value written back. It also asserts the rule this must not break — a value change on a saved row is still ignored — so a future simplification cannot quietly undo it.

## Verification

| | |
| --- | --- |
| Referral on a row with a saved result | Save offered without touching Edit |
| Same row, precision-exceeding reported value | Save enabled rather than blocked |
| After saving the referral | result still `95`, note reads "Orginal Result: 95", referral raised |
| Box ID link from the outstanding list | opens the box |

## Screenshots

No layout changes: a Save button now appears where it previously did not, and the Box ID links resolve.
