### PR TITLE
Fix published freezer migration checksum compatibility

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -71,6 +71,20 @@ jobs:
         with:
           repository: ${{github.repository}}
           submodules: recursive
+          fetch-depth: 2
+
+      - name: Preserve the prior revision's migration history for compatibility checks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          baseline="${BASE_SHA:-$(git rev-parse HEAD^)}"
+          if [ "$baseline" = "0000000000000000000000000000000000000000" ]; then
+            baseline="$(git rev-parse HEAD^)"
+          fi
+          git fetch --depth=1 origin "$baseline"
+          mkdir -p "$RUNNER_TEMP/published-migrations"
+          git archive FETCH_HEAD src/main/resources | tar -x -C "$RUNNER_TEMP/published-migrations"
+          echo "LIQUIBASE_BASELINE_DIR=$RUNNER_TEMP/published-migrations/src/main/resources" >> "$GITHUB_ENV"
 
       - name: check formatting
         run: mvn spotless:check

--- a/src/main/resources/liquibase/3.5.x.x/089-cold-storage-monitoring-hardening.xml
+++ b/src/main/resources/liquibase/3.5.x.x/089-cold-storage-monitoring-hardening.xml
@@ -7,6 +7,9 @@
   <property name="now" value="now()" dbms="postgresql"/>
 
   <changeSet id="3.5.0-089-add-freezer-offline-alert-type" author="mherman22">
+    <!-- Published before MICROBIOLOGY_CRITICAL was added to this SQL. Migration 099
+         applies that addition to databases where this changeset already ran. -->
+    <validCheckSum>8:962f26e3c0dbd5ab8e6f18de6f6c3d7b</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <tableExists schemaName="clinlims" tableName="alert"/>
     </preConditions>

--- a/src/main/resources/liquibase/3.5.x.x/092-freezer-humidity-alert-type.xml
+++ b/src/main/resources/liquibase/3.5.x.x/092-freezer-humidity-alert-type.xml
@@ -5,6 +5,8 @@
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
 
   <changeSet id="3.5.0-092-add-freezer-humidity-alert-type" author="mherman22">
+    <!-- Accept the published freezer-only revision; 099 upgrades its constraint. -->
+    <validCheckSum>8:9874f4ac18e40bc491bab25d06051072</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <tableExists schemaName="clinlims" tableName="alert"/>
     </preConditions>

