### PR TITLE
feat(eqa): say what the prep numbers count, which rule banded an analyst, and where follow-up lives (OGC-935)

### DIFF
--- a/docs/eqa/analyst-competency-rules.md
+++ b/docs/eqa/analyst-competency-rules.md
@@ -112,6 +112,35 @@ failure:
 4. **Competent** — everything else, which is `evaluable_n ≥ 4` and
    `failure_n ≤ 1`.
 
+### Which rule fired travels with the band
+
+Rows 2 and 3 both produce **Under review**, and they mean opposite things: one
+analyst has failed twice, the other has not been given enough work to judge. A
+reviewer who sees only the band cannot tell a performance concern from a gap in
+the evidence, and the two call for opposite actions.
+
+So `band()` emits a `reason` beside every `status`:
+
+| `reason`                | Band          | What the reviewer should do                                                  |
+| ----------------------- | ------------- | ---------------------------------------------------------------------------- |
+| `OPEN_ESCALATION`       | Not competent | Close the non-conformity.                                                    |
+| `REPEATED_FAILURE`      | Under review  | Review the failed results; raise a non-conformity or dismiss them on triage. |
+| `INSUFFICIENT_EVIDENCE` | Under review  | Assign more proficiency testing samples. Nothing is wrong with the analyst.  |
+| `MEETS_EVIDENCE`        | Competent     | Nothing.                                                                     |
+
+**The stored status is not split.** `reason` is derived on every read, like the
+band itself, so there is no second value to keep in step and no migration.
+
+The analyst's headline row carries `statusReasons`: one entry per analyte
+sitting at the headline band, each with **that analyte's** evaluable and failure
+counts. The analyst's own totals span every analyte and are not the denominator
+any rule fired on, so quoting them beside a rule would be arithmetic that does
+not add up.
+
+The rollup also publishes `windowStart`, `windowEnd`, `windowMonths` and
+`evidenceFloor`, so the page states the window and the floor it was judged
+against rather than repeating the constants in copy.
+
 ### Three clauses deliberately not implemented
 
 - **"2+ consecutive `questionable_score`"** (FRS, band table row 4). Every

