### PR TITLE
perf(frontend): compress and cache the built assets

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -39,6 +39,10 @@ CMD ["npm", "start"]
 # ---- build: produce dist/ (intermediate stage, never shipped directly) ----
 FROM base AS build
 RUN npm run build
+# Pre-compress for gzip_static. Done once here rather than per request at the
+# edge, where the largest chunk would cost real CPU on every cold client.
+RUN find dist -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' \
+      -o -name '*.json' -o -name '*.svg' \) -size +1k -exec gzip -9 -k {} +
 
 # ---- runtime: nginx serving static SPA on HTTP :80 (edge-termination pattern) ----
 FROM nginx:1.27-alpine AS runtime

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -2,6 +2,16 @@ server {
     listen 80;
     server_name _;
 
+    # The build writes a .gz beside every compressible artefact, so nginx hands
+    # those over directly instead of compressing a 13 MB bundle per request.
+    # gzip on is the fallback for anything the build did not pre-compress.
+    gzip_static on;
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/javascript application/json
+               image/svg+xml application/manifest+json;
+
     # Deployment-supplied translation overrides, mounted over this directory.
     # Kept out of the SPA fallback below: that rewrites anything missing to
     # index.html, so a locale the deployment does not override would answer 200
@@ -19,9 +29,28 @@ server {
         default_type application/json;
     }
 
+    # Vite names each artefact by content hash, so a URL under /assets/ cannot
+    # change meaning: a year and immutable, which also drops the revalidation
+    # round-trip this otherwise pays once per chunk on every visit.
+    location /assets/ {
+        root /usr/share/nginx/html;
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
+    # index.html names those hashes, so caching it is what serves a chunk list a
+    # deploy has already deleted. The header is repeated on the block below
+    # because try_files ending in =404 tries /index.html as a file rather than
+    # redirecting to it, so a deep link never enters this location.
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache" always;
+    }
+
     location / {
         root /usr/share/nginx/html;
         index index.html index.htm;
         try_files $uri $uri/ /index.html =404;
+        add_header Cache-Control "no-cache" always;
     }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
-    sourcemap: true,
+    // Maps are 40 MB against 22 MB of JS and ship readable source in the image.
+    sourcemap: false,
   },
   test: {
     alias: [


### PR DESCRIPTION
Fixes #4279

`frontend/nginx/nginx.conf` served the built SPA with no compression and no cache
headers, and `vite.config.ts` shipped source maps into the runtime image.

## What changed

- **`gzip_static on`**, with the build writing a `.gz` beside every compressible
  artefact. Pre-compressing once at build time rather than per request matters here
  because the largest chunk is 13 MB — compressing that on every cold client would
  move the cost from bandwidth to CPU rather than removing it. `gzip on` stays as the
  fallback for anything not pre-compressed.
- **`Cache-Control: public, max-age=31536000, immutable` on `/assets/`**. Safe because
  Vite names every artefact by content hash, so a URL there cannot change meaning.
- **`no-cache` on `index.html` and on the SPA fallback**, since that document names the
  hashes and a stale copy points at chunks a deploy has deleted. The header is on both
  blocks deliberately: `try_files` ending in `=404` treats `/index.html` as a file to
  try, not an internal redirect, so a deep link never enters `location = /index.html`.
- **`sourcemap: false`**, removing 34 maps totalling 40.6 MB from the image.

`/translation/` keeps `no-store`; that block is untouched.

## Measured, before and after

Driven in Chromium against the built image, first contentful paint:

| link | before | after |
|---|---|---|
| 50 Mbit/s, 20 ms RTT | 4.2 s | **1.3 s** |
| 10 Mbit/s, 40 ms RTT | 18.6 s | **5.0 s** |
| 4 Mbit/s, 80 ms RTT | 46.0 s | **12.0 s** |
| 1.6 Mbit/s, 150 ms RTT | 114.3 s | **29.3 s** |

Bytes over the wire:

| | before | after |
|---|---|---|
| cold visit | 21.71 MB | **5.50 MB** |
| repeat visit | 13.23 MB | **0.00 MB** |
| image html directory | 65.4 MB | **33.0 MB** |

The repeat-visit figure is the `immutable` header: before, no conditional request
succeeded and Chrome re-fetched the 13 MB chunk in full.

Headers verified on the built image:

```
/assets/Layout-*.js   Content-Encoding: gzip   Vary: Accept-Encoding
                      Cache-Control: public, max-age=31536000, immutable
                      Content-Length: 3781816   (was 13868852)
/                     Content-Encoding: gzip   Cache-Control: no-cache
/FreezerMonitoring    Content-Encoding: gzip   Cache-Control: no-cache
/login                Content-Encoding: gzip   Cache-Control: no-cache
/translation/*.json   Cache-Control: no-store
```

## What this does not fix

The login page still executes the whole application to render a login form — 5.5 MB
compressed, and about 12 s to first paint on a 4 Mbit/s link. That is #4281, and it
is where the remaining time goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