--- a/src/main/resources/liquibase/3.5.x.x/099-reconcile-freezer-microbiology-alert-types.xml
+++ b/src/main/resources/liquibase/3.5.x.x/099-reconcile-freezer-microbiology-alert-types.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd">
+
+  <changeSet id="3.5.0-099-reconcile-freezer-microbiology-alert-types" author="pmanko">
+    <preConditions onFail="HALT">
+      <tableExists schemaName="clinlims" tableName="alert"/>
+    </preConditions>
+    <comment>The published 089/092 revisions did not include MICROBIOLOGY_CRITICAL.
+      Accepting their checksums alone does not rerun their SQL. Reconcile the constraint
+      explicitly, preserving every freezer and shared alert type and all existing rows.</comment>
+    <sql>
+      ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+      ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+      CHECK (alert_type IN (
+        'FREEZER_TEMPERATURE', 'FREEZER_HUMIDITY', 'FREEZER_OFFLINE', 'EQUIPMENT_FAILURE', 'INVENTORY_LOW',
+        'SAMPLE_TRACKING', 'OTHER', 'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING', 'STAT_OVERDUE',
+        'CRITICAL_UNACKNOWLEDGED', 'REQUIRED_BY_DEADLINE', 'REFERRAL_CRITICAL_RESULT', 'REFERRAL_REJECTED',
+        'CRITICAL_RESULT', 'MICROBIOLOGY_CRITICAL'
+      ));
+    </sql>
+    <rollback>
+      <!-- The preceding 092 in this release declares this same union. Keep it on
+           rollback so previously recorded microbiology alerts remain valid. -->
+      <sql>
+        ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+        ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+        CHECK (alert_type IN (
+          'FREEZER_TEMPERATURE', 'FREEZER_HUMIDITY', 'FREEZER_OFFLINE', 'EQUIPMENT_FAILURE', 'INVENTORY_LOW',
+          'SAMPLE_TRACKING', 'OTHER', 'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING', 'STAT_OVERDUE',
+          'CRITICAL_UNACKNOWLEDGED', 'REQUIRED_BY_DEADLINE', 'REFERRAL_CRITICAL_RESULT', 'REFERRAL_REJECTED',
+          'CRITICAL_RESULT', 'MICROBIOLOGY_CRITICAL'
+        ));
+      </sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/liquibase/3.5.x.x/base.xml
+++ b/src/main/resources/liquibase/3.5.x.x/base.xml
@@ -505,7 +505,7 @@
 
   <!-- Cold-storage monitoring hardening (issues #3743/#3904). Its first changeset redeclares
        chk_alert_type wholesale (086's union plus FREEZER_OFFLINE). 092 below redeclares it once more to
-       add FREEZER_HUMIDITY and is now the last word on that constraint - see the note there. -->
+       add FREEZER_HUMIDITY; 099 reconciles both published versions after these have run. -->
   <include relativeToChangelogFile="true" file="089-cold-storage-monitoring-hardening.xml"/>
 
   <!-- Acknowledgment notes on alert, so the detail modal's notes field is no longer dropped on acknowledge. -->
@@ -515,8 +515,11 @@
        existence makes 089's guarded insert MARK_RAN. -->
   <include relativeToChangelogFile="true" file="091-freezer-monitoring-enabled-value-type.xml"/>
 
-  <!-- FREEZER_HUMIDITY on the alert_type constraint. This is now the last changeset anywhere in
-       base-changelog.xml that may redeclare chk_alert_type - it inherits 089's ordering invariant. -->
+  <!-- FREEZER_HUMIDITY on the alert_type constraint. Keep this after earlier constraint declarations. -->
   <include relativeToChangelogFile="true" file="092-freezer-humidity-alert-type.xml"/>
+
+  <!-- Final union: reconcile databases that ran the published freezer-only versions of 089/092.
+       Any future constraint migration must preserve every type in this union. -->
+  <include relativeToChangelogFile="true" file="099-reconcile-freezer-microbiology-alert-types.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/org/openelisglobal/liquibase/FreezerAlertUpgradeTest.java
+++ b/src/test/java/org/openelisglobal/liquibase/FreezerAlertUpgradeTest.java
@@ -1,0 +1,117 @@
+package org.openelisglobal.liquibase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.parser.core.xml.XMLChangeLogSAXParser;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@RunWith(Parameterized.class)
+public class FreezerAlertUpgradeTest {
+
+    private static final String CURRENT = "liquibase/3.5.x.x/";
+    private static final String HISTORICAL = "database-upgrades/freezer-history/";
+    private static final String OFFLINE = "089-cold-storage-monitoring-hardening.xml";
+    private static final String HUMIDITY = "092-freezer-humidity-alert-type.xml";
+    private static final String REPAIR = "099-reconcile-freezer-microbiology-alert-types.xml";
+    private final String baseline;
+
+    public FreezerAlertUpgradeTest(String baseline) {
+        this.baseline = baseline;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<String> baselines() {
+        return List.of("fresh", "published-freezer", "published-microbiology");
+    }
+
+    @Test
+    public void upgradesBothPublishedHistoriesWithoutLosingAlerts() throws Exception {
+        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14.4").withDatabaseName("clinlims")
+                .withUsername("clinlims").withPassword("clinlims")) {
+            postgres.start();
+            try (var connection = DriverManager.getConnection(postgres.getJdbcUrl(), "clinlims", "clinlims");
+                    var statement = connection.createStatement()) {
+                statement.execute("CREATE SCHEMA clinlims");
+                statement.execute(
+                        "CREATE TABLE clinlims.alert (id SERIAL PRIMARY KEY, alert_type VARCHAR(100) NOT NULL)");
+                statement.execute("INSERT INTO clinlims.alert(alert_type) VALUES ('FREEZER_TEMPERATURE')");
+            }
+            if (!baseline.equals("fresh")) {
+                String prefix = baseline.equals("published-freezer") ? HISTORICAL : CURRENT;
+                try (Liquibase before = migrations(postgres, prefix, false)) {
+                    before.update(new Contexts());
+                }
+            }
+            try (Liquibase upgrade = migrations(postgres, CURRENT, true)) {
+                upgrade.update(new Contexts());
+                upgrade.update(new Contexts());
+                assertTrue(upgrade.listUnrunChangeSets(new Contexts()).isEmpty());
+                try (var connection = DriverManager.getConnection(postgres.getJdbcUrl(), "clinlims", "clinlims");
+                        var statement = connection.createStatement()) {
+                    try (var rows = statement.executeQuery(
+                            "SELECT count(*) FROM clinlims.alert WHERE id=1 AND alert_type='FREEZER_TEMPERATURE'")) {
+                        rows.next();
+                        assertEquals("Existing alert is retained", 1, rows.getInt(1));
+                    }
+                    for (String type : List.of("FREEZER_HUMIDITY", "FREEZER_OFFLINE", "MICROBIOLOGY_CRITICAL",
+                            "CRITICAL_RESULT", "REFERRAL_CRITICAL_RESULT", "EQA_DEADLINE")) {
+                        statement.executeUpdate("INSERT INTO clinlims.alert(alert_type) VALUES ('" + type + "')");
+                    }
+                    try {
+                        statement.executeUpdate("INSERT INTO clinlims.alert(alert_type) VALUES ('NOT_AN_ALERT_TYPE')");
+                        fail("The constraint must still reject unsupported alert types");
+                    } catch (SQLException expected) {
+                        assertEquals("23514", expected.getSQLState());
+                    }
+                    if (baseline.equals("published-freezer")) {
+                        try (var rows = statement.executeQuery(
+                                "SELECT md5sum FROM clinlims.databasechangelog WHERE id='3.5.0-092-add-freezer-humidity-alert-type'")) {
+                            rows.next();
+                            assertEquals("Published checksum is retained", "8:9874f4ac18e40bc491bab25d06051072",
+                                    rows.getString(1));
+                        }
+                    }
+                }
+                // The preceding release already permits this union. Rolling back the
+                // reconciliation must not reject microbiology alerts recorded since upgrade.
+                upgrade.rollback(1, new Contexts(), new LabelExpression());
+                upgrade.update(new Contexts());
+            }
+        }
+    }
+
+    private static Liquibase migrations(PostgreSQLContainer<?> postgres, String prefix, boolean repair)
+            throws Exception {
+        var resources = new ClassLoaderResourceAccessor();
+        var parser = new XMLChangeLogSAXParser();
+        var changes = new DatabaseChangeLog();
+        for (String file : repair ? List.of(OFFLINE, HUMIDITY, REPAIR) : List.of(OFFLINE, HUMIDITY)) {
+            // Execute the actual alert changeset; unrelated freezer tables are not
+            // part of this focused fixture. Historical snapshots retain logical paths.
+            changes.addChangeSet(
+                    parser.parse(prefix + file, new ChangeLogParameters(), resources).getChangeSets().get(0));
+        }
+        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(
+                new JdbcConnection(DriverManager.getConnection(postgres.getJdbcUrl(), "clinlims", "clinlims")));
+        database.setDefaultSchemaName("clinlims");
+        database.setLiquibaseSchemaName("clinlims");
+        return new Liquibase(changes, resources, database);
+    }
+}

--- a/src/test/java/org/openelisglobal/liquibase/PublishedMigrationCompatibilityTest.java
+++ b/src/test/java/org/openelisglobal/liquibase/PublishedMigrationCompatibilityTest.java
@@ -1,0 +1,55 @@
+package org.openelisglobal.liquibase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.parser.core.xml.XMLChangeLogSAXParser;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.FileSystemResourceAccessor;
+import org.junit.Test;
+
+/**
+ * Compares real historical changesets, rather than rebuilding history from
+ * candidate SQL.
+ */
+public class PublishedMigrationCompatibilityTest {
+
+    @Test
+    public void candidateAcceptsPreviouslyPublishedChangesetChecksums() throws Exception {
+        String directory = System.getenv("LIQUIBASE_BASELINE_DIR");
+        assumeTrue("Set LIQUIBASE_BASELINE_DIR to an earlier revision's src/main/resources", directory != null);
+        File root = new File(directory);
+        assertTrue("Historical changelog must exist", new File(root, "liquibase/base-changelog.xml").isFile());
+        var parser = new XMLChangeLogSAXParser();
+        var previousResources = new FileSystemResourceAccessor(root);
+        try (var candidateResources = new ClassLoaderResourceAccessor()) {
+            var previous = parser.parse("liquibase/base-changelog.xml", new ChangeLogParameters(), previousResources);
+            var candidate = parser.parse("liquibase/base-changelog.xml", new ChangeLogParameters(), candidateResources);
+            Map<String, ChangeSet> current = new HashMap<>();
+            for (ChangeSet change : candidate.getChangeSets()) {
+                current.put(identity(change), change);
+            }
+            for (ChangeSet old : previous.getChangeSets()) {
+                ChangeSet change = current.get(identity(old));
+                assertNotNull("Published changeset was removed: " + identity(old), change);
+                if (change.shouldAlwaysRun() || change.shouldRunOnChange()) {
+                    continue;
+                }
+                assertTrue(
+                        "Published changeset changed without accepting its prior checksum: " + identity(old) + " ("
+                                + old.generateCheckSum() + "). Use a new migration for the schema change.",
+                        change.isCheckSumValid(old.generateCheckSum()));
+            }
+        }
+    }
+
+    private static String identity(ChangeSet change) {
+        return change.getFilePath() + "::" + change.getId() + "::" + change.getAuthor();
+    }
+}

--- a/src/test/resources/database-upgrades/freezer-history/089-cold-storage-monitoring-hardening.xml
+++ b/src/test/resources/database-upgrades/freezer-history/089-cold-storage-monitoring-hardening.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Snapshot of the first changeset shipped at develop 5c1c33dc42743db3ae290ecd47fca568fba36938. -->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd"
+    logicalFilePath="liquibase/3.5.x.x/089-cold-storage-monitoring-hardening.xml">
+    <changeSet id="3.5.0-089-add-freezer-offline-alert-type"
+        author="mherman22">
+        <preConditions onFail="MARK_RAN">
+            <tableExists schemaName="clinlims" tableName="alert" />
+        </preConditions>
+        <comment>Add FREEZER_OFFLINE to alert_type CHECK constraint so an
+            unresponsive device can raise its own alert. The
+            constraint is redeclared wholesale by every changeset that touches it, so this
+            list is 086's union plus
+            FREEZER_OFFLINE. The "must be last" invariant has moved to 092, which redeclares the
+            constraint again to add
+            FREEZER_HUMIDITY - no changeset anywhere in base-changelog.xml may redeclare
+            chk_alert_type after 092,
+            including the analyzer/ and qc/ changelogs, which base-changelog.xml includes
+            after 3.5.x.x/base.xml.</comment>
+        <sql>
+            ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+            ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+            CHECK (alert_type IN (
+            'FREEZER_TEMPERATURE', 'FREEZER_OFFLINE', 'EQUIPMENT_FAILURE', 'INVENTORY_LOW',
+            'SAMPLE_TRACKING', 'OTHER',
+            'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING', 'STAT_OVERDUE',
+            'CRITICAL_UNACKNOWLEDGED',
+            'REQUIRED_BY_DEADLINE', 'REFERRAL_CRITICAL_RESULT', 'REFERRAL_REJECTED', 'CRITICAL_RESULT'
+            ));
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/database-upgrades/freezer-history/092-freezer-humidity-alert-type.xml
+++ b/src/test/resources/database-upgrades/freezer-history/092-freezer-humidity-alert-type.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Snapshot of the first changeset shipped at develop 5c1c33dc42743db3ae290ecd47fca568fba36938. -->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.8.xsd"
+    logicalFilePath="liquibase/3.5.x.x/092-freezer-humidity-alert-type.xml">
+    <changeSet id="3.5.0-092-add-freezer-humidity-alert-type"
+        author="mherman22">
+        <preConditions onFail="MARK_RAN">
+            <tableExists schemaName="clinlims" tableName="alert" />
+        </preConditions>
+        <comment>Add FREEZER_HUMIDITY to alert_type CHECK constraint so a
+            humidity excursion can raise its own alert
+            instead of only colouring the reading. A separate type from
+            FREEZER_TEMPERATURE because alerts deduplicate on
+            (alert_type, entity type, entity id), so sharing one would collapse a humidity
+            breach and a temperature breach
+            on the same unit into a single row. The constraint is redeclared
+            wholesale by every changeset that touches it,
+            so this list is 089's plus FREEZER_HUMIDITY - and this changeset now
+            takes over 089's invariant: no changeset
+            anywhere in base-changelog.xml may redeclare chk_alert_type after this one,
+            including the analyzer/ and qc/
+            changelogs, which base-changelog.xml includes after 3.5.x.x/base.xml.</comment>
+        <sql>
+            ALTER TABLE clinlims.alert DROP CONSTRAINT IF EXISTS chk_alert_type;
+            ALTER TABLE clinlims.alert ADD CONSTRAINT chk_alert_type
+            CHECK (alert_type IN (
+            'FREEZER_TEMPERATURE', 'FREEZER_HUMIDITY', 'FREEZER_OFFLINE', 'EQUIPMENT_FAILURE',
+            'INVENTORY_LOW',
+            'SAMPLE_TRACKING', 'OTHER', 'EQA_DEADLINE', 'SAMPLE_EXPIRATION', 'STAT_UPCOMING',
+            'STAT_OVERDUE',
+            'CRITICAL_UNACKNOWLEDGED', 'REQUIRED_BY_DEADLINE', 'REFERRAL_CRITICAL_RESULT',
+            'REFERRAL_REJECTED',
+            'CRITICAL_RESULT'
+            ));
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
The testing server stopped booting after #4136 added `MICROBIOLOGY_CRITICAL` to two freezer migrations that had already run. Liquibase correctly rejected their changed checksums. Fresh installs could pass while existing databases could not start.

Accept only the two known published freezer checksums and add migration 099 to apply the complete alert-type constraint to databases where 089/092 already ran. The newer published versions remain valid. Existing alerts are retained; accepting a checksum alone would not apply the missing constraint change.

The backend workflow now supplies the previous revision's real changelog to a generic compatibility test. It rejects removed or incompatible one-time changesets instead of reconstructing migration history from the candidate's SQL. Intentional `runAlways`/`runOnChange` changesets retain their semantics. This check runs in this repository's backend CI.

Validation:

- Java 21 WAR build and required Spotless/frontend formatting completed. Frontend formatter changes are excluded from this PR.
- Three PostgreSQL upgrade cases pass: fresh alert schema, the published freezer history, and the published microbiology history. They cover repeat execution, preserved records/checksums, supported and unsupported alert types, and rollback/reapply with microbiology alerts present.
- Full application changelog integration tests pass for both existing analyzer-data scenarios; three existing microbiology rollback tests pass.
- Historical compatibility passes against develop `5c1c33dc42743db3ae290ecd47fca568fba36938`. A negative control using the unfixed generated resources fails on the original checksum rewrite; restoring the fix passes.

Testing's operational reset to published develop `672c92a` is separate from this repair. A reset does not remediate upgrades for existing installations. No checksum clearing or live database-history edits are part of this change.