--- a/frontend/playwright/helpers/seed-eqa-data.ts
+++ b/frontend/playwright/helpers/seed-eqa-data.ts
@@ -448,7 +448,7 @@ export function seedReportedResults(
 /**
  * The organization this installation calls itself, which is what splits the
  * two follow-up surfaces: rows about this lab belong to the participant
- * Follow-Up Queue, every other row to the provider register. The backend
+ * This Lab's Follow-Up, every other row to the provider register. The backend
  * resolves it from the SiteName site-information value, falling back to the
  * literal "This laboratory" when that is blank, and returns null when no
  * organization carries the name — in which case the queue can never

--- a/frontend/playwright/tests/foundational/core/eqa-followup-split.spec.ts
+++ b/frontend/playwright/tests/foundational/core/eqa-followup-split.spec.ts
@@ -9,7 +9,7 @@ import { seedFollowups, FollowupSeed } from "../../../helpers/seed-eqa-data";
  * One scored cycle carries two follow-up rows — one about this laboratory,
  * one about another participant. Which page a row appears on is decided by
  * nothing more than that: rows about this lab are the participant's own
- * corrective work and belong to the Follow-Up Queue, rows about other labs
+ * corrective work and belong to This Lab's Follow-Up, rows about other labs
  * are correspondence and belong to the provider register. Getting that
  * backwards would put another lab's failure into this lab's non-conformity
  * workflow, which is why both directions are asserted rather than one.
@@ -41,7 +41,7 @@ test.describe("EQA follow-up registers", () => {
     await test.step("the queue holds this lab's row and not the other lab's", async () => {
       await page.goto("/qa/eqa/follow-up-queue", { timeout: NAV_TIMEOUT });
       await expect(
-        page.getByRole("heading", { name: "Follow-Up Queue" }),
+        page.getByRole("heading", { name: "This Lab's Follow-Up" }),
       ).toBeVisible({ timeout: UI_TIMEOUT });
       for (const tile of [
         "kpi-queued",

--- a/frontend/src/components/eqa/Competency/AnalystCompetencyPage.jsx
+++ b/frontend/src/components/eqa/Competency/AnalystCompetencyPage.jsx
@@ -88,6 +88,29 @@ const AnalystCompetencyPage = () => {
       dismissed: t("eqa.competency.outcome.dismissed", "Dismissed on triage"),
     })[outcome] || "—";
 
+  /**
+   * Under review is reached by two rules that mean opposite things, so the band
+   * alone is not a finding. The short name separates them at a glance and the
+   * sentence carries the rule, the window it was read over, the denominator and
+   * what the reviewer should do next.
+   */
+  const ruleLabel = (reason) =>
+    ({
+      MEETS_EVIDENCE: t("eqa.competency.rule.meetsEvidence", "Evidence met"),
+      REPEATED_FAILURE: t(
+        "eqa.competency.rule.repeatedFailure",
+        "Repeated failure",
+      ),
+      INSUFFICIENT_EVIDENCE: t(
+        "eqa.competency.rule.insufficientEvidence",
+        "Insufficient evidence",
+      ),
+      OPEN_ESCALATION: t(
+        "eqa.competency.rule.openEscalation",
+        "Open non-conformity",
+      ),
+    })[reason] || null;
+
   const eventLabel = (eventType) =>
     eventType
       ? t(`eqa.competency.event.${eventType}`, eventType.replace(/_/g, " "))
@@ -103,6 +126,64 @@ const AnalystCompetencyPage = () => {
   }
 
   const { kpis, analysts } = data;
+  const judgedOver = {
+    from: formatDateOnly(data.windowStart),
+    to: formatDateOnly(data.windowEnd),
+    floor: data.evidenceFloor,
+  };
+
+  /** The sentence behind one band: rule, window, denominator, next action. */
+  const reasonSentence = (reason, evaluable, failures) => {
+    const values = { ...judgedOver, evaluable, failures };
+    switch (reason) {
+      case "MEETS_EVIDENCE":
+        return t(
+          "eqa.competency.reason.meetsEvidence",
+          "{evaluable} assessable samples with {failures} failures between {from} and {to}, at or above the evidence floor of {floor}. Nothing to action.",
+          values,
+        );
+      case "REPEATED_FAILURE":
+        return t(
+          "eqa.competency.reason.repeatedFailure",
+          "{failures} failures in {evaluable} assessable samples between {from} and {to}. This is a performance concern: review the failed results and raise a non-conformity, or dismiss them on triage.",
+          values,
+        );
+      case "INSUFFICIENT_EVIDENCE":
+        return t(
+          "eqa.competency.reason.insufficientEvidence",
+          "{evaluable} assessable samples between {from} and {to}, short of the evidence floor of {floor}. This is not a performance concern: assign this analyst more proficiency testing samples.",
+          values,
+        );
+      case "OPEN_ESCALATION":
+        return t(
+          "eqa.competency.reason.openEscalation",
+          "An escalated non-conformity raised between {from} and {to} is still open, over {evaluable} assessable samples with {failures} failures. Close the non-conformity to clear the band.",
+          values,
+        );
+      default:
+        return null;
+    }
+  };
+
+  /**
+   * The band's rule and its sentence, under whichever tag it explains. The
+   * analyte is named because a rule reads over one analyte at a time, so its
+   * counts are that analyte's rather than the analyst's.
+   */
+  const BandReason = ({ reason, analyteName, evaluable, failures }) =>
+    ruleLabel(reason) ? (
+      <div style={{ marginTop: "0.25rem" }}>
+        <div style={{ ...hintStyle, fontWeight: 600 }}>
+          {analyteName
+            ? `${ruleLabel(reason)} · ${analyteName}`
+            : ruleLabel(reason)}
+        </div>
+        <div style={hintStyle}>
+          {reasonSentence(reason, evaluable, failures)}
+        </div>
+      </div>
+    ) : null;
+
   const rows = analysts.filter((analyst) =>
     filter
       ? (analyst.analystName || "").toLowerCase().includes(filter.toLowerCase())
@@ -149,10 +230,16 @@ const AnalystCompetencyPage = () => {
             <Heading>
               {t("banner.menu.eqa.analystCompetency", "Analyst Competency")}
             </Heading>
-            <p style={{ ...hintStyle, marginBottom: "1.5rem" }}>
+            <p style={hintStyle}>
               {t(
                 "eqa.competency.subtitle",
                 "Every analyst assigned to proficiency testing in the last twelve months, banded per analyte. An analyst is competent only where the evidence says so — fewer than four assessable samples reads as under review, not as a pass.",
+              )}
+            </p>
+            <p style={{ ...hintStyle, marginBottom: "1.5rem" }}>
+              {t(
+                "eqa.competency.whatIsAnAnalyst",
+                "An analyst is an OpenELIS user account on the scheme's analyst roster, recorded against the sample they ran. That is a separate record from whoever entered the result and whoever validated it.",
               )}
             </p>
           </Section>
@@ -312,6 +399,15 @@ const AnalystCompetencyPage = () => {
                       <Tag type={BAND_TAG[analyst.status]} size="sm">
                         {bandLabel(analyst.status)}
                       </Tag>
+                      {(analyst.statusReasons || []).map((why) => (
+                        <BandReason
+                          key={`${why.reason}-${why.analyteName}`}
+                          reason={why.reason}
+                          analyteName={why.analyteName}
+                          evaluable={why.evaluableCount}
+                          failures={why.failureCount}
+                        />
+                      ))}
                     </TableCell>
                     <TableCell>
                       <Button
@@ -390,6 +486,11 @@ const AnalystCompetencyPage = () => {
                                   >
                                     {bandLabel(analyte.status)}
                                   </Tag>
+                                  <BandReason
+                                    reason={analyte.reason}
+                                    evaluable={analyte.evaluableCount}
+                                    failures={analyte.failureCount}
+                                  />
                                 </TableCell>
                               </TableRow>
                             ))}

--- a/frontend/src/components/eqa/Competency/__tests__/AnalystCompetencyPage.test.jsx
+++ b/frontend/src/components/eqa/Competency/__tests__/AnalystCompetencyPage.test.jsx
@@ -20,10 +20,14 @@ vi.mock("../../../common/PageBreadCrumb", () => ({
 }));
 
 const ROLLUP = {
+  windowStart: "2025-09-10",
+  windowEnd: "2026-09-10",
+  windowMonths: 12,
+  evidenceFloor: 4,
   kpis: {
-    analystCount: 3,
+    analystCount: 4,
     competentCount: 1,
-    underReviewCount: 1,
+    underReviewCount: 2,
     notCompetentCount: 1,
     assessedSampleCount: 14,
   },
@@ -38,11 +42,20 @@ const ROLLUP = {
       failureCount: 0,
       mostRecentPerformance: "acceptable",
       mostRecentDate: "2026-07-30",
+      statusReasons: [
+        {
+          reason: "MEETS_EVIDENCE",
+          analyteName: "HIV viral load",
+          evaluableCount: 6,
+          failureCount: 0,
+        },
+      ],
       analytes: [
         {
           analyteId: 1,
           analyteName: "HIV viral load",
           status: "COMPETENT",
+          reason: "MEETS_EVIDENCE",
           evaluableCount: 6,
           failureCount: 0,
           latestPerformance: "acceptable",
@@ -73,11 +86,20 @@ const ROLLUP = {
       failureCount: 1,
       mostRecentPerformance: "unacceptable",
       mostRecentDate: "2026-08-02",
+      statusReasons: [
+        {
+          reason: "OPEN_ESCALATION",
+          analyteName: "CD4 count",
+          evaluableCount: 5,
+          failureCount: 1,
+        },
+      ],
       analytes: [
         {
           analyteId: 2,
           analyteName: "CD4 count",
           status: "NOT_COMPETENT",
+          reason: "OPEN_ESCALATION",
           evaluableCount: 5,
           failureCount: 1,
           latestPerformance: "unacceptable",
@@ -118,7 +140,60 @@ const ROLLUP = {
       failureCount: 0,
       mostRecentPerformance: "acceptable",
       mostRecentDate: "2026-06-01",
-      analytes: [],
+      statusReasons: [
+        {
+          reason: "INSUFFICIENT_EVIDENCE",
+          analyteName: "Syphilis RPR",
+          evaluableCount: 3,
+          failureCount: 0,
+        },
+      ],
+      analytes: [
+        {
+          analyteId: 3,
+          analyteName: "Syphilis RPR",
+          status: "UNDER_REVIEW",
+          reason: "INSUFFICIENT_EVIDENCE",
+          evaluableCount: 3,
+          failureCount: 0,
+          latestPerformance: "acceptable",
+          latestDate: "2026-06-01",
+          openEscalation: false,
+        },
+      ],
+      history: [],
+    },
+    {
+      analystId: 14,
+      analystName: "Daniel Mwangi",
+      status: "UNDER_REVIEW",
+      sampleCount: 5,
+      sampleCountThisYear: 5,
+      evaluableCount: 5,
+      failureCount: 2,
+      mostRecentPerformance: "unacceptable",
+      mostRecentDate: "2026-08-20",
+      statusReasons: [
+        {
+          reason: "REPEATED_FAILURE",
+          analyteName: "Hepatitis B surface antigen",
+          evaluableCount: 5,
+          failureCount: 2,
+        },
+      ],
+      analytes: [
+        {
+          analyteId: 4,
+          analyteName: "Hepatitis B surface antigen",
+          status: "UNDER_REVIEW",
+          reason: "REPEATED_FAILURE",
+          evaluableCount: 5,
+          failureCount: 2,
+          latestPerformance: "unacceptable",
+          latestDate: "2026-08-20",
+          openEscalation: false,
+        },
+      ],
       history: [],
     },
   ],
@@ -144,12 +219,12 @@ describe("AnalystCompetencyPage", () => {
   it("counts the analysts in each band", async () => {
     renderPage();
 
-    expect(await screen.findByTestId("kpi-analysts")).toHaveTextContent("3");
+    expect(await screen.findByTestId("kpi-analysts")).toHaveTextContent("4");
     expect(screen.getByTestId("kpi-analysts")).toHaveTextContent(
       "14 PT samples",
     );
     expect(screen.getByTestId("kpi-competent")).toHaveTextContent("1");
-    expect(screen.getByTestId("kpi-under-review")).toHaveTextContent("1");
+    expect(screen.getByTestId("kpi-under-review")).toHaveTextContent("2");
     expect(screen.getByTestId("kpi-not-competent")).toHaveTextContent("1");
   });
 
@@ -179,6 +254,60 @@ describe("AnalystCompetencyPage", () => {
     expect(history).toHaveTextContent("Dismissed — equipment");
     expect(history).toHaveTextContent("Excused");
     expect(history).toHaveTextContent("Failure");
+  });
+
+  it("tells the two under-review rules apart on the row itself", async () => {
+    const { container } = renderPage();
+
+    await screen.findByText("Carol Achieng");
+    const rowFor = (name) =>
+      [...container.querySelectorAll("tbody tr")].find((tr) =>
+        tr.textContent.includes(name),
+      );
+
+    // Same band, opposite findings. Carol has done too little to judge; Daniel
+    // has failed twice. The band alone cannot separate them, so the rule does.
+    const carol = rowFor("Carol Achieng");
+    expect(carol).toHaveTextContent("Under review");
+    expect(carol).toHaveTextContent("Insufficient evidence · Syphilis RPR");
+    expect(carol).toHaveTextContent("short of the evidence floor of 4");
+    expect(carol).toHaveTextContent("not a performance concern");
+    expect(carol).toHaveTextContent(
+      "assign this analyst more proficiency testing samples",
+    );
+
+    const daniel = rowFor("Daniel Mwangi");
+    expect(daniel).toHaveTextContent("Under review");
+    expect(daniel).toHaveTextContent(
+      "Repeated failure · Hepatitis B surface antigen",
+    );
+    expect(daniel).toHaveTextContent("2 failures in 5 assessable samples");
+    expect(daniel).toHaveTextContent("This is a performance concern");
+    expect(daniel).not.toHaveTextContent("Insufficient evidence");
+  });
+
+  it("names the rule behind a band that is not under review", async () => {
+    const { container } = renderPage();
+
+    await screen.findByText("Brian Okello");
+    const brian = [...container.querySelectorAll("tbody tr")].find((tr) =>
+      tr.textContent.includes("Brian Okello"),
+    );
+    expect(brian).toHaveTextContent("Open non-conformity · CD4 count");
+    expect(brian).toHaveTextContent(
+      "Close the non-conformity to clear the band",
+    );
+  });
+
+  it("says what an analyst is, and what it is not", async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText(/An analyst is an OpenELIS user account/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/separate record from whoever entered the result/i),
+    ).toBeInTheDocument();
   });
 
   it("filters the table by analyst name", async () => {

--- a/frontend/src/components/eqa/FollowUp/FollowUpQueuePage.jsx
+++ b/frontend/src/components/eqa/FollowUp/FollowUpQueuePage.jsx
@@ -250,13 +250,21 @@ const FollowUpQueuePage = () => {
         <Column lg={16} md={8} sm={4}>
           <Section>
             <Heading>
-              {t("eqa.oversight.followUpQueue", "Follow-Up Queue")}
+              {t("eqa.oversight.followUpQueue", "This Lab's Follow-Up")}
             </Heading>
+            {/* The two registers are easy to confuse — one holds this lab's own
+                corrective actions, the other correspondence about someone
+                else's submissions — so the subtitle names the other one and
+                links to where it actually lives. */}
             <p style={{ ...hintStyle, marginBottom: "1rem" }}>
               {t(
                 "eqa.oversight.queueSubtitle",
-                "This lab's questionable EQA scores awaiting corrective review, from external providers and our own in-house schemes. Provider-side follow-up on other labs' submissions lives in EQA Program Management.",
-              )}
+                "This lab's questionable EQA scores awaiting corrective review, from external providers and this lab's own in-house schemes. Correspondence with the laboratories that take part in the schemes this lab provides is a different register:",
+              )}{" "}
+              <RouterLink to="/qa/eqa/provider/follow-ups">
+                {t("eqa.oversight.queueSubtitle.link", "Participant follow-up")}
+              </RouterLink>
+              .
             </p>
           </Section>
 

--- a/frontend/src/components/eqa/FollowUp/__tests__/FollowUpQueuePage.test.jsx
+++ b/frontend/src/components/eqa/FollowUp/__tests__/FollowUpQueuePage.test.jsx
@@ -115,6 +115,28 @@ describe("FollowUpQueuePage", () => {
     );
   });
 
+  it("names the other register and links to where it actually lives", async () => {
+    renderPage();
+
+    // The subtitle used to send a provider to "EQA Program Management", which
+    // is not where the participant follow-up register lives.
+    expect(
+      await screen.findByText(/Correspondence with the laboratories/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/EQA Program Management/i)).toBeNull();
+
+    const link = screen.getByRole("link", { name: "Participant follow-up" });
+    expect(link).toHaveAttribute("href", "/qa/eqa/provider/follow-ups");
+  });
+
+  it("titles itself so it cannot be mistaken for the provider's register", async () => {
+    renderPage();
+
+    expect(
+      await screen.findByRole("heading", { name: "This Lab's Follow-Up" }),
+    ).toBeInTheDocument();
+  });
+
   it("renders one row per register entry with its source and worst z-score", async () => {
     renderPage();
 

--- a/frontend/src/components/eqa/InHouse/BlindingWizard.jsx
+++ b/frontend/src/components/eqa/InHouse/BlindingWizard.jsx
@@ -25,6 +25,7 @@ import {
 import { useIntl } from "react-intl";
 import { useHistory } from "react-router-dom";
 import PageBreadCrumb from "../../common/PageBreadCrumb";
+import { formatDateOnly } from "../../utils/Utils";
 import { createCycle, createPanel, failed, fetchTests } from "../eqaApi";
 import {
   downloadLabelSheet,
@@ -36,6 +37,7 @@ import {
 } from "./inHouseApi";
 import {
   ASSIGNMENT_MODES,
+  assignedAnalysts,
   expandForMode,
   modeBlockers,
   prepBlockers,
@@ -128,8 +130,8 @@ const BlindingWizard = () => {
     ...modeBlockers(roster, assignmentMode),
   ];
 
-  const label = (id, fallback) =>
-    intl.formatMessage({ id, defaultMessage: fallback });
+  const label = (id, fallback, values) =>
+    intl.formatMessage({ id, defaultMessage: fallback }, values);
 
   const updateSample = (key, field, value) =>
     setSamples((rows) =>
@@ -273,6 +275,8 @@ const BlindingWizard = () => {
     return analyst ? analyst.displayName : "—";
   };
 
+  const assignedAnalystNames = assignedAnalysts(samples, roster);
+
   if (sealed) {
     return (
       <>
@@ -297,6 +301,29 @@ const BlindingWizard = () => {
                   <li key={code}>{code}</li>
                 ))}
               </ul>
+              {/* Sealing hands the panel to two people who are not on this
+                  screen: the analysts who must run it before the unblind date,
+                  and whoever tracks the cycle. Both facts and both destinations
+                  belong here rather than one step back through the menu. */}
+              <p>
+                {label(
+                  "eqa.inhouse.sealed.deadline",
+                  "Unblind date, and the deadline for the analysts to submit: {date}",
+                  { date: formatDateOnly(cycle.unblindDate) },
+                )}
+              </p>
+              <p>
+                {assignedAnalystNames.length > 0
+                  ? label(
+                      "eqa.inhouse.sealed.analysts",
+                      "Assigned analysts: {names}",
+                      { names: assignedAnalystNames.join(", ") },
+                    )
+                  : label(
+                      "eqa.inhouse.sealed.noAnalysts",
+                      "No analyst is assigned to any sample on this panel.",
+                    )}
+              </p>
               <Button
                 kind="tertiary"
                 onClick={() =>
@@ -312,6 +339,18 @@ const BlindingWizard = () => {
                 }
               >
                 {label("eqa.inhouse.labels.print", "Print label sheet")}
+              </Button>{" "}
+              <Button
+                kind="tertiary"
+                onClick={() => history.push("/qa/eqa/my-cycles")}
+              >
+                {label("eqa.inhouse.sealed.toMyCycles", "Open My Cycles")}
+              </Button>{" "}
+              <Button
+                kind="tertiary"
+                onClick={() => history.push("/WorkPlanByTestSection")}
+              >
+                {label("eqa.inhouse.sealed.toWorkplan", "Open the Workplan")}
               </Button>{" "}
               <Button onClick={() => history.push("/qa/eqa/in-house")}>
                 {label("eqa.inhouse.sealed.done", "Back to in-house panels")}

--- a/frontend/src/components/eqa/InHouse/BlindingWizard.jsx
+++ b/frontend/src/components/eqa/InHouse/BlindingWizard.jsx
@@ -686,6 +686,10 @@ const BlindingWizard = () => {
               onChange={({ selectedItems }) =>
                 setRosterUsers((selectedItems || []).map((user) => user.id))
               }
+              helperText={label(
+                "eqa.inhouse.roster.help",
+                "Analysts are OpenELIS user accounts. Everyone selected here joins this scheme's roster and can be assigned samples to run; the roster is separate from who enters and who validates a result.",
+              )}
             />
             <Select
               id="inhouse-assignment-mode"

--- a/frontend/src/components/eqa/InHouse/__tests__/blindingRules.test.js
+++ b/frontend/src/components/eqa/InHouse/__tests__/blindingRules.test.js
@@ -1,4 +1,5 @@
 import {
+  assignedAnalysts,
   expandForMode,
   modeBlockers,
   panelKpis,
@@ -163,5 +164,39 @@ describe("landing KPI tiles", () => {
     // The far-off SEALED panel and the already-scored ones are out; a
     // null unblind date must not count as imminent.
     expect(panelKpis(panels, today).unblindingSoon).toBe(2);
+  });
+});
+
+describe("the analysts a sealed deal was dealt to", () => {
+  const roster = [
+    { systemUserId: 7, displayName: "Aisha Nakato" },
+    { systemUserId: 8, displayName: "Brian Okello" },
+  ];
+
+  test("names each analyst once however many samples they hold", () => {
+    // An identical-set deal repeats the whole roster per sample, which is what
+    // would otherwise print one person four times.
+    const deal = [
+      { key: "a", analystId: 7 },
+      { key: "b", analystId: 8 },
+      { key: "c", analystId: 7 },
+      { key: "d", analystId: 8 },
+    ];
+    expect(assignedAnalysts(deal, roster)).toEqual([
+      "Aisha Nakato",
+      "Brian Okello",
+    ]);
+  });
+
+  test("skips rows with no analyst rather than listing a blank", () => {
+    expect(
+      assignedAnalysts([{ key: "a", analystId: null }, { key: "b" }], roster),
+    ).toEqual([]);
+  });
+
+  test("falls back to the id when the roster does not hold the analyst", () => {
+    expect(assignedAnalysts([{ key: "a", analystId: 99 }], roster)).toEqual([
+      "99",
+    ]);
   });
 });

--- a/frontend/src/components/eqa/InHouse/blindingRules.js
+++ b/frontend/src/components/eqa/InHouse/blindingRules.js
@@ -80,6 +80,32 @@ export const modeBlockers = (roster, mode) =>
 // Deliberately no cipher name — the mockup's "AES-256" is a claim we cannot make
 // per install: EncryptionConverter delegates to Jasypt's TextEncryptor, whose
 // algorithm comes from deployment configuration.
+/**
+ * The distinct analysts a sealed deal was dealt to, in the order they first
+ * appear. An identical-set deal repeats every analyst once per sample, so the
+ * sealed screen would otherwise list the same person as many times as there are
+ * samples. Rows with no analyst contribute nothing.
+ */
+export const assignedAnalysts = (samples, roster) => {
+  // Keyed by analyst id, so a Map is the de-duplication: it keeps each analyst
+  // at the position they first appeared, whatever the deal repeats after that.
+  const names = new Map();
+  (samples || []).forEach((sample) => {
+    if (!sample.analystId) {
+      return;
+    }
+    const analyst = (roster || []).find(
+      (candidate) =>
+        String(candidate.systemUserId) === String(sample.analystId),
+    );
+    names.set(
+      String(sample.analystId),
+      analyst ? analyst.displayName : String(sample.analystId),
+    );
+  });
+  return [...names.values()];
+};
+
 export const sealState = (panel) => {
   if (["SEALED", "DISTRIBUTED"].includes(panel.status)) {
     return { key: "eqa.inhouse.seal.sealed", sealed: true };

--- a/frontend/src/components/eqa/Provider/Workbench/PrepWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/PrepWorkbench.jsx
@@ -5,6 +5,7 @@ import {
   Column,
   Grid,
   InlineNotification,
+  Link,
   NumberInput,
   Tag,
   TextArea,
@@ -12,7 +13,12 @@ import {
 } from "@carbon/react";
 import { useIntl } from "react-intl";
 import { resolveApiErrorMessage } from "../../../utils/Utils";
-import { hintStyle, kpiLabelStyle, kpiValueStyle } from "../../eqaCommon";
+import {
+  hintStyle,
+  isDispatched,
+  kpiLabelStyle,
+  kpiValueStyle,
+} from "../../eqaCommon";
 import { savePrep, requestReadyToShip } from "./workbenchApi";
 
 /**
@@ -23,7 +29,13 @@ import { savePrep, requestReadyToShip } from "./workbenchApi";
  * the request is still refused server-side with 409 when a stale page clicks it
  * — the gate has one home, in the cycle transition.
  */
-const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
+const PrepWorkbench = ({
+  prep,
+  shipmentRows = [],
+  onChanged,
+  onNotice,
+  onGoToShipments,
+}) => {
   const intl = useIntl();
   const t = (id, defaultMessage, values) =>
     intl.formatMessage({ id, defaultMessage }, values);
@@ -33,6 +45,13 @@ const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
 
   const panels = prep?.panels || [];
   const blockers = prep?.blockers || [];
+  const selected = prep?.participantCount ?? 0;
+  const enrolled = prep?.enrolledParticipantCount ?? selected;
+  const dispatchedCount = shipmentRows.filter(isDispatched).length;
+  // Prep can only clear a cycle while it is in prep, so every other state is a
+  // reason in its own right rather than a missing prerequisite.
+  const inPrep = prep?.cycleStatus === "PREP_IN_PROGRESS";
+  const pastPrep = !inPrep && prep?.cycleStatus !== "PLANNED";
 
   const draftOf = (panel) => ({
     aliquotsProduced: panel.aliquotsProduced,
@@ -100,16 +119,39 @@ const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
       <Grid style={{ marginBottom: "1rem" }}>
         <Column sm={4} md={2} lg={4}>
           <Tile>
-            <div style={kpiValueStyle}>{prep?.participantCount ?? 0}</div>
+            <div style={kpiValueStyle}>
+              {t("eqa.prep.ofTotal", "{n} of {total}", {
+                n: selected,
+                total: enrolled,
+              })}
+            </div>
             <div style={kpiLabelStyle}>
-              {t("eqa.prep.participants", "Participants")}
+              {t(
+                "eqa.prep.tile.participants",
+                "Enrolled laboratories selected for this cycle",
+              )}
             </div>
           </Tile>
         </Column>
         <Column sm={4} md={2} lg={4}>
           <Tile>
             <div style={kpiValueStyle}>{panels.length}</div>
-            <div style={kpiLabelStyle}>{t("eqa.prep.panels", "Panels")}</div>
+            <div style={kpiLabelStyle}>
+              {t("eqa.prep.tile.panels", "Material panels prepared")}
+            </div>
+          </Tile>
+        </Column>
+        <Column sm={4} md={2} lg={4}>
+          <Tile>
+            <div style={kpiValueStyle}>
+              {t("eqa.prep.ofTotal", "{n} of {total}", {
+                n: dispatchedCount,
+                total: shipmentRows.length,
+              })}
+            </div>
+            <div style={kpiLabelStyle}>
+              {t("eqa.prep.dispatched", "Participant shipments dispatched")}
+            </div>
           </Tile>
         </Column>
         <Column sm={4} md={4} lg={8}>
@@ -153,7 +195,7 @@ const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
             <div style={hintStyle}>
               {t(
                 "eqa.prep.needExplained",
-                "{samples} samples x {participants} participants + {reserved} reserved = {needed} aliquots needed; {shipped} shipped so far.",
+                "{samples, plural, one {# sample} other {# samples}} x {participants, plural, one {# participant} other {# participants}} + {reserved} held in reserve = {needed, plural, one {# aliquot} other {# aliquots}} needed; {shipped, plural, one {# aliquot} other {# aliquots}} dispatched so far.",
                 {
                   samples: panel.sampleCount,
                   participants: prep.participantCount,
@@ -242,20 +284,40 @@ const PrepWorkbench = ({ prep, onChanged, onNotice }) => {
         );
       })}
 
-      <Button
-        disabled={!prep?.readyToShipAllowed}
-        onClick={handleReadyToShip}
-        title={
-          prep?.readyToShipAllowed
-            ? undefined
-            : t(
-                "eqa.prep.readyToShip.blocked",
-                "Prep is incomplete, or the cycle is not in prep.",
-              )
-        }
-      >
+      <Button disabled={!prep?.readyToShipAllowed} onClick={handleReadyToShip}>
         {t("eqa.prep.readyToShip", "Mark cycle ready to ship")}
       </Button>
+      {/* A disabled control has to say which of the two rules stopped it: an
+          unmet prerequisite, or a cycle that is simply past this step. The
+          second is not a failure, so it reads as the state it is in and points
+          at where the work continues. */}
+      {!prep?.readyToShipAllowed && (
+        <div style={{ ...hintStyle, marginTop: "0.5rem" }}>
+          {inPrep
+            ? t(
+                "eqa.prep.readyToShip.blockedByGate",
+                "Prep is incomplete. The ready-to-ship gate above lists what is still outstanding.",
+              )
+            : t(
+                "eqa.prep.readyToShip.notInPrep",
+                "Cycle state: {status}. Clearing to ship is only offered while the cycle is in prep.",
+                {
+                  status: t(
+                    `eqa.cycle.status.${(prep?.cycleStatus || "").toLowerCase()}`,
+                    prep?.cycleStatus || "",
+                  ),
+                },
+              )}
+          {pastPrep && onGoToShipments && (
+            <>
+              {" "}
+              <Link href="#" onClick={onGoToShipments}>
+                {t("eqa.prep.goToShipments", "Open the Shipments tab")}
+              </Link>
+            </>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ProviderWorkbenchPage.jsx
@@ -45,6 +45,9 @@ const ProviderWorkbenchPage = () => {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
   const [notice, setNotice] = useState(null);
+  // Controlled so the prep panel can hand an operator to the tab where the
+  // cycle's next step actually lives.
+  const [tab, setTab] = useState(0);
 
   // Reloading after a save keeps the rendered page; only a change of cycle goes
   // back to the spinner, since none of the current page's numbers survive it.
@@ -113,7 +116,10 @@ const ProviderWorkbenchPage = () => {
               workbench surfaces share one cycle banner and one state, so
               sidebar child routes would multiply route plumbing for no
               workflow gain. */}
-          <Tabs>
+          <Tabs
+            selectedIndex={tab}
+            onChange={({ selectedIndex }) => setTab(selectedIndex)}
+          >
             <TabList
               aria-label={t("eqa.provider.workbench.tabs", "Workbenches")}
             >
@@ -126,10 +132,15 @@ const ProviderWorkbenchPage = () => {
               <TabPanel>
                 <PrepWorkbench
                   prep={prep}
+                  shipmentRows={rows}
                   onChanged={(updated) =>
                     updated ? setPrep(updated) : reload()
                   }
                   onNotice={setNotice}
+                  onGoToShipments={(e) => {
+                    e.preventDefault();
+                    setTab(1);
+                  }}
                 />
               </TabPanel>
               <TabPanel>

--- a/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/ShipmentWorkbench.jsx
@@ -20,7 +20,7 @@ import {
   resolveApiErrorMessage,
   toLocalIsoDate,
 } from "../../../utils/Utils";
-import { calendarOnlyInput, hintStyle } from "../../eqaCommon";
+import { calendarOnlyInput, hintStyle, isDispatched } from "../../eqaCommon";
 import {
   generateLabelPDF,
   generateManifestPDF,
@@ -75,8 +75,6 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
       ...prev,
       [organizationId]: { ...(prev[organizationId] || {}), ...patch },
     }));
-
-  const dispatched = (row) => row.boxState === "SENT" || !!row.shippedDate;
 
   const handleSave = (row) => {
     const draft = draftOf(row);
@@ -224,7 +222,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
     });
   };
 
-  const selectable = rows.filter((row) => !dispatched(row) && row.boxId);
+  const selectable = rows.filter((row) => !isDispatched(row) && row.boxId);
   const allSelected =
     selectable.length > 0 && selected.length === selectable.length;
 
@@ -295,7 +293,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
             <TableBody>
               {rows.map((row) => {
                 const draft = draftOf(row);
-                const isDispatched = dispatched(row);
+                const rowDispatched = isDispatched(row);
                 return (
                   <TableRow key={row.organizationId}>
                     <TableCell>
@@ -308,7 +306,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                         )}
                         hideLabel
                         checked={selected.includes(row.organizationId)}
-                        disabled={isDispatched || !row.boxId}
+                        disabled={rowDispatched || !row.boxId}
                         onChange={(_e, { checked }) =>
                           setSelected((prev) =>
                             checked
@@ -342,7 +340,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                         hideLabel
                         size="sm"
                         value={draft.courier}
-                        disabled={isDispatched}
+                        disabled={rowDispatched}
                         onChange={(e) =>
                           setDraft(row.organizationId, {
                             courier: e.target.value,
@@ -361,7 +359,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                         hideLabel
                         size="sm"
                         value={draft.trackingNumber}
-                        disabled={isDispatched}
+                        disabled={rowDispatched}
                         onChange={(e) =>
                           setDraft(row.organizationId, {
                             trackingNumber: e.target.value,
@@ -396,13 +394,13 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                           hideLabel
                           size="sm"
                           placeholder="dd/mm/yyyy"
-                          disabled={isDispatched}
+                          disabled={rowDispatched}
                           {...calendarOnlyInput}
                         />
                       </DatePicker>
                     </TableCell>
                     <TableCell>
-                      {!isDispatched && (
+                      {!rowDispatched && (
                         <Button
                           kind="ghost"
                           size="sm"
@@ -430,7 +428,7 @@ const ShipmentWorkbench = ({ cycleId, prep, rows, onChanged, onNotice }) => {
                           </Button>
                         </>
                       )}
-                      {isDispatched && (
+                      {rowDispatched && (
                         <div style={hintStyle}>
                           {t("eqa.shipment.shippedOn", "Shipped {date}", {
                             date: (row.shippedDate || "").slice(0, 10),

--- a/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
+++ b/frontend/src/components/eqa/Provider/Workbench/__tests__/ProviderWorkbenchPage.test.jsx
@@ -44,6 +44,7 @@ const PREP_SHORT = {
   cycleName: "2026 Round 1",
   cycleStatus: "PREP_IN_PROGRESS",
   participantCount: 2,
+  enrolledParticipantCount: 3,
   panels: [
     {
       panelId: 11,
@@ -126,16 +127,86 @@ const renderWorkbench = (prep = PREP_SHORT, rows = ROWS, samplesByUrl = {}) => {
   );
 };
 
-/**
- * Carbon renders this button's hint as a title attribute, so the accessible name
- * is the hint rather than the label — reach it through its visible text.
- */
 const readyToShipButton = () =>
   screen.getByText("Mark cycle ready to ship").closest("button");
 
 describe("ProviderWorkbenchPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test("the participants tile counts the roster against the scheme's enrollment", () => {
+    renderWorkbench();
+
+    // 2 of the scheme's 3 enrolled laboratories were selected onto this cycle.
+    expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    expect(
+      screen.getByText("Enrolled laboratories selected for this cycle"),
+    ).toBeInTheDocument();
+  });
+
+  test("the dispatch tile counts shipments that have actually left", () => {
+    renderWorkbench(PREP_SHORT, [
+      { ...ROWS[0], boxState: "SENT", shippedDate: "2026-09-02 09:00:00" },
+      ROWS[1],
+    ]);
+
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+    expect(
+      screen.getByText("Participant shipments dispatched"),
+    ).toBeInTheDocument();
+  });
+
+  test("the arithmetic line names a unit for every number and pluralises", () => {
+    renderWorkbench({
+      ...PREP_SHORT,
+      participantCount: 1,
+      enrolledParticipantCount: 1,
+      panels: [
+        {
+          ...PREP_SHORT.panels[0],
+          sampleCount: 1,
+          aliquotsReserved: 0,
+          aliquotsNeeded: 1,
+          aliquotsShipped: 1,
+          shortfall: 0,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(
+        "1 sample x 1 participant + 0 held in reserve = 1 aliquot needed; 1 aliquot dispatched so far.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("a disabled button in prep points at the gate, not at the cycle state", () => {
+    renderWorkbench();
+
+    expect(readyToShipButton()).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Prep is incomplete. The ready-to-ship gate above lists what is still outstanding.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Open the Shipments tab")).toBeNull();
+  });
+
+  test("a cycle past prep says which state it is in and offers the next step", () => {
+    renderWorkbench({ ...PREP_CLEAR, cycleStatus: "SHIPPED" });
+
+    expect(readyToShipButton()).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Cycle state: Shipped. Clearing to ship is only offered while the cycle is in prep.",
+      ),
+    ).toBeInTheDocument();
+
+    // The link is the "where the next step lives" half: it moves the page to the
+    // tab that owns the work, so the reason is actionable rather than only true.
+    fireEvent.click(screen.getByText("Open the Shipments tab"));
+    expect(screen.getByText("District Lab A")).toBeInTheDocument();
   });
 
   test("prep tab shows the shortfall and every gate blocker", () => {

--- a/frontend/src/components/eqa/eqaCommon.jsx
+++ b/frontend/src/components/eqa/eqaCommon.jsx
@@ -54,6 +54,14 @@ export const calendarOnlyInput = {
   onPaste: (e) => e.preventDefault(),
 };
 
+/**
+ * A participant's box has left the building. Read from either the box state or
+ * the shipment's own date, because the two are written by different steps and a
+ * box dispatched before the shipment row was stamped still counts.
+ */
+export const isDispatched = (row) =>
+  row.boxState === "SENT" || !!row.shippedDate;
+
 /** RFC 4180 cell: everything quoted, embedded quotes doubled. */
 export const csvCell = (value) =>
   `"${String(value ?? "").replace(/"/g, '""')}"`;

--- a/frontend/src/components/resultPage/SearchResultForm.jsx
+++ b/frontend/src/components/resultPage/SearchResultForm.jsx
@@ -1180,7 +1180,7 @@ export function SearchResults(props) {
           label={intl.formatMessage({
             id: "eqa.result.analyst.tooltip",
             defaultMessage:
-              "Shown because this run includes an EQA sample whose scheme records who ran each sample. Non-EQA rows take no input.",
+              "Shown because this run includes an EQA sample whose scheme records who ran each sample. Choose the OpenELIS user who ran the sample, from the scheme's analyst roster — that is a separate record from whoever enters this result and whoever validates it. Non-EQA rows take no input.",
           })}
         >
           <span>

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -7985,7 +7985,7 @@
   "eqa.distribution.updateSuccess": "Draft distribution updated.",
   "banner.menu.eqa.myCycles": "My Cycles",
   "banner.menu.eqa.labPerformance": "Lab Performance",
-  "banner.menu.eqa.followUpQueue": "Follow-Up Queue",
+  "banner.menu.eqa.followUpQueue": "This Lab's Follow-Up",
   "banner.menu.eqa.analystCompetency": "Analyst Competency",
   "banner.menu.eqa.provider": "EQA Provider",
   "eqa.participant.myCycles.title": "My EQA Cycles",
@@ -8297,8 +8297,8 @@
   "eqa.performance.ACCEPTABLE": "Acceptable",
   "eqa.performance.QUESTIONABLE": "Questionable",
   "eqa.performance.UNACCEPTABLE": "Unacceptable",
-  "eqa.oversight.followUpQueue": "Follow-Up Queue",
-  "eqa.oversight.queueSubtitle": "This lab's questionable EQA scores awaiting corrective review, from external providers and our own in-house schemes. Provider-side follow-up on other labs' submissions lives in EQA Program Management.",
+  "eqa.oversight.followUpQueue": "This Lab's Follow-Up",
+  "eqa.oversight.queueSubtitle": "This lab's questionable EQA scores awaiting corrective review, from external providers and this lab's own in-house schemes. Correspondence with the laboratories that take part in the schemes this lab provides is a different register:",
   "eqa.queue.policyTitle": "Auto-NCE policy active.",
   "eqa.queue.policyBody": "Unacceptable scores on any external scheme this lab participates in open an NCE automatically. This queue holds the questionable range (2 < |Z| ≤ 3) and in-house failures, which need human triage.",
   "eqa.queue.kpi.queued": "Items queued",
@@ -8655,5 +8655,12 @@
   "eqa.competency.reason.insufficientEvidence": "{evaluable} assessable samples between {from} and {to}, short of the evidence floor of {floor}. This is not a performance concern: assign this analyst more proficiency testing samples.",
   "eqa.competency.reason.openEscalation": "An escalated non-conformity raised between {from} and {to} is still open, over {evaluable} assessable samples with {failures} failures. Close the non-conformity to clear the band.",
   "eqa.competency.whatIsAnAnalyst": "An analyst is an OpenELIS user account on the scheme's analyst roster, recorded against the sample they ran. That is a separate record from whoever entered the result and whoever validated it.",
-  "eqa.inhouse.roster.help": "Analysts are OpenELIS user accounts. Everyone selected here joins this scheme's roster and can be assigned samples to run; the roster is separate from who enters and who validates a result."
+  "eqa.inhouse.roster.help": "Analysts are OpenELIS user accounts. Everyone selected here joins this scheme's roster and can be assigned samples to run; the roster is separate from who enters and who validates a result.",
+  "banner.menu.eqa.providerFollowups": "Participant Follow-Up",
+  "eqa.oversight.queueSubtitle.link": "Participant follow-up",
+  "eqa.inhouse.sealed.deadline": "Unblind date, and the deadline for the analysts to submit: {date}",
+  "eqa.inhouse.sealed.analysts": "Assigned analysts: {names}",
+  "eqa.inhouse.sealed.noAnalysts": "No analyst is assigned to any sample on this panel.",
+  "eqa.inhouse.sealed.toMyCycles": "Open My Cycles",
+  "eqa.inhouse.sealed.toWorkplan": "Open the Workplan"
 }

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8090,7 +8090,7 @@
   "eqa.prep.gate.clear": "All prep requirements met",
   "eqa.prep.noPanel.title": "No panel prepared",
   "eqa.prep.noPanel.body": "Create the cycle's panel and its samples before recording prep progress.",
-  "eqa.prep.needExplained": "{samples} samples x {participants} participants + {reserved} reserved = {needed} aliquots needed; {shipped} shipped so far.",
+  "eqa.prep.needExplained": "{samples, plural, one {# sample} other {# samples}} x {participants, plural, one {# participant} other {# participants}} + {reserved} held in reserve = {needed, plural, one {# aliquot} other {# aliquots}} needed; {shipped, plural, one {# aliquot} other {# aliquots}} dispatched so far.",
   "eqa.prep.produced": "Aliquots produced",
   "eqa.prep.reserved": "Aliquots reserved",
   "eqa.prep.shortfall": "{n} short",
@@ -8100,7 +8100,6 @@
   "eqa.prep.saved": "Prep record updated.",
   "eqa.prep.saveFailed": "Prep record was not saved.",
   "eqa.prep.readyToShip": "Mark cycle ready to ship",
-  "eqa.prep.readyToShip.blocked": "Prep is incomplete, or the cycle is not in prep.",
   "eqa.prep.readyToShip.success": "Cycle cleared to ship — record courier details on the Shipments tab.",
   "eqa.prep.readyToShip.refused": "The cycle was not cleared to ship. Resolve the outstanding prep items and try again.",
   "eqa.shipment.tab": "Shipments",
@@ -8639,5 +8638,12 @@
   "eqa.cycle.close": "Close cycle",
   "eqa.cycle.closeHeading": "Close this cycle",
   "eqa.cycle.closeHelp": "A closed cycle is final: participants see it as closed and no further verdicts are recorded against it. Closing is refused while a follow-up is open or a missed-deadline result is still waiting on an answer.",
-  "eqa.cycle.closeFailed": "Could not close this cycle"
+  "eqa.cycle.closeFailed": "Could not close this cycle",
+  "eqa.prep.ofTotal": "{n} of {total}",
+  "eqa.prep.tile.participants": "Enrolled laboratories selected for this cycle",
+  "eqa.prep.tile.panels": "Material panels prepared",
+  "eqa.prep.dispatched": "Participant shipments dispatched",
+  "eqa.prep.readyToShip.blockedByGate": "Prep is incomplete. The ready-to-ship gate above lists what is still outstanding.",
+  "eqa.prep.readyToShip.notInPrep": "Cycle state: {status}. Clearing to ship is only offered while the cycle is in prep.",
+  "eqa.prep.goToShipments": "Open the Shipments tab"
 }

--- a/frontend/src/languages/en.json
+++ b/frontend/src/languages/en.json
@@ -8499,7 +8499,7 @@
   "eqa.program.perAnalyst": "Record the analyst on every result",
   "eqa.program.perAnalyst.on": "Analyst recorded",
   "eqa.program.perAnalyst.off": "Not recorded",
-  "eqa.result.analyst.tooltip": "Shown because this run includes an EQA sample whose scheme records who ran each sample. Non-EQA rows take no input.",
+  "eqa.result.analyst.tooltip": "Shown because this run includes an EQA sample whose scheme records who ran each sample. Choose the OpenELIS user who ran the sample, from the scheme's analyst roster — that is a separate record from whoever enters this result and whoever validates it. Non-EQA rows take no input.",
   "shipment.settings.siteOrgUnsetTitle": "Site organization not set",
   "shipment.settings.siteOrgUnsetSubtitle": "Incoming consignments are not filtered to this site and outgoing boxes carry no sender. Select the organization that represents this laboratory.",
   "shipment.settings.siteOrgUnmatchedTitle": "Set to an organization this instance does not hold",
@@ -8645,5 +8645,15 @@
   "eqa.prep.dispatched": "Participant shipments dispatched",
   "eqa.prep.readyToShip.blockedByGate": "Prep is incomplete. The ready-to-ship gate above lists what is still outstanding.",
   "eqa.prep.readyToShip.notInPrep": "Cycle state: {status}. Clearing to ship is only offered while the cycle is in prep.",
-  "eqa.prep.goToShipments": "Open the Shipments tab"
+  "eqa.prep.goToShipments": "Open the Shipments tab",
+  "eqa.competency.rule.meetsEvidence": "Evidence met",
+  "eqa.competency.rule.repeatedFailure": "Repeated failure",
+  "eqa.competency.rule.insufficientEvidence": "Insufficient evidence",
+  "eqa.competency.rule.openEscalation": "Open non-conformity",
+  "eqa.competency.reason.meetsEvidence": "{evaluable} assessable samples with {failures} failures between {from} and {to}, at or above the evidence floor of {floor}. Nothing to action.",
+  "eqa.competency.reason.repeatedFailure": "{failures} failures in {evaluable} assessable samples between {from} and {to}. This is a performance concern: review the failed results and raise a non-conformity, or dismiss them on triage.",
+  "eqa.competency.reason.insufficientEvidence": "{evaluable} assessable samples between {from} and {to}, short of the evidence floor of {floor}. This is not a performance concern: assign this analyst more proficiency testing samples.",
+  "eqa.competency.reason.openEscalation": "An escalated non-conformity raised between {from} and {to} is still open, over {evaluable} assessable samples with {failures} failures. Close the non-conformity to clear the band.",
+  "eqa.competency.whatIsAnAnalyst": "An analyst is an OpenELIS user account on the scheme's analyst roster, recorded against the sample they ran. That is a separate record from whoever entered the result and whoever validated it.",
+  "eqa.inhouse.roster.help": "Analysts are OpenELIS user accounts. Everyone selected here joins this scheme's roster and can be assigned samples to run; the roster is separate from who enters and who validates a result."
 }

--- a/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAAnalystCompetencyServiceImpl.java
@@ -48,6 +48,18 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
     private static final String NOT_COMPETENT = "NOT_COMPETENT";
 
     /**
+     * Which rule produced a band. UNDER_REVIEW is reached by two rules that mean
+     * opposite things — an analyst who has failed twice, and an analyst nobody has
+     * given enough work to judge — and they call for opposite actions. The stored
+     * status stays one value; this says which branch of {@link #band} set it, so
+     * the page can tell the reader what to do about it.
+     */
+    private static final String MEETS_EVIDENCE = "MEETS_EVIDENCE";
+    private static final String REPEATED_FAILURE = "REPEATED_FAILURE";
+    private static final String INSUFFICIENT_EVIDENCE = "INSUFFICIENT_EVIDENCE";
+    private static final String OPEN_ESCALATION = "OPEN_ESCALATION";
+
+    /**
      * Statuses that close a non-conformity, as the Lab Performance rollup reads
      * them.
      */
@@ -183,6 +195,12 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
         Map<String, Object> page = new LinkedHashMap<>();
         List<Map<String, Object>> analysts = analysts(rows, openEscalatedNces());
         page.put("kpis", kpis(analysts));
+        // The rule's own parameters travel with its verdicts, so the page quotes the
+        // window and the floor it was actually judged against.
+        page.put("windowStart", windowStart.toString());
+        page.put("windowEnd", LocalDate.now().toString());
+        page.put("windowMonths", WINDOW_MONTHS);
+        page.put("evidenceFloor", EVIDENCE_FLOOR);
         page.put("analysts", analysts);
         return page;
     }
@@ -290,6 +308,22 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
                 headline = worst(headline, (String) banded.get("status"));
             }
             analytes.sort(Comparator.comparing(row -> String.valueOf(row.get("analyteName"))));
+            // The headline is the worst band across the analytes, so the rules that
+            // produced it are those of the analytes sitting at that band. Each one
+            // carries its own counts: a rule reads over one analyte, and the
+            // analyst's totals across every analyte are not the denominator it
+            // fired on.
+            List<Map<String, Object>> headlineReasons = new ArrayList<>();
+            for (Map<String, Object> banded : analytes) {
+                if (headline.equals(banded.get("status"))) {
+                    Map<String, Object> why = new LinkedHashMap<>();
+                    why.put("reason", banded.get("reason"));
+                    why.put("analyteName", banded.get("analyteName"));
+                    why.put("evaluableCount", banded.get("evaluableCount"));
+                    why.put("failureCount", banded.get("failureCount"));
+                    headlineReasons.add(why);
+                }
+            }
 
             List<EQACompetencyRow> facts = facts(owned);
             EQACompetencyRow latest = facts.stream().filter(row -> VERDICT.containsValue(row.outcome))
@@ -299,6 +333,7 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
             dto.put("analystId", entry.getKey());
             dto.put("analystName", analystName(entry.getKey()));
             dto.put("status", headline);
+            dto.put("statusReasons", headlineReasons);
             dto.put("sampleCount", facts.size());
             dto.put("sampleCountThisYear",
                     (int) facts.stream().filter(row -> row.date.getYear() == currentYear).count());
@@ -335,18 +370,24 @@ public class EQAAnalystCompetencyServiceImpl implements EQAAnalystCompetencyServ
                 .anyMatch(row -> row.escalation && (row.nceId == null || openNces.contains(row.nceId)));
 
         String status;
+        String reason;
         if (openEscalation) {
             status = NOT_COMPETENT;
+            reason = OPEN_ESCALATION;
         } else if (failures >= 2) {
             status = UNDER_REVIEW;
+            reason = REPEATED_FAILURE;
         } else if (evaluable < EVIDENCE_FLOOR) {
             status = UNDER_REVIEW;
+            reason = INSUFFICIENT_EVIDENCE;
         } else {
             status = COMPETENT;
+            reason = MEETS_EVIDENCE;
         }
 
         Map<String, Object> dto = new LinkedHashMap<>();
         dto.put("status", status);
+        dto.put("reason", reason);
         dto.put("evaluableCount", evaluable);
         dto.put("failureCount", failures);
         dto.put("openEscalation", openEscalation);

--- a/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
+++ b/src/main/java/org/openelisglobal/eqa/service/EQAShipmentServiceImpl.java
@@ -67,6 +67,9 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
     private EQAProgramEnrollmentDAO eqaProgramEnrollmentDAO;
 
     @Autowired
+    private EQAProgramEnrollmentService eqaProgramEnrollmentService;
+
+    @Autowired
     private EQACycleParticipantDAO eqaCycleParticipantDAO;
 
     @Autowired
@@ -227,6 +230,10 @@ public class EQAShipmentServiceImpl implements EQAShipmentService {
         status.put("distributionMethod",
                 cycle.getDistributionMethod() == null ? null : cycle.getDistributionMethod().name());
         status.put("participantCount", gate.participantCount());
+        // The denominator the tile was missing: a cycle ships to the laboratories
+        // selected onto its roster, which is a subset of the scheme's enrollment.
+        status.put("enrolledParticipantCount", cycle.getScheme() == null ? 0
+                : (int) eqaProgramEnrollmentService.countActiveEnrollments(cycle.getScheme().getId()));
         status.put("panels", panelDtos);
         status.put("blockers", gate.blockers());
         // The button state the workbench renders; the gate itself is enforced on the

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -154,6 +154,8 @@
   <include file="liquibase/qa/039-eqa-result-text.xml" />
   <!-- EQA V2.2 — OGC-935: lifecycle status on a laboratory's own enrolment (qa-081) -->
   <include file="liquibase/qa/042-eqa-lab-enrollment-status.xml" />
+  <!-- EQA V2.5 — OGC-935: menu row for the provider's participant follow-up register (qa-082) -->
+  <include file="liquibase/qa/043-eqa-provider-followup-menu.xml" />
 
   <!-- Clears an eqa-v2-start tag that an earlier version of qa/040 recorded without
        applying. Last on purpose: it repairs a changelog row, so it has to run after

--- a/src/main/resources/liquibase/qa/043-eqa-provider-followup-menu.xml
+++ b/src/main/resources/liquibase/qa/043-eqa-provider-followup-menu.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    EQA V2.5 (OGC-935): the menu row for the provider's Participant follow-up
+    register. qa/019 seeded the five V2 lanes and qa/031 added In-House
+    Blinding, but this register was reachable only from links inside the
+    provider workbench and from the participant's own queue — so a provider who
+    had not scored a cycle recently had no way to find it.
+
+    The action_url is the route the SPA serves (/qa/eqa/provider/follow-ups),
+    the convention qa/029 established after the My Cycles row shipped as a dead
+    click. Presentation order 75 puts it beside the Provider row it belongs
+    with.
+
+    The row carries no role linkage because the menu model has none: menu rows
+    are visible to every authenticated user on this lineage, and the page's own
+    grant is what gates it. This matches every other row under menu_eqa rather
+    than inventing gating the model cannot enforce.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+    <changeSet author="openelisglobal" id="qa-082-add-menu-eqa-provider-followups">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM clinlims.menu WHERE element_id = 'menu_eqa_provider_followups'</sqlCheck>
+        </preConditions>
+        <comment>Participant follow-up — the provider's register of correspondence with other labs</comment>
+        <insert tableName="menu" schemaName="clinlims">
+            <column name="id" valueSequenceNext="menu_seq" />
+            <column name="parent_id" valueComputed="(SELECT id FROM clinlims.menu WHERE element_id = 'menu_eqa')" />
+            <column name="presentation_order" value="75" />
+            <column name="element_id" value="menu_eqa_provider_followups" />
+            <column name="action_url" value="/qa/eqa/provider/follow-ups" />
+            <column name="display_key" value="banner.menu.eqa.providerFollowups" />
+            <column name="tool_tip_key" value="banner.menu.eqa.providerFollowups" />
+            <column name="new_window" valueBoolean="false" />
+            <column name="is_active" valueBoolean="true" />
+            <column name="hide_in_old_ui" valueBoolean="true" />
+        </insert>
+        <rollback>
+            <delete tableName="menu" schemaName="clinlims">
+                <where>element_id = 'menu_eqa_provider_followups'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/openelisglobal/eqa/EQAAnalystCompetencyIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAAnalystCompetencyIntegrationTest.java
@@ -50,6 +50,11 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
     private static final String UNDER_REVIEW = "UNDER_REVIEW";
     private static final String NOT_COMPETENT = "NOT_COMPETENT";
 
+    private static final String MEETS_EVIDENCE = "MEETS_EVIDENCE";
+    private static final String REPEATED_FAILURE = "REPEATED_FAILURE";
+    private static final String INSUFFICIENT_EVIDENCE = "INSUFFICIENT_EVIDENCE";
+    private static final String OPEN_ESCALATION = "OPEN_ESCALATION";
+
     @Autowired
     private EQAAnalystCompetencyService competencyService;
 
@@ -108,6 +113,7 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         assertEquals(1, analytes.size());
         assertEquals(ANALYTE_NAME, analytes.get(0).get("analyteName"));
         assertEquals(COMPETENT, analytes.get(0).get("status"));
+        assertEquals(MEETS_EVIDENCE, analytes.get(0).get("reason"));
         assertEquals(4, analytes.get(0).get("evaluableCount"));
     }
 
@@ -122,6 +128,10 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
                 analyst.get("status"));
         assertEquals(3, analyst.get("evaluableCount"));
         assertEquals(0, analyst.get("failureCount"));
+        // The half of the pair that is not a performance finding: same band as
+        // twoFailuresAmongFourSamplesAssertUnderReview, opposite rule.
+        assertEquals(INSUFFICIENT_EVIDENCE, analytes(analyst).get(0).get("reason"));
+        assertEquals(INSUFFICIENT_EVIDENCE, headlineReasons(analyst).get(0).get("reason"));
     }
 
     @Test
@@ -135,6 +145,10 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         assertEquals(UNDER_REVIEW, analyst.get("status"));
         assertEquals(4, analyst.get("evaluableCount"));
         assertEquals(2, analyst.get("failureCount"));
+        // Same band as threeAcceptableResultsAreInsufficientEvidence, and the
+        // reason is what tells the two apart.
+        assertEquals(REPEATED_FAILURE, analytes(analyst).get(0).get("reason"));
+        assertEquals(REPEATED_FAILURE, headlineReasons(analyst).get(0).get("reason"));
         assertEquals("the worst recent verdict is what the page shows", "unacceptable",
                 analyst.get("mostRecentPerformance"));
     }
@@ -287,6 +301,7 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         assertEquals("an escalated score is one failed sample, not two", 1, analyst.get("failureCount"));
         assertEquals(5, analyst.get("evaluableCount"));
         assertEquals(Boolean.TRUE, analytes(analyst).get(0).get("openEscalation"));
+        assertEquals(OPEN_ESCALATION, analytes(analyst).get(0).get("reason"));
     }
 
     @Test
@@ -325,6 +340,30 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
         assertEquals(SECOND_ANALYTE_NAME, analytes.get(1).get("analyteName"));
         assertEquals(UNDER_REVIEW, analytes.get(1).get("status"));
         assertEquals(2, analytes.get(1).get("failureCount"));
+
+        // The headline reason names the analyte that produced it and carries that
+        // analyte's own counts, not the analyst's. The competent analyte
+        // contributes nothing, which is the control: a reason list that simply
+        // collected every analyte would hold two entries here.
+        List<Map<String, Object>> why = headlineReasons(analyst);
+        assertEquals(1, why.size());
+        assertEquals(REPEATED_FAILURE, why.get(0).get("reason"));
+        assertEquals(SECOND_ANALYTE_NAME, why.get(0).get("analyteName"));
+        assertEquals("the rule read two samples, not the analyst's six", 2, why.get(0).get("evaluableCount"));
+        assertEquals(2, why.get(0).get("failureCount"));
+        assertEquals("the analyst's own totals span both analytes", 6, analyst.get("evaluableCount"));
+    }
+
+    @Test
+    public void theRollupPublishesTheWindowAndFloorItJudgedAgainst() {
+        scoredResult(EQAPerformanceStatus.ACCEPTABLE, ANALYTE);
+
+        Map<String, Object> page = competencyService.getCompetencyRollup();
+        assertEquals(12, page.get("windowMonths"));
+        assertEquals(4, page.get("evidenceFloor"));
+        assertEquals(LocalDate.now().toString(), page.get("windowEnd"));
+        assertEquals("the window is the twelve months the rollup actually read",
+                LocalDate.now().minusMonths(12).toString(), page.get("windowStart"));
     }
 
     @Test
@@ -516,6 +555,11 @@ public class EQAAnalystCompetencyIntegrationTest extends EQASpineTestBase {
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> analytes(Map<String, Object> analyst) {
         return (List<Map<String, Object>>) analyst.get("analytes");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> headlineReasons(Map<String, Object> analyst) {
+        return (List<Map<String, Object>>) analyst.get("statusReasons");
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAShipmentWorkbenchIntegrationTest.java
@@ -129,6 +129,8 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         Map<String, Object> prep = shipmentService.getPrepStatus(cycle.getId());
 
         assertEquals(2, prep.get("participantCount"));
+        assertEquals("no roster, so the cycle is sized by the scheme's enrollment", 2,
+                prep.get("enrolledParticipantCount"));
         Map<String, Object> panelRow = panels(prep).get(0);
         assertEquals("2 samples x 2 participants + 0 reserve", 4, panelRow.get("aliquotsNeeded"));
         assertEquals(4, panelRow.get("shortfall"));
@@ -384,8 +386,11 @@ public class EQAShipmentWorkbenchIntegrationTest extends EQASpineTestBase {
         enroll(ORG_C);
         addToRoster(ORG_A);
 
-        assertEquals("3 enrolled, 1 on this cycle's roster", 1,
-                shipmentService.getPrepStatus(cycle.getId()).get("participantCount"));
+        Map<String, Object> prep = shipmentService.getPrepStatus(cycle.getId());
+        assertEquals("3 enrolled, 1 on this cycle's roster", 1, prep.get("participantCount"));
+        // The tile's denominator is the scheme's enrollment, not the roster, so the
+        // two numbers have to differ here or the workbench reads "1 of 1".
+        assertEquals(3, prep.get("enrolledParticipantCount"));
         List<Map<String, Object>> rows = shipmentService.getShipmentRows(cycle.getId());
         assertEquals(1, rows.size());
         assertEquals(ORG_A, rows.get(0).get("organizationId"));

--- a/src/test/java/org/openelisglobal/eqa/EQAV2MenuPermissionIntegrationTest.java
+++ b/src/test/java/org/openelisglobal/eqa/EQAV2MenuPermissionIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.openelisglobal.eqa;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,12 @@ public class EQAV2MenuPermissionIntegrationTest extends BaseWebContextSensitiveT
                     "true" },
             // qa/032: T-24's scheme list is the page this row was waiting for, so it
             // moves onto the served route and comes back on.
-            { "menu_eqa_provider", "/qa/eqa/provider/schemes", "banner.menu.eqa.provider", "true" } };
+            { "menu_eqa_provider", "/qa/eqa/provider/schemes", "banner.menu.eqa.provider", "true" },
+            // qa/043: the provider's participant follow-up register had no way in
+            // from the menu at all — only links out of the workbench and the
+            // participant's own queue.
+            { "menu_eqa_provider_followups", "/qa/eqa/provider/follow-ups", "banner.menu.eqa.providerFollowups",
+                    "true" } };
 
     private static final String[] TIERS = { "qa.eqa.participant", "qa.eqa.oversight", "qa.eqa.provider",
             "qa.eqa.inhouse.unblind" };
@@ -94,6 +100,48 @@ public class EQAV2MenuPermissionIntegrationTest extends BaseWebContextSensitiveT
             assertEquals(menu[0] + " parent", "menu_eqa", row.get("parent"));
             assertEquals(menu[0] + " active", Boolean.valueOf(menu[3]), row.get("is_active"));
         }
+    }
+
+    /**
+     * "In the provider lane" is a claim about ordering, since the rows are flat
+     * under menu_eqa. The register has to sit immediately after the Provider row it
+     * belongs with, which means the neighbours on both sides are part of the
+     * assertion — reading only the two provider rows would pass on any slot after
+     * Provider, including one past In-House Blinding.
+     */
+    @Test
+    public void theParticipantFollowUpRowSitsBesideTheProviderRow() {
+        List<String> lane = jdbc.queryForList(
+                "SELECT element_id FROM clinlims.menu"
+                        + " WHERE parent_id = (SELECT id FROM clinlims.menu WHERE element_id = 'menu_eqa')"
+                        + "   AND element_id IN ('menu_eqa_analyst_competency', 'menu_eqa_provider',"
+                        + "       'menu_eqa_provider_followups', 'menu_eqa_in_house')" + " ORDER BY presentation_order",
+                String.class);
+        assertEquals(List.of("menu_eqa_analyst_competency", "menu_eqa_provider", "menu_eqa_provider_followups",
+                "menu_eqa_in_house"), lane);
+    }
+
+    /**
+     * The menu model carries no role linkage, so a row cannot be gated by grant;
+     * the page's own permission is what gates it. Recorded as an assertion so the
+     * next reader does not go looking for RBAC that is not there.
+     *
+     * <p>
+     * The absence is only evidence alongside the presence: the same query has to
+     * find the columns the model does have, or a typo in the table name would
+     * report the same empty answer.
+     */
+    @Test
+    public void theNewRowCarriesNoRoleLinkageBecauseTheMenuModelHasNone() {
+        List<String> columns = jdbc.queryForList("SELECT column_name FROM information_schema.columns"
+                + " WHERE table_schema = 'clinlims' AND table_name = 'menu'", String.class);
+
+        assertTrue("the query reached the menu table at all", columns.containsAll(
+                List.of("element_id", "action_url", "parent_id", "display_key", "is_active", "presentation_order")));
+        assertEquals("nothing on menu names a role, a module or a permission", List.of(),
+                columns.stream().filter(
+                        column -> column.contains("role") || column.contains("module") || column.contains("permission"))
+                        .toList());
     }
 
     @Test


### PR DESCRIPTION
# Pull Requests Requirements

- [x] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [x] The PR title follows conventional commit label standards.
- [x] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [x] The changes include tests or are validated by existing tests.
- [x] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

No video: every change here is a number, a sentence or a link on an existing
screen, and the three commits below name each one against the copy it replaces.

## Summary

Three EQA screens that state something without saying what it means. One commit
each; the commits are independent and can be read in any order.

### The prep workbench numbers do not say what they count (`97bbf3a`)

The participants tile was the bare word "Participants" over the cycle's selected
recipients, with nothing to say the scheme has more enrolled laboratories than
the cycle ships to. It now reads `2 of 3` against the scheme's active
enrollments, which `GET /rest/eqa/cycles/{id}/prep` answers as
`enrolledParticipantCount`.

The arithmetic line named a unit for the need but not for the dispatch, so
"1 shipped so far" could be read as one panel, one box, one participant or one
aliquot, with the answer on another tab. It now says "1 aliquot dispatched so
far", every count has a plural form so a one-sample panel no longer reads
"1 samples", and a third tile counts participant shipments actually dispatched
against the roster — from rows the page already fetches for the Shipments tab,
so no new endpoint.

The disabled ready-to-ship button offered "Prep is incomplete, or the cycle is
not in prep" through a `title` attribute nobody sees, and a cycle that had
already shipped got no reason at all. The reason is now on screen and names one
state or the other: the gate above when prep is genuinely incomplete, otherwise
the cycle's own state plus a link to the Shipments tab.

The "has this box left" test moves out of the shipment table into `eqaCommon` as
`isDispatched`, so the new tile and the table cannot drift apart.

### A competency band never says which rule produced it (`b28e732`)

Under review was two findings wearing one label. An analyst reaches it by
failing twice, and again by not having been given four assessable samples yet.
The first is a performance concern, the second is not, and they call for
opposite actions — but the band that reached the page could not be told apart.

`band()` now carries a reason out beside the status: `OPEN_ESCALATION`,
`REPEATED_FAILURE`, `INSUFFICIENT_EVIDENCE` or `MEETS_EVIDENCE`. **The stored
status is not split** and nothing is persisted: the reason is derived on every
read exactly as the band is, so there is no second value to keep in step and no
migration. Splitting the stored status is a schema decision and is deliberately
left alone.

Analyst Competency renders the rule beside every band with the analyte it read,
the window it read over, that analyte's own denominator and the next action. The
analyst's headline row carries one reason per analyte sitting at the headline
band, each with **that analyte's** counts — the analyst's totals span every
analyte and are not the denominator any rule fired on. The rollup also publishes
`windowStart`, `windowEnd`, `windowMonths` and `evidenceFloor`, so the page
quotes the values it was judged against instead of repeating the constants in
copy.

Three surfaces now say what an analyst is, because nothing did: the competency
page, the scheme roster in the blinding wizard, and the Analyst column on result
entry. Each keeps the assigned analyst distinct from whoever entered the result
and whoever validated it.

`docs/eqa/analyst-competency-rules.md` gains the reason table.

### Two ways in that do not exist (`54268bd`)

The provider's participant follow-up register had no menu row at all. It was
reachable only from a link on the workbench's Receipts & scoring tab and from
the participant's own queue, so a provider who had not scored a cycle recently
could not find it. `qa/043` (`qa-082`) adds the row at presentation order 75,
beside Provider, on the route the SPA serves (`/qa/eqa/provider/follow-ups`) —
the convention `qa/029` established after the My Cycles row shipped as a dead
click.

The row carries no role linkage, because the menu model has none: menu rows are
visible to every authenticated user on this lineage and the page's own grant is
what gates it. That matches the surrounding rows rather than inventing gating the
model cannot enforce, and there is a test saying so, so the next reader does not
go looking for it.

The participant queue's subtitle claimed provider-side follow-up "lives in EQA
Program Management", which is not where it lives. It now names the register and
links to it. The two are easy to confuse — one holds this lab's own corrective
actions, the other correspondence about another lab's submissions — so the
participant page is now **This Lab's Follow-Up** and the provider's is
**Participant Follow-Up**.

Sealing an in-house panel told the truth and then handed over nothing to click.
Beside the blind codes it now shows the unblind date the analysts are working to
and the analysts the samples were dealt to, and offers My Cycles and the Workplan
alongside the way back.

## Screenshots

Not attached. The changes are copy, tile arithmetic and links on existing
screens; the assertions below name the exact strings.

## Related Issue

OGC-935.

## Other

**Database.** One changeset, `liquibase/qa/043-eqa-provider-followup-menu.xml`
(`qa-082`), inserting one `menu` row with a matching `<rollback>` and a
`MARK_RAN` precondition, so it is idempotent on a database that already carries
the row.

**Translations.** New keys are added to `en.json` only. Four existing English
strings change and will go back through Transifex: the prep arithmetic line, the
result-entry Analyst tooltip, the follow-up queue heading and its subtitle. The
last two are the point of the third commit — the two registers were
indistinguishable by name.

`eqa.prep.participants` and `eqa.prep.panels` keep their short text because
`ProviderSchemeList` uses them as table column headers; the workbench tiles got
their own keys instead, which also keeps the churn to what the change needs.

**Tests.** Every new rule is proved by inversion — broken deliberately, with the
intended test failing and nothing else:

| Broken | Failed |
| --- | --- |
| `enrolledParticipantCount` returns the roster count | `aCycleRosterOverridesTheSchemeEnrollmentEverywhere`, `expected:<3> but was:<1>` — while the equal-numbers case stayed green as its control |
| the dispatch tile counts every row, dispatched or not | the dispatch tile test alone |
| the arithmetic line loses its plurals and its dispatch unit | the arithmetic test alone |
| the button's reason is always the gate sentence | the past-prep test alone |
| both under-review branches report the same rule | `twoFailuresAmongFourSamplesAssertUnderReview` and `theAnalystBandIsTheWorstOfTheirAnalytes` |
| the headline collects every analyte, not the ones at the band | `theAnalystBandIsTheWorstOfTheirAnalytes`, `expected:<1> but was:<2>` |
| the menu row lands past In-House Blinding | `theParticipantFollowUpRowSitsBesideTheProviderRow` |
| the subtitle keeps pointing at EQA Program Management | the cross-link test alone |
| `assignedAnalysts` collects into a list instead of keying by analyst | the de-duplication test alone |

Two findings came out of running those:

- An early version of `assignedAnalysts` carried a `names.has(...)` guard that
  could not change the result — the `Map` keying was already the
  de-duplication. The inversion passed, which is how the dead code was found;
  it is gone, and the mechanism is inverted through the `Map` instead.
- The test asserting the `menu` table carries no role linkage would have passed
  on a typo'd table name, since an absence is what it looks for. It now reads
  the column list once and asserts both that the columns the model does have are
  there and that nothing names a role, module or permission.

A Playwright assertion on the old "Follow-Up Queue" heading is updated with the
rename.

**Suites run:** full frontend gate as CI runs it from `frontend/` — prettier,
eslint, 182 files / 1267 tests. Backend: `EQAShipmentWorkbenchIntegrationTest`
(43), `EQAAnalystCompetencyIntegrationTest` (20),
`EQAV2MenuPermissionIntegrationTest` (5), `EQAV1AbsorptionMigrationTest` (6).
